### PR TITLE
docs: add site screenshots to README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,21 @@ jobs:
             --title "$SUBJECT — $(date -u +%Y-%m-%d)" \
             --notes "Auto-generated from docs/SMPD_ALPR_Findings.md at commit ${{ github.sha }}"
 
+      - name: Screenshot pages
+        run: uv run python scripts/screenshot_pages.py --out /tmp/screenshots
+
+      - name: Update README screenshots
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan readme-assets
+          git rm -rf --quiet .
+          cp /tmp/screenshots/*.png .
+          git add *.png
+          git commit -m "update readme screenshots"
+          git push origin readme-assets --force
+          git checkout main
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Tools and source documents for investigating the San Mateo Police Department's Automated License Plate Reader program.
 
-**[View the interactive sharing map](https://none-below.github.io/sm-alpr/sharing_map.html)** | **[Read the findings (PDF)](https://none-below.github.io/sm-alpr/SMPD_ALPR_Findings.pdf)**
+**[View the interactive sharing map](https://none-below.github.io/sm-alpr/sharing_map.html)** | **[Read the findings (PDF)](https://none-below.github.io/sm-alpr/SMPD_ALPR_Findings.pdf)** | **[Scoreboard](https://none-below.github.io/sm-alpr/scoreboard.html)**
+
+[![Sharing Map](https://raw.githubusercontent.com/none-below/sm-alpr/readme-assets/sharing_map.png)](https://none-below.github.io/sm-alpr/sharing_map.html)
+
+[![Scoreboard](https://raw.githubusercontent.com/none-below/sm-alpr/readme-assets/scoreboard.png)](https://none-below.github.io/sm-alpr/scoreboard.html)
 
 ## Publishing
 


### PR DESCRIPTION
## Summary
- Added clickable screenshots of the sharing map and scoreboard to the README
- Added scoreboard link alongside existing map and findings links
- Screenshots served from a `readme-assets` orphan branch

## Test plan
- [ ] Verify images render on the PR/repo page