### PR TITLE
Fix GoatCounter CSP: add beacon domain to connect-src

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com;">
 <title>SMPD ALPR Investigation</title>
 <style>
   body { font-family: -apple-system, system-ui, sans-serif; max-width: 700px; margin: 40px auto; padding: 0 20px; color: #1f2937; line-height: 1.6; }

--- a/docs/scoreboard.html
+++ b/docs/scoreboard.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com;">
 <title>ALPR Sharing Scoreboard — California</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -286,7 +286,7 @@ def _generate_html(marker_count):
 <meta charset="utf-8">
 <title>Flock ALPR Sharing Map — California</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://gc.zgo.at; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org data:; connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://unpkg.com https://nominatim.openstreetmap.org https://gc.zgo.at;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://gc.zgo.at; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org data:; connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://unpkg.com https://nominatim.openstreetmap.org https://gc.zgo.at https://none-below.goatcounter.com;">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="anonymous" />
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- GoatCounter loads its script from `gc.zgo.at` but sends beacons to `none-below.goatcounter.com/count`
- CSP `connect-src` only had `gc.zgo.at`, so the beacon was silently blocked
- Added `https://none-below.goatcounter.com` to `connect-src` on all three pages (index.html, scoreboard.html, build_map.py template)

## Test plan
- [ ] Load each page in Chrome without extensions
- [ ] Confirm `count.js` loads (200) AND a second request to `none-below.goatcounter.com/count` fires
- [ ] Check GoatCounter dashboard registers the visit