### PR TITLE
feat: map visibility rules for CA sharing relationships

### DIFF
--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -64,18 +64,46 @@ def main():
             print(f"  ... and {len(not_in_registry) - 10} more")
         print("Run build_agency_registry.py --merge to add them.\n")
 
-    # Build map data — only from registry entries
+    # Build map data.
+    #
+    # Visibility rules (applied by JS via the "visible" flag):
+    #   1. All crawled CA agencies — always shown
+    #   2. Agencies with any sharing relationship with a CA agency (either
+    #      direction) — shown regardless of crawl/state
+    #   3. Non-public CA agencies that only send (HOAs, businesses with no
+    #      CA-agency connection) — included in data but hidden by default;
+    #      JS reveals them when a connected agency is clicked
+
     markers = []
     geocoded = 0
     ungeocodable = []
-
     seen_slugs = set()
 
+    # Pre-compute which slugs receive data from a CA agency
+    # (i.e. a CA agency lists them in outbound_slugs)
+    ca_outbound_targets = set()
     for slug, data in graph["agencies"].items():
-        # Skip alias slugs
+        reg = registry_by_slug.get(slug, {})
+        if reg.get("state") == "CA":
+            for target in data.get("outbound_slugs", []):
+                ca_outbound_targets.add(target)
+
+    def should_show(slug, reg, data):
+        """Determine default visibility for a marker."""
+        crawled = data.get("crawled", False)
+        # Rule 1: all crawled CA agencies
+        if reg.get("state") == "CA" and crawled:
+            return True
+        # Rule 2: recipients of CA agency data — shown regardless of crawl
+        if slug in ca_outbound_targets:
+            return True
+        # Rule 3: everything else (senders-only, uncrawled non-recipients)
+        # hidden by default; JS reveals on click
+        return False
+
+    for slug, data in graph["agencies"].items():
         if slug in alias_to_primary:
             continue
-        # Skip slugs not in registry
         if slug not in registry_by_slug:
             continue
         reg = registry_by_slug[slug]
@@ -93,6 +121,7 @@ def main():
             "lng": reg["lng"],
             "cameras": cameras,
             "crawled": crawled,
+            "visible": should_show(slug, reg, data),
             "outbound_count": data["outbound_count"],
             "inbound_count": data["inbound_count"],
             "retention_days": data.get("data_retention_days"),
@@ -107,12 +136,15 @@ def main():
         if not reg.get("lat") or not reg.get("lng"):
             continue
         geocoded += 1
