### PR TITLE
fix: always generate text sidecars for all PDFs

### DIFF
--- a/assets/san-mateo-public-records/W012376-032026/W012376-032026_Message_History.pdf.df2c1a3b.txt
+++ b/assets/san-mateo-public-records/W012376-032026/W012376-032026_Message_History.pdf.df2c1a3b.txt
@@ -1,0 +1,132 @@
+--- page 1 ---
+W012376-032026 - California Public Records Request
+Message History (4)
+Page 1
+
+--- page 2 ---
+On 4/3/2026 3:54:00 PM, San Mateo Public Records Center wrote:
+Subject: California Public Records Request :: W012376-032026
+Body: 
+RE: PUBLIC RECORDS REQUEST of March 20, 2026, Reference # W012376-032026
+ 
+Dear Brian C,
+ 
+The City received the following records request from you on March 20, 2026.
+ 
+Pursuant to the California Public Records Act (Gov. Code § 7920 et seq.), I request the following:
+1) All memoranda of understanding, data sharing agreements, or other written agreements between SMPD and 
+the Northern California Regional Intelligence Center (NCRIC) governing the sharing of ALPR data, from 
+January 2020 through the present. SMPD shares data with NCRIC through at least two channels: the NCRIC 
+Astrometrics platform referenced in SOP 205, and through the Flock network where NCRIC appears on 
+SMPD's transparency portal. I request agreements covering both. 
+2) Any analysis, memorandum, or correspondence assessing whether NCRIC qualifies as a "public agency" as 
+defined in Civil Code § 1798.90.5(f). Section 1798.90.55(b) permits ALPR data sharing only with entities 
+meeting this definition. 
+3) The standard NCRIC MOU template contains language granting NCRIC authority to further share 
+contributed data with other public safety entities, and to execute additional sharing agreements without further 
+review or approval by the member agency. If SMPD's agreement contains similar terms, I request any records 
+of SMPD exercising its right to explicitly deny or restrict NCRIC's re-sharing of SMPD's ALPR data with 
+specific entities or categories of entities. I note that NCRIC's own Flock transparency portal lists entities that 
+may not qualify as public agencies under § 1798.90.5(f). If no responsive records exist, please clarify whether 
+(a) SMPD's agreement does not contain such re-sharing terms, or (b) SMPD has not exercised its right to deny 
+or restrict re-sharing.
+If no records are located for any individual item, please respond to that item separately and continue 
+processing the remaining items.
+Responses for items 1) and 3) were previously provided to you. The responsive document for 2) is 
+attached. We have made a good faith and diligent effort to complete your request, in which responsive records 
+have been collected. These records are available on the San Mateo Records Request Portal. Select the link 
+below to view. 
+ 
+The City has completed its response to your request and now considers this record request 
+W012376-032026 closed.
+ 
+If you have any questions, please contact me using the below contact information.
+ 
+Sincerely, 
+ 
+Page 2
+
+--- page 3 ---
+Jennifer Maravillas
+Captain-Support Services 
+Police
+650-522-7633
+On 3/27/2026 5:12:01 PM, San Mateo Public Records Center wrote:
+Subject: California Public Records Request :: W012376-032026
+Body: 
+RE: PUBLIC RECORDS REQUEST of March 20, 2026, Reference # W012376-032026
+ 
+Dear Brian C,
+ 
+The City received the following records request from you on March 20, 2026.
+ 
+Pursuant to the California Public Records Act (Gov. Code § 7920 et seq.), I request the following:
+1) All memoranda of understanding, data sharing agreements, or other written agreements between SMPD and 
+the Northern California Regional Intelligence Center (NCRIC) governing the sharing of ALPR data, from 
+January 2020 through the present. SMPD shares data with NCRIC through at least two channels: the NCRIC 
+Astrometrics platform referenced in SOP 205, and through the Flock network where NCRIC appears on 
+SMPD's transparency portal. I request agreements covering both. Responsive-See attached
+2) Any analysis, memorandum, or correspondence assessing whether NCRIC qualifies as a "public agency" as 
+defined in Civil Code § 1798.90.5(f). Section 1798.90.55(b) permits ALPR data sharing only with entities 
+meeting this definition. Processing-Rolling 
+3) The standard NCRIC MOU template contains language granting NCRIC authority to further share 
+contributed data with other public safety entities, and to execute additional sharing agreements without further 
+review or approval by the member agency. If SMPD's agreement contains similar terms, I request any records 
+of SMPD exercising its right to explicitly deny or restrict NCRIC's re-sharing of SMPD's ALPR data with 
+specific entities or categories of entities. I note that NCRIC's own Flock transparency portal lists entities that 
+may not qualify as public agencies under § 1798.90.5(f). If no responsive records exist, please clarify whether 
+(a) SMPD's agreement does not contain such re-sharing terms, or (b) SMPD has not exercised its right to deny 
+or restrict re-sharing. No responsive records
+If no records are located for any individual item, please respond to that item separately and continue processing 
+the remaining items.
+ 
+Due to the large number of records which are associated with this request, the City will send you records on a 
+rolling production basis. An initial batch of records has been released and made available on the San Mateo 
+Records Request Portal. You will be receiving more batches of responsive records in the future. Select the link 
+below to view what is currently available.
+ 
+We will further respond to your request with updates no later than 4/13/26.
+Page 3
+
+--- page 4 ---
+If you have any questions, please contact me using the below contact information.
+ 
+Sincerely, 
+ 
+Jennifer Maravillas
+Captain-Support Services 
+Police
+650-522-7633
+On 3/20/2026 2:08:49 PM, San Mateo Public Records Center wrote:
+Thank you for your interest in public records of the City of San Mateo.  Your request was received by the City 
+of San Mateo on 3/20/2026 and given the reference number W012376-032026 for tracking purposes.
+Record(s) Requested: Pursuant to the California Public Records Act (Gov. Code § 7920 et seq.), I request 
+the following:
+1) All memoranda of understanding, data sharing agreements, or other written agreements between 
+SMPD and the Northern California Regional Intelligence Center (NCRIC) governing the sharing of 
+ALPR data, from January 2020 through the present. SMPD shares data with NCRIC through at least 
+two channels: the NCRIC Astrometrics platform referenced in SOP 205, and through the Flock network 
+where NCRIC appears on SMPD's transparency portal. I request agreements covering both.
+2) Any analysis, memorandum, or correspondence assessing whether NCRIC qualifies as a "public 
+agency" as defined in Civil Code § 1798.90.5(f). Section 1798.90.55(b) permits ALPR data sharing only 
+with entities meeting this definition.
+3) The standard NCRIC MOU template contains language granting NCRIC authority to further share 
+contributed data with other public safety entities, and to execute additional sharing agreements without 
+Page 4
+
+--- page 5 ---
+further review or approval by the member agency. If SMPD's agreement contains similar terms, I 
+request any records of SMPD exercising its right to explicitly deny or restrict NCRIC's re-sharing of 
+SMPD's ALPR data with specific entities or categories of entities. I note that NCRIC's own Flock 
+transparency portal lists entities that may not qualify as public agencies under § 1798.90.5(f). If no 
+responsive records exist, please clarify whether (a) SMPD's agreement does not contain such re-sharing 
+terms, or (b) SMPD has not exercised its right to deny or restrict re-sharing.
+If no records are located for any individual item, please respond to that item separately and continue 
+processing the remaining items.
+The request is being forwarded to appropriate department(s) for processing.
+Monitor request progress at the link below.  The City will email you when the request is complete.  Thank you 
+for using the San Mateo Records Center.
+To monitor the progress or update this request please log into the San Mateo Records Center.
+On 3/20/2026 2:07:38 PM, Brian C wrote:
+Request Created on Public Portal
+Page 5

