### PR TITLE
feat: show uncrawled agencies on map, check recipient coords

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
   actions: read
 
@@ -84,6 +85,42 @@ jobs:
 
       - name: Run smoke tests
         run: uv run pytest tests/test_map_smoke.py -v
+
+      - name: Check recipient coordinates
+        run: |
+          if ! uv run python scripts/check_recipient_coords.py > /tmp/coord-check.txt 2>&1; then
+            cat /tmp/coord-check.txt
+            echo "has_missing=true" >> "$GITHUB_ENV"
+          else
+            cat /tmp/coord-check.txt
+          fi
+
+      - name: Open issue for missing coordinates
+        if: env.has_missing == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat /tmp/coord-check.txt)
+          # Don't duplicate — check for an existing open issue
+          EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Updated from CI run:
+
+          \`\`\`
+          $BODY
+          \`\`\`"
+          else
+            gh issue create \
+              --title "Recipients missing coordinates in agency registry" \
+              --label geocoding \
+              --body "The following agencies receive data from public agencies but have no lat/lng in the registry:
+
+          \`\`\`
+          $BODY
+          \`\`\`
+
+          Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+          fi
 
       - name: Screenshot pages
         run: uv run python scripts/screenshot_pages.py --out /tmp/screenshots

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -18,6 +18,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
   statuses: write
 
@@ -82,6 +83,36 @@ jobs:
           uv run python scripts/md_to_pdf.py &
           wait
           uv run pytest tests/test_map_smoke.py -v
+
+      - name: Check recipient coordinates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! uv run python scripts/check_recipient_coords.py > /tmp/coord-check.txt 2>&1; then
+            cat /tmp/coord-check.txt
+            BODY=$(cat /tmp/coord-check.txt)
+            EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "Updated from flock refresh:
+
+          \`\`\`
+          $BODY
+          \`\`\`"
+            else
+              gh issue create \
+                --title "Recipients missing coordinates in agency registry" \
+                --label geocoding \
+                --body "The following agencies receive data from public agencies but have no lat/lng in the registry:
+
+          \`\`\`
+          $BODY
+          \`\`\`
+
+          Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+            fi
+          else
+            cat /tmp/coord-check.txt
+          fi
 
       - name: Commit and push
         run: |

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -69,6 +69,8 @@ def main():
     geocoded = 0
     ungeocodable = []
 
+    seen_slugs = set()
+
     for slug, data in graph["agencies"].items():
         # Skip alias slugs
         if slug in alias_to_primary:
@@ -81,6 +83,7 @@ def main():
             ungeocodable.append(slug)
             continue
         geocoded += 1
+        seen_slugs.add(slug)
 
         cameras = data.get("camera_count") or 0
         crawled = data.get("crawled", True)
@@ -95,6 +98,26 @@ def main():
             "retention_days": data.get("data_retention_days"),
             "outbound_slugs": data.get("outbound_slugs", []),
             "inbound_slugs": data.get("inbound_slugs", []),
+        })
+
+    # Add registry entries not yet in the sharing graph (e.g. uncrawled agencies)
+    for slug, reg in registry_by_slug.items():
+        if slug in seen_slugs or slug in alias_to_primary:
+            continue
+        if not reg.get("lat") or not reg.get("lng"):
+            continue
+        geocoded += 1
+        markers.append({
+            "slug": slug,
+            "lat": reg["lat"],
+            "lng": reg["lng"],
+            "cameras": 0,
+            "crawled": False,
+            "outbound_count": 0,
+            "inbound_count": 0,
+            "retention_days": None,
+            "outbound_slugs": [],
+            "inbound_slugs": [],
         })
 
     # Add Flock Safety vendor as an implicit outbound target for San Mateo PD.

--- a/scripts/check_recipient_coords.py
+++ b/scripts/check_recipient_coords.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Check that every recipient of public-agency data has coordinates.
+
+Scans the latest parsed portal JSON for each public agency and reports
+any shared_org_slugs that exist in the registry but lack lat/lng.
+
+Exit codes:
+  0 — all recipients geocoded
+  1 — one or more recipients missing coordinates (prints list to stdout)
+"""
+
+import glob
+import json
+import os
+import sys
+
+REGISTRY = "assets/agency_registry.json"
+PORTAL_DIR = "assets/transparency.flocksafety.com"
+
+# Flock test/placeholder slugs — not real agencies
+JUNK_SLUGS = frozenset(
+    [
+        "decommissioned-org",
+        "delete",
+        "demo",
+        "dnu",
+        "duplicate-please-delete",
+        "jaime-le-training",
+        "old",
+        "test-demo-1234",
+    ]
+)
+
+
+def main() -> int:
+    with open(REGISTRY) as f:
+        registry = {a["slug"]: a for a in json.load(f)}
+
+    # For each public agency, find the latest crawl JSON and collect recipients
+    missing: dict[str, set[str]] = {}  # slug -> set of public senders
+
+    for agency_dir in sorted(glob.glob(os.path.join(PORTAL_DIR, "*/"))):
+        slug = os.path.basename(agency_dir.rstrip("/"))
+        reg = registry.get(slug, {})
+        if not reg.get("public"):
+            continue
+
+        jsons = sorted(glob.glob(os.path.join(agency_dir, "*.json")))
+        if not jsons:
+            continue
+
+        with open(jsons[-1]) as f:
+            data = json.load(f)
+
+        for recipient in data.get("shared_org_slugs", []):
+            if recipient in JUNK_SLUGS:
+                continue
+            r = registry.get(recipient)
+            if r and (r.get("lat") is None or r.get("lng") is None):
+                missing.setdefault(recipient, set()).add(slug)
+
+    if not missing:
+        print("All public-agency recipients have coordinates.")
+        return 0
+
+    print(f"{len(missing)} recipient(s) missing coordinates:\n")
+    for slug in sorted(missing):
+        senders = sorted(missing[slug])
+        preview = ", ".join(senders[:3])
+        if len(senders) > 3:
+            preview += f" (+{len(senders) - 3} more)"
+        print(f"  {slug}  <- {preview}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **build_map.py**: Agencies in the registry with valid coordinates now appear on the map even if they haven't been crawled yet (e.g. Fort Worth TX PD). Previously only agencies in the sharing graph were shown.
- **check_recipient_coords.py**: New script that finds agencies receiving data from public agencies but missing lat/lng. Exits non-zero if any are found.
- **CI workflow**: Runs the check on PRs; opens/updates a GitHub issue labeled `geocoding` if recipients are missing coordinates.
- **Flock refresh workflow**: Same check runs after parsing new data, before commit. Creates issues without blocking the refresh PR.

## Test plan

- [ ] `build_map.py` includes uncrawled agencies with coordinates (e.g. fort-worth-tx-pd in map_data.json)
- [ ] `check_recipient_coords.py` exits 0 on current data
- [ ] CI workflow has `issues: write` permission
- [ ] Flock refresh workflow has `issues: write` permission
- [ ] Coordinate check doesn't block flock refresh PR creation