### PR TITLE
feat: extract embedded CSV search audit from Flock HTML

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -32,7 +32,10 @@ print = functools.partial(print, flush=True)
 
 import argparse
 import base64
+import csv
 import hashlib
+import html.parser
+import io
 import json
 import os
 import random
@@ -40,6 +43,7 @@ import re
 import sys
 import tempfile
 import time
+import urllib.parse
 from collections import Counter
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -447,6 +451,44 @@ def parse_portal_text(raw_text, slug, datestamp):
 
 
 # ═══════════════════════════════════════════════════════════
+# CSV extraction from HTML
+# ═══════════════════════════════════════════════════════════
+
+class _CSVLinkExtractor(html.parser.HTMLParser):
+    """Extract data-URI CSVs from <a download="*.csv" href="data:..."> tags."""
+
+    def __init__(self):
+        super().__init__()
+        self.csvs = []  # list of (filename, csv_text)
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        attrs_dict = dict(attrs)
+        download = attrs_dict.get("download", "")
+        href = attrs_dict.get("href", "")
+        if download.endswith(".csv") and href.startswith("data:"):
+            try:
+                _, encoded = href.split(",", 1)
+                csv_text = urllib.parse.unquote(encoded)
+                self.csvs.append((download, csv_text))
+            except (ValueError, UnicodeDecodeError):
+                pass
+
+
+def extract_csvs_from_html(html_text):
+    """Parse HTML and return list of (filename, [row_dicts]) for embedded CSVs."""
+    parser = _CSVLinkExtractor()
+    parser.feed(html_text)
+    results = []
+    for filename, csv_text in parser.csvs:
+        reader = csv.DictReader(io.StringIO(csv_text))
+        rows = list(reader)
+        results.append((filename, rows))
+    return results
+
+
+# ═══════════════════════════════════════════════════════════
 # Crawl: fetch pages, save .txt + .pdf
 # ═══════════════════════════════════════════════════════════
 
@@ -505,11 +547,18 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
     # 1. Raw DOM text (source of truth for parsing)
     txt_path.write_text(page_text, encoding="utf-8")
 
-    # 1b. Full HTML (source of truth for re-rendering)
+    # 1b. Full HTML (source of truth for re-rendering + CSV extraction)
     html_path = slug_dir / f"{datestamp}.html"
-    html_path.write_text(page.content(), encoding="utf-8")
+    page_html = page.content()
+    html_path.write_text(page_html, encoding="utf-8")
 
-    # 2. Parsed JSON (derived from .txt)
+    # 1c. Extract embedded CSVs from HTML
+    for csv_name, csv_rows in extract_csvs_from_html(page_html):
+        field = csv_name.replace(".csv", "").replace("-", "_") + "_csv"
+        portal_data[field] = csv_rows
+        print(f"    extracted {csv_name}: {len(csv_rows)} rows")
+
+    # 2. Parsed JSON (derived from .txt + html)
     json_path.write_text(json.dumps(portal_data, indent=2) + "\n")
 
     # 3. PDF visual archive
@@ -760,6 +809,17 @@ def cmd_parse(args):
 
             raw_text = txt_path.read_text(encoding="utf-8")
             portal_data = parse_portal_text(raw_text, slug, datestamp)
+
+            # Extract embedded CSVs from HTML if available
+            html_path = slug_dir / f"{datestamp}.html"
+            if html_path.exists():
+                for csv_name, csv_rows in extract_csvs_from_html(
+                    html_path.read_text(encoding="utf-8")
+                ):
+                    field = csv_name.replace(".csv", "").replace("-", "_") + "_csv"
+                    portal_data[field] = csv_rows
+                    print(f"    extracted {csv_name}: {len(csv_rows)} rows")
+
             json_path.write_text(json.dumps(portal_data, indent=2) + "\n")
             cameras = portal_data.get("camera_count") or "?"
             orgs = portal_data.get("shared_org_count", 0)

