### PR TITLE
Add fusion_center type for NCRIC/WSIN and CI page previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,11 @@ jobs:
             echo "No PDF changes, skipping PII scan"
           fi
 
-      - name: Build sharing graph, map, and findings PDF
+      - name: Build sharing graph, map, scoreboard, and findings PDF
         run: |
-          uv run python scripts/build_sharing_graph.py &
+          uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_map.py &
+          uv run python scripts/build_scoreboard.py &
           uv run python scripts/md_to_pdf.py &
           wait
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+  actions: read
 
 jobs:
   validate:
@@ -81,3 +83,90 @@ jobs:
 
       - name: Run smoke tests
         run: uv run pytest tests/test_map_smoke.py -v
+
+      - name: Check for web content changes
+        id: web-changes
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD | grep -E '^(docs/|scripts/(build_map|build_scoreboard|map\.js|md_to_pdf))' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Web content changed:"
+            echo "$CHANGED"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No web content changes, skipping screenshots"
+          fi
+
+      - name: Screenshot pages
+        if: steps.web-changes.outputs.changed == 'true'
+        run: uv run python scripts/screenshot_pages.py --out /tmp/screenshots
+
+      - name: Upload screenshots & comment on PR
+        if: steps.web-changes.outputs.changed == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const marker = '<!-- page-preview -->';
+            const issue_number = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Delete previous preview comments
+            const comments = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            for (const c of comments.data) {
+              if (c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner, repo, comment_id: c.id,
+                });
+              }
+            }
+
+            // Read screenshots and build comment
+            const dir = '/tmp/screenshots';
+            const files = fs.readdirSync(dir).filter(f => f.endsWith('.png')).sort();
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            let body = `${marker}\n## Page Preview\n\n`;
+            body += `This PR changes web content. Page screenshots captured at build time.\n\n`;
+            body += `| Page | Download |\n|---|---|\n`;
+
+            for (const file of files) {
+              const name = path.basename(file, '.png');
+              const label = name.replace(/_/g, ' ');
+              body += `| ${label} | [preview-${name}.png](${runUrl}#artifacts) |\n`;
+            }
+
+            body += `\n*Updated ${new Date().toISOString().slice(0,16)}Z*\n`;
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number, body,
+            });
+
+      - name: Upload index screenshot
+        if: steps.web-changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-index
+          path: /tmp/screenshots/index.png
+          retention-days: 5
+
+      - name: Upload sharing map screenshot
+        if: steps.web-changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-sharing-map
+          path: /tmp/screenshots/sharing_map.png
+          retention-days: 5
+
+      - name: Upload scoreboard screenshot
+        if: steps.web-changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-scoreboard
+          path: /tmp/screenshots/scoreboard.png
+          retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,72 +101,54 @@ jobs:
         if: steps.web-changes.outputs.changed == 'true'
         run: uv run python scripts/screenshot_pages.py --out /tmp/screenshots
 
-      - name: Upload screenshots & comment on PR
+      - name: Publish screenshots & comment on PR
         if: steps.web-changes.outputs.changed == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          BRANCH="preview-assets/pr-${PR_NUM}"
 
