### PR TITLE
Add GoatCounter analytics to Pages site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at;">
 <title>SMPD ALPR Investigation</title>
 <style>
   body { font-family: -apple-system, system-ui, sans-serif; max-width: 700px; margin: 40px auto; padding: 0 20px; color: #1f2937; line-height: 1.6; }
@@ -41,5 +41,7 @@
   <h3><a href="https://github.com/none-below/sm-alpr">Source Repository</a></h3>
   <p>All source documents, scripts, and data on GitHub.</p>
 </div>
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/docs/scoreboard.html
+++ b/docs/scoreboard.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://gc.zgo.at;">
 <title>ALPR Sharing Scoreboard — California</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -198,5 +198,7 @@ fetch('data/scoreboard_data.json')
   });
 </script>
 
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/docs/sharing_map.html
+++ b/docs/sharing_map.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>Flock ALPR Sharing Map — California</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org data:; connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://unpkg.com https://nominatim.openstreetmap.org;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://gc.zgo.at; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org data:; connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://unpkg.com https://nominatim.openstreetmap.org;">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="anonymous" />
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
@@ -155,5 +155,7 @@
 <div class="offmap-panel" id="offmap"></div>
 <script src="data/map_data.json" type="application/json" id="mapData"></script>
 <script src="js/map.js?v=1775121663"></script>
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds privacy-friendly GoatCounter page view tracking to all 3 HTML pages (index, scoreboard, sharing map)
- Updates Content-Security-Policy headers to allow `gc.zgo.at` script source
- No cookies, no PII, no fingerprinting — just page view counts
- Dashboard: https://none-below.goatcounter.com

## Test plan
- [ ] Verify pages load without CSP errors in browser console
- [ ] Confirm hits appear on the GoatCounter dashboard after visiting each page