+        seen_slugs.add(slug)
+        empty_data = {"crawled": False}
         markers.append({
             "slug": slug,
             "lat": reg["lat"],
             "lng": reg["lng"],
             "cameras": 0,
             "crawled": False,
+            "visible": should_show(slug, reg, empty_data),
             "outbound_count": 0,
             "inbound_count": 0,
             "retention_days": None,
@@ -130,19 +162,27 @@ def main():
         flock_inbound = [s for s in FLOCK_53_AGENCIES if s in existing_slugs]
 
         if flock_inbound:
-            markers.append({
-                "slug": "flock-safety-vendor",
-                "lat": flock_reg["lat"],
-                "lng": flock_reg["lng"],
-                "cameras": 0,
-                "crawled": False,
-                "outbound_count": 0,
-                "inbound_count": len(flock_inbound),
-                "retention_days": None,
-                "outbound_slugs": [],
-                "inbound_slugs": flock_inbound,
-            })
-            geocoded += 1
+            # Update existing marker or create new one
+            flock_existing = next((m for m in markers if m["slug"] == "flock-safety-vendor"), None)
+            if flock_existing:
+                flock_existing["inbound_slugs"] = flock_inbound
+                flock_existing["inbound_count"] = len(flock_inbound)
+                flock_existing["visible"] = True
+            else:
+                markers.append({
+                    "slug": "flock-safety-vendor",
+                    "lat": flock_reg["lat"],
+                    "lng": flock_reg["lng"],
+                    "cameras": 0,
+                    "crawled": False,
+                    "visible": True,
+                    "outbound_count": 0,
+                    "inbound_count": len(flock_inbound),
+                    "retention_days": None,
+                    "outbound_slugs": [],
+                    "inbound_slugs": flock_inbound,
+                })
+                geocoded += 1
             # Add Flock to each confirmed agency's outbound
             for m in markers:
                 if m["slug"] in FLOCK_53_AGENCIES:

--- a/scripts/build_sharing_graph.py
+++ b/scripts/build_sharing_graph.py
@@ -85,9 +85,13 @@ def main():
         outbound_names = portal_data.get("shared_org_names", [])
         outbound_slugs = portal_data.get("shared_org_slugs", [])
 
-        inbound_names = extract_inbound_orgs(raw_text)
-        inbound_slugs = [flock_name_to_slug(n) for n in inbound_names]
-        inbound_slugs = [s for s in inbound_slugs if s]  # drop unresolved
+        # Prefer parsed JSON for inbound data; fall back to raw text extraction
+        inbound_slugs = portal_data.get("orgs_sharing_with_slugs", [])
+        inbound_names = portal_data.get("orgs_sharing_with_names", [])
+        if not inbound_slugs:
+            inbound_names = extract_inbound_orgs(raw_text)
+            inbound_slugs = [flock_name_to_slug(n) for n in inbound_names]
+            inbound_slugs = [s for s in inbound_slugs if s]  # drop unresolved
 
         agencies[slug] = {
             "slug": slug,
@@ -171,19 +175,27 @@ def main():
     most_shared_with = sorted(inbound_counts.items(), key=lambda x: -x[1])[:30]
 
     # ── Build entries for uncrawled entities ──
-    # We know they exist because crawled agencies list them as recipients.
+    # We know they exist because crawled agencies list them as recipients
+    # or as sources (via inbound claims).
+
+    # Reverse inbound_edges: if B says "A shares with B", then A -> B
+    inbound_claimed_outbound = defaultdict(set)  # source -> {targets}
+    for target, sources in inbound_edges.items():
+        for source in sources:
+            inbound_claimed_outbound[source].add(target)
 
     uncrawled = {}
     for entity in sorted(all_entities - set(agencies.keys())):
         received_from = sorted(s for s, targets in outbound_edges.items() if entity in targets)
+        sends_to = sorted(inbound_claimed_outbound.get(entity, set()))
         uncrawled[entity] = {
             "archived_date": None,
             "crawled": False,
             "camera_count": None,
             "data_retention_days": None,
-            "outbound_count": 0,
+            "outbound_count": len(sends_to),
             "inbound_count": inbound_counts.get(entity, 0),
-            "outbound_slugs": [],
+            "outbound_slugs": sends_to,
             "inbound_slugs": received_from,
         }
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -255,6 +255,18 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     lineLayer.clearLayers();
     clearTempMarkers();
 
+    // Reveal hidden markers connected to the selected agency
+    const connectedSlugs = new Set([
+      ...(m.outbound_slugs || []),
+      ...(m.inbound_slugs || []),
+    ]);
+    connectedSlugs.forEach(slug => {
+      const c = markersBySlug[slug];
+      if (c && !markerLayer.hasLayer(c)) {
+        markerLayer.addLayer(c);
+      }
+    });
+
     let outConnected = 0;
     let outViolations = 0;
     let outNotMapped = 0;
@@ -488,13 +500,19 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     map.setView(targetLatLng, 6);
   }
 
-  // Pre-compute which slugs are recipients (receive data from someone)
+  // Pre-compute marker data lookup and recipient set
+  const markerDataBySlug = {};
+  markers.forEach(m => { markerDataBySlug[m.slug] = m; });
+
   const recipientSlugs = new Set();
   markers.forEach(mm => {
     (mm.outbound_slugs || []).forEach(t => recipientSlugs.add(t));
   });
 
   function shouldShowByDefault(slug) {
+    const md = markerDataBySlug[slug];
+    if (md && md.visible !== undefined) return md.visible;
+    // Fallback for off-map entities added dynamically
     const info = agencyInfo[slug] || {};
     return info.public !== false || recipientSlugs.has(slug);
   }
@@ -578,8 +596,6 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
   });
 
   // Navigate to slug from info panel
-  const markerDataBySlug = {};
-  markers.forEach(m => { markerDataBySlug[m.slug] = m; });
 
   window.clickSlug = function(slug) {
     // Update URL hash for shareable links


### PR DESCRIPTION
## Summary

- **build_sharing_graph.py**: Use `orgs_sharing_with_slugs` from parsed JSON for inbound data (fixes missing edges for agencies like Fort Worth TX PD that share with CA agencies). Compute outbound edges for uncrawled entities from inbound claims.
- **build_map.py**: Add `visible` flag to markers:
  - All crawled CA agencies — always visible
  - Recipients of CA agency data — visible regardless of crawl/state
  - Senders-only (out-of-state agencies sharing to CA) — hidden by default, revealed on click
- **map.js**: Respect `visible` flag; reveal hidden connected markers when an agency is selected

Before: Fort Worth TX PD had no sharing edges despite 6 CA agencies listing it as an inbound source. After: Fort Worth shows as hidden marker with 6 outbound connections, revealed when clicking Beaumont/Oceanside/etc.

396 visible markers, 81 hidden (mostly out-of-state senders).

## Test plan

- [ ] Fort Worth TX PD hidden by default, appears when clicking Beaumont CA PD
- [ ] Sharing lines draw correctly between Fort Worth and CA agencies
- [ ] Clicking map background hides Fort Worth again
- [ ] All crawled CA agencies still visible
- [ ] Smoke tests pass (except pre-existing mobile layout overlap)