### PR TITLE
fix: add -ca-so as slug variation for sheriff offices

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -106,6 +106,10 @@ def slug_variations(slug):
         variations.append(slug[:-3] + "-sheriffs-office")
         variations.append(re.sub(r"-ca-so$", "-so", slug))
 
+    # Try with "-ca-so": foo-sheriffs-office -> foo-ca-so
+    if "sheriffs-office" in slug:
+        variations.append(re.sub(r"-(?:ca-)?sheriffs-office(?:-ca)?$", "-ca-so", slug))
+
     # Try pd-ca instead of ca-pd: downey-pd-ca -> downey-ca-pd
     if re.search(r"-pd-ca$", slug):
         variations.append(re.sub(r"-pd-ca$", "-ca-pd", slug))


### PR DESCRIPTION
## Summary
- When crawling, if a sheriff office slug uses the `sheriffs-office` suffix, also try the `-ca-so` form as a portal URL variation
- Handles patterns like `amador-county-ca-sheriffs-office` → `amador-county-ca-so` and `kings-county-sheriffs-office-ca` → `kings-county-ca-so`

## Test plan
- [x] Verified `slug_variations` produces correct `-ca-so` candidates for all sheriff office slug patterns
- [x] 109 tests pass