--- a/assets/san-mateo-public-records/W012376-032026/_ALPR_Technology_in_the_News_and_Resources_for_Partner_Agencies_and_the_Public__1_.pdf.135283aa.txt
+++ b/assets/san-mateo-public-records/W012376-032026/_ALPR_Technology_in_the_News_and_Resources_for_Partner_Agencies_and_the_Public__1_.pdf.135283aa.txt
@@ -1,0 +1,78 @@
+--- page 1 ---
+Date:
+Fri, 1 Aug 2025 9:03:48 PM (UTC)
+Sent:
+Fri, 1 Aug 2025 9:01:55 PM (UTC)
+Subject: ALPR Technology in the News and Resources for Partner Agencies and the Public
+From:
+info@ncric.net
+To:
+Stephan Casazza <casazza@cityofsanmateo.org >;
+Dear Partner,
+ 
+ 
+Last week, a news story was released titled “California cops are breaking surveillance laws. Who’s going to stop
+them?” at https://sfstandard.com/2025/07/23/california- police-sharing-flock-license-plate-data. Based on
+the data that the author of the story presented, no federal agency personnel had access to California law
+enforcement agencies’ ALPR systems. Authorized state and local law enforcement personnel used the systems
+under their authority, but they used federal case numbers for joint investigations with the federal agency
+acronym as a reference number associated with their research.
+ 
+ 
+Local and state law enforcement personnel, including analysts, use ALPR data daily as a pointer system to help
+locate subjects of investigation, victims of crime, and witnesses. ALPR data is only one of many systems that
+provide state and local law enforcement personnel working joint violent crime and major crime investigations
+with the potential location of the subject(s) that they are attempting to locate for active criminal cases. 
+Under SB 34, state and local law enforcement personnel can’t share ALPR  information with federal law
+enforcement personnel, as they are not part of a “public agency” which is defined as “the state, any city,
+county, or city and county, or any agency or political subdivision of the state or a city, county, or city and county,
+including, but not limited to, a law enforcement agency.” (Civ. Code, § 1798.90.5) State and local law
+enforcement personnel working joint investigations with federal agencies can share data from other sources,
+as long as the information sharing complies with SB 54. (See the links below for the California Department of
+Justice's guidance on SB 34 and SB 54)
+ 
+ 
+This 
+ SB34 ALPR Presentation 31JULY2025.pptx may be saved and edited to provide public presentations
+on ALPR technology. We also have NCRIC policies at https://ncric.ca.gov/privacy- and-policy-documents/ and
+additional resources at https://www.theiacp.org/projects/automated- license-plate-recognition to help you with
+any future conversations regarding ALPR technology.
+ 
+ 
+At the NCRIC/NC HIDTA, we comply with SB34 and SB54. Only California law enforcement agencies may access
+the ALPR data through our Single Sign On (SSO) System, . No Federal or out of state law enforcement agencies
+have access to the ALPR system and no authorized law enforcement user or agency may access the ALPR
+database for the sole purpose of immigration enforcement. In gathering, sharing, and storing information, the
+NCRIC complies with all applicable laws, rules, and regulations, including but not limited to, to the extent
+applicable, the California Values Act (Government Code Section 7284 et seq.). The NCRIC will, consistent with
+Section 7284.8 (b) work to ensure that databases are governed in a manner that limits the availability of
+information therein to the fullest extent practicable and consistent with federal and state law, to anyone or
+any entity for the sole purpose of immigration enforcement.
+ 
+ 
+Thank you for your support and please let us know if you have any questions by contacting us at
+
+--- page 2 ---
+dutyofficer@ncric.ca.gov.
+ 
+ 
+Mike Sena
+Executive Director
+Northern California High Intensity Drug Trafficking Area
+Northern California Regional Intelligence Center
+Attachment Link(s):
+SB34 CA DOJ Memo 2023-DLE-065.pdf (5 pages)
+This Information Bulletin provides guidance to California state and local law enforcement agencies
+(collectively California LEAs) regarding the governance of Automated License Plate Recognition
+(ALPR) information to ensure that the storage, collection, sharing, and use of this information is
+consistent with California law.
+SB54 CA DOJ Memo 23-01-cjis5.pdf (4 pages)
+This Information Bulletin (IB) provides updated guidance to California state and local law enforcement
+agencies (collectively, California LEAs) regarding the governance of databases under Senate Bill (SB)
+No. 54 (De León; 2017-2018 Regular Session) (“the Values Act” or SB 54) and supplements the
+previous IB 18-10-CJIS. Specifically, this IB provides updated guidance regarding specific databases to
+ensure information is limited for immigration enforcement purposes to the fullest extent practicable and
+consistent with federal and state law. California LEAs are strongly encouraged to review and update their
+existing database governance polices consistent with this guidance and that in IB 18-10-CJIS.
+Link(s) will expire on 8/1/2026
+To remove yourself from this mailing list, Click here

--- a/assets/san-mateo-public-records/emails/29_bedford_uop_2026-03-11.pdf.1f0ea31f.txt
+++ b/assets/san-mateo-public-records/emails/29_bedford_uop_2026-03-11.pdf.1f0ea31f.txt
@@ -1,0 +1,42 @@
+--- page 1 ---
+Re: California Public Records Act Request — ALPR Data Sharing
+From
+Grant Bedford <gbedford@pacific.edu>
+To
+Brian C 
+Date
+2026-03-12 08:45
+Dear Sir,
+While University of the Pacific is a private institution and therefore not subject to the CPRA, we are happy to share Pacific’s
+policy regarding the ALPR system, posted here: https://www.pacific.edu/student-life/safety-and-conduct/public-safety/campus-
+parking/ALPRS
+Sincerely,
+Grant Bedford
+Chief of Police
+University of the Pacific
+3601 Pacific Avenue | Stockton, CA 95211
+________________________________
+From: Brian C
+Sent: Sunday, March 1, 2026 6:59 PM
+To: Grant Bedford 
+Subject: California Public Records Act Request — ALPR Data Sharing
+CAUTION: This email originated from outside of Pacific. Do not click any links or open attachments if this is unsolicited email.
+Dear Chief Bedford,
+Pursuant to the California Public Records Act (Gov. Code § 7920.000 et
+seq.), I request the following records from the University of the
+Pacific Department of Public Safety:
+1) Any Automated License Plate Reader (ALPR) usage and privacy policy
+maintained by the Department of Public Safety pursuant to Civil Code §
+1798.90.51 or § 1798.90.53.
+2) Any agreements with Flock Safety, Inc. related to ALPR systems, data
+sharing, or access to the Flock Safety network.
+3) Any records documenting the legal basis under which the University of
+the Pacific receives ALPR data from other law enforcement agencies
+through the Flock Safety platform.
+I request responsive records in electronic format where available.
+Please contact me if clarification would help narrow or expedite this
+request.
+-brian
+3/16/26, 10:38 AM
+ Re: California Public Records Act Request — ALPR Data Sharing
+1