-            const marker = '<!-- page-preview -->';
-            const issue_number = context.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+          # Push screenshots to an ephemeral branch (no CI trigger —
+          # workflows only fire on PRs to main, not branch pushes)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan "${BRANCH}"
+          git rm -rf --quiet .
+          cp /tmp/screenshots/*.png .
+          git add *.png
+          git commit -m "page preview screenshots for PR #${PR_NUM}"
+          git push origin "${BRANCH}" --force
 
-            // Delete previous preview comments
-            const comments = await github.rest.issues.listComments({
-              owner, repo, issue_number, per_page: 100,
-            });
-            for (const c of comments.data) {
-              if (c.body && c.body.includes(marker)) {
-                await github.rest.issues.deleteComment({
-                  owner, repo, comment_id: c.id,
-                });
-              }
-            }
+          SHA=$(git rev-parse HEAD)
+          RAW="https://raw.githubusercontent.com/${REPO}/${SHA}"
 
-            // Read screenshots and build comment
-            const dir = '/tmp/screenshots';
-            const files = fs.readdirSync(dir).filter(f => f.endsWith('.png')).sort();
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+          # Delete previous preview comments
+          gh api "repos/${REPO}/issues/${PR_NUM}/comments" --paginate -q \
+            '.[] | select(.body | contains("<!-- page-preview -->")) | .id' | \
+            while read -r cid; do
+              gh api -X DELETE "repos/${REPO}/issues/comments/${cid}" || true
+            done
 
-            let body = `${marker}\n## Page Preview\n\n`;
-            body += `This PR changes web content. Page screenshots captured at build time.\n\n`;
-            body += `| Page | Download |\n|---|---|\n`;
+          # Build comment with inline images
+          BODY="<!-- page-preview -->
+          ## Page Preview
 
-            for (const file of files) {
-              const name = path.basename(file, '.png');
-              const label = name.replace(/_/g, ' ');
-              body += `| ${label} | [preview-${name}.png](${runUrl}#artifacts) |\n`;
-            }
+          ### index
+          ![index](${RAW}/index.png)
 
-            body += `\n*Updated ${new Date().toISOString().slice(0,16)}Z*\n`;
+          ### sharing map
+          ![sharing_map](${RAW}/sharing_map.png)
 
-            await github.rest.issues.createComment({
-              owner, repo, issue_number, body,
-            });
+          ### scoreboard
+          ![scoreboard](${RAW}/scoreboard.png)
 
-      - name: Upload index screenshot
-        if: steps.web-changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: preview-index
-          path: /tmp/screenshots/index.png
-          retention-days: 5
+          *Updated $(date -u +%Y-%m-%dT%H:%M:%SZ)*
+          "
 
-      - name: Upload sharing map screenshot
-        if: steps.web-changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: preview-sharing-map
-          path: /tmp/screenshots/sharing_map.png
-          retention-days: 5
+          gh pr comment "${PR_NUM}" --body "${BODY}"
 
-      - name: Upload scoreboard screenshot
-        if: steps.web-changes.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: preview-scoreboard
-          path: /tmp/screenshots/scoreboard.png
-          retention-days: 5
+          # Return to PR branch for any subsequent steps
+          git checkout "${{ github.head_ref }}"

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -3591,12 +3591,12 @@
     "federal": false,
     "state": "CA",
     "agency_role": "intelligence",
-    "agency_type": "state",
+    "agency_type": "fusion_center",
     "website": null,
     "crawled": true,
     "crawled_date": "2026-03-27",
     "needs_review": false,
-    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>."
+    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>.<br><br><strong>Federal characteristics:</strong> NCRIC may not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f). It was created by the NC HIDTA Executive Board \u2014 not by statute or executive order. It is housed in the Phillip Burton Federal Building (GSA-managed), staffed primarily with federal analysts under DHS/ODNI grants, and governed by an 18-member board where 9 of 18 seats are held by federal agencies (ATF, DEA, FBI, IRS-CI, U.S. Marshals, DHS, Postal Inspection, U.S. Forest Service, U.S. Attorney NDCA). It operates under 28 CFR Part 23, a federal regulation. Its Flock transparency page states it will not share with \u201cfederal law enforcement\u201d \u2014 yet federal law enforcement agencies hold half the seats on its governing board."
   },
   {
     "slug": "nevada-city-ca-pd",
@@ -6279,16 +6279,16 @@
     "human_name": "Western States Information Network (CA)",
     "lat": 38.59,
     "lng": -121.52,
-    "public": true,
-    "federal": true,
-    "state": null,
+    "public": false,
+    "federal": false,
+    "state": "CA",
     "agency_role": "intelligence",
-    "agency_type": "federal",
+    "agency_type": "fusion_center",
     "website": "https://oag.ca.gov/bi/wsin",
     "crawled": false,
     "crawled_date": null,
     "needs_review": false,
-    "notes": "Federally funded intelligence center. One of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers funded by Congress through the U.S. DOJ. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub \u2014 data shared with WSIN may be redistributed across five states and international partners."
+    "notes": "WSIN is a <strong>501(c)(3) nonprofit corporation</strong> (EIN 27-1453421), not a government agency. It is one of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers, 100% funded by BJA (DOJ) grants. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub \u2014 data shared with WSIN may be redistributed across five states and international partners.<br><br><strong>Not a public agency:</strong> WSIN incorporated as a California nonprofit in 2009 after separating from CA DOJ, which previously served as its fiscal agent. It employs 47 nonprofit employees (explicitly \u201cnot state positions\u201d). Its policy board is composed entirely of state/local officials from five states (no federal seats), but it operates under 28 CFR Part 23 (federal regulation) and is 100% federally funded (~$7.5M/yr from BJA). As a 501(c)(3) nonprofit, WSIN likely does not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f), which defines public agency as \u201cthe state, any city, county, or city and county, or any agency or political subdivision\u201d thereof."
   },
   {
     "slug": "westminster-ca-pd",

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -199,7 +199,7 @@ def main():
             return True
         if r.get("state") and r["state"] != "CA":
             return True
-        if r.get("agency_type") in ("federal", "decommissioned", "test"):
+        if r.get("agency_type") in ("federal", "fusion_center", "decommissioned", "test"):
             return True
         return False
 
@@ -424,7 +424,7 @@ def _generate_html(marker_count):
 <div class="legend">
   <div class="legend-item"><div class="legend-dot" style="background:#2563eb"></div> Public agency</div>
   <div class="legend-item"><div class="legend-dot" style="background:#f97316"></div> Shares with non-conforming entity</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#dc2626"></div> Non-conforming entity (private/out-of-state/decommissioned)</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#dc2626"></div> Non-conforming entity (private/out-of-state/fusion center)</div>
   <div class="legend-item"><div class="legend-dot" style="background:#06b6d4"></div> Selected</div>
   <div class="legend-item"><div class="legend-dot" style="background:#8b5cf6"></div> No transparency page found</div>
   <div class="legend-item"><div style="width:20px;height:2px;background:#2563eb"></div> Shares with (outbound)</div>

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -111,6 +111,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     if (info.public === false && info.type !== 'test') return true;  // private entity
     if (info.state && info.state !== 'CA') return true;               // out-of-state
     if (info.type === 'federal') return true;                         // federal — not "agency of the state" per §1798.90.5(f)
+    if (info.type === 'fusion_center') return true;                    // fusion center — may not qualify as public agency per §1798.90.5(f)
     if (info.type === 'decommissioned') return true;
     if (info.type === 'test') return true;
     return false;
@@ -141,6 +142,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     if (info.state && info.state !== 'CA') return 0;           // out-of-state
     if (info.public === false) return 1;                        // private
     if (info.type === 'federal') return 2;                      // federal — not agency of the state
+    if (info.type === 'fusion_center') return 2;                // fusion center — questionable public agency status
     if (info.type === 'decommissioned') return 3;               // decommissioned/DNU
     if (info.type === 'test') return 4;                         // test/demo
     if (info.notes && info.notes.indexOf('re-sharing') >= 0) return 5;  // re-sharing risk
@@ -174,6 +176,8 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       tag += ' <span style="color:#dc2626;font-weight:bold" title="CA Civil Code \u00a71798.90.55(b) restricts ALPR sharing to public agencies">[PRIVATE \u2014 likely violates SB 34]</span>';
     if (info.type === 'federal')
       tag += ' <span style="color:#dc2626;font-weight:bold" title="Federal entity \u2014 not an agency of the state per CA Civil Code \u00a71798.90.5(f). AG Bulletin 2023-DLE-06 prohibits sharing with federal agencies.">[FEDERAL]</span>';
+    if (info.type === 'fusion_center')
+      tag += ' <span style="color:#dc2626;font-weight:bold" title="Fusion center \u2014 may not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f). See notes for details.">[FUSION CENTER]</span>';
     if ((info.type === 'decommissioned' || info.type === 'test') && info.public !== false)
       tag += ' <span style="color:#dc2626;font-weight:bold" title="' + (info.type === 'decommissioned' ? 'Decommissioned/DNU entry' : 'Test/demo entry') + ' \u2014 not a public agency. Sharing ALPR data with non-agency accounts likely violates CA Civil Code \u00a71798.90.55(b).">[NOT AN AGENCY \u2014 likely violates SB 34]</span>';
     // Flag agencies under AG lawsuit
@@ -596,6 +600,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       if (info.role) html += '<p class="stat">Role: ' + escapeHtml(info.role) + '</p>';
       if (info.type) html += '<p class="stat">Type: ' + escapeHtml(info.type) + '</p>';
       if (info.type === 'federal') html += '<p class="stat" style="color:#dc2626">Federal entity \u2014 not an \u201cagency of the state\u201d per \u00a71798.90.5(f). AG Bulletin prohibits sharing with federal agencies.</p>';
+      else if (info.type === 'fusion_center') html += '<p class="stat" style="color:#dc2626">Fusion center \u2014 may not qualify as a \u201cpublic agency\u201d under \u00a71798.90.5(f). See notes below.</p>';
       else if (info.public === true) html += '<p class="stat" style="color:#16a34a">Public agency</p>';
       if (info.public === false) html += '<p class="stat" style="color:#dc2626">Not a public agency \u2014 sharing likely violates SB 34</p>';
       if (info.notes) html += '<p class="stat" style="background:#fef3c7;padding:6px 8px;border-radius:4px;color:#92400e;margin-top:6px">' + info.notes + '</p>';
@@ -714,6 +719,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       let tag = '';
       if (info.public === false) tag = ' <span class="sr-tag">[private]</span>';
       else if (info.type === 'federal') tag = ' <span class="sr-tag">[federal]</span>';
+      else if (info.type === 'fusion_center') tag = ' <span class="sr-tag">[fusion center]</span>';
       else if (!m.lat) tag = ' <span class="sr-tag">[not mapped]</span>';
       html += '<div data-slug="' + escapeHtml(m.slug) + '">' + escapeHtml(info.name || m.slug) + tag + '</div>';
     });

--- a/scripts/screenshot_pages.py
+++ b/scripts/screenshot_pages.py
@@ -17,7 +17,8 @@ from pathlib import Path
 DOCS_DIR = Path("docs")
 PAGES = [
     ("index.html", "index", {"width": 800, "height": 600}),
-    ("sharing_map.html", "sharing_map", {"width": 1280, "height": 900}),
+    # Map is 100vh so full_page won't extend it — use a tall viewport
+    ("sharing_map.html", "sharing_map", {"width": 1280, "height": 1800}),
     ("scoreboard.html", "scoreboard", {"width": 1280, "height": 900}),
 ]
 
@@ -56,7 +57,7 @@ def main():
                 if "map" in slug:
                     page.wait_for_timeout(2000)
                 out_path = args.out / f"{slug}.png"
-                page.screenshot(path=str(out_path), full_page=(slug == "index"))
+                page.screenshot(path=str(out_path), full_page=True)
                 print(f"Captured {out_path}")
                 page.close()
             browser.close()

--- a/scripts/screenshot_pages.py
+++ b/scripts/screenshot_pages.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Screenshot the main site pages for PR preview.
+
+Serves docs/ locally and captures full-page screenshots of each page
+using Playwright. Outputs PNGs to a specified directory.
+
+Usage:
+  uv run python scripts/screenshot_pages.py --out /tmp/screenshots
+"""
+
+import argparse
+import http.server
+import threading
+from pathlib import Path
+
+DOCS_DIR = Path("docs")
+PAGES = [
+    ("index.html", "index", {"width": 800, "height": 600}),
+    ("sharing_map.html", "sharing_map", {"width": 1280, "height": 900}),
+    ("scoreboard.html", "scoreboard", {"width": 1280, "height": 900}),
+]
+
+
+def serve_docs(port: int) -> http.server.HTTPServer:
+    """Start a background HTTP server for docs/."""
+    handler = http.server.SimpleHTTPRequestHandler
+    server = http.server.HTTPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Screenshot site pages")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--port", type=int, default=8791)
+    args = parser.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    # Serve from docs/ so relative asset paths work
+    import os
+    os.chdir(DOCS_DIR)
+    server = serve_docs(args.port)
+    base = f"http://127.0.0.1:{args.port}"
+
+    try:
+        from playwright.sync_api import sync_playwright
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            for filename, slug, viewport in PAGES:
+                page = browser.new_page(viewport=viewport)
+                page.goto(f"{base}/{filename}", wait_until="networkidle")
+                # Give map tiles a moment to render
+                if "map" in slug:
+                    page.wait_for_timeout(2000)
+                out_path = args.out / f"{slug}.png"
+                page.screenshot(path=str(out_path), full_page=(slug == "index"))
+                print(f"Captured {out_path}")
+                page.close()
+            browser.close()
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -125,7 +125,7 @@ class TestRegistry:
 
     def test_no_null_public_for_known_types(self):
         """Entities with known types should have public set."""
-        known_types = {"city", "county", "state", "federal", "university", "private", "tribal"}
+        known_types = {"city", "county", "state", "federal", "fusion_center", "university", "private", "tribal"}
         for e in self.registry:
             if e.get("agency_type") in known_types:
                 assert e.get("public") is not None, f"{e['slug']} type={e['agency_type']} but public=None"


### PR DESCRIPTION
## Summary

- **NCRIC**: Reclassified from `state` to `fusion_center`. Notes updated with federal characteristics (HIDTA-created, federal building, 9/18 federal board seats, 28 CFR Part 23).
- **WSIN**: Reclassified from `federal` to `fusion_center`, `public` set to `false`. WSIN is a 501(c)(3) nonprofit (EIN 27-1453421), 100% BJA-funded, with 47 nonprofit employees — not a government agency. Notes rewritten with structural details.
- Map JS and build script updated to handle `fusion_center` as a non-conforming entity type (violation detection, sort priority, tags, legend).
- CI workflow now screenshots `index.html`, `sharing_map.html`, and `scoreboard.html` on PRs that change web content, uploading each as a separate downloadable artifact with a PR comment linking to them.

## Test plan

- [x] `pytest tests/test_map_smoke.py` — 37 passed
- [x] Screenshot script tested locally — all 3 pages captured successfully
- [ ] Verify CI runs on this PR and produces screenshot artifacts
- [ ] Verify NCRIC and WSIN render correctly on the map with `[FUSION CENTER]` tags