### PR TITLE
fix: run sharing graph before map build in refresh workflow

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Validate build outputs
         run: |
-          uv run python scripts/build_sharing_graph.py &
+          uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_map.py &
           uv run python scripts/md_to_pdf.py &
           wait


### PR DESCRIPTION
## Summary
- Remove `&` from `build_sharing_graph.py` in the refresh workflow so it completes before `build_map.py` starts
- `build_map.py` depends on `.sharing_graph_full.json` produced by the sharing graph step — running both concurrently caused the map build to exit immediately, leaving `sharing_map.html` and `map_data.json` missing
- All 23 smoke tests that depend on map artifacts were failing with "Run build_map.py first" / 404 errors

## Test plan
- [ ] Trigger a manual refresh workflow run and verify all 37 smoke tests pass