--- a/assets/san-mateo-public-records/portal-archives-031126/30_smpd_portal_2026-03-11.pdf.ee6221dd.txt
+++ b/assets/san-mateo-public-records/portal-archives-031126/30_smpd_portal_2026-03-11.pdf.ee6221dd.txt
@@ -1,0 +1,122 @@
+--- page 1 ---
+San Mateo CA PD
+Transparency Portal
+Last Updated: Thu Mar 12 2026
+Overview
+San Mateo CA PD uses Flock Safety technology to capture objective evidence without compromising on individual
+privacy. San Mateo CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, San Mateo CA
+PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and
+guardrails are in place, they have made the below policies and usage statistics available to the public.
+Policies
+What's Detected
+License Plates, Vehicles
+What's Not Detected
+Facial recognition, People, Gender, Race
+Acceptable Use Policy
+Data is used for law enforcement purposes only. Data is owned by San Mateo CA PD and is never
+sold to 3rd parties.
+Prohibited Uses
+Immigration enforcement, traffic enforcement, harrassment or intimidation, usage based solely on a
+protected class (i.e. race, sex, religion), Personal use.
+Access Policy
+All system access requires a valid reason and is stored indefinitely.
+Hotlist Policy
+Hotlist hits are required to be human verified prior to action.
+Usage
+Data retention (in days)
+30 days
+Number of LPR and other cameras
+66
+3/12/26, 10:04 AM
+Flock Safety - San Mateo CA PD Transparency Portal
+https://transparency.flocksafety.com/san-mateo-ca-pd
+1/4
+
+--- page 2 ---
+Hotlists Alerted On
+California SVS, NCMEC Amber Alert
+Vehicles detected in the last 30 days
+782,730
+Hotlist hits in the last 30 days
+8,201
+3/12/26, 10:04 AM
+Flock Safety - San Mateo CA PD Transparency Portal
+https://transparency.flocksafety.com/san-mateo-ca-pd
+2/4
+
+--- page 3 ---
+Organizations granted access to San Mateo CA PD data
+San Jose State University CA, Alameda County CA SO, Albany CA PD, Alhambra CA PD, Anaheim CA
+PD, Anderson CA PD, Angels Camp CA PD, Antioch CA PD, Atherton CA PD, Atwater CA PD, Auburn
+CA PD, Azusa CA PD, Bakersfield CA PD, Baldwin Park CA PD, Barstow CA PD, Beaumont CA PD, Bell
+CA PD, Belmont CA PD, Benicia CA PD, Berkeley CA PD, Beverly Hills CA PD, Bishop CA PD , Brawley
+CA PD, Brentwood CA PD, Brisbane CA PD, Burbank CA PD, Burlingame CA PD, Butte County CA SO,
+CA - Wasco PD , Cal Fire , Cal State Fullerton (CA), Cal State San Bernadino CA PD, Calexico CA PD,
+California Highway Patrol, California State Parks, Calistoga CA PD, Campbell CA PD, Capitola CA PD,
+Carmel CA PD, Cathedral City CA PD, Central Marin CA PD, Cerritos College CA PD, Chula Vista CA
+PD, Citrus Heights CA PD, City of Lemoore CA, City of Newman CA PD, Clayton CA PD, Clearlake CA
+PD, Cloverdale CA PD, Colma CA PD, Colton CA PD , Colusa CA PD , Concord CA PD, Contra Costa
+County CA SO, Corona CA PD, Coronado CA PD, Costa Mesa CA PD, Covina CA PD, Cypress CA PD,
+Daly City CA PD, Danville CA PD, Delano CA PD, Desert Hot Springs CA PD, Dinuba CA PD, Dixon CA
+PD, Downey PD CA, Dublin CA PD (ACSO), East Bay Parks CA PD, East Palo Alto CA PD, El Cajon CA
+PD, El Centro CA PD, El Cerrito CA PD, El Monte CA PD, Elk Grove CA PD, Emeryville CA PD, Escalon
+CA PD, Escondido CA PD, Fairfield CA PD, Folsom CA PD, Fontana CA PD, Foothill-DeAnza CA PD, Fort
+Bragg CA PD, Foster City CA PD, Fountain Valley CA PD, Fowler CA PD, Fremont CA PD, Fresno CA PD,
+Fullerton CA PD, Galt CA PD, Garden Grove CA PD, Gilroy CA PD, Glendale CA PD, Glendora (CA) PD,
+Grass Valley CA PD, Greenfield CA PD, Grover Beach CA PD, Gustine PD CA , Hanford CA PD,
+Hayward CA PD, Hemet CA PD , Hercules CA PD, Hillsborough CA PD, Hollister CA PD, Huntington
+Beach CA PD, Imperial City CA PD, Imperial County CA SO, Indio CA PD, Irvine CA PD, Irwindale CA
+PD, Kerman CA PD , Kern County CA SO , Kings County CA DAs Office, Kings County Sheriff's Office
+CA , La Habra CA PD, La Mesa CA PD, La Verne CA PD, Laguna Beach CA PD, Lake County CA SO,
+Lakeport CA PD, Lancaster CA PD, LASD CA - San Dimas Station, Lassen County SO (CA), Lathrop CA
+PD , Lincoln CA PD, Livermore CA PD, Livingston CA PD, Lodi CA PD, Lompoc CA PD, Los Alamitos PD
+CA, Los Altos CA PD, Los Angeles CA PD, Los Angeles County CA SD, Los Angeles Port Police CA,
+Madera CA PD, Madera County SO CA , Manteca CA PD, Marin County CA DA, Marina CA PD,
+Marysville CA PD, McFarland CA PD, Mendocino County SO-CA, Mendota CA PD, Menifee CA PD,
+Menlo Park CA PD, Merced County CA SO, Milpitas CA PD, Modoc County CA SO, Monrovia CA PD,
+Monterey County CA SO, Monterey County District Attorney's Office, Monterey Park CA PD, Moraga
+CA PD, Morgan Hill CA PD, Murrieta CA PD, Napa CA PD, Napa County CA SO, National City CA PD,
+NCRIC, Nevada County CA SO, Newark CA PD , Newport Beach PD CA, Novato CA PD, Oakland CA
+PD, Oakley CA PD, Oceanside CA PD, Ontario CA PD, Orange CA PD, Orange County Fire Authority
+(CA), Orange County SO CA, Orange Cove CA PD, Oroville CA PD, Oxnard CA PD , Pacifica CA PD,
+Palo Alto CA PD, Pasadena CA PD, Petaluma CA PD, Piedmont CA PD, Placentia CA PD, Placer County
+CA DA Office, Placer County CA SO, Pleasant Hill CA PD, Pleasanton CA PD, Pomona CA PD, Port
+Hueneme CA PD, Port of Stockton CA PD, Porterville CA PD, Redlands CA PD, Redondo Beach CA PD,
+Redwood City CA PD, Reedley CA PD, Ridgecrest CA PD, Rio Hondo College PD CA, Rio Vista CA PD,
+Riverside County CA District Attorney, Rocklin CA PD, Rohnert Park Department of Public Safety
+(CA), Roseville CA PD, Sacramento CA DA, Sacramento County Parks Department CA, Salinas CA PD,
+San Bruno CA PD, San Diego Harbor CA PD, San Fernando CA PD, San Francisco CA PD, San Francisco
+District Attorney CA, San Gabriel CA PD, San Joaquin CA DA, San Joaquin County CA SO, San Joaquin
+Delta College PD (CA), San Jose CA PD, San Leandro CA PD, San Luis Obispo CA PD , San Luis Obispo
+County (CA) Sheriff , San Mateo County CA SO, San Pablo CA PD , San Pasqual CA PD, San Ramon CA
+PD, Sand City CA PD, Sanger CA PD , Santa Barbara County CA SO, Santa Clara CA PD, Santa Clara DA
+CA, Santa Monica CA PD, Santa Paula CA PD, Santa Rosa CA PD, Sausalito CA PD, Seal Beach CA PD ,
+Seaside CA PD, Sequoias Community College District CA PD, Shafter PD CA, Shasta County SO, Simi
+Valley CA PD, Solano County DA CA, Soledad CA PD, Sonoma County CA SO, South Gate CA PD,
+South Pasadena CA PD, South San Francisco CA PD, Stallion Springs CA PD, Stockton CA PD, Suisun
+City CA PD , Sutter County CA SO , Taft CA PD, Tehachapi CA PD, Tehama County CA SO, Town of
+Woodside CA (SMCSO), Tracy CA PD, Tulare CA PD , Turlock CA PD, Tustin CA PD , UC Irvine
+Campus PD CA, Ukiah CA PD, Union City CA PD, University of California, Berkeley, Upland CA PD ,
+Vacaville CA PD, Vallejo CA PD, Ventura CA PD, Ventura County CA SO, Vernon CA PD, Visalia CA PD,
+Walnut Creek CA PD, Watsonville CA PD, West Covina CA PD, West Sacramento CA PD, West Valley
+Mission College Dist Campus (CA), Westminster CA PD, Westmorland CA PD, Wheatland CA PD,
+Whittier CA PD, Williams CA PD, Willits CA PD, Winters CA PD , Woodlake CA PD, Woodland CA PD,
+Yolo County CA SO, Yuba City CA PD, Yuba County Sheriffs Office
+Additional Info
+3/12/26, 10:04 AM
+Flock Safety - San Mateo CA PD Transparency Portal
+https://transparency.flocksafety.com/san-mateo-ca-pd
+3/4
+
+--- page 4 ---
+Provided by Flock Safety
+Policy Documents
+San Mateo PD Full Policy Manual can be found at the following link:
+https://www.cityofsanmateo.org/DocumentCenter/View/79089/San-Mateo-PD-Policy-Manual
+ALPR Policy
+San Mateo PD ALPR Policy can be found at the following link:
+https://www.cityofsanmateo.org/DocumentCenter/View/99914/ALPR-Policy-12-23-2025
+3/12/26, 10:04 AM
+Flock Safety - San Mateo CA PD Transparency Portal
+https://transparency.flocksafety.com/san-mateo-ca-pd
+4/4

