### PR TITLE
Add no-portal list to scoreboard, flag off sharing tags

### DIFF
--- a/docs/scoreboard.html
+++ b/docs/scoreboard.html
@@ -243,12 +243,12 @@ function renderDisclaimers(meta) {
   return html;
 }
 
-function renderNoSharingCard(list) {
+function renderListCard(title, subtitle, list) {
   if (!list || list.length === 0) return null;
   var card = document.createElement('div');
   card.className = 'no-sharing-card';
-  var html = '<div class="card-title">Transparency Gaps</div>'
-    + '<div class="card-subtitle">' + list.length + ' agencies have a portal but publish no sharing data</div>'
+  var html = '<div class="card-title">' + title + '</div>'
+    + '<div class="card-subtitle">' + subtitle + '</div>'
     + '<ul class="no-sharing-list">';
   for (var i = 0; i < list.length; i++) {
     html += '<li><a href="sharing_map.html#' + encodeURIComponent(list[i].slug)
@@ -257,6 +257,14 @@ function renderNoSharingCard(list) {
   html += '</ul>';
   card.innerHTML = html;
   return card;
+}
+
+function renderNoSharingCard(list) {
+  return renderListCard(
+    'Transparency Gaps',
+    list.length + ' agencies have a portal but publish no sharing data',
+    list
+  );
 }
 
 fetch('data/scoreboard_data.json')
@@ -277,6 +285,28 @@ fetch('data/scoreboard_data.json')
     if (noSharingCard) {
       grid.appendChild(noSharingCard);
     }
+
+    // Render no-portal card from map data
+    fetch('data/map_data.json')
+      .then(function(r) { return r.json(); })
+      .then(function(mapData) {
+        var noPortal = [];
+        var ai = mapData.agencyInfo || {};
+        for (var slug in ai) {
+          var info = ai[slug];
+          if (info.state === 'CA' && !info.crawled && info.public !== false
+              && info.type !== 'test' && info.type !== 'decommissioned') {
+            noPortal.push({ slug: slug, name: info.name || slug });
+          }
+        }
+        noPortal.sort(function(a, b) { return a.name.localeCompare(b.name); });
+        var card = renderListCard(
+          'No Transparency Portal',
+          noPortal.length + ' California agencies appear in sharing lists but have no findable portal',
+          noPortal
+        );
+        if (card) grid.appendChild(card);
+      });
   })
   .catch(function(err) {
     document.getElementById('grid').innerHTML =

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,3 +1,6 @@
+// Feature flags
+const SHOW_SHARES_WITH_TAGS = false; // [SHARES WITH NON-CONFORMING ENTITY] and [SHARES WITH SUED AGENCY]
+
 // Sanitization helpers
 function escapeHtml(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
@@ -185,13 +188,13 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       tag += ' <span style="color:#dc2626;font-weight:bold" title="CA Attorney General lawsuit for illegal out-of-state ALPR data sharing in violation of SB 34">[AG LAWSUIT \u2014 illegal sharing]</span>';
     // Check if this agency re-shares to violations (from marker data)
     const mData = (typeof markerDataBySlug !== 'undefined') && markerDataBySlug[s];
-    if (mData && !isViolation(s)) {
+    if (SHOW_SHARES_WITH_TAGS && mData && !isViolation(s)) {
       const hasOutboundViol = (mData.outbound_slugs || []).some(t => isViolation(t));
       if (hasOutboundViol)
         tag += ' <span style="color:#d97706;font-weight:bold" title="This agency shares data with non-conforming entities (private, federal, test)">[SHARES WITH NON-CONFORMING ENTITY]</span>';
     }
     // Flag agencies sharing with a sued agency
-    if (mData && !info.ag_lawsuit) {
+    if (SHOW_SHARES_WITH_TAGS && mData && !info.ag_lawsuit) {
       const sharesWithSued = (mData.outbound_slugs || []).some(t => (agencyInfo[t] || {}).ag_lawsuit);
       if (sharesWithSued)
         tag += ' <span style="color:#d97706;font-weight:bold" title="This agency shares ALPR data with an agency under AG lawsuit for illegal sharing">[SHARES WITH SUED AGENCY]</span>';


### PR DESCRIPTION
## Summary
- Adds a "No Transparency Portal" card to the scoreboard listing CA agencies that appear in other agencies' sharing lists but have no findable transparency portal. Derived client-side from map_data.json.
- Gates the `[SHARES WITH NON-CONFORMING ENTITY]` and `[SHARES WITH SUED AGENCY]` map tags behind a `SHOW_SHARES_WITH_TAGS` feature flag (off by default).

## Test plan
- [ ] Verify scoreboard loads and the new card appears at the bottom
- [ ] Verify map no longer shows the sharing tags
- [ ] Flip `SHOW_SHARES_WITH_TAGS` to `true` and confirm tags reappear