--- a/tests/test_flock_csv.py
+++ b/tests/test_flock_csv.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests for CSV extraction from Flock transparency HTML."""
+
+import importlib.util
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "flock_transparency",
+    Path(__file__).parent.parent / "scripts" / "flock_transparency.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+extract_csvs_from_html = _mod.extract_csvs_from_html
+
+
+def _make_csv_link(filename, csv_text):
+    """Build an <a> tag with an embedded data-URI CSV."""
+    encoded = urllib.parse.quote(csv_text, safe="")
+    return (
+        f'<a download="{filename}" '
+        f'href="data:text/csv;charset=utf-8,{encoded}" '
+        f'target="_blank" rel="noreferrer noopener">Download</a>'
+    )
+
+
+def _wrap_html(body):
+    return f"<html><body>{body}</body></html>"
+
+
+class TestExtractCsvs:
+    def test_no_csv_links(self):
+        html = _wrap_html("<p>No CSV here</p>")
+        assert extract_csvs_from_html(html) == []
+
+    def test_single_csv(self):
+        csv_text = '"id","userId","searchDate"\n"abc","***","2026-04-01T00:00:00Z"\n'
+        html = _wrap_html(_make_csv_link("search_audit.csv", csv_text))
+        results = extract_csvs_from_html(html)
+        assert len(results) == 1
+        filename, rows = results[0]
+        assert filename == "search_audit.csv"
+        assert len(rows) == 1
+        assert rows[0]["id"] == "abc"
+        assert rows[0]["userId"] == "***"
+        assert rows[0]["searchDate"] == "2026-04-01T00:00:00Z"
+
+    def test_csv_with_case_number_schema(self):
+        csv_text = (
+            '"id","userId","searchDate","networkCount","caseNumber","offenseType"\n'
+            '"row1","***","2026-04-01T00:00:00Z","5","CN-001","Theft"\n'
+            '"row2","***","2026-04-02T00:00:00Z","10","","Assault/Battery Offenses"\n'
+        )
+        html = _wrap_html(_make_csv_link("search_audit.csv", csv_text))
+        _, rows = extract_csvs_from_html(html)[0]
+        assert len(rows) == 2
+        assert rows[0]["caseNumber"] == "CN-001"
+        assert rows[0]["offenseType"] == "Theft"
+        assert rows[1]["caseNumber"] == ""
+
+    def test_csv_with_reason_schema(self):
+        csv_text = (
+            '"id","userId","searchDate","networkCount","reason"\n'
+            '"row1","***","2026-04-01T00:00:00Z","3","Stolen Vehicle"\n'
+        )
+        html = _wrap_html(_make_csv_link("search_audit.csv", csv_text))
+        _, rows = extract_csvs_from_html(html)[0]
+        assert rows[0]["reason"] == "Stolen Vehicle"
+        assert "caseNumber" not in rows[0]
+
+    def test_empty_csv_header_only(self):
+        csv_text = '"id","userId","searchDate"\n'
+        html = _wrap_html(_make_csv_link("search_audit.csv", csv_text))
+        _, rows = extract_csvs_from_html(html)[0]
+        assert rows == []
+
+    def test_non_csv_link_ignored(self):
+        html = _wrap_html(
+            '<a download="report.pdf" href="data:application/pdf;base64,abc">PDF</a>'
+        )
+        assert extract_csvs_from_html(html) == []
+
+    def test_csv_surrounded_by_other_content(self):
+        csv_text = '"col1"\n"val1"\n'
+        html = _wrap_html(
+            "<h2>Download CSV</h2>"
+            "<p>Some description</p>"
+            + _make_csv_link("search_audit.csv", csv_text)
+            + "<h2>Additional Info</h2>"
+            "<p>More stuff</p>"
+        )
+        results = extract_csvs_from_html(html)
+        assert len(results) == 1
+        assert results[0][1][0]["col1"] == "val1"
+
+    def test_special_characters_in_csv(self):
+        csv_text = (
+            '"id","offenseType"\n'
+            '"1","Assault/Battery (Domestic)"\n'
+            '"2","Wanted Person — Arrest Warrant"\n'
+        )
+        html = _wrap_html(_make_csv_link("search_audit.csv", csv_text))
+        _, rows = extract_csvs_from_html(html)[0]
+        assert rows[0]["offenseType"] == "Assault/Battery (Domestic)"
+        assert rows[1]["offenseType"] == "Wanted Person — Arrest Warrant"
+
+    def test_field_name_derivation(self):
+        """The caller derives the JSON field from the filename; verify the
+        filename comes through correctly for both known names."""
+        for name in ("search_audit.csv", "other-report.csv"):
+            csv_text = '"a"\n"1"\n'
+            html = _wrap_html(_make_csv_link(name, csv_text))
+            filename, _ = extract_csvs_from_html(html)[0]
+            assert filename == name


### PR DESCRIPTION
## Summary

- Flock transparency pages embed search audit CSVs as `data:text/csv` URIs in download links. This extracts and persists them into the agency JSON as `search_audit_csv` (list of row dicts) during both crawl and parse stages.
- Two CSV schemas observed across agencies: `caseNumber`/`offenseType` columns vs a single `reason` column. Both are handled by using `csv.DictReader` (schema-agnostic).
- Adds 9 tests covering empty HTML, both schemas, header-only CSVs, special characters, and non-CSV link filtering.

## Backfill

Run `parse --force` to backfill existing agencies from their stored `.html` files. New crawls will extract automatically.

## Test plan

- [x] `uv run pytest tests/test_flock_csv.py` — 9 pass
- [x] `uv run pytest tests/ -k 'not test_layout'` — 100 pass
- [ ] Verify on next flock-refresh cycle that CSVs appear in committed JSONs