--- a/assets/san-mateo-public-records/portal-archives-031126/30_stockton_portal_2026-03-11.pdf.202544c2.txt
+++ b/assets/san-mateo-public-records/portal-archives-031126/30_stockton_portal_2026-03-11.pdf.202544c2.txt
@@ -1,0 +1,129 @@
+--- page 1 ---
+Stockton CA PD
+Transparency Portal
+Last Updated: Thu Mar 12 2026
+Overview
+Stockton CA PD uses Flock Safety technology to capture objective evidence without compromising on individual
+privacy. Stockton CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Stockton CA PD
+utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and
+guardrails are in place, they have made the below policies and usage statistics available to the public.
+Policies
+What's Detected
+License Plates, Vehicles
+What's Not Detected
+Facial recognition, People, Gender, Race
+Acceptable Use Policy
+Data is used for law enforcement purposes only. Data is owned by Stockton CA PD and is never sold
+to 3rd parties.
+Prohibited Uses
+Immigration enforcement, traffic enforcement, harassment or intimidation, usage based solely on a
+protected class (i.e. race, sex, religion), Personal use.
+Access Policy
+All system access requires a valid reason and is stored indefinitely.
+Hotlist Policy
+Hotlist hits are required to be human verified prior to action.
+Usage
+Data retention (in days)
+30 days
+Number of LPR and other cameras
+140
+Organizations granted access to Stockton CA PD data
+3/12/26, 10:05 AM
+Flock Safety - Stockton CA PD Transparency Portal
+https://transparency.flocksafety.com/stockton-ca-pd
+1/3
+
+--- page 2 ---
+San Jose State University CA, Alameda CA PD, Alameda County CA SO, Albany CA PD, Alhambra CA
+PD, Amador County CA Sheriff's Office, Anaheim CA PD, Anderson CA PD, Angels Camp CA PD,
+Antioch CA PD, Arcadia CA PD, Atherton CA PD, Atwater CA PD, Auburn CA PD, Avenal CA PD, Azusa
+CA PD, Bakersfield CA PD, Baldwin Park CA PD, Barstow CA PD, Bear Valley Springs CA PD, Beaumont
+CA PD, Bell CA PD, Bell Gardens CA PD, Belmont CA PD, Belvedere CA PD, Benicia CA PD, Berkeley CA
+PD, Beverly Hills CA PD, Beverly Hills Unified School District CA PD, Bishop CA PD , Blue Lake
+Rancheria Tribal PD, Blythe CA PD , Brawley CA PD, Brentwood CA PD, Brisbane CA PD, Buena Park
+CA PD, Burbank CA PD, Burlingame CA PD, Butte County CA SO, CA Iipay Nation of Santa Ysabel, Cal
+Fire , Cal State Fullerton (CA), Calexico CA PD, California Department of Corrections, California
+Department of Fish & Wildlife (CA), California Highway Patrol, California State Parks, California State
+University Long Beach Campus PD, Calistoga CA PD, Campbell CA PD, Capitola CA PD, Carmel CA PD,
+Cathedral City CA PD, Central Marin CA PD, Cerritos College CA PD, Chino CA PD , Chula Vista CA PD,
+Citrus Heights CA PD, City of Lemoore CA, City of Riverside CA PD , Claremont CA PD, Clayton CA PD,
+Cloverdale CA PD, Colma CA PD, Colton CA PD , Colusa CA PD , Concord CA PD, Contra Costa County
+CA SO, Corcoran CA PD, Corona CA PD, Coronado CA PD, Costa Mesa CA PD, Cotati CA PD, Covina
+CA PD, Culver City CA PD, Cypress CA PD, Daly City CA PD, Danville CA PD, Decommissioned Org,
+Del Norte County CA SO, Delano CA PD, Desert Hot Springs CA PD, Dinuba CA PD, Dixon CA PD,
+Downey PD CA, Dublin CA PD (ACSO), East Bay Parks CA PD, East Palo Alto CA PD, El Cajon CA PD, El
+Centro CA PD, El Cerrito CA PD, El Dorado County CA SO, El Monte CA PD, El Segundo CA PD, Elk
+Grove CA PD, Emeryville CA PD, Escalon CA PD, Escondido CA PD, Fairfield CA PD, Folsom CA PD,
+Fontana CA PD, Foothill-DeAnza CA PD, Fort Bragg CA PD, Foster City CA PD, Fountain Valley CA PD,
+Fowler CA PD, Fremont CA PD, Fresno CA PD, Fullerton CA PD, Galt CA PD, Garden Grove CA PD,
+Gilroy CA PD, Glendora (CA) PD, Grass Valley CA PD, Greenfield CA PD, Grover Beach CA PD, Gustine
+PD CA , Hanford CA PD, Hayward CA PD, Hemet CA PD , Hercules CA PD, Hermosa Beach PD CA,
+Hillsborough CA PD, Hollister CA PD, Humboldt County CA SO, Imperial City CA PD, Imperial County
+CA SO, Indio CA PD, Inglewood CA PD, Irvine CA PD, Irwindale CA PD, Kerman CA PD , Kern County
+CA SO , Kings County CA DAs Office, Kings County Sheriff's Office CA , Kingsburg CA PD , La Habra
+CA PD, La Mesa CA PD, La Verne CA PD, Laguna Beach CA PD, Lake County CA SO, Lakeport CA PD,
+Lancaster CA PD, Lathrop CA PD , Lincoln CA PD, Livermore CA PD, Livingston CA PD, Lodi CA PD,
+Lompoc CA PD, Los Alamitos PD CA, Los Altos CA PD, Los Angeles CA PD, Los Angeles County CA SD,
+Los Angeles Port Police CA, Madera CA PD, Madera County SO CA , Manteca CA PD, Marin County
+CA DA, Marin County CA SO, Marina CA PD, McFarland CA PD, Mendocino County SO-CA, Mendota
+CA PD, Menifee CA PD, Menlo Park CA PD, Merced County CA SO, Mill Valley CA PD, Milpitas CA PD,
+Modoc County CA SO, Montclair CA PD, Monterey CA PD, Monterey County CA SO, Monterey County
+District Attorney's Office, Monterey Park CA PD, Moraga CA PD, Morgan Hill CA PD, Murrieta CA PD,
+Napa CA PD, Napa County CA SO, National City CA PD, NCRIC, Nevada City CA PD, Nevada County
+CA SO, Newark CA PD , Newport Beach PD CA, Novato CA PD, Oakland CA PD, Oakley CA PD,
+Oceanside CA PD, Ontario CA PD, Orange CA PD, Orange County (CA) DA Office , Orange County Fire
+Authority (CA), Orange County SO CA, Oroville CA PD, Oxnard CA PD , Pacific Grove CA PD, Pacifica
+CA PD, Palm Springs CA PD, Palo Alto CA PD, Pasadena CA PD, Petaluma CA PD, Piedmont CA PD,
+Placentia CA PD, Placer County CA DA Office, Placer County CA SO, Pleasant Hill CA PD, Pleasanton
+CA PD, Port of Stockton CA PD, Porterville CA PD, Redding PD - CA, Redondo Beach CA PD, Redwood
+City CA PD, Reedley CA PD, Rialto PD CA, Ridgecrest CA PD, Rio Hondo College PD CA, Rio Vista CA
+PD, RIV CO ARSON TF CA PD, Riverside County CA District Attorney, Riverside County CA SO, Rocklin
+CA PD, Rohnert Park Department of Public Safety (CA), Roseville CA PD, Sacramento CA DA,
+Sacramento CA PD, Sacramento County CA SO, Sacramento County Parks Department CA, Salinas
+CA PD, San Benito County SO CA, San Bernardino CA PD, San Bernardino Community College CA PD,
+San Bernardino County CA Human Services [Law Enforcement], San Bernardino County CA SO, San
+Bruno CA PD, San Diego CA PD, San Diego County CA SD, San Diego Harbor CA PD, San Fernando CA
+PD, San Francisco CA PD, San Francisco District Attorney CA, San Gabriel CA PD, San Joaquin CA DA,
+San Joaquin County CA SO, San Joaquin Delta College PD (CA), San Jose - Evergreen Community
+College Campus PD CA , San Jose CA PD, San Leandro CA PD, San Luis Obispo CA PD , San Luis
+Obispo County (CA) Sheriff , San Mateo CA PD, San Mateo County CA SO, San Pablo CA PD , San
+Pasqual CA PD, San Rafael CA PD, San Ramon CA PD, Sanger CA PD , Santa Ana CA PD, Santa Barbara
+County CA SO, Santa Clara CA PD, Santa Clara County CA SO, Santa Cruz CA PD (deactivated), Santa
+Monica CA PD, Santa Rosa CA PD, Sausalito CA PD, Seal Beach CA PD , Seaside CA PD, Selma CA PD ,
+Sequoias Community College District CA PD, Shafter PD CA, Shasta County SO, Signal Hill CA PD,
+Simi Valley CA PD, Solano County CA SO, Solano County DA CA, Soledad CA PD, Sonoma County CA
+SO, South Gate CA PD, South Pasadena CA PD, Stallion Springs CA PD, Stanford University CA PD,
+Suisun City CA PD , Sunnyvale CA PD, Sutter County CA SO , Taft CA PD, Tehachapi CA PD, Tehama
+County CA SO, Tiburon CA PD, Town of Los Gatos CA, Tracy CA PD, Trinity County SO CA , Truckee
+CA PD, Tulare CA PD , Tulare County CA SO, Turlock CA PD, Tustin CA PD , Ukiah CA PD, Union City
+CA PD, University of CA - Santa Barbara CA PD, University of California, Berkeley, University of San
+3/12/26, 10:05 AM
+Flock Safety - Stockton CA PD Transparency Portal
+https://transparency.flocksafety.com/stockton-ca-pd
+2/3
+
+--- page 3 ---
+Provided by Flock Safety
+Francisco CA PD, University of the Pacific (CA), Upland CA PD , Vacaville CA PD, Vallejo CA PD,
+Ventura CA PD, Ventura County CA SO, Ventura County District Attorney's Office CA, Vernon CA PD,
+Visalia CA PD, Walnut Creek CA PD, Watsonville CA PD, West Covina CA PD, West Sacramento CA
+PD, West Valley Mission College Dist Campus (CA), Westminster CA PD, Wheatland CA PD, Whittier
+CA PD, Williams CA PD, Willits CA PD, Winters CA PD , Woodlake CA PD, Woodland CA PD, Yolo
+County CA SO, Yreka CA PD, Yuba City CA PD, Yuba County Sheriffs Office
+Hotlists Alerted On
+California SVS, NCMEC Amber Alert
+Vehicles detected in the last 30 days
+907,584
+Hotlist hits in the last 30 days
+35,822
+Searches in the last 30 days
+1,643
+Public Search Audit
+Download CSV
+Additional Info
+Recent Success Story
+Additional Info
+3/12/26, 10:05 AM
+Flock Safety - Stockton CA PD Transparency Portal
+https://transparency.flocksafety.com/stockton-ca-pd
+3/3

