### PR TITLE
Add build_scoreboard.py to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,11 @@ jobs:
           packages: tesseract-ocr
           version: 1.0
 
-      - name: Build sharing graph, map, and findings PDF
+      - name: Build sharing graph, map, scoreboard, and findings PDF
         run: |
-          uv run python scripts/build_sharing_graph.py &
+          uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_map.py &
+          uv run python scripts/build_scoreboard.py &
           uv run python scripts/md_to_pdf.py docs/SMPD_ALPR_Findings.md "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" &
           wait
 


### PR DESCRIPTION
## Summary
- Scoreboard data JSON was previously committed but is now gitignored (build artifact)
- Deploy workflow was missing `build_scoreboard.py`, so scoreboard page would break after deploy
- Graph builds first (dependency), then map, scoreboard, and PDF run in parallel

## Test plan
- [ ] Merge and verify deploy succeeds
- [ ] Confirm scoreboard page loads with data at none-below.github.io/sm-alpr/scoreboard.html