### PR TITLE
fix: correct Yuba County Sheriff slug

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -6499,7 +6499,7 @@
     "needs_review": false
   },
   {
-    "slug": "yuba-county-sheriffs-office",
+    "slug": "yuba-county-ca-so",
     "flock_name": "Yuba County Sheriffs Office",
     "human_name": "Yuba County Sheriffs Office",
     "lat": 39.2627,
@@ -9252,9 +9252,9 @@
     "needs_review": false
   },
   {
-    "slug": "yuba-county-sheriffs-office-hotlists-alerted-on-california-svs",
-    "flock_name": "yuba-county-sheriffs-office-hotlists-alerted-on-california-svs",
-    "human_name": "yuba-county-sheriffs-office-hotlists-alerted-on-california-svs",
+    "slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
+    "flock_name": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
+    "human_name": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
     "lat": null,
     "lng": null,
     "public": false,

--- a/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-01.json
+++ b/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-01.json
@@ -456,7 +456,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 265,
   "orgs_sharing_with_names": [
@@ -991,6 +991,6 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-08.json
@@ -456,7 +456,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 265,
   "orgs_sharing_with_names": [
@@ -991,7 +991,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Antioch CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Antioch CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Antioch CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "https://www.antiochca.gov/DocumentCenter/View/3622/Antioch-PD-Policy-Manual--PDF",

--- a/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-15.json
+++ b/assets/transparency.flocksafety.com/antioch-ca-pd/2026-04-15.json
@@ -462,7 +462,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 266,
   "orgs_sharing_with_names": [
@@ -999,7 +999,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Antioch CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Antioch CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Antioch CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "https://www.antiochca.gov/DocumentCenter/View/3622/Antioch-PD-Policy-Manual--PDF",

--- a/assets/transparency.flocksafety.com/atherton-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/atherton-ca-pd/2026-03-27.json
@@ -648,7 +648,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/atherton-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/atherton-ca-pd/2026-04-03.json
@@ -648,7 +648,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/atherton-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/atherton-ca-pd/2026-04-10.json
@@ -650,7 +650,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/auburn-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/auburn-ca-pd/2026-03-28.json
@@ -644,7 +644,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/auburn-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/auburn-ca-pd/2026-04-04.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/auburn-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/auburn-ca-pd/2026-04-11.json
@@ -648,7 +648,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-03-28.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-04-04.json
@@ -742,7 +742,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/bakersfield-ca-pd/2026-04-11.json
@@ -742,7 +742,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-03-28.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 259,
   "orgs_sharing_with_names": [
@@ -1183,6 +1183,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-04-04.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 259,
   "orgs_sharing_with_names": [
@@ -1183,7 +1183,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T03:18:11.287373+00:00"
 }

--- a/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/baldwin-park-ca-pd/2026-04-11.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 260,
   "orgs_sharing_with_names": [
@@ -1185,7 +1185,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Baldwin Park CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Baldwin Park CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Baldwin Park CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/barstow-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/barstow-ca-pd/2026-03-28.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/barstow-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/barstow-ca-pd/2026-04-04.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/barstow-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/barstow-ca-pd/2026-04-11.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-03-28.json
@@ -642,7 +642,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 347,
   "orgs_sharing_with_names": [
@@ -1341,6 +1341,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-04-04.json
@@ -642,7 +642,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 346,
   "orgs_sharing_with_names": [
@@ -1339,7 +1339,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T05:37:16.146462+00:00"
 }

--- a/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/beaumont-ca-pd/2026-04-11.json
@@ -644,7 +644,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 347,
   "orgs_sharing_with_names": [
@@ -1343,7 +1343,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Beaumont CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Beaumont CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Beaumont CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/bell-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/bell-ca-pd/2026-03-28.json
@@ -744,7 +744,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/bell-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/bell-ca-pd/2026-04-04.json
@@ -744,7 +744,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/bell-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/bell-ca-pd/2026-04-11.json
@@ -744,7 +744,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/belmont-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/belmont-ca-pd/2026-03-27.json
@@ -306,7 +306,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/belmont-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/belmont-ca-pd/2026-04-03.json
@@ -306,7 +306,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/belmont-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/belmont-ca-pd/2026-04-10.json
@@ -306,7 +306,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-03-28.json
@@ -644,7 +644,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-04-04.json
@@ -644,7 +644,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/beverly-hills-ca-pd/2026-04-11.json
@@ -644,7 +644,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/brawley-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/brawley-ca-pd/2026-03-28.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/brawley-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/brawley-ca-pd/2026-04-04.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/brawley-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/brawley-ca-pd/2026-04-11.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/burbank-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/burbank-ca-pd/2026-03-28.json
@@ -740,7 +740,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/burbank-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/burbank-ca-pd/2026-04-04.json
@@ -740,7 +740,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/burbank-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/burbank-ca-pd/2026-04-11.json
@@ -738,7 +738,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/butte-county-ca-so/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/butte-county-ca-so/2026-03-28.json
@@ -628,7 +628,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/butte-county-ca-so/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/butte-county-ca-so/2026-04-04.json
@@ -630,7 +630,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/butte-county-ca-so/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/butte-county-ca-so/2026-04-11.json
@@ -630,7 +630,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-03-28.json
@@ -754,7 +754,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-04-04.json
@@ -754,7 +754,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/calistoga-ca-pd/2026-04-11.json
@@ -754,7 +754,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/campbell-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/campbell-ca-pd/2026-03-28.json
@@ -662,7 +662,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/campbell-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/campbell-ca-pd/2026-04-04.json
@@ -662,7 +662,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/campbell-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/campbell-ca-pd/2026-04-11.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-03-28.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-04-04.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/cathedral-city-ca-pd/2026-04-11.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-03-28.json
@@ -644,7 +644,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-04-04.json
@@ -644,7 +644,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/chula-vista-ca-pd/2026-04-11.json
@@ -644,7 +644,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/citrus-heights-ca-pd/2026-04-02.json
+++ b/assets/transparency.flocksafety.com/citrus-heights-ca-pd/2026-04-02.json
@@ -724,6 +724,6 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/citrus-heights-ca-pd/2026-04-09.json
+++ b/assets/transparency.flocksafety.com/citrus-heights-ca-pd/2026-04-09.json
@@ -724,7 +724,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/city-of-lemoore-ca/2026-04-02.json
+++ b/assets/transparency.flocksafety.com/city-of-lemoore-ca/2026-04-02.json
@@ -574,6 +574,6 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/city-of-lemoore-ca/2026-04-09.json
+++ b/assets/transparency.flocksafety.com/city-of-lemoore-ca/2026-04-09.json
@@ -574,7 +574,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-03-28.json
@@ -290,7 +290,7 @@
     "willits-ca-pd",
     "winters-ca-pd",
     "woodland-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-04-04.json
@@ -290,7 +290,7 @@
     "willits-ca-pd",
     "winters-ca-pd",
     "woodland-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/clearlake-ca-pd/2026-04-11.json
@@ -290,7 +290,7 @@
     "willits-ca-pd",
     "winters-ca-pd",
     "woodland-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/colma-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/colma-ca-pd/2026-03-27.json
@@ -666,7 +666,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/colma-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/colma-ca-pd/2026-04-03.json
@@ -666,7 +666,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/colma-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/colma-ca-pd/2026-04-10.json
@@ -668,7 +668,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-03-28.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-04-04.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/contra-costa-county-ca-so/2026-04-11.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/coronado-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/coronado-ca-pd/2026-03-28.json
@@ -630,7 +630,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/coronado-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/coronado-ca-pd/2026-04-04.json
@@ -630,7 +630,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/coronado-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/coronado-ca-pd/2026-04-11.json
@@ -632,7 +632,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-03-28.json
@@ -728,7 +728,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-04-04.json
@@ -728,7 +728,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/costa-mesa-ca-pd/2026-04-11.json
@@ -728,7 +728,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/danville-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/danville-ca-pd/2026-03-28.json
@@ -730,7 +730,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/danville-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/danville-ca-pd/2026-04-04.json
@@ -730,7 +730,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/danville-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/danville-ca-pd/2026-04-11.json
@@ -730,7 +730,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/delano-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/delano-ca-pd/2026-03-28.json
@@ -710,7 +710,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/delano-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/delano-ca-pd/2026-04-04.json
@@ -710,7 +710,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/delano-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/delano-ca-pd/2026-04-11.json
@@ -710,7 +710,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-03-28.json
@@ -558,7 +558,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-04-04.json
@@ -558,7 +558,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/dinuba-ca-pd/2026-04-11.json
@@ -560,7 +560,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dixon-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/dixon-ca-pd/2026-03-28.json
@@ -712,7 +712,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dixon-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/dixon-ca-pd/2026-04-04.json
@@ -712,7 +712,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/dixon-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/dixon-ca-pd/2026-04-11.json
@@ -712,7 +712,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-03-27.json
@@ -622,7 +622,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-04-03.json
@@ -622,7 +622,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/east-palo-alto-ca-pd/2026-04-10.json
@@ -630,7 +630,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-03-28.json
@@ -666,7 +666,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 285,
   "orgs_sharing_with_names": [
@@ -1241,6 +1241,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-04-04.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 284,
   "orgs_sharing_with_names": [
@@ -1231,7 +1231,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T14:54:21.096774+00:00"
 }

--- a/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/el-cerrito-ca-pd/2026-04-11.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 284,
   "orgs_sharing_with_names": [
@@ -1233,7 +1233,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "El Cerrito Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. El Cerrito Police Department utilizes retroactive searches to solve crimes after they've occurred. Additionally, the El Cerrito Police Department utilizes real-time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/escondido-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/escondido-ca-pd/2026-03-28.json
@@ -624,7 +624,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/escondido-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/escondido-ca-pd/2026-04-04.json
@@ -624,7 +624,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/escondido-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/escondido-ca-pd/2026-04-11.json
@@ -626,7 +626,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-03-28.json
@@ -738,7 +738,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-04-04.json
@@ -736,7 +736,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/fairfield-ca-pd/2026-04-11.json
@@ -734,7 +734,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/folsom-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/folsom-ca-pd/2026-03-28.json
@@ -658,7 +658,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/folsom-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/folsom-ca-pd/2026-04-04.json
@@ -660,7 +660,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/folsom-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/folsom-ca-pd/2026-04-11.json
@@ -662,7 +662,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fontana-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/fontana-ca-pd/2026-03-28.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fontana-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/fontana-ca-pd/2026-04-04.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fontana-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/fontana-ca-pd/2026-04-11.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-03-28.json
@@ -624,7 +624,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 281,
   "orgs_sharing_with_names": [
@@ -1191,6 +1191,6 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-04-04.json
@@ -624,7 +624,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 281,
   "orgs_sharing_with_names": [
@@ -1191,7 +1191,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T16:55:52.856143+00:00"
 }

--- a/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/fort-bragg-ca-pd/2026-04-11.json
@@ -624,7 +624,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 281,
   "orgs_sharing_with_names": [
@@ -1191,7 +1191,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Fort Bragg CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Fort Bragg CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Fort Bragg CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-03-28.json
@@ -550,7 +550,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-04-04.json
@@ -552,7 +552,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/fountain-valley-ca-pd/2026-04-11.json
@@ -552,7 +552,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-03-28.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 291,
   "orgs_sharing_with_names": [
@@ -1257,6 +1257,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-04-04.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 291,
   "orgs_sharing_with_names": [
@@ -1257,7 +1257,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T17:49:58.881094+00:00"
 }

--- a/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/fullerton-ca-pd/2026-04-11.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 292,
   "orgs_sharing_with_names": [
@@ -1259,7 +1259,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Fullerton CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Fullerton CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Fullerton CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/galt-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/galt-ca-pd/2026-03-28.json
@@ -598,7 +598,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/galt-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/galt-ca-pd/2026-04-04.json
@@ -598,7 +598,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/galt-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/galt-ca-pd/2026-04-11.json
@@ -598,7 +598,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-03-28.json
@@ -690,7 +690,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-04-04.json
@@ -690,7 +690,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/gilroy-ca-pd/2026-04-11.json
@@ -692,7 +692,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/glendale-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/glendale-ca-pd/2026-04-03.json
@@ -668,7 +668,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/glendale-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/glendale-ca-pd/2026-04-10.json
@@ -668,7 +668,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-03-28.json
@@ -636,7 +636,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-04-04.json
@@ -636,7 +636,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/grover-beach-ca-pd/2026-04-11.json
@@ -636,7 +636,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hanford-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/hanford-ca-pd/2026-03-28.json
@@ -688,7 +688,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hanford-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/hanford-ca-pd/2026-04-04.json
@@ -688,7 +688,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hanford-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/hanford-ca-pd/2026-04-11.json
@@ -688,7 +688,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hayward-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/hayward-ca-pd/2026-03-28.json
@@ -668,7 +668,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hayward-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/hayward-ca-pd/2026-04-04.json
@@ -668,7 +668,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hayward-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/hayward-ca-pd/2026-04-11.json
@@ -670,7 +670,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hercules-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/hercules-ca-pd/2026-03-28.json
@@ -674,7 +674,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hercules-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/hercules-ca-pd/2026-04-04.json
@@ -674,7 +674,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hercules-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/hercules-ca-pd/2026-04-11.json
@@ -674,7 +674,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-03-27.json
@@ -650,7 +650,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-04-03.json
@@ -650,7 +650,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/hillsborough-ca-pd/2026-04-10.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/hollister-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/hollister-ca-pd/2026-03-28.json
@@ -672,7 +672,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 272,
   "orgs_sharing_with_names": [
@@ -1221,6 +1221,6 @@
     "woodlake-ca-pd",
     "woodland-ca-pd",
     "yolo-county-ca-so",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/hollister-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/hollister-ca-pd/2026-04-04.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 272,
   "orgs_sharing_with_names": [
@@ -1219,7 +1219,7 @@
     "woodlake-ca-pd",
     "woodland-ca-pd",
     "yolo-county-ca-so",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T20:51:28.819677+00:00"
 }

--- a/assets/transparency.flocksafety.com/hollister-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/hollister-ca-pd/2026-04-11.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 273,
   "orgs_sharing_with_names": [
@@ -1219,7 +1219,7 @@
     "woodlake-ca-pd",
     "woodland-ca-pd",
     "yolo-county-ca-so",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Hollister CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Hollister CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Hollister CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-03-28.json
@@ -574,7 +574,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-04-04.json
@@ -574,7 +574,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/kings-county-ca-das-office/2026-04-11.json
@@ -574,7 +574,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lake-county-ca-so/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/lake-county-ca-so/2026-03-28.json
@@ -662,7 +662,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lake-county-ca-so/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/lake-county-ca-so/2026-04-04.json
@@ -662,7 +662,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lake-county-ca-so/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/lake-county-ca-so/2026-04-11.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-03-28.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-04-04.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/lincoln-ca-pd/2026-04-11.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/livermore-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/livermore-ca-pd/2026-03-28.json
@@ -704,7 +704,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/livermore-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/livermore-ca-pd/2026-04-04.json
@@ -704,7 +704,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/livermore-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/livermore-ca-pd/2026-04-11.json
@@ -704,7 +704,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/livingston-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/livingston-ca-pd/2026-03-28.json
@@ -575,6 +575,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/livingston-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/livingston-ca-pd/2026-04-04.json
@@ -573,7 +573,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "crawled_at": "2026-04-04T22:50:46.738879+00:00"
 }

--- a/assets/transparency.flocksafety.com/livingston-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/livingston-ca-pd/2026-04-11.json
@@ -573,7 +573,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Livingston CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. We do not share our data with any federal agencies. Livingston CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Livingston CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/lodi-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/lodi-ca-pd/2026-03-28.json
@@ -776,7 +776,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lodi-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/lodi-ca-pd/2026-04-04.json
@@ -776,7 +776,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lodi-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/lodi-ca-pd/2026-04-11.json
@@ -772,7 +772,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-03-28.json
@@ -656,7 +656,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-04-04.json
@@ -656,7 +656,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/lompoc-ca-pd/2026-04-11.json
@@ -656,7 +656,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/manteca-ca-pd/2026-03-28.json
+++ b/assets/transparency.flocksafety.com/manteca-ca-pd/2026-03-28.json
@@ -746,7 +746,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/manteca-ca-pd/2026-04-04.json
+++ b/assets/transparency.flocksafety.com/manteca-ca-pd/2026-04-04.json
@@ -746,7 +746,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/manteca-ca-pd/2026-04-11.json
+++ b/assets/transparency.flocksafety.com/manteca-ca-pd/2026-04-11.json
@@ -746,7 +746,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menifee-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/menifee-ca-pd/2026-03-29.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menifee-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/menifee-ca-pd/2026-04-06.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menifee-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/menifee-ca-pd/2026-04-13.json
@@ -740,7 +740,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-03-27.json
@@ -502,7 +502,7 @@
     "williams-ca-pd",
     "woodland-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-04-03.json
@@ -502,7 +502,7 @@
     "williams-ca-pd",
     "woodland-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/menlo-park-ca-pd/2026-04-10.json
@@ -502,7 +502,7 @@
     "williams-ca-pd",
     "woodland-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/merced-county-ca-so/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/merced-county-ca-so/2026-03-29.json
@@ -774,7 +774,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/merced-county-ca-so/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/merced-county-ca-so/2026-04-06.json
@@ -774,7 +774,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/merced-county-ca-so/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/merced-county-ca-so/2026-04-13.json
@@ -770,7 +770,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-03-29.json
@@ -638,7 +638,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-04-06.json
@@ -638,7 +638,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/modoc-county-ca-so/2026-04-13.json
@@ -640,7 +640,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-03-29.json
@@ -662,7 +662,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-04-06.json
@@ -662,7 +662,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/monrovia-ca-pd/2026-04-13.json
@@ -662,7 +662,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-03-29.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-04-06.json
@@ -450,7 +450,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yreka-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/monterey-park-ca-pd/2026-04-13.json
@@ -454,7 +454,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yreka-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-03-29.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-04-06.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/morgan-hill-ca-pd/2026-04-13.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-03-29.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-04-06.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/murrieta-ca-pd/2026-04-13.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/napa-ca-pd/2026-03-29.json
@@ -610,7 +610,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-ca-pd/2026-04-06.json
+++ b/assets/transparency.flocksafety.com/napa-ca-pd/2026-04-06.json
@@ -610,7 +610,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-ca-pd/2026-04-13.json
+++ b/assets/transparency.flocksafety.com/napa-ca-pd/2026-04-13.json
@@ -610,7 +610,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-county-ca-so/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/napa-county-ca-so/2026-03-29.json
@@ -674,7 +674,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-county-ca-so/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/napa-county-ca-so/2026-04-07.json
@@ -674,7 +674,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/napa-county-ca-so/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/napa-county-ca-so/2026-04-14.json
@@ -676,7 +676,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/national-city-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/national-city-ca-pd/2026-03-29.json
@@ -628,7 +628,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/national-city-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/national-city-ca-pd/2026-04-07.json
@@ -628,7 +628,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ncric/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/ncric/2026-03-27.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ncric/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/ncric/2026-04-03.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ncric/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/ncric/2026-04-10.json
@@ -656,7 +656,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-03-29.json
@@ -622,7 +622,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-04-07.json
@@ -622,7 +622,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/newport-beach-pd-ca/2026-04-14.json
@@ -622,7 +622,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/novato-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/novato-ca-pd/2026-03-29.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/novato-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/novato-ca-pd/2026-04-07.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/novato-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/novato-ca-pd/2026-04-14.json
@@ -648,7 +648,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/oakley-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/oakley-ca-pd/2026-03-29.json
@@ -712,7 +712,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/oakley-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/oakley-ca-pd/2026-04-07.json
@@ -712,7 +712,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/oakley-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/oakley-ca-pd/2026-04-14.json
@@ -712,7 +712,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-03-29.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 268,
   "orgs_sharing_with_names": [
@@ -1195,6 +1195,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-04-07.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 270,
   "orgs_sharing_with_names": [
@@ -1199,7 +1199,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Oceanside CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Oceanside CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Oceanside CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "The Oceanside Police Department Automated License Plate Reader (ALPR) Policy is available here:\n\nhttps://www.oceansidepolice.com/transparency/policies-procedures/-folder-559#docfold_14_2171_4130_559",

--- a/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/oceanside-ca-pd/2026-04-14.json
@@ -654,7 +654,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 271,
   "orgs_sharing_with_names": [
@@ -1201,7 +1201,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Oceanside CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Oceanside CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Oceanside CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "The Oceanside Police Department Automated License Plate Reader (ALPR) Policy is available here:\n\nhttps://www.oceansidepolice.com/transparency/policies-procedures/-folder-559#docfold_14_2171_4130_559",

--- a/assets/transparency.flocksafety.com/ontario-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/ontario-ca-pd/2026-03-29.json
@@ -690,7 +690,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ontario-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/ontario-ca-pd/2026-04-07.json
@@ -690,7 +690,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ontario-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/ontario-ca-pd/2026-04-14.json
@@ -690,7 +690,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/orange-ca-pd/2026-03-29.json
+++ b/assets/transparency.flocksafety.com/orange-ca-pd/2026-03-29.json
@@ -600,7 +600,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 305,
   "orgs_sharing_with_names": [
@@ -1215,6 +1215,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/orange-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/orange-ca-pd/2026-04-07.json
@@ -600,7 +600,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 306,
   "orgs_sharing_with_names": [
@@ -1217,7 +1217,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Orange PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Orange PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Orange PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/orange-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/orange-ca-pd/2026-04-14.json
@@ -600,7 +600,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 307,
   "orgs_sharing_with_names": [
@@ -1219,7 +1219,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Orange PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Orange PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Orange PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-03-27.json
@@ -580,7 +580,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-04-03.json
@@ -580,7 +580,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/pacifica-ca-pd/2026-04-10.json
@@ -582,7 +582,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-03-30.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-04-07.json
+++ b/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-04-07.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-04-14.json
+++ b/assets/transparency.flocksafety.com/pasadena-ca-pd/2026-04-14.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/placer-county-ca-so/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/placer-county-ca-so/2026-03-30.json
@@ -724,7 +724,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/placer-county-ca-so/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/placer-county-ca-so/2026-04-08.json
@@ -724,7 +724,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/placer-county-ca-so/2026-04-15.json
+++ b/assets/transparency.flocksafety.com/placer-county-ca-so/2026-04-15.json
@@ -724,7 +724,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-03-30.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-04-08.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-04-15.json
+++ b/assets/transparency.flocksafety.com/pleasanton-ca-pd/2026-04-15.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/port-hueneme-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/port-hueneme-ca-pd/2026-03-30.json
@@ -514,7 +514,7 @@
     "woodlake-ca-pd",
     "woodland-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/port-hueneme-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/port-hueneme-ca-pd/2026-04-08.json
@@ -514,7 +514,7 @@
     "woodlake-ca-pd",
     "woodland-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/port-of-stockton-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/port-of-stockton-ca-pd/2026-03-30.json
@@ -608,7 +608,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/port-of-stockton-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/port-of-stockton-ca-pd/2026-04-08.json
@@ -608,7 +608,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/porterville-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/porterville-ca-pd/2026-03-30.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/porterville-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/porterville-ca-pd/2026-04-08.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/reedley-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/reedley-ca-pd/2026-03-30.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/reedley-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/reedley-ca-pd/2026-04-08.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ridgecrest-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/ridgecrest-ca-pd/2026-03-30.json
@@ -614,7 +614,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/ridgecrest-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/ridgecrest-ca-pd/2026-04-08.json
@@ -614,7 +614,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/rohnert-park-department-of-public-safety-ca/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/rohnert-park-department-of-public-safety-ca/2026-03-30.json
@@ -472,7 +472,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/rohnert-park-department-of-public-safety-ca/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/rohnert-park-department-of-public-safety-ca/2026-04-08.json
@@ -472,7 +472,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-03-27.json
@@ -686,7 +686,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-04-03.json
@@ -686,7 +686,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/san-bruno-ca-pd/2026-04-10.json
@@ -686,7 +686,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-francisco-ca-pd/2026-04-09.json
+++ b/assets/transparency.flocksafety.com/san-francisco-ca-pd/2026-04-09.json
@@ -660,7 +660,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-gabriel-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/san-gabriel-ca-pd/2026-03-30.json
@@ -634,7 +634,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-gabriel-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/san-gabriel-ca-pd/2026-04-08.json
@@ -634,7 +634,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-joaquin-county-ca-so/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/san-joaquin-county-ca-so/2026-03-30.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-joaquin-county-ca-so/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/san-joaquin-county-ca-so/2026-04-08.json
@@ -646,7 +646,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-jose-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/san-jose-ca-pd/2026-03-30.json
@@ -608,7 +608,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-jose-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/san-jose-ca-pd/2026-04-08.json
@@ -608,7 +608,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-03-27.json
@@ -576,7 +576,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-04-03.json
@@ -576,7 +576,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/san-mateo-ca-pd/2026-04-10.json
@@ -576,7 +576,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-03-27.json
@@ -618,7 +618,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-04-03.json
@@ -616,7 +616,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/san-mateo-county-ca-so/2026-04-10.json
@@ -616,7 +616,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/santa-clara-ca-pd/2026-03-30.json
+++ b/assets/transparency.flocksafety.com/santa-clara-ca-pd/2026-03-30.json
@@ -734,7 +734,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/santa-clara-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/santa-clara-ca-pd/2026-04-08.json
@@ -734,7 +734,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/santa-rosa-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/santa-rosa-ca-pd/2026-03-31.json
@@ -636,7 +636,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/santa-rosa-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/santa-rosa-ca-pd/2026-04-08.json
@@ -648,7 +648,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/sausalito-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/sausalito-ca-pd/2026-03-31.json
@@ -604,7 +604,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/sausalito-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/sausalito-ca-pd/2026-04-08.json
@@ -604,7 +604,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/seaside-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/seaside-ca-pd/2026-03-31.json
@@ -708,7 +708,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/seaside-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/seaside-ca-pd/2026-04-08.json
@@ -706,7 +706,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/sequoias-community-college-district-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/sequoias-community-college-district-ca-pd/2026-03-31.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/sequoias-community-college-district-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/sequoias-community-college-district-ca-pd/2026-04-08.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/shasta-county-so/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/shasta-county-so/2026-03-31.json
@@ -186,7 +186,7 @@
     "whittier-ca-pd",
     "williams-ca-pd",
     "yolo-county-ca-so",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/shasta-county-so/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/shasta-county-so/2026-04-08.json
@@ -186,7 +186,7 @@
     "whittier-ca-pd",
     "williams-ca-pd",
     "yolo-county-ca-so",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/simi-valley-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/simi-valley-ca-pd/2026-03-31.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/simi-valley-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/simi-valley-ca-pd/2026-04-08.json
@@ -668,7 +668,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/south-gate-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/south-gate-ca-pd/2026-03-31.json
@@ -650,7 +650,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 232,
   "orgs_sharing_with_names": [
@@ -1119,6 +1119,6 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/south-gate-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/south-gate-ca-pd/2026-04-08.json
@@ -650,7 +650,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 233,
   "orgs_sharing_with_names": [
@@ -1121,7 +1121,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "South Gate CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. South Gate CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, South Gate CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/south-pasadena-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/south-pasadena-ca-pd/2026-03-31.json
@@ -666,7 +666,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/south-pasadena-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/south-pasadena-ca-pd/2026-04-08.json
@@ -666,7 +666,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/stockton-ca-pd/2026-03-27.json
+++ b/assets/transparency.flocksafety.com/stockton-ca-pd/2026-03-27.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/stockton-ca-pd/2026-04-03.json
+++ b/assets/transparency.flocksafety.com/stockton-ca-pd/2026-04-03.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/stockton-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/stockton-ca-pd/2026-04-10.json
@@ -672,7 +672,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/tiburon-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/tiburon-ca-pd/2026-04-10.json
@@ -416,7 +416,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/tracy-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/tracy-ca-pd/2026-03-31.json
@@ -750,7 +750,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/tracy-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/tracy-ca-pd/2026-04-08.json
@@ -750,7 +750,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/union-city-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/union-city-ca-pd/2026-03-31.json
@@ -622,7 +622,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/union-city-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/union-city-ca-pd/2026-04-08.json
@@ -622,7 +622,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/vacaville-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/vacaville-ca-pd/2026-03-31.json
@@ -556,7 +556,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/vacaville-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/vacaville-ca-pd/2026-04-08.json
@@ -556,7 +556,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/vallejo-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/vallejo-ca-pd/2026-03-31.json
@@ -580,7 +580,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 317,
   "orgs_sharing_with_names": [
@@ -1219,6 +1219,6 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ]
 }

--- a/assets/transparency.flocksafety.com/vallejo-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/vallejo-ca-pd/2026-04-08.json
@@ -580,7 +580,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 318,
   "orgs_sharing_with_names": [
@@ -1221,7 +1221,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Vallejo CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Vallejo CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Vallejo CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/visalia-ca-pd/2026-03-31.json
+++ b/assets/transparency.flocksafety.com/visalia-ca-pd/2026-03-31.json
@@ -628,7 +628,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/visalia-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/visalia-ca-pd/2026-04-08.json
@@ -628,7 +628,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/watsonville-ca-pd/2026-04-01.json
+++ b/assets/transparency.flocksafety.com/watsonville-ca-pd/2026-04-01.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/watsonville-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/watsonville-ca-pd/2026-04-08.json
@@ -652,7 +652,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/west-covina-ca-pd/2026-04-01.json
+++ b/assets/transparency.flocksafety.com/west-covina-ca-pd/2026-04-01.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/west-covina-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/west-covina-ca-pd/2026-04-08.json
@@ -670,7 +670,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/west-sacramento-ca-pd/2026-04-01.json
+++ b/assets/transparency.flocksafety.com/west-sacramento-ca-pd/2026-04-01.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/west-sacramento-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/west-sacramento-ca-pd/2026-04-08.json
@@ -658,7 +658,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/westminster-ca-pd/2026-04-01.json
+++ b/assets/transparency.flocksafety.com/westminster-ca-pd/2026-04-01.json
@@ -676,7 +676,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/westminster-ca-pd/2026-04-08.json
+++ b/assets/transparency.flocksafety.com/westminster-ca-pd/2026-04-08.json
@@ -676,7 +676,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/williams-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/williams-ca-pd/2026-04-10.json
@@ -594,7 +594,7 @@
     "woodland-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],

--- a/assets/transparency.flocksafety.com/woodland-ca-pd/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/woodland-ca-pd/2026-04-10.json
@@ -664,7 +664,7 @@
     "yolo-county-ca-so",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 293,
   "orgs_sharing_with_names": [
@@ -1255,7 +1255,7 @@
     "woodlake-ca-pd",
     "yolo-county-ca-so",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "overview": "Woodland CA PD uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Woodland CA PD utilizes retroactive search to solve crimes after they've occurred. Additionally, Woodland CA PD utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/yolo-county-ca-so/2026-04-10.json
+++ b/assets/transparency.flocksafety.com/yolo-county-ca-so/2026-04-10.json
@@ -648,7 +648,7 @@
     "woodland-ca-pd",
     "yreka-ca-pd",
     "yuba-city-ca-pd",
-    "yuba-county-sheriffs-office"
+    "yuba-county-ca-so"
   ],
   "orgs_sharing_with_count": 0,
   "orgs_sharing_with_names": [],


### PR DESCRIPTION
## Summary
- Corrects Yuba County Sheriff's Office slug from `yuba-county-sheriffs-office` to `yuba-county-ca-so` — the old slug was a placeholder that didn't resolve on Flock's transparency portal
- Updates the agency registry and all crawled sharing partner data (296 files)

## Test plan
- [x] Verify `https://transparency.flocksafety.com/yuba-county-ca-so` resolves in a browser
- [ ] Confirm next flock refresh runs cleanly with the updated slug