--- a/assets/san-mateo-public-records/stockton-pra-10310081/27_stockton_pd_uop_sharing.pdf.818254cd.txt
+++ b/assets/san-mateo-public-records/stockton-pra-10310081/27_stockton_pd_uop_sharing.pdf.818254cd.txt
@@ -1,0 +1,74 @@
+--- page 1 ---
+Request #:
+10310081
+Entered:
+03/01/2026 6:53 PM
+Status:
+Closed
+Request Type:
+Problem
+Topic:
+Public Records
+Description:
+Pursuant to the California Public Records Act (Gov. Code § 7920.000 et seq.), I request the
+following records from the Stockton Police Department: Any agreements between the City of Stockton or Stockton
+Police Department and the University of the Pacific or its Department of Public Safety that authorize the sharing of
+Automated License Plate Reader (ALPR) data or access to ALPR systems. Any records documenting the legal
+basis or authorization for sharing ALPR data with the University of the Pacific, including but not limited to
+determinations that UOP qualifies as a "public agency" under Civil Code § 1798.90.5(f). Any ALPR usage and
+privacy policy, data sharing agreements, or Flock Safety network sharing configurations that include the University
+of the Pacific as an authorized recipient of ALPR information. I request responsive records in electronic format
+where available. Please contact me if clarification would help narrow or expedite this request.
+Date Closed:
+03/04/2026 11:42 AM
+Reason Closed:
+Hello, We have no responsive records to your requests. Any terms agreements between
+agencies are created and maintained by Flock. Thank you, Maryann Weiman
+Email Message you sent - 03/04/2026 12:23 PM
+Ms. Weiman — thank you for the quick response. A follow-up question:
+You noted that sharing agreements are created and maintained by Flock.
+However, the University of the Pacific Department of Public Safety
+appears as a sharing partner on Stockton PD's Flock transparency portal:
+https://transparency.flocksafety.com/stockton-ca-pd
+I understand that UOP has its own contract with Flock Safety, but
+agencies must affirmatively select their sharing partners within the
+Flock platform. UOP is a private university. California Civil Code §
+1798.90.5(f) restricts ALPR data sharing to public agencies as defined
+in Government Code § 6252(a).
+Did the City or Stockton PD independently determine that UOP qualifies
+as a public agency before selecting them as a sharing partner?
+If not, who made that determination?
+If no such determination exists, I would request any records identifying
+which entity authorized UOP's inclusion, and any communications between
+the City and Flock Safety regarding UOP's access.
+Thank you,
+Brian
+On 2026-03-04 11:42, Stockton wrote:
+> ---
+Email Message you sent - 03/04/2026 11:52 AM
+Ms. Weiman — thank you for the quick response. A follow-up question:
+3/5/26, 10:56 AM
+user.govoutreach.com/stockton/case.php?id=10310081&access=6133356662396435
+https://user.govoutreach.com/stockton/case.php?id=10310081&access=6133356662396435
+1/2
+
+--- page 2 ---
+You noted that sharing agreements are created and maintained by Flock. However, the University of
+the Pacific Department of Public Safety appears as a sharing partner on Stockton PD's Flock
+transparency portal: https://transparency.flocksafety.com/stockton-ca-pd
+I understand that UOP has its own contract with Flock Safety, but agencies must affirmatively select
+their sharing partners within the Flock platform. UOP is a private university. California Civil Code §
+1798.90.5(f) restricts ALPR data sharing to public agencies as defined in Government Code §
+6252(a).
+Did the City or Stockton PD independently determine that UOP qualifies as a public agency before
+selecting them as a sharing partner? If not, who made that determination?
+If no such determination exists, I would request any records identifying which entity authorized UOP's
+inclusion, and any communications between the City and Flock Safety regarding UOP's access.
+Thank you,
+Brian
+If you want to add information to this request, enter it below and press the Update button
+Update  Cancel
+3/5/26, 10:56 AM
+user.govoutreach.com/stockton/case.php?id=10310081&access=6133356662396435
+https://user.govoutreach.com/stockton/case.php?id=10310081&access=6133356662396435
+2/2

--- a/scripts/ocr_sidecar.py
+++ b/scripts/ocr_sidecar.py
@@ -95,11 +95,6 @@ def generate_sidecar(pdf_path, force=False):
         else:
             pages.append(f"--- page {page_num + 1} ---\n{native}")
 
-    # Skip if OCR added no meaningful text — the PDF is already searchable
-    if ocr_chars == 0:
-        doc.close()
-        return None
-
     doc.close()
 
     full_text = "\n\n".join(pages)


### PR DESCRIPTION
## Summary
- Remove the `ocr_chars == 0` skip in `ocr_sidecar.py` so sidecars are generated for all PDFs, not just image-based ones
- Downstream tools can now always read the `.txt` sidecar without detecting PDF type
- Generates 6 missing sidecars across existing PRA assets

## Test plan
- [ ] Verify `ocr_sidecar.py` produces sidecars for both native-text and image-based PDFs
- [ ] Confirm existing sidecars are not regenerated unnecessarily