### PR TITLE
refactor: stable agency identity model (PR 1/3)

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -1,9270 +1,12461 @@
 [
   {
+    "agency_id": "971ef5e8-3761-532f-ac31-4406140dcbe0",
+    "slug": "-el-cajon-pd-ca",
+    "flock_active_slug": "-el-cajon-pd-ca",
+    "flock_slugs": [
+      "-el-cajon-pd-ca"
+    ],
+    "flock_names": [
+      "El Cajon CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.7948,
+    "lng": -116.9625,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": "Sued by the CA Attorney General for illegally sharing ALPR data with out-of-state agencies in violation of SB 34 (CA Civil Code \u00a71798.90.55(b)). <a href=\"https://oag.ca.gov/news/press-releases/attorney-general-bonta-sues-el-cajon-illegally-sharing-license-plate-data-out\" target=\"_blank\">AG press release</a>.",
+    "tags": [
+      "ag-lawsuit",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b07531d3-82c2-5a47-8e26-110ed4fc9242",
+    "slug": "1800-block-s-orange-grove-ca",
+    "flock_active_slug": "1800-block-s-orange-grove-ca",
+    "flock_slugs": [
+      "1800-block-s-orange-grove-ca"
+    ],
+    "flock_names": [
+      "1800 Block S Orange Grove (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "2f6226a0-476b-51a7-85e3-bbf9cb76d96f",
     "slug": "18th-judicial-district-das-office-la-pd",
-    "flock_name": "18th Judicial District DA's Office- LA PD",
-    "human_name": "18th Judicial District DA's Office- LA PD",
+    "flock_active_slug": "18th-judicial-district-das-office-la-pd",
+    "flock_slugs": [
+      "18th-judicial-district-das-office-la-pd"
+    ],
+    "flock_names": [
+      "18th Judicial District DA's Office- LA PD"
+    ],
+    "display_name": null,
     "lat": 30.4515,
     "lng": -91.1871,
-    "public": true,
-    "federal": false,
     "state": "LA",
     "agency_role": "da",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "85858ce8-5bbc-5b4f-8017-daf6107c7e28",
     "slug": "acratt-ca",
-    "flock_name": "ACRATT -CA",
-    "human_name": "Alameda County Regional Auto Theft Task Force",
+    "flock_active_slug": "acratt-ca",
+    "flock_slugs": [
+      "acratt-ca"
+    ],
+    "flock_names": [
+      "ACRATT -CA"
+    ],
+    "display_name": "Alameda County Regional Auto Theft Task Force",
     "lat": 37.675,
     "lng": -122.075,
-    "public": true,
-    "federal": false,
     "state": "CA",
     "agency_role": "police",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Alameda County Regional Auto Theft Task Force (ACRATT). Multi-agency task force."
-  },
-  {
-    "slug": "alameda-ca-pd",
-    "flock_name": "Alameda CA PD",
-    "human_name": "Alameda CA PD",
-    "lat": 37.7652,
-    "lng": -122.2416,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "alameda-county-ca-so",
-    "flock_name": "Alameda County CA SO",
-    "human_name": "Alameda County CA SO",
-    "lat": 37.775,
-    "lng": -122.224,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "albany-ca-pd",
-    "flock_name": "Albany CA PD",
-    "human_name": "Albany CA PD",
-    "lat": 37.8869,
-    "lng": -122.2978,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "alhambra-ca-pd",
-    "flock_name": "Alhambra CA PD",
-    "human_name": "Alhambra CA PD",
-    "lat": 34.0953,
-    "lng": -118.127,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "alpine-county-ca-so",
-    "flock_name": "Alpine County CA SO",
-    "human_name": "Alpine County CA SO",
-    "lat": 38.5941,
-    "lng": -119.8207,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "amador-county-ca-sheriffs-office",
-    "flock_name": "Amador County CA Sheriff's Office",
-    "human_name": "Amador County CA Sheriff's Office",
-    "lat": 38.4468,
-    "lng": -120.6543,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "american-canyon-ca-pd",
-    "flock_name": "American Canyon CA PD",
-    "human_name": "American Canyon CA PD",
-    "lat": 38.1749,
-    "lng": -122.2608,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "anaheim-ca-pd",
-    "flock_name": "Anaheim CA PD",
-    "human_name": "Anaheim CA PD",
-    "lat": 33.8366,
-    "lng": -117.9143,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "anderson-ca-pd",
-    "flock_name": "Anderson CA PD",
-    "human_name": "Anderson CA PD",
-    "lat": 40.4485,
-    "lng": -122.2977,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "angels-camp-ca-pd",
-    "flock_name": "Angels Camp CA PD",
-    "human_name": "Angels Camp CA PD",
-    "lat": 38.0685,
-    "lng": -120.5396,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "antioch-ca-pd",
-    "flock_name": "Antioch CA PD",
-    "human_name": "Antioch CA PD",
-    "lat": 38.0049,
-    "lng": -121.8058,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-04-01",
-    "needs_review": false
-  },
-  {
-    "slug": "arcadia-ca-pd",
-    "flock_name": "Arcadia CA PD",
-    "human_name": "Arcadia CA PD",
-    "lat": 34.1397,
-    "lng": -118.0353,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "arvin-ca-pd",
-    "flock_name": "Arvin CA PD",
-    "human_name": "Arvin CA PD",
-    "lat": 35.2094,
-    "lng": -118.8282,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "atherton-ca-pd",
-    "flock_name": "Atherton CA PD",
-    "human_name": "Atherton CA PD",
-    "lat": 37.4613,
-    "lng": -122.1975,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "atwater-ca-pd",
-    "flock_name": "Atwater CA PD",
-    "human_name": "Atwater CA PD",
-    "lat": 37.3477,
-    "lng": -120.609,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "auburn-ca-pd",
-    "flock_name": "Auburn CA PD",
-    "human_name": "Auburn CA PD",
-    "lat": 38.8966,
-    "lng": -121.0769,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "avenal-ca-pd",
-    "flock_name": "Avenal CA PD",
-    "human_name": "Avenal CA PD",
-    "lat": 36.0041,
-    "lng": -120.1271,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "azusa-ca-pd",
-    "flock_name": "Azusa CA PD",
-    "human_name": "Azusa CA PD",
-    "lat": 34.1336,
-    "lng": -117.9076,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "bakersfield-ca-pd",
-    "flock_name": "Bakersfield CA PD",
-    "human_name": "Bakersfield CA PD",
-    "lat": 35.3733,
-    "lng": -119.0187,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "baldwin-park-ca-pd",
-    "flock_name": "Baldwin Park CA PD",
-    "human_name": "Baldwin Park CA PD",
-    "lat": 34.0854,
-    "lng": -117.9609,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "barstow-ca-pd",
-    "flock_name": "Barstow CA PD",
-    "human_name": "Barstow CA PD",
-    "lat": 34.8958,
-    "lng": -117.0173,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "bear-valley-springs-ca-pd",
-    "flock_name": "Bear Valley Springs CA PD",
-    "human_name": "Bear Valley Springs CA PD",
-    "lat": 35.1539,
-    "lng": -118.6284,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "beaumont-ca-pd",
-    "flock_name": "Beaumont CA PD",
-    "human_name": "Beaumont CA PD",
-    "lat": 33.9295,
-    "lng": -116.977,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "bell-ca-pd",
-    "flock_name": "Bell CA PD",
-    "human_name": "Bell CA PD",
-    "lat": 33.9775,
-    "lng": -118.187,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "bell-gardens-ca-pd",
-    "flock_name": "Bell Gardens CA PD",
-    "human_name": "Bell Gardens CA PD",
-    "lat": 33.9653,
-    "lng": -118.1514,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "belmont-ca-pd",
-    "flock_name": "Belmont CA PD",
-    "human_name": "Belmont CA PD",
-    "lat": 37.5202,
-    "lng": -122.2758,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "belvedere-ca-pd",
-    "flock_name": "Belvedere CA PD",
-    "human_name": "Belvedere CA PD",
-    "lat": 37.8727,
-    "lng": -122.4946,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "benicia-ca-pd",
-    "flock_name": "Benicia CA PD",
-    "human_name": "Benicia CA PD",
-    "lat": 38.0494,
-    "lng": -122.1586,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "berkeley-ca-pd",
-    "flock_name": "Berkeley CA PD",
-    "human_name": "Berkeley CA PD",
-    "lat": 37.8716,
-    "lng": -122.2727,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "beverly-hills-ca-pd",
-    "flock_name": "Beverly Hills CA PD",
-    "human_name": "Beverly Hills CA PD",
-    "lat": 34.0736,
-    "lng": -118.4004,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "bishop-ca-pd",
-    "flock_name": "Bishop CA PD",
-    "human_name": "Bishop CA PD",
-    "lat": 37.3636,
-    "lng": -118.3951,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "blue-lake-rancheria-tribal-pd",
-    "flock_name": "Blue Lake Rancheria Tribal PD",
-    "human_name": "Blue Lake Rancheria Tribal PD",
-    "lat": 40.8835,
-    "lng": -123.9828,
-    "public": true,
-    "federal": false,
-    "state": null,
-    "agency_role": "tribal",
-    "agency_type": "tribal",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "blythe-ca-pd",
-    "flock_name": "Blythe CA PD",
-    "human_name": "Blythe CA PD",
-    "lat": 33.6175,
-    "lng": -114.5883,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "brawley-ca-pd",
-    "flock_name": "Brawley CA PD",
-    "human_name": "Brawley CA PD",
-    "lat": 32.9787,
-    "lng": -115.5305,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "brea-ca-pd",
-    "flock_name": "Brea CA PD",
-    "human_name": "Brea CA PD",
-    "lat": 33.9167,
-    "lng": -117.9,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "brentwood-ca-pd",
-    "flock_name": "Brentwood CA PD",
-    "human_name": "Brentwood CA PD",
-    "lat": 37.9319,
-    "lng": -121.6958,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "brisbane-ca-pd",
-    "flock_name": "Brisbane CA PD",
-    "human_name": "Brisbane CA PD",
-    "lat": 37.6808,
-    "lng": -122.3999,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "buena-park-ca-pd",
-    "flock_name": "Buena Park CA PD",
-    "human_name": "Buena Park CA PD",
-    "lat": 33.8676,
-    "lng": -117.9981,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "burbank-airport-ca-pd",
-    "flock_name": "Burbank Airport CA PD",
-    "human_name": "Burbank Airport CA PD",
-    "lat": 34.1975,
-    "lng": -118.3585,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Hollywood Burbank Airport Police. Airport is owned by the Burbank-Glendale-Pasadena Airport Authority, a public joint powers authority."
-  },
-  {
-    "slug": "burbank-ca-pd",
-    "flock_name": "Burbank CA PD",
-    "human_name": "Burbank CA PD",
-    "lat": 34.1808,
-    "lng": -118.309,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "burlingame-ca-pd",
-    "flock_name": "Burlingame CA PD",
-    "human_name": "Burlingame CA PD",
-    "lat": 37.5841,
-    "lng": -122.3661,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "butte-county-ca-so",
-    "flock_name": "Butte County CA SO",
-    "human_name": "Butte County CA SO",
-    "lat": 39.6667,
-    "lng": -121.6,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "ca-iipay-nation-of-santa-ysabel",
-    "flock_name": "CA Iipay Nation of Santa Ysabel",
-    "human_name": "CA Iipay Nation of Santa Ysabel",
-    "lat": 33.11,
-    "lng": -116.67,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "tribal",
-    "agency_type": "tribal",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "ca-napa-valley-college-campus",
-    "flock_name": "CA - Napa Valley College Campus",
-    "human_name": "CA - Napa Valley College Campus",
-    "lat": 38.2618,
-    "lng": -122.2727,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Napa Valley College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "ca-wasco-pd",
-    "flock_name": "CA - Wasco PD",
-    "human_name": "CA - Wasco PD",
-    "lat": 35.5944,
-    "lng": -119.3406,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "cal-fire",
-    "flock_name": "Cal Fire",
-    "human_name": "Cal Fire",
-    "lat": 38.5816,
-    "lng": -121.5,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "fire",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "cal-state-fullerton-ca",
-    "flock_name": "Cal State Fullerton (CA)",
-    "human_name": "Cal State Fullerton (CA)",
-    "lat": 33.8829,
-    "lng": -117.8853,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "cal-state-san-bernadino-ca-pd",
-    "flock_name": "Cal State San Bernadino CA PD",
-    "human_name": "Cal State San Bernadino CA PD",
-    "lat": 34.1817,
-    "lng": -117.3232,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "calexico-ca-pd",
-    "flock_name": "Calexico CA PD",
-    "human_name": "Calexico CA PD",
-    "lat": 32.679,
-    "lng": -115.4989,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-city-pd-ca",
-    "flock_name": "California City PD CA",
-    "human_name": "California City PD CA",
-    "lat": 35.1258,
-    "lng": -117.9859,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-department-of-corrections",
-    "flock_name": "California Department of Corrections",
-    "human_name": "California Department of Corrections",
-    "lat": 38.575,
-    "lng": -121.485,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "corrections",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-department-of-fish-wildlife-ca",
-    "flock_name": "California Department of Fish & Wildlife (CA)",
-    "human_name": "California Department of Fish & Wildlife (CA)",
-    "lat": 38.568,
-    "lng": -121.495,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "fish_wildlife",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-department-of-insurance-fraud",
-    "flock_name": "California Department of Insurance Fraud",
-    "human_name": "California Department of Insurance Fraud",
-    "lat": 38.577,
-    "lng": -121.49,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "california-highway-patrol",
-    "flock_name": "California Highway Patrol",
-    "human_name": "California Highway Patrol",
-    "lat": 38.56,
-    "lng": -121.51,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "highway_patrol",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-state-parks",
-    "flock_name": "California State Parks",
-    "human_name": "California State Parks",
-    "lat": 38.575,
-    "lng": -121.505,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "state_parks",
-    "agency_type": "state",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "california-state-university-long-beach-campus-pd",
-    "flock_name": "California State University Long Beach Campus PD",
-    "human_name": "California State University Long Beach Campus PD",
-    "lat": 33.783,
-    "lng": -118.1129,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public university (CSU Long Beach). Part of the <a href=\"https://www.calstate.edu/attend/campuses\" target=\"_blank\">California State University</a> system."
-  },
-  {
-    "slug": "calistoga-ca-pd",
-    "flock_name": "Calistoga CA PD",
-    "human_name": "Calistoga CA PD",
-    "lat": 38.5788,
-    "lng": -122.5797,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "campbell-ca-pd",
-    "flock_name": "Campbell CA PD",
-    "human_name": "Campbell CA PD",
-    "lat": 37.2872,
-    "lng": -121.95,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "capitola-ca-pd",
-    "flock_name": "Capitola CA PD",
-    "human_name": "Capitola CA PD",
-    "lat": 36.9752,
-    "lng": -121.9531,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "carmel-ca-pd",
-    "flock_name": "Carmel CA PD",
-    "human_name": "Carmel CA PD",
-    "lat": 36.5554,
-    "lng": -121.9233,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "cathedral-city-ca-pd",
-    "flock_name": "Cathedral City CA PD",
-    "human_name": "Cathedral City CA PD",
-    "lat": 33.7797,
-    "lng": -116.4653,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "central-marin-ca-pd",
-    "flock_name": "Central Marin CA PD",
-    "human_name": "Central Marin CA PD",
-    "lat": 37.96,
-    "lng": -122.51,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "cerritos-college-ca-pd",
-    "flock_name": "Cerritos College CA PD",
-    "human_name": "Cerritos College CA PD",
-    "lat": 33.8583,
-    "lng": -118.0648,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Cerritos College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "chabot-college-campus-safety-security-department-ca",
-    "flock_name": "Chabot College Campus Safety & Security Department CA",
-    "human_name": "Chabot College Campus Safety & Security Department CA",
-    "lat": 37.6525,
-    "lng": -122.0947,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Chabot College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "chaffey-college-pd-ca",
-    "flock_name": "Chaffey College PD (CA)",
-    "human_name": "Chaffey College PD (CA)",
-    "lat": 34.1047,
-    "lng": -117.5765,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Chaffey College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "chino-ca-pd",
-    "flock_name": "Chino CA PD",
-    "human_name": "Chino CA PD",
-    "lat": 34.0122,
-    "lng": -117.6889,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "chula-vista-ca-pd",
-    "flock_name": "Chula Vista CA PD",
-    "human_name": "Chula Vista CA PD",
-    "lat": 32.6401,
-    "lng": -117.0842,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "citrus-heights-ca-pd",
-    "flock_name": "Citrus Heights CA PD",
-    "human_name": "Citrus Heights CA PD",
-    "lat": 38.7071,
-    "lng": -121.281,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "city-of-lemoore-ca",
-    "flock_name": "City of Lemoore CA",
-    "human_name": "City of Lemoore CA",
-    "lat": 36.3008,
-    "lng": -119.7826,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "city-of-menifee-ca-pd",
-    "flock_name": "City of Menifee CA PD",
-    "human_name": "City of Menifee CA PD",
-    "lat": 33.685,
-    "lng": -117.1464,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "monte-sereno-ca-pd",
-    "flock_name": "City of Monte Sereno CA",
-    "human_name": "City of Monte Sereno CA",
-    "lat": 37.2363,
-    "lng": -121.9928,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "city-of-newman-ca-pd",
-    "flock_name": "City of Newman CA PD",
-    "human_name": "City of Newman CA PD",
-    "lat": 37.3133,
-    "lng": -121.0208,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "city-of-riverside-ca-pd",
-    "flock_name": "City of Riverside CA PD",
-    "human_name": "City of Riverside CA PD",
-    "lat": 33.9806,
-    "lng": -117.3755,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "claremont-ca-pd",
-    "flock_name": "Claremont CA PD",
-    "human_name": "Claremont CA PD",
-    "lat": 34.0967,
-    "lng": -117.7198,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "clayton-ca-pd",
-    "flock_name": "Clayton CA PD",
-    "human_name": "Clayton CA PD",
-    "lat": 37.941,
-    "lng": -121.9358,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "clearlake-ca-pd",
-    "flock_name": "Clearlake CA PD",
-    "human_name": "Clearlake CA PD",
-    "lat": 38.9582,
-    "lng": -122.6264,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "cloverdale-ca-pd",
-    "flock_name": "Cloverdale CA PD",
-    "human_name": "Cloverdale CA PD",
-    "lat": 38.8054,
-    "lng": -123.0171,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "coalinga-ca-pd",
-    "flock_name": "Coalinga CA PD",
-    "human_name": "Coalinga CA PD",
-    "lat": 36.1397,
-    "lng": -120.36,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "colma-ca-pd",
-    "flock_name": "Colma CA PD",
-    "human_name": "Colma CA PD",
-    "lat": 37.6769,
-    "lng": -122.4597,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "colton-ca-pd",
-    "flock_name": "Colton CA PD",
-    "human_name": "Colton CA PD",
-    "lat": 34.0739,
-    "lng": -117.3137,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "colusa-ca-pd",
-    "flock_name": "Colusa CA PD",
-    "human_name": "Colusa CA PD",
-    "lat": 39.2141,
-    "lng": -122.0097,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "concord-ca-pd",
-    "flock_name": "Concord CA PD",
-    "human_name": "Concord CA PD",
-    "lat": 37.978,
-    "lng": -122.0311,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "contra-costa-county-ca-so",
-    "flock_name": "Contra Costa County CA SO",
-    "human_name": "Contra Costa County CA SO",
-    "lat": 37.9535,
-    "lng": -121.9018,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "corcoran-ca-pd",
-    "flock_name": "Corcoran CA PD",
-    "human_name": "Corcoran CA PD",
-    "lat": 36.098,
-    "lng": -119.5604,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "cornerstone-community-school-ca",
-    "flock_name": "Cornerstone Community School (CA)",
-    "human_name": "Cornerstone Community School (CA)",
-    "lat": 33.8676,
-    "lng": -117.2139,
-    "public": false,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "school",
-    "agency_type": "private",
-    "website": "https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770",
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Private school receiving ALPR data from law enforcement agencies. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>. <a href=\"https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770\" target=\"_blank\">CDE listing</a>."
-  },
-  {
-    "slug": "corona-ca-pd",
-    "flock_name": "Corona CA PD",
-    "human_name": "Corona CA PD",
-    "lat": 33.8753,
-    "lng": -117.5664,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "coronado-ca-pd",
-    "flock_name": "Coronado CA PD",
-    "human_name": "Coronado CA PD",
-    "lat": 32.6859,
-    "lng": -117.1831,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "costa-mesa-ca-pd",
-    "flock_name": "Costa Mesa CA PD",
-    "human_name": "Costa Mesa CA PD",
-    "lat": 33.6412,
-    "lng": -117.9187,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "cotati-ca-pd",
-    "flock_name": "Cotati CA PD",
-    "human_name": "Cotati CA PD",
-    "lat": 38.3277,
-    "lng": -122.7069,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "covina-ca-pd",
-    "flock_name": "Covina CA PD",
-    "human_name": "Covina CA PD",
-    "lat": 34.09,
-    "lng": -117.8903,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "csu-long-beach-pd-ca",
-    "flock_name": "CSU Long Beach PD (CA)",
-    "human_name": "CSU Long Beach PD (CA)",
-    "lat": 33.783,
-    "lng": -118.1129,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "culver-city-ca-pd",
-    "flock_name": "Culver City CA PD",
-    "human_name": "Culver City CA PD",
-    "lat": 34.0211,
-    "lng": -118.3965,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "cypress-ca-pd",
-    "flock_name": "Cypress CA PD",
-    "human_name": "Cypress CA PD",
-    "lat": 33.817,
-    "lng": -118.0374,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "daly-city-ca-pd",
-    "flock_name": "Daly City CA PD",
-    "human_name": "Daly City CA PD",
-    "lat": 37.6879,
-    "lng": -122.4702,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "danville-ca-pd",
-    "flock_name": "Danville CA PD",
-    "human_name": "Danville CA PD",
-    "lat": 37.8216,
-    "lng": -121.9999,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "decommissioned-org",
-    "flock_name": "Decommissioned Org",
-    "human_name": "Decommissioned Org",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "del-norte-county-ca-so",
-    "flock_name": "Del Norte County CA SO",
-    "human_name": "Del Norte County CA SO",
-    "lat": 41.7434,
-    "lng": -124.1829,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "delano-ca-pd",
-    "flock_name": "Delano CA PD",
-    "human_name": "Delano CA PD",
-    "lat": 35.7688,
-    "lng": -119.2471,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "delete",
-    "flock_name": "Delete",
-    "human_name": "Delete",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "demo",
-    "flock_name": "Demo",
-    "human_name": "Demo",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "desert-hot-springs-ca-pd",
-    "flock_name": "Desert Hot Springs CA PD",
-    "human_name": "Desert Hot Springs CA PD",
-    "lat": 33.9611,
-    "lng": -116.5017,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "dinuba-ca-pd",
-    "flock_name": "Dinuba CA PD",
-    "human_name": "Dinuba CA PD",
-    "lat": 36.543,
-    "lng": -119.3868,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "dixon-ca-pd",
-    "flock_name": "Dixon CA PD",
-    "human_name": "Dixon CA PD",
-    "lat": 38.4455,
-    "lng": -121.8233,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "dnu",
-    "flock_name": "DNU",
-    "human_name": "DNU",
-    "lat": null,
-    "lng": null,
-    "public": true,
-    "federal": false,
-    "state": null,
-    "agency_role": "decommissioned",
-    "agency_type": "decommissioned",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "dnu-glendale-pd-ca-condor",
-    "flock_name": "DNU - Glendale PD CA (Condor)",
-    "human_name": "DNU - Glendale PD CA (Condor)",
-    "lat": 34.1425,
-    "lng": -118.2551,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "decommissioned",
-    "agency_type": "decommissioned",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "dnu-santa-clara-university-campus-safety-raven",
-    "flock_name": "DNU - Santa Clara University Campus Safety (Raven)",
-    "human_name": "DNU - Santa Clara University Campus Safety (Raven)",
-    "lat": 37.3496,
-    "lng": -121.939,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "decommissioned",
-    "agency_type": "decommissioned",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Santa Clara University is a private institution. Entry marked \"Do Not Use\" by Flock but still appears in sharing lists. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only."
-  },
-  {
-    "slug": "downey-pd-ca",
-    "flock_name": "Downey PD CA",
-    "human_name": "Downey PD CA",
-    "lat": 33.9401,
-    "lng": -118.1332,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "dublin-ca-pd",
-    "flock_name": "Dublin CA PD (ACSO)",
-    "human_name": "Dublin CA PD (ACSO)",
-    "lat": 37.7022,
-    "lng": -121.9358,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "duplicate-please-delete",
-    "flock_name": "DUPLICATE PLEASE DELETE",
-    "human_name": "DUPLICATE PLEASE DELETE",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "east-bay-parks-ca-pd",
-    "flock_name": "East Bay Parks CA PD",
-    "human_name": "East Bay Parks CA PD",
-    "lat": 37.82,
-    "lng": -122.26,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "east-palo-alto-ca-pd",
-    "flock_name": "East Palo Alto CA PD",
-    "human_name": "East Palo Alto CA PD",
-    "lat": 37.4688,
-    "lng": -122.1411,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "-el-cajon-pd-ca",
-    "flock_name": "El Cajon CA PD",
-    "human_name": "El Cajon CA PD",
-    "lat": 32.7948,
-    "lng": -116.9625,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "ag_lawsuit": true,
-    "notes": "Sued by the CA Attorney General for illegally sharing ALPR data with out-of-state agencies in violation of SB 34 (CA Civil Code §1798.90.55(b)). <a href=\"https://oag.ca.gov/news/press-releases/attorney-general-bonta-sues-el-cajon-illegally-sharing-license-plate-data-out\" target=\"_blank\">AG press release</a>."
-  },
-  {
-    "slug": "el-centro-ca-pd",
-    "flock_name": "El Centro CA PD",
-    "human_name": "El Centro CA PD",
-    "lat": 32.792,
-    "lng": -115.5631,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "el-cerrito-ca-pd",
-    "flock_name": "El Cerrito CA PD",
-    "human_name": "El Cerrito CA PD",
-    "lat": 37.9161,
-    "lng": -122.3122,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "el-dorado-county-ca-so",
-    "flock_name": "El Dorado County CA SO",
-    "human_name": "El Dorado County CA SO",
-    "lat": 38.7296,
-    "lng": -120.7985,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "el-monte-ca-pd",
-    "flock_name": "El Monte CA PD",
-    "human_name": "El Monte CA PD",
-    "lat": 34.0686,
-    "lng": -118.0276,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "el-segundo-ca-pd",
-    "flock_name": "El Segundo CA PD",
-    "human_name": "El Segundo CA PD",
-    "lat": 33.9192,
-    "lng": -118.4165,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "elk-grove-ca-pd",
-    "flock_name": "Elk Grove CA PD",
-    "human_name": "Elk Grove CA PD",
-    "lat": 38.4088,
-    "lng": -121.3716,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "emeryville-ca-pd",
-    "flock_name": "Emeryville CA PD",
-    "human_name": "Emeryville CA PD",
-    "lat": 37.8313,
-    "lng": -122.2852,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "escalon-ca-pd",
-    "flock_name": "Escalon CA PD",
-    "human_name": "Escalon CA PD",
-    "lat": 37.7974,
-    "lng": -120.9983,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "escondido-ca-pd",
-    "flock_name": "Escondido CA PD",
-    "human_name": "Escondido CA PD",
-    "lat": 33.1192,
-    "lng": -117.0864,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "fairfield-ca-pd",
-    "flock_name": "Fairfield CA PD",
-    "human_name": "Fairfield CA PD",
-    "lat": 38.2494,
-    "lng": -122.04,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "farmersville-ca-pd",
-    "flock_name": "Farmersville CA PD",
-    "human_name": "Farmersville CA PD",
-    "lat": 36.2991,
-    "lng": -119.2068,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "folsom-ca-pd",
-    "flock_name": "Folsom CA PD",
-    "human_name": "Folsom CA PD",
-    "lat": 38.678,
-    "lng": -121.1761,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "fontana-ca-pd",
-    "flock_name": "Fontana CA PD",
-    "human_name": "Fontana CA PD",
-    "lat": 34.0922,
-    "lng": -117.435,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "foothilldeanza-ca-pd",
-    "flock_name": "Foothill-DeAnza CA PD",
-    "human_name": "Foothill-DeAnza CA PD",
-    "lat": 37.3616,
-    "lng": -122.1281,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "fort-bragg-ca-pd",
-    "flock_name": "Fort Bragg CA PD",
-    "human_name": "Fort Bragg CA PD",
-    "lat": 39.4457,
-    "lng": -123.8053,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "foster-city-ca-pd",
-    "flock_name": "Foster City CA PD",
-    "human_name": "Foster City CA PD",
-    "lat": 37.5585,
-    "lng": -122.2711,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "fountain-valley-ca-pd",
-    "flock_name": "Fountain Valley CA PD",
-    "human_name": "Fountain Valley CA PD",
-    "lat": 33.7092,
-    "lng": -117.9536,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "fowler-ca-pd",
-    "flock_name": "Fowler CA PD",
-    "human_name": "Fowler CA PD",
-    "lat": 36.6307,
-    "lng": -119.6809,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "fremont-ca-pd",
-    "flock_name": "Fremont CA PD",
-    "human_name": "Fremont CA PD",
-    "lat": 37.5485,
-    "lng": -121.9886,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "fresno-ca-pd",
-    "flock_name": "Fresno CA PD",
-    "human_name": "Fresno CA PD",
-    "lat": 36.7378,
-    "lng": -119.7871,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "fullerton-ca-pd",
-    "flock_name": "Fullerton CA PD",
-    "human_name": "Fullerton CA PD",
-    "lat": 33.8704,
-    "lng": -117.9242,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "galt-ca-pd",
-    "flock_name": "Galt CA PD",
-    "human_name": "Galt CA PD",
-    "lat": 38.2546,
-    "lng": -121.3,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "garden-grove-ca-pd",
-    "flock_name": "Garden Grove CA PD",
-    "human_name": "Garden Grove CA PD",
-    "lat": 33.7743,
-    "lng": -117.9379,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "gilroy-ca-pd",
-    "flock_name": "Gilroy CA PD",
-    "human_name": "Gilroy CA PD",
-    "lat": 37.0058,
-    "lng": -121.5683,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "glendale-ca-pd",
-    "flock_name": "Glendale CA PD",
-    "human_name": "Glendale CA PD",
-    "lat": 34.1425,
-    "lng": -118.2551,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "glendora-ca-pd",
-    "flock_name": "Glendora (CA) PD",
-    "human_name": "Glendora (CA) PD",
-    "lat": 34.1361,
-    "lng": -117.8653,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "goshen-village-ny-pd",
-    "flock_name": "Goshen Village NY PD",
-    "human_name": "Goshen Village NY PD",
-    "lat": 41.3812,
-    "lng": -74.324,
-    "public": true,
-    "federal": false,
-    "state": "NY",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "grass-valley-ca-pd",
-    "flock_name": "Grass Valley CA PD",
-    "human_name": "Grass Valley CA PD",
-    "lat": 39.219,
-    "lng": -121.0611,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "greenfield-ca-pd",
-    "flock_name": "Greenfield CA PD",
-    "human_name": "Greenfield CA PD",
-    "lat": 36.3208,
-    "lng": -121.2438,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "grover-beach-ca-pd",
-    "flock_name": "Grover Beach CA PD",
-    "human_name": "Grover Beach CA PD",
-    "lat": 35.1217,
-    "lng": -120.621,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "gustine-pd-ca",
-    "flock_name": "Gustine PD CA",
-    "human_name": "Gustine PD CA",
-    "lat": 37.2577,
-    "lng": -120.9983,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "hanford-ca-pd",
-    "flock_name": "Hanford CA PD",
-    "human_name": "Hanford CA PD",
-    "lat": 36.3274,
-    "lng": -119.6457,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "hawthorne-ca-pd",
-    "flock_name": "Hawthorne CA PD",
-    "human_name": "Hawthorne CA PD",
-    "lat": 33.9164,
-    "lng": -118.3526,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "hayward-ca-pd",
-    "flock_name": "Hayward CA PD",
-    "human_name": "Hayward CA PD",
-    "lat": 37.6688,
-    "lng": -122.0808,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "healdsburg-ca-pd",
-    "flock_name": "Healdsburg CA PD",
-    "human_name": "Healdsburg CA PD",
-    "lat": 38.6127,
-    "lng": -122.8694,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "hemet-ca-pd",
-    "flock_name": "Hemet CA PD",
-    "human_name": "Hemet CA PD",
-    "lat": 33.7475,
-    "lng": -116.9719,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "hercules-ca-pd",
-    "flock_name": "Hercules CA PD",
-    "human_name": "Hercules CA PD",
-    "lat": 38.0172,
-    "lng": -122.2886,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "hermosa-beach-pd-ca",
-    "flock_name": "Hermosa Beach PD CA",
-    "human_name": "Hermosa Beach PD CA",
-    "lat": 33.8622,
-    "lng": -118.3995,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "hillsborough-ca-pd",
-    "flock_name": "Hillsborough CA PD",
-    "human_name": "Hillsborough CA PD",
-    "lat": 37.5741,
-    "lng": -122.3794,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "hollister-ca-pd",
-    "flock_name": "Hollister CA PD",
-    "human_name": "Hollister CA PD",
-    "lat": 36.8525,
-    "lng": -121.4016,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "humboldt-county-ca-so",
-    "flock_name": "Humboldt County CA SO",
-    "human_name": "Humboldt County CA SO",
-    "lat": 40.745,
-    "lng": -123.8695,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "huntington-beach-ca-pd",
-    "flock_name": "Huntington Beach CA PD",
-    "human_name": "Huntington Beach CA PD",
-    "lat": 33.6595,
-    "lng": -117.9988,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "imperial-city-ca-pd",
-    "flock_name": "Imperial City CA PD",
-    "human_name": "Imperial City CA PD",
-    "lat": 32.8473,
-    "lng": -115.5694,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "imperial-county-ca-so",
-    "flock_name": "Imperial County CA SO",
-    "human_name": "Imperial County CA SO",
-    "lat": 32.8473,
-    "lng": -115.5694,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "indio-ca-pd",
-    "flock_name": "Indio CA PD",
-    "human_name": "Indio CA PD",
-    "lat": 33.7206,
-    "lng": -116.2156,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "inglewood-ca-pd",
-    "flock_name": "Inglewood CA PD",
-    "human_name": "Inglewood CA PD",
-    "lat": 33.9617,
-    "lng": -118.3531,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "irvine-ca-pd",
-    "flock_name": "Irvine CA PD",
-    "human_name": "Irvine CA PD",
-    "lat": 33.6846,
-    "lng": -117.8265,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "irwindale-ca-pd",
-    "flock_name": "Irwindale CA PD",
-    "human_name": "Irwindale CA PD",
-    "lat": 34.107,
-    "lng": -117.9351,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "jaime-le-training",
-    "flock_name": "Jaime LE Training",
-    "human_name": "Jaime LE Training",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "kensington-ca-pd",
-    "flock_name": "Kensington CA PD",
-    "human_name": "Kensington CA PD",
-    "lat": 37.9103,
-    "lng": -122.2802,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "kerman-ca-pd",
-    "flock_name": "Kerman CA PD",
-    "human_name": "Kerman CA PD",
-    "lat": 36.7236,
-    "lng": -120.0596,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "kern-county-ca-so",
-    "flock_name": "Kern County CA SO",
-    "human_name": "Kern County CA SO",
-    "lat": 35.3733,
-    "lng": -118.9515,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "kings-county-ca-das-office",
-    "flock_name": "Kings County CA DAs Office",
-    "human_name": "Kings County CA DAs Office",
-    "lat": 36.0988,
-    "lng": -119.8159,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "kings-county-sheriffs-office-ca",
-    "flock_name": "Kings County Sheriff's Office CA",
-    "human_name": "Kings County Sheriff's Office CA",
-    "lat": 36.3274,
-    "lng": -119.6457,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "kingsburg-ca-pd",
-    "flock_name": "Kingsburg CA PD",
-    "human_name": "Kingsburg CA PD",
-    "lat": 36.5136,
-    "lng": -119.5537,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "la-habra-ca-pd",
-    "flock_name": "La Habra CA PD",
-    "human_name": "La Habra CA PD",
-    "lat": 33.9319,
-    "lng": -117.9462,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "la-mesa-ca-pd",
-    "flock_name": "La Mesa CA PD",
-    "human_name": "La Mesa CA PD",
-    "lat": 32.7679,
-    "lng": -117.0231,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "la-verne-ca-pd",
-    "flock_name": "La Verne CA PD",
-    "human_name": "La Verne CA PD",
-    "lat": 34.1008,
-    "lng": -117.7678,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "laguna-beach-ca-pd",
-    "flock_name": "Laguna Beach CA PD",
-    "human_name": "Laguna Beach CA PD",
-    "lat": 33.5427,
-    "lng": -117.7854,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "lake-county-ca-so",
-    "flock_name": "Lake County CA SO",
-    "human_name": "Lake County CA SO",
-    "lat": 39.0429,
-    "lng": -122.7538,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "lake-county-da-ca",
-    "flock_name": "Lake County DA CA",
-    "human_name": "Lake County DA CA",
-    "lat": 39.0429,
-    "lng": -122.7538,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "lakeport-ca-pd",
-    "flock_name": "Lakeport CA PD",
-    "human_name": "Lakeport CA PD",
-    "lat": 39.0432,
-    "lng": -122.9158,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "lancaster-ca-pd",
-    "flock_name": "Lancaster CA PD",
-    "human_name": "Lancaster CA PD",
-    "lat": 34.6868,
-    "lng": -118.1542,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "lasd-ca-san-dimas-station",
-    "flock_name": "LASD CA - San Dimas Station",
-    "human_name": "LASD CA - San Dimas Station",
-    "lat": 34.1067,
-    "lng": -117.8087,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "lassen-county-so-ca",
-    "flock_name": "Lassen County SO (CA)",
-    "human_name": "Lassen County SO (CA)",
-    "lat": 40.6736,
-    "lng": -120.7253,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "lathrop-ca-pd",
-    "flock_name": "Lathrop CA PD",
-    "human_name": "Lathrop CA PD",
-    "lat": 37.8227,
-    "lng": -121.2766,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "lincoln-ca-pd",
-    "flock_name": "Lincoln CA PD",
-    "human_name": "Lincoln CA PD",
-    "lat": 38.8916,
-    "lng": -121.293,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "lindsay-public-safety-department-ca",
-    "flock_name": "Lindsay Public Safety Department CA",
-    "human_name": "Lindsay Public Safety Department CA",
-    "lat": 36.203,
-    "lng": -119.0882,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "livermore-ca-pd",
-    "flock_name": "Livermore CA PD",
-    "human_name": "Livermore CA PD",
-    "lat": 37.6819,
-    "lng": -121.7681,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "livingston-ca-pd",
-    "flock_name": "Livingston CA PD",
-    "human_name": "Livingston CA PD",
-    "lat": 37.3866,
-    "lng": -120.7233,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "lodi-ca-pd",
-    "flock_name": "Lodi CA PD",
-    "human_name": "Lodi CA PD",
-    "lat": 38.1302,
-    "lng": -121.2724,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "lompoc-ca-pd",
-    "flock_name": "Lompoc CA PD",
-    "human_name": "Lompoc CA PD",
-    "lat": 34.6392,
-    "lng": -120.4579,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "los-alamitos-pd-ca",
-    "flock_name": "Los Alamitos PD CA",
-    "human_name": "Los Alamitos PD CA",
-    "lat": 33.8031,
-    "lng": -118.0726,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "los-alto-hills-ca-pd",
-    "flock_name": "Los Alto Hills CA PD",
-    "human_name": "Los Alto Hills CA PD",
-    "lat": 37.3796,
-    "lng": -122.1377,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "los-altos-ca-pd",
-    "flock_name": "Los Altos CA PD",
-    "human_name": "Los Altos CA PD",
-    "lat": 37.3852,
-    "lng": -122.1141,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "los-angeles-ca-pd",
-    "flock_name": "Los Angeles CA PD",
-    "human_name": "Los Angeles CA PD",
-    "lat": 34.0522,
-    "lng": -118.2437,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "los-angeles-county-ca-sd",
-    "flock_name": "Los Angeles County CA SD",
-    "human_name": "Los Angeles County CA SD",
-    "lat": 34.0587,
-    "lng": -118.2114,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "los-angeles-port-police-ca",
-    "flock_name": "Los Angeles Port Police CA",
-    "human_name": "Los Angeles Port Police CA",
-    "lat": 33.7361,
-    "lng": -118.2639,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "madera-ca-pd",
-    "flock_name": "Madera CA PD",
-    "human_name": "Madera CA PD",
-    "lat": 36.9613,
-    "lng": -120.0607,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "madera-county-so-ca",
-    "flock_name": "Madera County SO CA",
-    "human_name": "Madera County SO CA",
-    "lat": 37.218,
-    "lng": -119.7631,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "mammoth-lakes-ca-pd",
-    "flock_name": "Mammoth Lakes CA PD",
-    "human_name": "Mammoth Lakes CA PD",
-    "lat": 37.6485,
-    "lng": -118.9721,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "manteca-ca-pd",
-    "flock_name": "Manteca CA PD",
-    "human_name": "Manteca CA PD",
-    "lat": 37.7974,
-    "lng": -121.2161,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "marin-county-ca-da",
-    "flock_name": "Marin County CA DA",
-    "human_name": "Marin County CA DA",
-    "lat": 38.075,
-    "lng": -122.73,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "marin-county-ca-so",
-    "flock_name": "Marin County CA SO",
-    "human_name": "Marin County CA SO",
-    "lat": 38.055,
-    "lng": -122.735,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "marina-ca-pd",
-    "flock_name": "Marina CA PD",
-    "human_name": "Marina CA PD",
-    "lat": 36.6844,
-    "lng": -121.8022,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-28",
-    "needs_review": false
-  },
-  {
-    "slug": "marysville-ca-pd",
-    "flock_name": "Marysville CA PD",
-    "human_name": "Marysville CA PD",
-    "lat": 39.1457,
-    "lng": -121.5914,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "mcfarland-ca-pd",
-    "flock_name": "McFarland CA PD",
-    "human_name": "McFarland CA PD",
-    "lat": 35.6783,
-    "lng": -119.2293,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "mendocino-county-soca",
-    "flock_name": "Mendocino County SO-CA",
-    "human_name": "Mendocino County SO-CA",
-    "lat": 39.3076,
-    "lng": -123.7995,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "mendota-ca-pd",
-    "flock_name": "Mendota CA PD",
-    "human_name": "Mendota CA PD",
-    "lat": 36.7536,
-    "lng": -120.3818,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "menifee-ca-pd",
-    "flock_name": "Menifee CA PD",
-    "human_name": "Menifee CA PD",
-    "lat": 33.6781,
-    "lng": -117.1464,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false,
-    "also_known_as": [
-      "city-of-menifee-ca-pd"
+    "notes": "Alameda County Regional Auto Theft Task Force (ACRATT). Multi-agency task force.",
+    "tags": [
+      "public"
     ]
   },
   {
-    "slug": "menlo-park-ca-pd",
-    "flock_name": "Menlo Park CA PD",
-    "human_name": "Menlo Park CA PD",
-    "lat": 37.453,
-    "lng": -122.1817,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "merced-county-ca-so",
-    "flock_name": "Merced County CA SO",
-    "human_name": "Merced County CA SO",
-    "lat": 37.3022,
-    "lng": -120.483,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "mill-valley-ca-pd",
-    "flock_name": "Mill Valley CA PD",
-    "human_name": "Mill Valley CA PD",
-    "lat": 37.906,
-    "lng": -122.5416,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "milpitas-ca-pd",
-    "flock_name": "Milpitas CA PD",
-    "human_name": "Milpitas CA PD",
-    "lat": 37.4323,
-    "lng": -121.8996,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "modoc-county-ca-so",
-    "flock_name": "Modoc County CA SO",
-    "human_name": "Modoc County CA SO",
-    "lat": 41.5885,
-    "lng": -120.7253,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "monrovia-ca-pd",
-    "flock_name": "Monrovia CA PD",
-    "human_name": "Monrovia CA PD",
-    "lat": 34.1442,
-    "lng": -118.002,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "montclair-ca-pd",
-    "flock_name": "Montclair CA PD",
-    "human_name": "Montclair CA PD",
-    "lat": 34.0775,
-    "lng": -117.6898,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "montebello-ca-pd",
-    "flock_name": "Montebello CA PD",
-    "human_name": "Montebello CA PD",
-    "lat": 34.0165,
-    "lng": -118.1138,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "monterey-ca-pd",
-    "flock_name": "Monterey CA PD",
-    "human_name": "Monterey CA PD",
-    "lat": 36.6002,
-    "lng": -121.8947,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "monterey-county-ca-so",
-    "flock_name": "Monterey County CA SO",
-    "human_name": "Monterey County CA SO",
-    "lat": 36.61,
-    "lng": -121.88,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "monterey-county-district-attorneys-office",
-    "flock_name": "Monterey County District Attorney's Office",
-    "human_name": "Monterey County District Attorney's Office",
-    "lat": 36.24,
-    "lng": -121.32,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "monterey-park-ca-pd",
-    "flock_name": "Monterey Park CA PD",
-    "human_name": "Monterey Park CA PD",
-    "lat": 34.0625,
-    "lng": -118.1228,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "moraga-ca-pd",
-    "flock_name": "Moraga CA PD",
-    "human_name": "Moraga CA PD",
-    "lat": 37.8349,
-    "lng": -122.1297,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "morgan-hill-ca-pd",
-    "flock_name": "Morgan Hill CA PD",
-    "human_name": "Morgan Hill CA PD",
-    "lat": 37.1305,
-    "lng": -121.6544,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "murrieta-ca-pd",
-    "flock_name": "Murrieta CA PD",
-    "human_name": "Murrieta CA PD",
-    "lat": 33.5539,
-    "lng": -117.2139,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "napa-ca-pd",
-    "flock_name": "Napa CA PD",
-    "human_name": "Napa CA PD",
-    "lat": 38.2975,
-    "lng": -122.2869,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "napa-county-ca-probation-department",
-    "flock_name": "Napa County (CA) Probation Department",
-    "human_name": "Napa County (CA) Probation Department",
-    "lat": 38.2975,
-    "lng": -122.2869,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "napa-county-ca-so",
-    "flock_name": "Napa County CA SO",
-    "human_name": "Napa County CA SO",
-    "lat": 38.32,
-    "lng": -122.295,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "national-city-ca-pd",
-    "flock_name": "National City CA PD",
-    "human_name": "National City CA PD",
-    "lat": 32.6781,
-    "lng": -117.0992,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "ncric",
-    "flock_name": "NCRIC",
-    "human_name": "NCRIC",
-    "lat": 37.785,
-    "lng": -122.41,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "intelligence",
-    "agency_type": "fusion_center",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false,
-    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>.<br><br><strong>Federal characteristics:</strong> NCRIC may not qualify as a “public agency” under CA Civil Code §1798.90.5(f). It was created by the NC HIDTA Executive Board — not by statute or executive order. It is housed in the Phillip Burton Federal Building (GSA-managed), staffed primarily with federal analysts under DHS/ODNI grants, and governed by an 18-member board where 9 of 18 seats are held by federal agencies (ATF, DEA, FBI, IRS-CI, U.S. Marshals, DHS, Postal Inspection, U.S. Forest Service, U.S. Attorney NDCA). It operates under 28 CFR Part 23, a federal regulation. Its Flock transparency page states it will not share with “federal law enforcement” — yet federal law enforcement agencies hold half the seats on its governing board."
-  },
-  {
-    "slug": "nevada-city-ca-pd",
-    "flock_name": "Nevada City CA PD",
-    "human_name": "Nevada City CA PD",
-    "lat": 39.2616,
-    "lng": -121.016,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "nevada-county-ca-so",
-    "flock_name": "Nevada County CA SO",
-    "human_name": "Nevada County CA SO",
-    "lat": 39.28,
-    "lng": -121.03,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "newark-ca-pd",
-    "flock_name": "Newark CA PD",
-    "human_name": "Newark CA PD",
-    "lat": 37.5316,
-    "lng": -122.0402,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "newport-beach-pd-ca",
-    "flock_name": "Newport Beach PD CA",
-    "human_name": "Newport Beach PD CA",
-    "lat": 33.6189,
-    "lng": -117.9298,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "north-kern-cemetery-district-ca-pd",
-    "flock_name": "North Kern Cemetery District CA PD",
-    "human_name": "North Kern Cemetery District CA PD",
-    "lat": 35.49,
-    "lng": -119.27,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "novato-ca-pd",
-    "flock_name": "Novato CA PD",
-    "human_name": "Novato CA PD",
-    "lat": 38.1074,
-    "lng": -122.5697,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "oakland-ca-pd",
-    "flock_name": "Oakland CA PD",
-    "human_name": "Oakland CA PD",
-    "lat": 37.8044,
-    "lng": -122.2712,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "oakley-ca-pd",
-    "flock_name": "Oakley CA PD",
-    "human_name": "Oakley CA PD",
-    "lat": 37.9974,
-    "lng": -121.7125,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "oceanside-ca-pd",
-    "flock_name": "Oceanside CA PD",
-    "human_name": "Oceanside CA PD",
-    "lat": 33.1959,
-    "lng": -117.3795,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "old",
-    "flock_name": "Old",
-    "human_name": "Old",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Not a public agency. Receives ALPR data from at least 2 agencies (Lodi PD, Merced County SO)."
-  },
-  {
-    "slug": "ontario-ca-pd",
-    "flock_name": "Ontario CA PD",
-    "human_name": "Ontario CA PD",
-    "lat": 34.0633,
-    "lng": -117.6509,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "orange-ca-pd",
-    "flock_name": "Orange CA PD",
-    "human_name": "Orange CA PD",
-    "lat": 33.7878,
-    "lng": -117.8531,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "orange-coast-college-campus-ca-pd",
-    "flock_name": "Orange Coast College Campus CA PD",
-    "human_name": "Orange Coast College Campus CA PD",
-    "lat": 33.6715,
-    "lng": -117.9129,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Orange Coast College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "orange-county-ca-da-office",
-    "flock_name": "Orange County (CA) DA Office",
-    "human_name": "Orange County (CA) DA Office",
-    "lat": 33.7878,
-    "lng": -117.8531,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "orange-county-fire-authority-ca",
-    "flock_name": "Orange County Fire Authority (CA)",
-    "human_name": "Orange County Fire Authority (CA)",
-    "lat": 33.71,
-    "lng": -117.85,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "fire",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "orange-county-so-ca",
-    "flock_name": "Orange County SO CA",
-    "human_name": "Orange County SO CA",
-    "lat": 33.78,
-    "lng": -117.86,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "orange-cove-ca-pd",
-    "flock_name": "Orange Cove CA PD",
-    "human_name": "Orange Cove CA PD",
-    "lat": 36.6236,
-    "lng": -119.3129,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "oroville-ca-pd",
-    "flock_name": "Oroville CA PD",
-    "human_name": "Oroville CA PD",
-    "lat": 39.5138,
-    "lng": -121.5564,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "oxnard-ca-pd",
-    "flock_name": "Oxnard CA PD",
-    "human_name": "Oxnard CA PD",
-    "lat": 34.1975,
-    "lng": -119.1771,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "pacific-grove-ca-pd",
-    "flock_name": "Pacific Grove CA PD",
-    "human_name": "Pacific Grove CA PD",
-    "lat": 36.6177,
-    "lng": -121.9166,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "pacifica-ca-pd",
-    "flock_name": "Pacifica CA PD",
-    "human_name": "Pacifica CA PD",
-    "lat": 37.6138,
-    "lng": -122.4869,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "palm-springs-ca-pd",
-    "flock_name": "Palm Springs CA PD",
-    "human_name": "Palm Springs CA PD",
-    "lat": 33.8303,
-    "lng": -116.5453,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "palo-alto-ca-pd",
-    "flock_name": "Palo Alto CA PD",
-    "human_name": "Palo Alto CA PD",
-    "lat": 37.4419,
-    "lng": -122.143,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-29",
-    "needs_review": false
-  },
-  {
-    "slug": "pasadena-ca-pd",
-    "flock_name": "Pasadena CA PD",
-    "human_name": "Pasadena CA PD",
-    "lat": 34.1478,
-    "lng": -118.1445,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "petaluma-ca-pd",
-    "flock_name": "Petaluma CA PD",
-    "human_name": "Petaluma CA PD",
-    "lat": 38.2324,
-    "lng": -122.6367,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "piedmont-ca-pd",
-    "flock_name": "Piedmont CA PD",
-    "human_name": "Piedmont CA PD",
-    "lat": 37.8244,
-    "lng": -122.2316,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "placentia-ca-pd",
-    "flock_name": "Placentia CA PD",
-    "human_name": "Placentia CA PD",
-    "lat": 33.8722,
-    "lng": -117.8703,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "placer-county-ca-da-office",
-    "flock_name": "Placer County CA DA Office",
-    "human_name": "Placer County CA DA Office",
-    "lat": 38.95,
-    "lng": -121.08,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "placer-county-ca-so",
-    "flock_name": "Placer County CA SO",
-    "human_name": "Placer County CA SO",
-    "lat": 38.9666,
-    "lng": -121.0958,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "pleasant-hill-ca-pd",
-    "flock_name": "Pleasant Hill CA PD",
-    "human_name": "Pleasant Hill CA PD",
-    "lat": 37.948,
-    "lng": -122.0608,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "pleasanton-ca-pd",
-    "flock_name": "Pleasanton CA PD",
-    "human_name": "Pleasanton CA PD",
-    "lat": 37.6624,
-    "lng": -121.8747,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "pomona-ca-pd",
-    "flock_name": "Pomona CA PD",
-    "human_name": "Pomona CA PD",
-    "lat": 34.0551,
-    "lng": -117.75,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "port-hueneme-ca-pd",
-    "flock_name": "Port Hueneme CA PD",
-    "human_name": "Port Hueneme CA PD",
-    "lat": 34.1478,
-    "lng": -119.1951,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "port-of-stockton-ca-pd",
-    "flock_name": "Port of Stockton CA PD",
-    "human_name": "Port of Stockton CA PD",
-    "lat": 37.945,
-    "lng": -121.32,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "porterville-ca-pd",
-    "flock_name": "Porterville CA PD",
-    "human_name": "Porterville CA PD",
-    "lat": 36.0653,
-    "lng": -119.0168,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "redding-pd-ca",
-    "flock_name": "Redding PD - CA",
-    "human_name": "Redding PD - CA",
-    "lat": 40.5865,
-    "lng": -122.3917,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "redlands-ca-pd",
-    "flock_name": "Redlands CA PD",
-    "human_name": "Redlands CA PD",
-    "lat": 34.0556,
-    "lng": -117.1825,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "redondo-beach-ca-pd",
-    "flock_name": "Redondo Beach CA PD",
-    "human_name": "Redondo Beach CA PD",
-    "lat": 33.8492,
-    "lng": -118.3884,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "redwood-city-ca-pd",
-    "flock_name": "Redwood City CA PD",
-    "human_name": "Redwood City CA PD",
-    "lat": 37.4852,
-    "lng": -122.2364,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "reedley-ca-pd",
-    "flock_name": "Reedley CA PD",
-    "human_name": "Reedley CA PD",
-    "lat": 36.5963,
-    "lng": -119.4504,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "rialto-pd-ca",
-    "flock_name": "Rialto PD CA",
-    "human_name": "Rialto PD CA",
-    "lat": 34.1064,
-    "lng": -117.3703,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "richmond-ca-pd",
-    "flock_name": "Richmond CA PD",
-    "human_name": "Richmond CA PD",
-    "lat": 37.9358,
-    "lng": -122.3477,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "richmond-housing-authority-ca-pd",
-    "flock_name": "Richmond Housing Authority CA PD",
-    "human_name": "Richmond Housing Authority CA PD",
-    "lat": 37.9358,
-    "lng": -122.3477,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "ridgecrest-ca-pd",
-    "flock_name": "Ridgecrest CA PD",
-    "human_name": "Ridgecrest CA PD",
-    "lat": 35.6225,
-    "lng": -117.6709,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "rio-hondo-college-pd-ca",
-    "flock_name": "Rio Hondo College PD CA",
-    "human_name": "Rio Hondo College PD CA",
-    "lat": 34.0231,
-    "lng": -118.0359,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (Rio Hondo College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "rio-vista-ca-pd",
-    "flock_name": "Rio Vista CA PD",
-    "human_name": "Rio Vista CA PD",
-    "lat": 38.1748,
-    "lng": -121.6925,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "ripon-ca-pd",
-    "flock_name": "Ripon CA PD",
-    "human_name": "Ripon CA PD",
-    "lat": 37.7416,
-    "lng": -121.1244,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "riv-co-arson-tf-ca-pd",
-    "flock_name": "RIV CO ARSON TF CA PD",
-    "human_name": "RIV CO ARSON TF CA PD",
-    "lat": 33.9806,
-    "lng": -117.3755,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "riverside-county-ca-district-attorney",
-    "flock_name": "Riverside County CA District Attorney",
-    "human_name": "Riverside County CA District Attorney",
-    "lat": 33.9806,
-    "lng": -117.3755,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "riverside-county-ca-sd",
-    "flock_name": "Riverside County CA SO",
-    "human_name": "Riverside County CA SO",
-    "lat": 33.9806,
-    "lng": -117.3755,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "rocklin-ca-pd",
-    "flock_name": "Rocklin CA PD",
-    "human_name": "Rocklin CA PD",
-    "lat": 38.7908,
-    "lng": -121.2358,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "rohnert-park-department-of-public-safety-ca",
-    "flock_name": "Rohnert Park Department of Public Safety (CA)",
-    "human_name": "Rohnert Park Department of Public Safety (CA)",
-    "lat": 38.3397,
-    "lng": -122.7011,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "roseville-ca-pd",
-    "flock_name": "Roseville CA PD",
-    "human_name": "Roseville CA PD",
-    "lat": 38.7521,
-    "lng": -121.288,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sacramento-ca-da",
-    "flock_name": "Sacramento CA DA",
-    "human_name": "Sacramento CA DA",
-    "lat": 38.585,
-    "lng": -121.5,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sacramento-ca-pd",
-    "flock_name": "Sacramento CA PD",
-    "human_name": "Sacramento CA PD",
-    "lat": 38.5816,
-    "lng": -121.4944,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sacramento-county-ca-so",
-    "flock_name": "Sacramento County CA SO",
-    "human_name": "Sacramento County CA SO",
-    "lat": 38.57,
-    "lng": -121.47,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sacramento-county-parks-department-ca",
-    "flock_name": "Sacramento County Parks Department CA",
-    "human_name": "Sacramento County Parks Department CA",
-    "lat": 38.56,
-    "lng": -121.48,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "salinas-ca-pd",
-    "flock_name": "Salinas CA PD",
-    "human_name": "Salinas CA PD",
-    "lat": 36.6777,
-    "lng": -121.6555,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-benito-county-so-ca",
-    "flock_name": "San Benito County SO CA",
-    "human_name": "San Benito County SO CA",
-    "lat": 36.8525,
-    "lng": -121.4016,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-bernardino-ca-pd",
-    "flock_name": "San Bernardino CA PD",
-    "human_name": "San Bernardino CA PD",
-    "lat": 34.1083,
-    "lng": -117.2898,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-bernardino-community-college-ca-pd",
-    "flock_name": "San Bernardino Community College CA PD",
-    "human_name": "San Bernardino Community College CA PD",
-    "lat": 34.0906,
-    "lng": -117.2746,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (San Bernardino Valley College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "san-bernardino-county-ca-human-services-law-enforcement",
-    "flock_name": "San Bernardino County CA Human Services [Law Enforcement]",
-    "human_name": "San Bernardino County CA Human Services [Law Enforcement]",
-    "lat": 34.1083,
-    "lng": -117.2898,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "san-bernardino-county-ca-so",
-    "flock_name": "San Bernardino County CA SO",
-    "human_name": "San Bernardino County CA SO",
-    "lat": 34.1119,
-    "lng": -117.263,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-bruno-ca-pd",
-    "flock_name": "San Bruno CA PD",
-    "human_name": "San Bruno CA PD",
-    "lat": 37.6305,
-    "lng": -122.4111,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "san-diego-ca-pd",
-    "flock_name": "San Diego CA PD",
-    "human_name": "San Diego CA PD",
-    "lat": 32.7157,
-    "lng": -117.1611,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-diego-county-ca-sd",
-    "flock_name": "San Diego County CA SD",
-    "human_name": "San Diego County CA SD",
-    "lat": 32.734,
-    "lng": -117.1933,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-diego-harbor-ca-pd",
-    "flock_name": "San Diego Harbor CA PD",
-    "human_name": "San Diego Harbor CA PD",
-    "lat": 32.7157,
-    "lng": -117.17,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-fernando-ca-pd",
-    "flock_name": "San Fernando CA PD",
-    "human_name": "San Fernando CA PD",
-    "lat": 34.2889,
-    "lng": -118.439,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-francisco-ca-pd",
-    "flock_name": "San Francisco CA PD",
-    "human_name": "San Francisco CA PD",
-    "lat": 37.7749,
-    "lng": -122.4194,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-francisco-district-attorney-ca",
-    "flock_name": "San Francisco District Attorney CA",
-    "human_name": "San Francisco District Attorney CA",
-    "lat": 37.78,
-    "lng": -122.415,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-gabriel-ca-pd",
-    "flock_name": "San Gabriel CA PD",
-    "human_name": "San Gabriel CA PD",
-    "lat": 34.0961,
-    "lng": -118.1058,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "san-joaquin-ca-da",
-    "flock_name": "San Joaquin CA DA",
-    "human_name": "San Joaquin CA DA",
-    "lat": 37.9577,
-    "lng": -121.2908,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-joaquin-county-ca-so",
-    "flock_name": "San Joaquin County CA SO",
-    "human_name": "San Joaquin County CA SO",
-    "lat": 37.975,
-    "lng": -121.275,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "san-joaquin-delta-college-pd-ca",
-    "flock_name": "San Joaquin Delta College PD (CA)",
-    "human_name": "San Joaquin Delta College PD (CA)",
-    "lat": 37.9891,
-    "lng": -121.327,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (San Joaquin Delta College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "san-jose-ca-pd",
-    "flock_name": "San Jose CA PD",
-    "human_name": "San Jose CA PD",
-    "lat": 37.3382,
-    "lng": -121.8863,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "san-jose-evergreen-community-college-campus-pd-ca",
-    "flock_name": "San Jose - Evergreen Community College Campus PD CA",
-    "human_name": "San Jose - Evergreen Community College Campus PD CA",
-    "lat": 37.313,
-    "lng": -121.8081,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (San Jose-Evergreen CCD). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "san-jose-state-university-ca",
-    "flock_name": "San Jose State University CA",
-    "human_name": "San Jose State University CA",
-    "lat": 37.3352,
-    "lng": -121.8811,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public university (San Jose State University). Part of the <a href=\"https://www.calstate.edu/attend/campuses\" target=\"_blank\">California State University</a> system."
-  },
-  {
-    "slug": "san-juan-bautista-ca",
-    "flock_name": "San Juan Bautista CA",
-    "human_name": "San Juan Bautista CA",
-    "lat": 36.8454,
-    "lng": -121.5383,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "san-leandro-pd-ca",
-    "flock_name": "San Leandro CA PD",
-    "human_name": "San Leandro CA PD",
-    "lat": 37.7249,
-    "lng": -122.1561,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-luis-obispo-ca-pd",
-    "flock_name": "San Luis Obispo CA PD",
-    "human_name": "San Luis Obispo CA PD",
-    "lat": 35.2828,
-    "lng": -120.6596,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-luis-obispo-county-ca-sheriff",
-    "flock_name": "San Luis Obispo County (CA) Sheriff",
-    "human_name": "San Luis Obispo County (CA) Sheriff",
-    "lat": 35.295,
-    "lng": -120.67,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-marino-ca-pd",
-    "flock_name": "San Marino CA PD",
-    "human_name": "San Marino CA PD",
-    "lat": 34.1215,
-    "lng": -118.1064,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-mateo-ca-pd",
-    "flock_name": "San Mateo CA PD",
-    "human_name": "San Mateo CA PD",
-    "lat": 37.563,
-    "lng": -122.3255,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "san-mateo-county-ca-so",
-    "flock_name": "San Mateo County CA SO",
-    "human_name": "San Mateo County CA SO",
-    "lat": 37.49,
-    "lng": -122.23,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "san-pablo-ca-pd",
-    "flock_name": "San Pablo CA PD",
-    "human_name": "San Pablo CA PD",
-    "lat": 37.9621,
-    "lng": -122.3458,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-pasqual-ca-pd",
-    "flock_name": "San Pasqual CA PD",
-    "human_name": "San Pasqual CA PD",
-    "lat": 33.0947,
-    "lng": -116.9578,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-rafael-ca-pd",
-    "flock_name": "San Rafael CA PD",
-    "human_name": "San Rafael CA PD",
-    "lat": 37.9735,
-    "lng": -122.5311,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "san-ramon-ca-pd",
-    "flock_name": "San Ramon CA PD",
-    "human_name": "San Ramon CA PD",
-    "lat": 37.7799,
-    "lng": -121.978,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sand-city-ca-pd",
-    "flock_name": "Sand City CA PD",
-    "human_name": "Sand City CA PD",
-    "lat": 36.62,
-    "lng": -121.85,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sanger-ca-pd",
-    "flock_name": "Sanger CA PD",
-    "human_name": "Sanger CA PD",
-    "lat": 36.708,
-    "lng": -119.556,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-ana-ca-pd",
-    "flock_name": "Santa Ana CA PD",
-    "human_name": "Santa Ana CA PD",
-    "lat": 33.7455,
-    "lng": -117.8677,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-barbara-county-ca-so",
-    "flock_name": "Santa Barbara County CA SO",
-    "human_name": "Santa Barbara County CA SO",
-    "lat": 34.444,
-    "lng": -119.715,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-barbara-pd-ca",
-    "flock_name": "Santa Barbara PD CA",
-    "human_name": "Santa Barbara PD CA",
-    "lat": 34.4208,
-    "lng": -119.6982,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-clara-ca-pd",
-    "flock_name": "Santa Clara CA PD",
-    "human_name": "Santa Clara CA PD",
-    "lat": 37.3541,
-    "lng": -121.9552,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-30",
-    "needs_review": false
-  },
-  {
-    "slug": "santa-clara-county-ca-so",
-    "flock_name": "Santa Clara County CA SO",
-    "human_name": "Santa Clara County CA SO",
-    "lat": 37.34,
-    "lng": -121.935,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-clara-da-ca",
-    "flock_name": "Santa Clara DA CA",
-    "human_name": "Santa Clara DA CA",
-    "lat": 37.338,
-    "lng": -121.886,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-cruz-ca-pd",
-    "flock_name": "Santa Cruz CA PD (deactivated)",
-    "human_name": "Santa Cruz CA PD (deactivated)",
-    "lat": 36.9741,
-    "lng": -122.0308,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-maria-ca-pd",
-    "flock_name": "Santa Maria CA PD",
-    "human_name": "Santa Maria CA PD",
-    "lat": 34.953,
-    "lng": -120.4357,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-monica-ca-pd",
-    "flock_name": "Santa Monica CA PD",
-    "human_name": "Santa Monica CA PD",
-    "lat": 34.0195,
-    "lng": -118.4912,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "santa-paula-ca-pd",
-    "flock_name": "Santa Paula CA PD",
-    "human_name": "Santa Paula CA PD",
-    "lat": 34.3542,
-    "lng": -119.059,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "santa-rosa-band-of-cahuilla-indians-ca",
-    "flock_name": "Santa Rosa Band of Cahuilla Indians CA",
-    "human_name": "Santa Rosa Band of Cahuilla Indians CA",
-    "lat": 33.56,
-    "lng": -116.78,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "santa-rosa-ca-pd",
-    "flock_name": "Santa Rosa CA PD",
-    "human_name": "Santa Rosa CA PD",
-    "lat": 38.4404,
-    "lng": -122.7141,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "sausalito-ca-pd",
-    "flock_name": "Sausalito CA PD",
-    "human_name": "Sausalito CA PD",
-    "lat": 37.8591,
-    "lng": -122.4852,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "seal-beach-ca-pd",
-    "flock_name": "Seal Beach CA PD",
-    "human_name": "Seal Beach CA PD",
-    "lat": 33.7414,
-    "lng": -118.1048,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "seaside-ca-pd",
-    "flock_name": "Seaside CA PD",
-    "human_name": "Seaside CA PD",
-    "lat": 36.6107,
-    "lng": -121.8514,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "selma-ca-pd",
-    "flock_name": "Selma CA PD",
-    "human_name": "Selma CA PD",
-    "lat": 36.5708,
-    "lng": -119.6121,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sequoias-community-college-district-ca-pd",
-    "flock_name": "Sequoias Community College District CA PD",
-    "human_name": "Sequoias Community College District CA PD",
-    "lat": 36.3302,
-    "lng": -119.2921,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false,
-    "notes": "Public community college (College of the Sequoias). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "shafter-pd-ca",
-    "flock_name": "Shafter PD CA",
-    "human_name": "Shafter PD CA",
-    "lat": 35.5005,
-    "lng": -119.2718,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "shasta-arson-task-force-ca",
-    "flock_name": "Shasta Arson Task Force CA",
-    "human_name": "Shasta Arson Task Force CA",
-    "lat": 40.5865,
-    "lng": -122.3917,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "shasta-county-so",
-    "flock_name": "Shasta County SO",
-    "human_name": "Shasta County SO",
-    "lat": 40.5865,
-    "lng": -122.3917,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "sierra-madre-ca-pd",
-    "flock_name": "Sierra Madre CA PD",
-    "human_name": "Sierra Madre CA PD",
-    "lat": 34.1617,
-    "lng": -118.0528,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "signal-hill-ca-pd",
-    "flock_name": "Signal Hill CA PD",
-    "human_name": "Signal Hill CA PD",
-    "lat": 33.8042,
-    "lng": -118.1681,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "simi-valley-ca-pd",
-    "flock_name": "Simi Valley CA PD",
-    "human_name": "Simi Valley CA PD",
-    "lat": 34.2694,
-    "lng": -118.7815,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "siskiyou-county-so-ca",
-    "flock_name": "Siskiyou County SO CA",
-    "human_name": "Siskiyou County SO CA",
-    "lat": 41.7354,
-    "lng": -122.6347,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "solano-county-ca-so",
-    "flock_name": "Solano County CA SO",
-    "human_name": "Solano County CA SO",
-    "lat": 38.27,
-    "lng": -122.015,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "solano-county-da-ca",
-    "flock_name": "Solano County DA CA",
-    "human_name": "Solano County DA CA",
-    "lat": 38.2494,
-    "lng": -122.04,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "solano-county-special-investigations-bureau",
-    "flock_name": "Solano County Special Investigations Bureau",
-    "human_name": "Solano County Special Investigations Bureau",
-    "lat": 38.255,
-    "lng": -122.03,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "soledad-ca-pd",
-    "flock_name": "Soledad CA PD",
-    "human_name": "Soledad CA PD",
-    "lat": 36.4247,
-    "lng": -121.3263,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sonoma-county-ca-so",
-    "flock_name": "Sonoma County CA SO",
-    "human_name": "Sonoma County CA SO",
-    "lat": 38.511,
-    "lng": -122.9888,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "south-gate-ca-pd",
-    "flock_name": "South Gate CA PD",
-    "human_name": "South Gate CA PD",
-    "lat": 33.9547,
-    "lng": -118.212,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "south-pasadena-ca-pd",
-    "flock_name": "South Pasadena CA PD",
-    "human_name": "South Pasadena CA PD",
-    "lat": 34.1161,
-    "lng": -118.1503,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "south-san-francisco-ca-pd",
-    "flock_name": "South San Francisco CA PD",
-    "human_name": "South San Francisco CA PD",
-    "lat": 37.6547,
-    "lng": -122.4077,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "st-helena-ca-pd",
-    "flock_name": "St. Helena CA PD",
-    "human_name": "St. Helena CA PD",
-    "lat": 38.5052,
-    "lng": -122.4703,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "stallion-springs-ca-pd",
-    "flock_name": "Stallion Springs CA PD",
-    "human_name": "Stallion Springs CA PD",
-    "lat": 35.08,
-    "lng": -118.63,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "stanford-university-ca-pd",
-    "flock_name": "Stanford University CA PD",
-    "human_name": "Stanford University CA PD",
-    "lat": 37.4275,
-    "lng": -122.1697,
-    "public": false,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "private",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Stanford is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>."
-  },
-  {
-    "slug": "stockton-ca-pd",
-    "flock_name": "Stockton CA PD",
-    "human_name": "Stockton CA PD",
-    "lat": 37.9577,
-    "lng": -121.2908,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-27",
-    "needs_review": false
-  },
-  {
-    "slug": "suisun-city-ca-pd",
-    "flock_name": "Suisun City CA PD",
-    "human_name": "Suisun City CA PD",
-    "lat": 38.2383,
-    "lng": -122.04,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sunnyvale-ca-pd",
-    "flock_name": "Sunnyvale CA PD",
-    "human_name": "Sunnyvale CA PD",
-    "lat": 37.3688,
-    "lng": -122.0363,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "sutter-county-ca-so",
-    "flock_name": "Sutter County CA SO",
-    "human_name": "Sutter County CA SO",
-    "lat": 39.1596,
-    "lng": -121.6947,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "taft-ca-pd",
-    "flock_name": "Taft CA PD",
-    "human_name": "Taft CA PD",
-    "lat": 35.1425,
-    "lng": -119.4566,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tehachapi-ca-pd",
-    "flock_name": "Tehachapi CA PD",
-    "human_name": "Tehachapi CA PD",
-    "lat": 35.1322,
-    "lng": -118.449,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tehama-county-ca-so",
-    "flock_name": "Tehama County CA SO",
-    "human_name": "Tehama County CA SO",
-    "lat": 40.0258,
-    "lng": -122.1236,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "temecula-ca-pd",
-    "flock_name": "Temecula CA PD",
-    "human_name": "Temecula CA PD",
-    "lat": 33.4936,
-    "lng": -117.1484,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "test-demo-1234",
-    "flock_name": "Test Demo 1234",
-    "human_name": "Test Demo 1234",
-    "lat": null,
-    "lng": null,
-    "public": false,
-    "federal": false,
-    "state": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tiburon-ca-pd",
-    "flock_name": "Tiburon CA PD",
-    "human_name": "Tiburon CA PD",
-    "lat": 37.8735,
-    "lng": -122.4567,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "los-gatos-ca-pd",
-    "flock_name": "Town of Los Gatos CA",
-    "human_name": "Town of Los Gatos CA",
-    "lat": 37.2358,
-    "lng": -121.9624,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "town-of-woodside-ca-smcso",
-    "flock_name": "Town of Woodside CA (SMCSO)",
-    "human_name": "Town of Woodside CA (SMCSO)",
-    "lat": 37.4299,
-    "lng": -122.2539,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
-    "slug": "tracy-ca-pd",
-    "flock_name": "Tracy CA PD",
-    "human_name": "Tracy CA PD",
-    "lat": 37.7397,
-    "lng": -121.4252,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "trinity-county-so-ca",
-    "flock_name": "Trinity County SO CA",
-    "human_name": "Trinity County SO CA",
-    "lat": 40.739,
-    "lng": -122.9423,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "truckee-ca-pd",
-    "flock_name": "Truckee CA PD",
-    "human_name": "Truckee CA PD",
-    "lat": 39.328,
-    "lng": -120.1833,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tulare-ca-pd",
-    "flock_name": "Tulare CA PD",
-    "human_name": "Tulare CA PD",
-    "lat": 36.2077,
-    "lng": -119.3473,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tulare-county-ca-so",
-    "flock_name": "Tulare County CA SO",
-    "human_name": "Tulare County CA SO",
-    "lat": 36.23,
-    "lng": -119.32,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "turlock-ca-pd",
-    "flock_name": "Turlock CA PD",
-    "human_name": "Turlock CA PD",
-    "lat": 37.4947,
-    "lng": -120.8466,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "tustin-ca-pd",
-    "flock_name": "Tustin CA PD",
-    "human_name": "Tustin CA PD",
-    "lat": 33.7458,
-    "lng": -117.8262,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "uc-irvine-campus-pd-ca",
-    "flock_name": "UC Irvine Campus PD CA",
-    "human_name": "UC Irvine Campus PD CA",
-    "lat": 33.6405,
-    "lng": -117.8443,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public university (UC Irvine). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system."
-  },
-  {
-    "slug": "ukiah-pd-ca",
-    "flock_name": "Ukiah CA PD",
-    "human_name": "Ukiah CA PD",
-    "lat": 39.1502,
-    "lng": -123.2078,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "ukiah-fire-ca-fd",
-    "flock_name": "Ukiah Fire CA FD",
-    "human_name": "Ukiah Fire CA FD",
-    "lat": 39.1502,
-    "lng": -123.2078,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "fire",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "union-city-ca-pd",
-    "flock_name": "Union City CA PD",
-    "human_name": "Union City CA PD",
-    "lat": 37.5934,
-    "lng": -122.0439,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "union-pacific-railroad-pd",
-    "flock_name": "Union Pacific Railroad PD",
-    "human_name": "Union Pacific Railroad PD",
-    "lat": 41.2565,
-    "lng": -95.9345,
-    "public": false,
-    "federal": false,
-    "state": "NE",
-    "agency_role": "police",
-    "agency_type": "private",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Union Pacific Railroad Police is a <a href=\"https://en.wikipedia.org/wiki/Union_Pacific_Police_Department\" target=\"_blank\">private railroad police</a> force. While railroad police have some law enforcement authority under federal law (49 USC §28101), Union Pacific is a private corporation. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.5(f)</a>."
-  },
-  {
-    "slug": "university-of-ca-santa-barbara-ca-pd",
-    "flock_name": "University of CA - Santa Barbara CA PD",
-    "human_name": "University of CA - Santa Barbara CA PD",
-    "lat": 34.414,
-    "lng": -119.8489,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public university (UC Santa Barbara). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system."
-  },
-  {
-    "slug": "university-of-california-berkeley",
-    "flock_name": "University of California, Berkeley",
-    "human_name": "University of California, Berkeley",
-    "lat": 37.872,
-    "lng": -122.259,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public university (UC Berkeley). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system."
-  },
-  {
-    "slug": "university-of-san-francisco-ca-pd",
-    "flock_name": "University of San Francisco CA PD",
-    "human_name": "University of San Francisco CA PD",
-    "lat": 37.7767,
-    "lng": -122.4506,
-    "public": false,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "private",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Private Jesuit university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. USF is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>."
-  },
-  {
-    "slug": "university-of-the-pacific-ca",
-    "flock_name": "University of the Pacific (CA)",
-    "human_name": "University of the Pacific (CA)",
-    "lat": 37.9812,
-    "lng": -121.3114,
-    "public": false,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "private",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. UOP Chief of Police confirmed in writing that University of the Pacific is \"a private institution and therefore not subject to the CPRA.\" UOP was removed from SMPD’s portal after a resident raised the issue; it remains on Stockton PD’s portal. (<a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings, Source 29</a>)"
-  },
-  {
-    "slug": "upland-ca-pd",
-    "flock_name": "Upland CA PD",
-    "human_name": "Upland CA PD",
-    "lat": 34.0975,
-    "lng": -117.6484,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "vacaville-ca-pd",
-    "flock_name": "Vacaville CA PD",
-    "human_name": "Vacaville CA PD",
-    "lat": 38.3566,
-    "lng": -121.9877,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "vallejo-ca-pd",
-    "flock_name": "Vallejo CA PD",
-    "human_name": "Vallejo CA PD",
-    "lat": 38.1041,
-    "lng": -122.2566,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false,
-    "also_known_as": [
-      "city-of-vallejo-ca"
-    ]
-  },
-  {
-    "slug": "ventura-ca-pd",
-    "flock_name": "Ventura CA PD",
-    "human_name": "Ventura CA PD",
-    "lat": 34.2805,
-    "lng": -119.2945,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "ventura-county-ca-so",
-    "flock_name": "Ventura County CA SO",
-    "human_name": "Ventura County CA SO",
-    "lat": 34.29,
-    "lng": -119.28,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "ventura-county-district-attorneys-office-ca",
-    "flock_name": "Ventura County District Attorney's Office CA",
-    "human_name": "Ventura County District Attorney's Office CA",
-    "lat": 34.2805,
-    "lng": -119.2945,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "da",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "vernon-ca-pd",
-    "flock_name": "Vernon CA PD",
-    "human_name": "Vernon CA PD",
-    "lat": 33.9953,
-    "lng": -118.2298,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "visalia-ca-pd",
-    "flock_name": "Visalia CA PD",
-    "human_name": "Visalia CA PD",
-    "lat": 36.3302,
-    "lng": -119.2921,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-03-31",
-    "needs_review": false
-  },
-  {
-    "slug": "walnut-creek-ca-pd",
-    "flock_name": "Walnut Creek CA PD",
-    "human_name": "Walnut Creek CA PD",
-    "lat": 37.9101,
-    "lng": -122.0652,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "watsonville-ca-pd",
-    "flock_name": "Watsonville CA PD",
-    "human_name": "Watsonville CA PD",
-    "lat": 36.9102,
-    "lng": -121.7569,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-04-01",
-    "needs_review": false
-  },
-  {
-    "slug": "west-covina-ca-pd",
-    "flock_name": "West Covina CA PD",
-    "human_name": "West Covina CA PD",
-    "lat": 34.0686,
-    "lng": -117.9394,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-04-01",
-    "needs_review": false
-  },
-  {
-    "slug": "west-sacramento-ca-pd",
-    "flock_name": "West Sacramento CA PD",
-    "human_name": "West Sacramento CA PD",
-    "lat": 38.5805,
-    "lng": -121.5302,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-04-01",
-    "needs_review": false
-  },
-  {
-    "slug": "west-valley-mission-college-dist-campus-ca",
-    "flock_name": "West Valley Mission College Dist Campus (CA)",
-    "human_name": "West Valley Mission College Dist Campus (CA)",
-    "lat": 37.263,
-    "lng": -121.9188,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Public community college (West Valley-Mission CCD). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system."
-  },
-  {
-    "slug": "western-states-information-network-ca",
-    "flock_name": "Western States Information Network (CA)",
-    "human_name": "Western States Information Network (CA)",
-    "lat": 38.59,
-    "lng": -121.52,
-    "public": false,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "intelligence",
-    "agency_type": "fusion_center",
-    "website": "https://oag.ca.gov/bi/wsin",
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "WSIN is a <strong>501(c)(3) nonprofit corporation</strong> (EIN 27-1453421), not a government agency. It is one of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers, 100% funded by BJA (DOJ) grants. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub — data shared with WSIN may be redistributed across five states and international partners.<br><br><strong>Not a public agency:</strong> WSIN incorporated as a California nonprofit in 2009 after separating from CA DOJ, which previously served as its fiscal agent. It employs 47 nonprofit employees (explicitly “not state positions”). Its policy board is composed entirely of state/local officials from five states (no federal seats), but it operates under 28 CFR Part 23 (federal regulation) and is 100% federally funded (~$7.5M/yr from BJA). As a 501(c)(3) nonprofit, WSIN likely does not qualify as a “public agency” under CA Civil Code §1798.90.5(f), which defines public agency as “the state, any city, county, or city and county, or any agency or political subdivision” thereof."
-  },
-  {
-    "slug": "westminster-ca-pd",
-    "flock_name": "Westminster CA PD",
-    "human_name": "Westminster CA PD",
-    "lat": 33.7514,
-    "lng": -117.994,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": true,
-    "crawled_date": "2026-04-01",
-    "needs_review": false
-  },
-  {
-    "slug": "westmorland-ca-pd",
-    "flock_name": "Westmorland CA PD",
-    "human_name": "Westmorland CA PD",
-    "lat": 33.0378,
-    "lng": -115.6222,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "wheatland-ca-pd",
-    "flock_name": "Wheatland CA PD",
-    "human_name": "Wheatland CA PD",
-    "lat": 38.9986,
-    "lng": -121.4262,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "whittier-ca-pd",
-    "flock_name": "Whittier CA PD",
-    "human_name": "Whittier CA PD",
-    "lat": 33.9792,
-    "lng": -118.0328,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "williams-ca-pd",
-    "flock_name": "Williams CA PD",
-    "human_name": "Williams CA PD",
-    "lat": 39.1541,
-    "lng": -122.1497,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "willits-ca-pd",
-    "flock_name": "Willits CA PD",
-    "human_name": "Willits CA PD",
-    "lat": 39.4096,
-    "lng": -123.3556,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "windsor-ca-pd",
-    "flock_name": "Windsor CA PD",
-    "human_name": "Windsor CA PD",
-    "lat": 38.5469,
-    "lng": -122.8164,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "winters-ca-pd",
-    "flock_name": "Winters CA PD",
-    "human_name": "Winters CA PD",
-    "lat": 38.5249,
-    "lng": -121.9706,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "woodlake-ca-pd",
-    "flock_name": "Woodlake CA PD",
-    "human_name": "Woodlake CA PD",
-    "lat": 36.4136,
-    "lng": -119.0987,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "woodland-ca-pd",
-    "flock_name": "Woodland CA PD",
-    "human_name": "Woodland CA PD",
-    "lat": 38.6785,
-    "lng": -121.7733,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "yolo-county-ca-so",
-    "flock_name": "Yolo County CA SO",
-    "human_name": "Yolo County CA SO",
-    "lat": 38.685,
-    "lng": -121.75,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "yreka-ca-pd",
-    "flock_name": "Yreka CA PD",
-    "human_name": "Yreka CA PD",
-    "lat": 41.7354,
-    "lng": -122.6347,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "yuba-city-ca-pd",
-    "flock_name": "Yuba City CA PD",
-    "human_name": "Yuba City CA PD",
-    "lat": 39.1404,
-    "lng": -121.6169,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "yuba-county-ca-so",
-    "flock_name": "Yuba County Sheriffs Office",
-    "human_name": "Yuba County Sheriffs Office",
-    "lat": 39.2627,
-    "lng": -121.3502,
-    "public": true,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "1800-block-s-orange-grove-ca",
-    "flock_name": "1800-block-s-orange-grove-ca",
-    "human_name": "1800-block-s-orange-grove-ca",
-    "lat": null,
-    "lng": null,
-    "public": null,
-    "federal": false,
-    "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
-  },
-  {
+    "agency_id": "b572cf3e-7b46-57aa-a337-b438e3e62603",
     "slug": "adrian-mi-pd",
-    "flock_name": "adrian-mi-pd",
-    "human_name": "adrian-mi-pd",
+    "flock_active_slug": "adrian-mi-pd",
+    "flock_slugs": [
+      "adrian-mi-pd"
+    ],
+    "flock_names": [
+      "Adrian MI PD"
+    ],
+    "display_name": null,
     "lat": 41.8975,
     "lng": -84.0372,
-    "public": true,
-    "federal": false,
     "state": "MI",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "2f63da87-2936-5f56-8ad8-bdb9c3a0ba35",
     "slug": "akron-oh-pd",
-    "flock_name": "akron-oh-pd",
-    "human_name": "akron-oh-pd",
+    "flock_active_slug": "akron-oh-pd",
+    "flock_slugs": [
+      "akron-oh-pd"
+    ],
+    "flock_names": [
+      "Akron OH PD"
+    ],
+    "display_name": null,
     "lat": 41.0814,
     "lng": -81.519,
-    "public": true,
-    "federal": false,
     "state": "OH",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "aeee2f0f-6386-5a1a-b93a-30babdede4f9",
+    "slug": "alameda-ca-pd",
+    "flock_active_slug": "alameda-ca-pd",
+    "flock_slugs": [
+      "alameda-ca-pd"
+    ],
+    "flock_names": [
+      "Alameda CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7652,
+    "lng": -122.2416,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9c1c5b61-7dec-5fce-a5ec-a3be9ed47c86",
+    "slug": "alameda-county-ca-so",
+    "flock_active_slug": "alameda-county-ca-so",
+    "flock_slugs": [
+      "alameda-county-ca-so"
+    ],
+    "flock_names": [
+      "Alameda County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.775,
+    "lng": -122.224,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "24232b38-3789-556d-8a11-d27bcccf4d6f",
+    "slug": "albany-ca-pd",
+    "flock_active_slug": "albany-ca-pd",
+    "flock_slugs": [
+      "albany-ca-pd"
+    ],
+    "flock_names": [
+      "Albany CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8869,
+    "lng": -122.2978,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "76c0abef-bb08-5240-a02b-e29b90ce3da1",
     "slug": "alcoa-tn-pd",
-    "flock_name": "alcoa-tn-pd",
-    "human_name": "alcoa-tn-pd",
+    "flock_active_slug": "alcoa-tn-pd",
+    "flock_slugs": [
+      "alcoa-tn-pd"
+    ],
+    "flock_names": [
+      "Alcoa TN PD"
+    ],
+    "display_name": null,
     "lat": 35.7898,
     "lng": -83.9738,
-    "public": true,
-    "federal": false,
     "state": "TN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "cc269287-49ca-5831-af72-f6dacf356bd1",
+    "slug": "alhambra-ca-pd",
+    "flock_active_slug": "alhambra-ca-pd",
+    "flock_slugs": [
+      "alhambra-ca-pd"
+    ],
+    "flock_names": [
+      "Alhambra CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0953,
+    "lng": -118.127,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "73377a5f-3576-5463-a159-a8f5023d1e09",
     "slug": "alhambra-courtyard-shopping-center-alhambra-ca",
-    "flock_name": "alhambra-courtyard-shopping-center-alhambra-ca",
-    "human_name": "alhambra-courtyard-shopping-center-alhambra-ca",
+    "flock_active_slug": "alhambra-courtyard-shopping-center-alhambra-ca",
+    "flock_slugs": [
+      "alhambra-courtyard-shopping-center-alhambra-ca"
+    ],
+    "flock_names": [
+      "Alhambra Courtyard Shopping Center- Alhambra (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "ampm-beaumont-pd",
-    "flock_name": "ampm-beaumont-pd",
-    "human_name": "ampm-beaumont-pd",
-    "lat": 33.9295,
-    "lng": -116.977,
-    "public": true,
-    "federal": false,
+    "agency_id": "01f7379e-355c-5c9e-b078-d0b4fd9c69a8",
+    "slug": "alpine-county-ca-so",
+    "flock_active_slug": "alpine-county-ca-so",
+    "flock_slugs": [
+      "alpine-county-ca-so"
+    ],
+    "flock_names": [
+      "Alpine County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.5941,
+    "lng": -119.8207,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7f21a88e-2c0f-53d5-b5e3-22920a3f9872",
+    "slug": "amador-county-ca-sheriffs-office",
+    "flock_active_slug": "amador-county-ca-sheriffs-office",
+    "flock_slugs": [
+      "amador-county-ca-sheriffs-office"
+    ],
+    "flock_names": [
+      "Amador County CA Sheriff's Office"
+    ],
+    "display_name": null,
+    "lat": 38.4468,
+    "lng": -120.6543,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8f77bd22-c4a3-5d91-9b83-0be357c7d7ec",
+    "slug": "american-canyon-ca-pd",
+    "flock_active_slug": "american-canyon-ca-pd",
+    "flock_slugs": [
+      "american-canyon-ca-pd"
+    ],
+    "flock_names": [
+      "American Canyon CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.1749,
+    "lng": -122.2608,
     "state": "CA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "5ef4b958-39f6-55aa-8339-2c655f10df3a",
+    "slug": "ampm-beaumont-pd",
+    "flock_active_slug": "ampm-beaumont-pd",
+    "flock_slugs": [
+      "ampm-beaumont-pd"
+    ],
+    "flock_names": [
+      "AMPM - Beaumont PD"
+    ],
+    "display_name": null,
+    "lat": 33.9295,
+    "lng": -116.977,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8754d3fd-a97d-5f59-acf3-7e33328b8792",
+    "slug": "anaheim-ca-pd",
+    "flock_active_slug": "anaheim-ca-pd",
+    "flock_slugs": [
+      "anaheim-ca-pd"
+    ],
+    "flock_names": [
+      "Anaheim CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8366,
+    "lng": -117.9143,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6fc47404-6f79-5f5d-ace0-18db02bc2391",
+    "slug": "anderson-ca-pd",
+    "flock_active_slug": "anderson-ca-pd",
+    "flock_slugs": [
+      "anderson-ca-pd"
+    ],
+    "flock_names": [
+      "Anderson CA PD"
+    ],
+    "display_name": null,
+    "lat": 40.4485,
+    "lng": -122.2977,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c03e0e31-0b46-538a-a399-1575a4b43204",
     "slug": "anderson-in-pd",
-    "flock_name": "anderson-in-pd",
-    "human_name": "anderson-in-pd",
+    "flock_active_slug": "anderson-in-pd",
+    "flock_slugs": [
+      "anderson-in-pd"
+    ],
+    "flock_names": [
+      "Anderson IN PD"
+    ],
+    "display_name": null,
     "lat": 40.1053,
     "lng": -85.6803,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "adffbade-4d93-5a53-b1d6-c83d987b42e0",
+    "slug": "angels-camp-ca-pd",
+    "flock_active_slug": "angels-camp-ca-pd",
+    "flock_slugs": [
+      "angels-camp-ca-pd"
+    ],
+    "flock_names": [
+      "Angels Camp CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.0685,
+    "lng": -120.5396,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "005277fa-5e9a-5ca8-8480-fcd07a1be95f",
+    "slug": "antioch-ca-pd",
+    "flock_active_slug": "antioch-ca-pd",
+    "flock_slugs": [
+      "antioch-ca-pd"
+    ],
+    "flock_names": [
+      "Antioch CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.0049,
+    "lng": -121.8058,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f4a21139-b8d6-5bed-959f-5a847ba09031",
+    "slug": "arcadia-ca-pd",
+    "flock_active_slug": "arcadia-ca-pd",
+    "flock_slugs": [
+      "arcadia-ca-pd"
+    ],
+    "flock_names": [
+      "Arcadia CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1397,
+    "lng": -118.0353,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "89d05f4a-5f01-591a-b241-44223d0c216e",
+    "slug": "arvin-ca-pd",
+    "flock_active_slug": "arvin-ca-pd",
+    "flock_slugs": [
+      "arvin-ca-pd"
+    ],
+    "flock_names": [
+      "Arvin CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.2094,
+    "lng": -118.8282,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c136ebf4-e85a-59dc-bd1b-ae2ebf5a54ed",
+    "slug": "atherton-ca-pd",
+    "flock_active_slug": "atherton-ca-pd",
+    "flock_slugs": [
+      "atherton-ca-pd"
+    ],
+    "flock_names": [
+      "Atherton CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4613,
+    "lng": -122.1975,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c",
+    "slug": "atwater-ca-pd",
+    "flock_active_slug": "atwater-ca-pd",
+    "flock_slugs": [
+      "atwater-ca-pd"
+    ],
+    "flock_names": [
+      "Atwater CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3477,
+    "lng": -120.609,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ffac6c2a-ff84-59d5-be7a-a5c0939dffa0",
+    "slug": "auburn-ca-pd",
+    "flock_active_slug": "auburn-ca-pd",
+    "flock_slugs": [
+      "auburn-ca-pd"
+    ],
+    "flock_names": [
+      "Auburn CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.8966,
+    "lng": -121.0769,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d30c1555-ff35-55be-8226-4d5f62612e97",
+    "slug": "avenal-ca-pd",
+    "flock_active_slug": "avenal-ca-pd",
+    "flock_slugs": [
+      "avenal-ca-pd"
+    ],
+    "flock_names": [
+      "Avenal CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.0041,
+    "lng": -120.1271,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "cc02337b-23cf-5d95-864c-9b484c316d8c",
     "slug": "avon-in-pd",
-    "flock_name": "avon-in-pd",
-    "human_name": "avon-in-pd",
+    "flock_active_slug": "avon-in-pd",
+    "flock_slugs": [
+      "avon-in-pd"
+    ],
+    "flock_names": [
+      "Avon IN PD"
+    ],
+    "display_name": null,
     "lat": 39.7628,
     "lng": -86.3997,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "2ae777d7-191d-5d9d-8740-e0b8dd82c4f8",
+    "slug": "azusa-ca-pd",
+    "flock_active_slug": "azusa-ca-pd",
+    "flock_slugs": [
+      "azusa-ca-pd"
+    ],
+    "flock_names": [
+      "Azusa CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1336,
+    "lng": -117.9076,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dcfedabb-a49f-55a6-9f9f-eae5283c92ef",
+    "slug": "bakersfield-ca-pd",
+    "flock_active_slug": "bakersfield-ca-pd",
+    "flock_slugs": [
+      "bakersfield-ca-pd"
+    ],
+    "flock_names": [
+      "Bakersfield CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.3733,
+    "lng": -119.0187,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "35a898a6-482d-59e5-b592-2882674a68b4",
     "slug": "baldwin-county-ga-so",
-    "flock_name": "baldwin-county-ga-so",
-    "human_name": "baldwin-county-ga-so",
+    "flock_active_slug": "baldwin-county-ga-so",
+    "flock_slugs": [
+      "baldwin-county-ga-so"
+    ],
+    "flock_names": [
+      "Baldwin County GA SO"
+    ],
+    "display_name": null,
     "lat": 33.0684,
     "lng": -83.2308,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "7166c3d7-483b-58fe-b154-74480f768bd9",
+    "slug": "baldwin-park-ca-pd",
+    "flock_active_slug": "baldwin-park-ca-pd",
+    "flock_slugs": [
+      "baldwin-park-ca-pd"
+    ],
+    "flock_names": [
+      "Baldwin Park CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0854,
+    "lng": -117.9609,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "21b39f7d-aa0c-57f4-bc53-5b10e9444ba4",
+    "slug": "barstow-ca-pd",
+    "flock_active_slug": "barstow-ca-pd",
+    "flock_slugs": [
+      "barstow-ca-pd"
+    ],
+    "flock_names": [
+      "Barstow CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.8958,
+    "lng": -117.0173,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "10e1a69f-8089-5a30-aa8b-d29302c691fc",
     "slug": "baytown-tx-pd",
-    "flock_name": "baytown-tx-pd",
-    "human_name": "baytown-tx-pd",
+    "flock_active_slug": "baytown-tx-pd",
+    "flock_slugs": [
+      "baytown-tx-pd"
+    ],
+    "flock_names": [
+      "Baytown TX PD"
+    ],
+    "display_name": null,
     "lat": 29.7355,
     "lng": -94.9774,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "7810622c-5cfd-5d8c-922a-9acd7e2ea391",
+    "slug": "bear-valley-springs-ca-pd",
+    "flock_active_slug": "bear-valley-springs-ca-pd",
+    "flock_slugs": [
+      "bear-valley-springs-ca-pd"
+    ],
+    "flock_names": [
+      "Bear Valley Springs CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.1539,
+    "lng": -118.6284,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "70aa604f-1426-542a-be6f-9b1af8f3e04f",
+    "slug": "beaumont-ca-pd",
+    "flock_active_slug": "beaumont-ca-pd",
+    "flock_slugs": [
+      "beaumont-ca-pd"
+    ],
+    "flock_names": [
+      "Beaumont CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9295,
+    "lng": -116.977,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9e264173-f667-546e-afaf-544b5fa70371",
     "slug": "bel-air-hills-ca",
-    "flock_name": "bel-air-hills-ca",
-    "human_name": "bel-air-hills-ca",
+    "flock_active_slug": "bel-air-hills-ca",
+    "flock_slugs": [
+      "bel-air-hills-ca"
+    ],
+    "flock_names": [
+      "Bel Air Hills (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "0f1c51db-3652-5223-8cde-9609a4280756",
+    "slug": "bell-ca-pd",
+    "flock_active_slug": "bell-ca-pd",
+    "flock_slugs": [
+      "bell-ca-pd"
+    ],
+    "flock_names": [
+      "Bell CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9775,
+    "lng": -118.187,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fe2cc1bd-2e5c-5195-b87a-07c955b02df7",
+    "slug": "bell-gardens-ca-pd",
+    "flock_active_slug": "bell-gardens-ca-pd",
+    "flock_slugs": [
+      "bell-gardens-ca-pd"
+    ],
+    "flock_names": [
+      "Bell Gardens CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9653,
+    "lng": -118.1514,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a75c8827-a3fc-5e55-9a83-6c609d7986ff",
+    "slug": "belmont-ca-pd",
+    "flock_active_slug": "belmont-ca-pd",
+    "flock_slugs": [
+      "belmont-ca-pd"
+    ],
+    "flock_names": [
+      "Belmont CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5202,
+    "lng": -122.2758,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "934de712-400e-53bf-bc0c-fa0449480522",
+    "slug": "belvedere-ca-pd",
+    "flock_active_slug": "belvedere-ca-pd",
+    "flock_slugs": [
+      "belvedere-ca-pd"
+    ],
+    "flock_names": [
+      "Belvedere CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8727,
+    "lng": -122.4946,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c7aa543c-ebc0-5058-9720-c2dd84914ca6",
+    "slug": "benicia-ca-pd",
+    "flock_active_slug": "benicia-ca-pd",
+    "flock_slugs": [
+      "benicia-ca-pd"
+    ],
+    "flock_names": [
+      "Benicia CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.0494,
+    "lng": -122.1586,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "eca5a0e5-4ab4-5868-a688-c03da1dff9b1",
+    "slug": "berkeley-ca-pd",
+    "flock_active_slug": "berkeley-ca-pd",
+    "flock_slugs": [
+      "berkeley-ca-pd"
+    ],
+    "flock_names": [
+      "Berkeley CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8716,
+    "lng": -122.2727,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6b18acc6-e4b8-5f72-97e5-9942b2582e96",
+    "slug": "beverly-hills-ca-pd",
+    "flock_active_slug": "beverly-hills-ca-pd",
+    "flock_slugs": [
+      "beverly-hills-ca-pd"
+    ],
+    "flock_names": [
+      "Beverly Hills CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0736,
+    "lng": -118.4004,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c36a31e6-7415-5c5d-95fe-729510df1066",
     "slug": "beverly-hills-unified-school-district-ca",
-    "flock_name": "beverly-hills-unified-school-district-ca",
-    "human_name": "beverly-hills-unified-school-district-ca",
+    "flock_active_slug": "beverly-hills-unified-school-district-ca",
+    "flock_slugs": [
+      "beverly-hills-unified-school-district-ca"
+    ],
+    "flock_names": [
+      "Beverly Hills Unified School District CA"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "school",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "ef0c3682-0153-527c-a973-0bb7b07056be",
+    "slug": "bishop-ca-pd",
+    "flock_active_slug": "bishop-ca-pd",
+    "flock_slugs": [
+      "bishop-ca-pd"
+    ],
+    "flock_names": [
+      "Bishop CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3636,
+    "lng": -118.3951,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d7c14d6d-c9ac-53b5-a108-f6101da72139",
     "slug": "blackmanleoni-public-safety-mi",
-    "flock_name": "blackmanleoni-public-safety-mi",
-    "human_name": "blackmanleoni-public-safety-mi",
+    "flock_active_slug": "blackmanleoni-public-safety-mi",
+    "flock_slugs": [
+      "blackmanleoni-public-safety-mi"
+    ],
+    "flock_names": [
+      "Blackman/Leoni Public Safety MI"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "c649eb74-6ffa-5be7-96b5-a08458128a6d",
     "slug": "bloomfield-nm-pd",
-    "flock_name": "bloomfield-nm-pd",
-    "human_name": "bloomfield-nm-pd",
+    "flock_active_slug": "bloomfield-nm-pd",
+    "flock_slugs": [
+      "bloomfield-nm-pd"
+    ],
+    "flock_names": [
+      "Bloomfield NM PD"
+    ],
+    "display_name": null,
     "lat": 36.7112,
     "lng": -107.9845,
-    "public": true,
-    "federal": false,
     "state": "NM",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "39054b43-7c24-5b8f-a4ca-266e742af0d4",
+    "slug": "blue-lake-rancheria-tribal-pd",
+    "flock_active_slug": "blue-lake-rancheria-tribal-pd",
+    "flock_slugs": [
+      "blue-lake-rancheria-tribal-pd"
+    ],
+    "flock_names": [
+      "Blue Lake Rancheria Tribal PD"
+    ],
+    "display_name": null,
+    "lat": 40.8835,
+    "lng": -123.9828,
+    "state": null,
+    "agency_role": "tribal",
+    "agency_type": "tribal",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ca169c85-b556-58a0-a0bc-988c09bc6d01",
+    "slug": "blythe-ca-pd",
+    "flock_active_slug": "blythe-ca-pd",
+    "flock_slugs": [
+      "blythe-ca-pd"
+    ],
+    "flock_names": [
+      "Blythe CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6175,
+    "lng": -114.5883,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "50646c4d-c1af-593d-833a-abce07477c7d",
+    "slug": "brawley-ca-pd",
+    "flock_active_slug": "brawley-ca-pd",
+    "flock_slugs": [
+      "brawley-ca-pd"
+    ],
+    "flock_names": [
+      "Brawley CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.9787,
+    "lng": -115.5305,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9bf26a51-28bf-519a-a823-3bc3df220f57",
+    "slug": "brea-ca-pd",
+    "flock_active_slug": "brea-ca-pd",
+    "flock_slugs": [
+      "brea-ca-pd"
+    ],
+    "flock_names": [
+      "Brea CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9167,
+    "lng": -117.9,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "de913a80-ceee-5eef-a74c-0093e8dcc033",
+    "slug": "brentwood-ca-pd",
+    "flock_active_slug": "brentwood-ca-pd",
+    "flock_slugs": [
+      "brentwood-ca-pd"
+    ],
+    "flock_names": [
+      "Brentwood CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9319,
+    "lng": -121.6958,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fbe076a7-2ead-54ab-a501-be61eab23d7b",
+    "slug": "brisbane-ca-pd",
+    "flock_active_slug": "brisbane-ca-pd",
+    "flock_slugs": [
+      "brisbane-ca-pd"
+    ],
+    "flock_names": [
+      "Brisbane CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6808,
+    "lng": -122.3999,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "82b7d6b0-9096-560a-ad40-1a6ac8b928ce",
     "slug": "brookhaven-circle-ca",
-    "flock_name": "brookhaven-circle-ca",
-    "human_name": "brookhaven-circle-ca",
+    "flock_active_slug": "brookhaven-circle-ca",
+    "flock_slugs": [
+      "brookhaven-circle-ca"
+    ],
+    "flock_names": [
+      "Brookhaven Circle (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "ca-newport-beach-country-club",
-    "flock_name": "ca-newport-beach-country-club",
-    "human_name": "ca-newport-beach-country-club",
-    "lat": null,
-    "lng": null,
-    "public": null,
-    "federal": false,
+    "agency_id": "6494c374-d653-5ac4-a6f5-2ad460c090a0",
+    "slug": "buena-park-ca-pd",
+    "flock_active_slug": "buena-park-ca-pd",
+    "flock_slugs": [
+      "buena-park-ca-pd"
+    ],
+    "flock_names": [
+      "Buena Park CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8676,
+    "lng": -117.9981,
     "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
+    "agency_role": "police",
+    "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "ca-topgolf-usa-el-segundo",
-    "flock_name": "ca-topgolf-usa-el-segundo",
-    "human_name": "ca-topgolf-usa-el-segundo",
-    "lat": null,
-    "lng": null,
-    "public": null,
-    "federal": false,
+    "agency_id": "d890fe3d-dbc9-56dc-9360-d977a774f0a5",
+    "slug": "burbank-airport-ca-pd",
+    "flock_active_slug": "burbank-airport-ca-pd",
+    "flock_slugs": [
+      "burbank-airport-ca-pd"
+    ],
+    "flock_names": [
+      "Burbank Airport CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1975,
+    "lng": -118.3585,
     "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
+    "agency_role": "police",
+    "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "notes": "Hollywood Burbank Airport Police. Airport is owned by the Burbank-Glendale-Pasadena Airport Authority, a public joint powers authority.",
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "cabana-isle-ca",
-    "flock_name": "cabana-isle-ca",
-    "human_name": "cabana-isle-ca",
-    "lat": null,
-    "lng": null,
-    "public": null,
-    "federal": false,
+    "agency_id": "9f23df85-6bfa-5a6d-9600-367266638274",
+    "slug": "burbank-ca-pd",
+    "flock_active_slug": "burbank-ca-pd",
+    "flock_slugs": [
+      "burbank-ca-pd"
+    ],
+    "flock_names": [
+      "Burbank CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1808,
+    "lng": -118.309,
     "state": "CA",
-    "agency_role": "other",
-    "agency_type": "other",
+    "agency_role": "police",
+    "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "cahuilla-tribal-gaming-agency-ca-rcsd",
-    "flock_name": "cahuilla-tribal-gaming-agency-ca-rcsd",
-    "human_name": "cahuilla-tribal-gaming-agency-ca-rcsd",
-    "lat": 33.5,
-    "lng": -116.85,
-    "public": true,
-    "federal": false,
+    "agency_id": "f4073ba9-2a85-50ab-82d6-1800ff5491c6",
+    "slug": "burlingame-ca-pd",
+    "flock_active_slug": "burlingame-ca-pd",
+    "flock_slugs": [
+      "burlingame-ca-pd"
+    ],
+    "flock_names": [
+      "Burlingame CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5841,
+    "lng": -122.3661,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "34e3cde6-f6dd-5182-89b7-7b7b4a2c0364",
+    "slug": "butte-county-ca-so",
+    "flock_active_slug": "butte-county-ca-so",
+    "flock_slugs": [
+      "butte-county-ca-so"
+    ],
+    "flock_names": [
+      "Butte County CA SO"
+    ],
+    "display_name": null,
+    "lat": 39.6667,
+    "lng": -121.6,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9f6b9744-828d-5dce-9160-54e355b51c4d",
+    "slug": "ca-iipay-nation-of-santa-ysabel",
+    "flock_active_slug": "ca-iipay-nation-of-santa-ysabel",
+    "flock_slugs": [
+      "ca-iipay-nation-of-santa-ysabel"
+    ],
+    "flock_names": [
+      "CA Iipay Nation of Santa Ysabel"
+    ],
+    "display_name": null,
+    "lat": 33.11,
+    "lng": -116.67,
     "state": "CA",
     "agency_role": "tribal",
     "agency_type": "tribal",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "cal-maritime-ca",
-    "flock_name": "cal-maritime-ca",
-    "human_name": "cal-maritime-ca",
+    "agency_id": "ab5fa6fd-2596-5801-b147-6c28f49c1f13",
+    "slug": "ca-napa-valley-college-campus",
+    "flock_active_slug": "ca-napa-valley-college-campus",
+    "flock_slugs": [
+      "ca-napa-valley-college-campus"
+    ],
+    "flock_names": [
+      "CA - Napa Valley College Campus"
+    ],
+    "display_name": null,
+    "lat": 38.2618,
+    "lng": -122.2727,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Napa Valley College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fc2484a4-1d34-59da-a19c-7287c6145501",
+    "slug": "ca-newport-beach-country-club",
+    "flock_active_slug": "ca-newport-beach-country-club",
+    "flock_slugs": [
+      "ca-newport-beach-country-club"
+    ],
+    "flock_names": [
+      "CA- Newport Beach Country Club"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "12ebc7de-4d60-5ae0-adc4-dc634c1b344c",
+    "slug": "ca-topgolf-usa-el-segundo",
+    "flock_active_slug": "ca-topgolf-usa-el-segundo",
+    "flock_slugs": [
+      "ca-topgolf-usa-el-segundo"
+    ],
+    "flock_names": [
+      "CA - Topgolf USA El Segundo"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "ec0349b0-2d81-546b-acf9-ded505a551a7",
+    "slug": "ca-wasco-pd",
+    "flock_active_slug": "ca-wasco-pd",
+    "flock_slugs": [
+      "ca-wasco-pd"
+    ],
+    "flock_names": [
+      "CA - Wasco PD"
+    ],
+    "display_name": null,
+    "lat": 35.5944,
+    "lng": -119.3406,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3723f745-0b10-5d08-a5f2-750990665097",
+    "slug": "cabana-isle-ca",
+    "flock_active_slug": "cabana-isle-ca",
+    "flock_slugs": [
+      "cabana-isle-ca"
+    ],
+    "flock_names": [
+      "Cabana Isle (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "338dc553-eb17-59c2-8ec8-2c1d6033907b",
+    "slug": "cahuilla-tribal-gaming-agency-ca-rcsd",
+    "flock_active_slug": "cahuilla-tribal-gaming-agency-ca-rcsd",
+    "flock_slugs": [
+      "cahuilla-tribal-gaming-agency-ca-rcsd"
+    ],
+    "flock_names": [
+      "Cahuilla Tribal Gaming Agency CA - RCSD"
+    ],
+    "display_name": null,
+    "lat": 33.5,
+    "lng": -116.85,
+    "state": "CA",
+    "agency_role": "tribal",
+    "agency_type": "tribal",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "eef11480-824c-5b76-9049-541470c862b1",
+    "slug": "cal-fire",
+    "flock_active_slug": "cal-fire",
+    "flock_slugs": [
+      "cal-fire"
+    ],
+    "flock_names": [
+      "Cal Fire"
+    ],
+    "display_name": null,
+    "lat": 38.5816,
+    "lng": -121.5,
+    "state": "CA",
+    "agency_role": "fire",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "60a5a098-8a57-5e97-9f61-0d01d8740d4e",
+    "slug": "cal-maritime-ca",
+    "flock_active_slug": "cal-maritime-ca",
+    "flock_slugs": [
+      "cal-maritime-ca"
+    ],
+    "flock_names": [
+      "Cal Maritime (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "46022a7f-7efe-5f30-9695-ef9a6c9f2093",
+    "slug": "cal-state-fullerton-ca",
+    "flock_active_slug": "cal-state-fullerton-ca",
+    "flock_slugs": [
+      "cal-state-fullerton-ca"
+    ],
+    "flock_names": [
+      "Cal State Fullerton (CA)"
+    ],
+    "display_name": null,
+    "lat": 33.8829,
+    "lng": -117.8853,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "589597b2-0d45-5add-ac97-bf6a042fceae",
+    "slug": "cal-state-san-bernadino-ca-pd",
+    "flock_active_slug": "cal-state-san-bernadino-ca-pd",
+    "flock_slugs": [
+      "cal-state-san-bernadino-ca-pd"
+    ],
+    "flock_names": [
+      "Cal State San Bernadino CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1817,
+    "lng": -117.3232,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "69489e25-1027-5396-86a7-c68d5111eecd",
+    "slug": "calexico-ca-pd",
+    "flock_active_slug": "calexico-ca-pd",
+    "flock_slugs": [
+      "calexico-ca-pd"
+    ],
+    "flock_names": [
+      "Calexico CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.679,
+    "lng": -115.4989,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6ef44a20-6901-53fd-b690-edd487d115d3",
     "slug": "calhoun-county-al-so",
-    "flock_name": "calhoun-county-al-so",
-    "human_name": "calhoun-county-al-so",
+    "flock_active_slug": "calhoun-county-al-so",
+    "flock_slugs": [
+      "calhoun-county-al-so"
+    ],
+    "flock_names": [
+      "Calhoun County AL SO"
+    ],
+    "display_name": null,
     "lat": 33.7714,
     "lng": -85.8266,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "8a88be54-e69a-5e38-88f2-02bc79b89ebe",
+    "slug": "california-city-pd-ca",
+    "flock_active_slug": "california-city-pd-ca",
+    "flock_slugs": [
+      "california-city-pd-ca"
+    ],
+    "flock_names": [
+      "California City PD CA"
+    ],
+    "display_name": null,
+    "lat": 35.1258,
+    "lng": -117.9859,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "98a2b052-2421-5f90-a95c-88c85615e128",
+    "slug": "california-department-of-corrections",
+    "flock_active_slug": "california-department-of-corrections",
+    "flock_slugs": [
+      "california-department-of-corrections"
+    ],
+    "flock_names": [
+      "California Department of Corrections"
+    ],
+    "display_name": null,
+    "lat": 38.575,
+    "lng": -121.485,
+    "state": "CA",
+    "agency_role": "corrections",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a0b27d09-cfa7-5b41-be70-1ecafb6dd3d5",
+    "slug": "california-department-of-fish-wildlife-ca",
+    "flock_active_slug": "california-department-of-fish-wildlife-ca",
+    "flock_slugs": [
+      "california-department-of-fish-wildlife-ca"
+    ],
+    "flock_names": [
+      "California Department of Fish & Wildlife (CA)"
+    ],
+    "display_name": null,
+    "lat": 38.568,
+    "lng": -121.495,
+    "state": "CA",
+    "agency_role": "fish_wildlife",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2549113a-a3d1-5d5c-9a3c-98fe21f27b17",
+    "slug": "california-department-of-insurance-fraud",
+    "flock_active_slug": "california-department-of-insurance-fraud",
+    "flock_slugs": [
+      "california-department-of-insurance-fraud"
+    ],
+    "flock_names": [
+      "California Department of Insurance Fraud"
+    ],
+    "display_name": null,
+    "lat": 38.577,
+    "lng": -121.49,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5",
+    "slug": "california-highway-patrol",
+    "flock_active_slug": "california-highway-patrol",
+    "flock_slugs": [
+      "california-highway-patrol"
+    ],
+    "flock_names": [
+      "California Highway Patrol"
+    ],
+    "display_name": null,
+    "lat": 38.56,
+    "lng": -121.51,
+    "state": "CA",
+    "agency_role": "highway_patrol",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "12c4f64a-7e32-56ec-b95d-b0645a5d1a4b",
+    "slug": "california-state-parks",
+    "flock_active_slug": "california-state-parks",
+    "flock_slugs": [
+      "california-state-parks"
+    ],
+    "flock_names": [
+      "California State Parks"
+    ],
+    "display_name": null,
+    "lat": 38.575,
+    "lng": -121.505,
+    "state": "CA",
+    "agency_role": "state_parks",
+    "agency_type": "state",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9079f9e0-e3c2-5611-8f09-a0276b7911f8",
+    "slug": "california-state-university-long-beach-campus-pd",
+    "flock_active_slug": "california-state-university-long-beach-campus-pd",
+    "flock_slugs": [
+      "california-state-university-long-beach-campus-pd"
+    ],
+    "flock_names": [
+      "California State University Long Beach Campus PD"
+    ],
+    "display_name": null,
+    "lat": 33.783,
+    "lng": -118.1129,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public university (CSU Long Beach). Part of the <a href=\"https://www.calstate.edu/attend/campuses\" target=\"_blank\">California State University</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b6d82e23-bb59-50ab-a318-86edd1e4daa6",
+    "slug": "calistoga-ca-pd",
+    "flock_active_slug": "calistoga-ca-pd",
+    "flock_slugs": [
+      "calistoga-ca-pd"
+    ],
+    "flock_names": [
+      "Calistoga CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5788,
+    "lng": -122.5797,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "752f6cb4-d099-5d28-b6eb-ebdaaa0f3000",
     "slug": "calle-roberto-west-ca",
-    "flock_name": "calle-roberto-west-ca",
-    "human_name": "calle-roberto-west-ca",
+    "flock_active_slug": "calle-roberto-west-ca",
+    "flock_slugs": [
+      "calle-roberto-west-ca"
+    ],
+    "flock_names": [
+      "Calle Roberto West (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "6590b59f-a52f-59ff-8ca0-b68e2a3f9607",
+    "slug": "campbell-ca-pd",
+    "flock_active_slug": "campbell-ca-pd",
+    "flock_slugs": [
+      "campbell-ca-pd"
+    ],
+    "flock_names": [
+      "Campbell CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.2872,
+    "lng": -121.95,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c4a71a99-f296-566b-b788-a75be7b08c79",
+    "slug": "capitola-ca-pd",
+    "flock_active_slug": "capitola-ca-pd",
+    "flock_slugs": [
+      "capitola-ca-pd"
+    ],
+    "flock_names": [
+      "Capitola CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.9752,
+    "lng": -121.9531,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "cb8557a9-d203-58f7-9cdf-f7150a347ef1",
+    "slug": "carmel-ca-pd",
+    "flock_active_slug": "carmel-ca-pd",
+    "flock_slugs": [
+      "carmel-ca-pd"
+    ],
+    "flock_names": [
+      "Carmel CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.5554,
+    "lng": -121.9233,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "11780c28-0850-5ff1-807d-a472190781c7",
     "slug": "carson-city-nv-so",
-    "flock_name": "carson-city-nv-so",
-    "human_name": "carson-city-nv-so",
+    "flock_active_slug": "carson-city-nv-so",
+    "flock_slugs": [
+      "carson-city-nv-so"
+    ],
+    "flock_names": [
+      "Carson City NV SO"
+    ],
+    "display_name": null,
     "lat": 39.1638,
     "lng": -119.7674,
-    "public": true,
-    "federal": false,
     "state": "NV",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "433df0bc-bbfd-5183-b5e4-02bf458f85e8",
+    "slug": "cathedral-city-ca-pd",
+    "flock_active_slug": "cathedral-city-ca-pd",
+    "flock_slugs": [
+      "cathedral-city-ca-pd"
+    ],
+    "flock_names": [
+      "Cathedral City CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7797,
+    "lng": -116.4653,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9ac8088b-6a6c-550e-92ef-6b9e90470c4c",
+    "slug": "central-marin-ca-pd",
+    "flock_active_slug": "central-marin-ca-pd",
+    "flock_slugs": [
+      "central-marin-ca-pd"
+    ],
+    "flock_names": [
+      "Central Marin CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.96,
+    "lng": -122.51,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a76f1a12-ea0c-5138-9c77-57a4e6b510ca",
+    "slug": "cerritos-college-ca-pd",
+    "flock_active_slug": "cerritos-college-ca-pd",
+    "flock_slugs": [
+      "cerritos-college-ca-pd"
+    ],
+    "flock_names": [
+      "Cerritos College CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8583,
+    "lng": -118.0648,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Cerritos College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3fc7d46a-3f58-5638-a86a-182bbaf116b4",
+    "slug": "chabot-college-campus-safety-security-department-ca",
+    "flock_active_slug": "chabot-college-campus-safety-security-department-ca",
+    "flock_slugs": [
+      "chabot-college-campus-safety-security-department-ca"
+    ],
+    "flock_names": [
+      "Chabot College Campus Safety & Security Department CA"
+    ],
+    "display_name": null,
+    "lat": 37.6525,
+    "lng": -122.0947,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Chabot College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3dbed6a1-dadc-5951-b32d-32d3f816d17d",
+    "slug": "chaffey-college-pd-ca",
+    "flock_active_slug": "chaffey-college-pd-ca",
+    "flock_slugs": [
+      "chaffey-college-pd-ca"
+    ],
+    "flock_names": [
+      "Chaffey College PD (CA)"
+    ],
+    "display_name": null,
+    "lat": 34.1047,
+    "lng": -117.5765,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Chaffey College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1430e4e5-d018-50ab-9b4a-d347c319e73e",
     "slug": "chambers-county-al-so",
-    "flock_name": "chambers-county-al-so",
-    "human_name": "chambers-county-al-so",
+    "flock_active_slug": "chambers-county-al-so",
+    "flock_slugs": [
+      "chambers-county-al-so"
+    ],
+    "flock_names": [
+      "Chambers County AL SO"
+    ],
+    "display_name": null,
     "lat": 32.8953,
     "lng": -85.3916,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "fae06461-0698-548b-ad4e-a8e2b5d8539a",
+    "slug": "chino-ca-pd",
+    "flock_active_slug": "chino-ca-pd",
+    "flock_slugs": [
+      "chino-ca-pd"
+    ],
+    "flock_names": [
+      "Chino CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0122,
+    "lng": -117.6889,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ad2a4cd9-a2df-50b6-9c64-348bfa3b8caf",
     "slug": "chino-valley-az-pd",
-    "flock_name": "chino-valley-az-pd",
-    "human_name": "chino-valley-az-pd",
+    "flock_active_slug": "chino-valley-az-pd",
+    "flock_slugs": [
+      "chino-valley-az-pd"
+    ],
+    "flock_names": [
+      "Chino Valley AZ PD"
+    ],
+    "display_name": null,
     "lat": 34.7575,
     "lng": -112.4535,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "2329d5a6-b311-56d2-bd0b-3d6caa375ab0",
+    "slug": "chula-vista-ca-pd",
+    "flock_active_slug": "chula-vista-ca-pd",
+    "flock_slugs": [
+      "chula-vista-ca-pd"
+    ],
+    "flock_names": [
+      "Chula Vista CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.6401,
+    "lng": -117.0842,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ffbb5eb3-3274-54a9-a1b1-840a58c1e6fd",
+    "slug": "citrus-heights-ca-pd",
+    "flock_active_slug": "citrus-heights-ca-pd",
+    "flock_slugs": [
+      "citrus-heights-ca-pd"
+    ],
+    "flock_names": [
+      "Citrus Heights CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.7071,
+    "lng": -121.281,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3aad45fc-4bb4-56da-907c-f2a82be406df",
     "slug": "city-of-half-moon-bay",
-    "flock_name": "city-of-half-moon-bay",
-    "human_name": "city-of-half-moon-bay",
+    "flock_active_slug": "city-of-half-moon-bay",
+    "flock_slugs": [
+      "city-of-half-moon-bay"
+    ],
+    "flock_names": [
+      "City of Half Moon Bay (SMCSO)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "9101f109-689a-5ad2-9a41-b7e859fc5121",
+    "slug": "city-of-lemoore-ca",
+    "flock_active_slug": "city-of-lemoore-ca",
+    "flock_slugs": [
+      "city-of-lemoore-ca"
+    ],
+    "flock_names": [
+      "City of Lemoore CA"
+    ],
+    "display_name": null,
+    "lat": 36.3008,
+    "lng": -119.7826,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4df8ea7d-7b9b-5ece-9184-0e1dbf236060",
+    "slug": "city-of-menifee-ca-pd",
+    "flock_active_slug": "city-of-menifee-ca-pd",
+    "flock_slugs": [
+      "city-of-menifee-ca-pd"
+    ],
+    "flock_names": [
+      "City of Menifee CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.685,
+    "lng": -117.1464,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5610e604-ad2c-5626-8287-33433f9c275f",
+    "slug": "city-of-newman-ca-pd",
+    "flock_active_slug": "city-of-newman-ca-pd",
+    "flock_slugs": [
+      "city-of-newman-ca-pd"
+    ],
+    "flock_names": [
+      "City of Newman CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3133,
+    "lng": -121.0208,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "76cb73e9-49c4-5198-bf3e-a1c921e65231",
+    "slug": "city-of-riverside-ca-pd",
+    "flock_active_slug": "city-of-riverside-ca-pd",
+    "flock_slugs": [
+      "city-of-riverside-ca-pd"
+    ],
+    "flock_names": [
+      "City of Riverside CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9806,
+    "lng": -117.3755,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2e8cee09-5590-5153-ab05-16a4c38f3959",
     "slug": "city-of-vallejo-ca",
-    "flock_name": "city-of-vallejo-ca",
-    "human_name": "city-of-vallejo-ca",
+    "flock_active_slug": "city-of-vallejo-ca",
+    "flock_slugs": [
+      "city-of-vallejo-ca"
+    ],
+    "flock_names": [
+      "City of Vallejo (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "class-acts-autobody-ca",
-    "flock_name": "class-acts-autobody-ca",
-    "human_name": "class-acts-autobody-ca",
+    "agency_id": "46f81c72-6a0c-559e-8e04-d696181aaa0e",
+    "slug": "cjm-ron",
+    "flock_active_slug": "cjm-ron",
+    "flock_slugs": [
+      "cjm-ron"
+    ],
+    "flock_names": [
+      "CJM - Ron"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
+    "state": null,
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "3ccb7773-cd90-5c79-a676-eacfceed3115",
+    "slug": "claremont-ca-pd",
+    "flock_active_slug": "claremont-ca-pd",
+    "flock_slugs": [
+      "claremont-ca-pd"
+    ],
+    "flock_names": [
+      "Claremont CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0967,
+    "lng": -117.7198,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b300fbd0-6bd8-5d1c-a943-0f0bcf55edc5",
+    "slug": "class-acts-autobody-ca",
+    "flock_active_slug": "class-acts-autobody-ca",
+    "flock_slugs": [
+      "class-acts-autobody-ca"
+    ],
+    "flock_names": [
+      "Class Acts Autobody (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": "CA",
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "a21104f6-63a3-5730-8f5a-6a6801bb0e80",
+    "slug": "clayton-ca-pd",
+    "flock_active_slug": "clayton-ca-pd",
+    "flock_slugs": [
+      "clayton-ca-pd"
+    ],
+    "flock_names": [
+      "Clayton CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.941,
+    "lng": -121.9358,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c50df642-b9d6-5b24-b8f9-a0b16371f97c",
+    "slug": "clearlake-ca-pd",
+    "flock_active_slug": "clearlake-ca-pd",
+    "flock_slugs": [
+      "clearlake-ca-pd"
+    ],
+    "flock_names": [
+      "Clearlake CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.9582,
+    "lng": -122.6264,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "15ef1d17-dfba-5844-9ce8-da8c2d9861f9",
     "slug": "clearwater-fl-pd",
-    "flock_name": "clearwater-fl-pd",
-    "human_name": "clearwater-fl-pd",
+    "flock_active_slug": "clearwater-fl-pd",
+    "flock_slugs": [
+      "clearwater-fl-pd"
+    ],
+    "flock_names": [
+      "Clearwater FL PD"
+    ],
+    "display_name": null,
     "lat": 27.9659,
     "lng": -82.8001,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "a24c4de9-ca70-5829-838e-12907c88c3a9",
+    "slug": "cloverdale-ca-pd",
+    "flock_active_slug": "cloverdale-ca-pd",
+    "flock_slugs": [
+      "cloverdale-ca-pd"
+    ],
+    "flock_names": [
+      "Cloverdale CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.8054,
+    "lng": -123.0171,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6b9004ff-75a7-54a3-bff6-2095bb998de4",
+    "slug": "coalinga-ca-pd",
+    "flock_active_slug": "coalinga-ca-pd",
+    "flock_slugs": [
+      "coalinga-ca-pd"
+    ],
+    "flock_names": [
+      "Coalinga CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.1397,
+    "lng": -120.36,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "96ab8fbc-f76a-5cc0-8a9f-05dd6a836de8",
     "slug": "cobb-county-ga-pd",
-    "flock_name": "cobb-county-ga-pd",
-    "human_name": "cobb-county-ga-pd",
+    "flock_active_slug": "cobb-county-ga-pd",
+    "flock_slugs": [
+      "cobb-county-ga-pd"
+    ],
+    "flock_names": [
+      "Cobb County GA PD"
+    ],
+    "display_name": null,
     "lat": 33.9562,
     "lng": -84.5499,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "ffa6dcd8-0e87-59a0-b27b-015382b55620",
     "slug": "collier-county-fl-so",
-    "flock_name": "collier-county-fl-so",
-    "human_name": "collier-county-fl-so",
+    "flock_active_slug": "collier-county-fl-so",
+    "flock_slugs": [
+      "collier-county-fl-so"
+    ],
+    "flock_names": [
+      "Collier County FL SO"
+    ],
+    "display_name": null,
     "lat": 26.1224,
     "lng": -81.7603,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "daeeaa81-10ea-53a3-86e8-684280bd07c8",
+    "slug": "colma-ca-pd",
+    "flock_active_slug": "colma-ca-pd",
+    "flock_slugs": [
+      "colma-ca-pd"
+    ],
+    "flock_names": [
+      "Colma CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6769,
+    "lng": -122.4597,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c",
+    "slug": "colton-ca-pd",
+    "flock_active_slug": "colton-ca-pd",
+    "flock_slugs": [
+      "colton-ca-pd"
+    ],
+    "flock_names": [
+      "Colton CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0739,
+    "lng": -117.3137,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b0282cab-63a4-5000-be9e-b444def1f5fd",
+    "slug": "colusa-ca-pd",
+    "flock_active_slug": "colusa-ca-pd",
+    "flock_slugs": [
+      "colusa-ca-pd"
+    ],
+    "flock_names": [
+      "Colusa CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.2141,
+    "lng": -122.0097,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "270aae46-f0d1-558e-bb3f-249d03b0510f",
+    "slug": "concord-ca-pd",
+    "flock_active_slug": "concord-ca-pd",
+    "flock_slugs": [
+      "concord-ca-pd"
+    ],
+    "flock_names": [
+      "Concord CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.978,
+    "lng": -122.0311,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "86e42e3d-4245-5dc8-b64c-89d45592a7bb",
+    "slug": "contra-costa-county-ca-so",
+    "flock_active_slug": "contra-costa-county-ca-so",
+    "flock_slugs": [
+      "contra-costa-county-ca-so"
+    ],
+    "flock_names": [
+      "Contra Costa County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.9535,
+    "lng": -121.9018,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4e876f28-fcca-5c87-9e65-f0730980ea1d",
+    "slug": "corcoran-ca-pd",
+    "flock_active_slug": "corcoran-ca-pd",
+    "flock_slugs": [
+      "corcoran-ca-pd"
+    ],
+    "flock_names": [
+      "Corcoran CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.098,
+    "lng": -119.5604,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4e67c5a9-b324-5d8a-a880-1c7ecc0cd846",
+    "slug": "cornerstone-community-school-ca",
+    "flock_active_slug": "cornerstone-community-school-ca",
+    "flock_slugs": [
+      "cornerstone-community-school-ca"
+    ],
+    "flock_names": [
+      "Cornerstone Community School (CA)"
+    ],
+    "display_name": null,
+    "lat": 33.8676,
+    "lng": -117.2139,
+    "state": "CA",
+    "agency_role": "school",
+    "agency_type": "private",
+    "website": "https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770",
+    "notes": "Private school receiving ALPR data from law enforcement agencies. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>. <a href=\"https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770\" target=\"_blank\">CDE listing</a>.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "66a4b49e-c138-5a25-9eff-3e28388407f5",
+    "slug": "corona-ca-pd",
+    "flock_active_slug": "corona-ca-pd",
+    "flock_slugs": [
+      "corona-ca-pd"
+    ],
+    "flock_names": [
+      "Corona CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8753,
+    "lng": -117.5664,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d08c0756-3527-5f74-a605-2a6f1d65af2c",
+    "slug": "coronado-ca-pd",
+    "flock_active_slug": "coronado-ca-pd",
+    "flock_slugs": [
+      "coronado-ca-pd"
+    ],
+    "flock_names": [
+      "Coronado CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.6859,
+    "lng": -117.1831,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1808b50d-b58e-5245-b233-3b7b31dd5c29",
+    "slug": "costa-mesa-ca-pd",
+    "flock_active_slug": "costa-mesa-ca-pd",
+    "flock_slugs": [
+      "costa-mesa-ca-pd"
+    ],
+    "flock_names": [
+      "Costa Mesa CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6412,
+    "lng": -117.9187,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d6c5ad02-cd10-5b27-b307-f1ecce74374f",
+    "slug": "cotati-ca-pd",
+    "flock_active_slug": "cotati-ca-pd",
+    "flock_slugs": [
+      "cotati-ca-pd"
+    ],
+    "flock_names": [
+      "Cotati CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.3277,
+    "lng": -122.7069,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "462eac38-7949-59ba-af6f-913445b1b334",
     "slug": "country-club-vista-ca",
-    "flock_name": "country-club-vista-ca",
-    "human_name": "country-club-vista-ca",
+    "flock_active_slug": "country-club-vista-ca",
+    "flock_slugs": [
+      "country-club-vista-ca"
+    ],
+    "flock_names": [
+      "Country Club Vista (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "7b25055d-119d-5a60-b457-2ee42f56dd20",
     "slug": "country-rose-ca",
-    "flock_name": "country-rose-ca",
-    "human_name": "country-rose-ca",
+    "flock_active_slug": "country-rose-ca",
+    "flock_slugs": [
+      "country-rose-ca"
+    ],
+    "flock_names": [
+      "Country Rose (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "1ff2d645-29d6-505b-bca1-271ddb4973ee",
+    "slug": "covina-ca-pd",
+    "flock_active_slug": "covina-ca-pd",
+    "flock_slugs": [
+      "covina-ca-pd"
+    ],
+    "flock_names": [
+      "Covina CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.09,
+    "lng": -117.8903,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "cc1000e2-0754-5577-95b3-76649924222d",
+    "slug": "csu-long-beach-pd-ca",
+    "flock_active_slug": "csu-long-beach-pd-ca",
+    "flock_slugs": [
+      "csu-long-beach-pd-ca"
+    ],
+    "flock_names": [
+      "CSU Long Beach PD (CA)"
+    ],
+    "display_name": null,
+    "lat": 33.783,
+    "lng": -118.1129,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ecbb841f-9df2-5841-9b28-91f1ce5af0fa",
+    "slug": "culver-city-ca-pd",
+    "flock_active_slug": "culver-city-ca-pd",
+    "flock_slugs": [
+      "culver-city-ca-pd"
+    ],
+    "flock_names": [
+      "Culver City CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0211,
+    "lng": -118.3965,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "011d335d-6066-5c83-bc1c-2b6c3fb6a9c3",
     "slug": "cuyahoga-falls-oh-pd",
-    "flock_name": "cuyahoga-falls-oh-pd",
-    "human_name": "cuyahoga-falls-oh-pd",
+    "flock_active_slug": "cuyahoga-falls-oh-pd",
+    "flock_slugs": [
+      "cuyahoga-falls-oh-pd"
+    ],
+    "flock_names": [
+      "Cuyahoga Falls OH PD"
+    ],
+    "display_name": null,
     "lat": 41.134,
     "lng": -81.4845,
-    "public": true,
-    "federal": false,
     "state": "OH",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "5077b862-25fa-52a7-9ead-bb712a54b7af",
+    "slug": "cypress-ca-pd",
+    "flock_active_slug": "cypress-ca-pd",
+    "flock_slugs": [
+      "cypress-ca-pd"
+    ],
+    "flock_names": [
+      "Cypress CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.817,
+    "lng": -118.0374,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "34b09634-c949-542c-90ce-e790b877570d",
+    "slug": "daly-city-ca-pd",
+    "flock_active_slug": "daly-city-ca-pd",
+    "flock_slugs": [
+      "daly-city-ca-pd"
+    ],
+    "flock_names": [
+      "Daly City CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6879,
+    "lng": -122.4702,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "31c416f0-bbdb-5e25-85c1-778824309af9",
+    "slug": "danville-ca-pd",
+    "flock_active_slug": "danville-ca-pd",
+    "flock_slugs": [
+      "danville-ca-pd"
+    ],
+    "flock_names": [
+      "Danville CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8216,
+    "lng": -121.9999,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "da6219bf-6886-513d-9175-e366f2ee23b5",
+    "slug": "deactivated",
+    "flock_active_slug": "deactivated",
+    "flock_slugs": [
+      "deactivated"
+    ],
+    "flock_names": [
+      "deactivated"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "4d52aa1d-f8c9-5b7f-91b5-36999d2eb021",
     "slug": "decatur-ga-pd",
-    "flock_name": "decatur-ga-pd",
-    "human_name": "decatur-ga-pd",
+    "flock_active_slug": "decatur-ga-pd",
+    "flock_slugs": [
+      "decatur-ga-pd"
+    ],
+    "flock_names": [
+      "Decatur GA PD"
+    ],
+    "display_name": null,
     "lat": 33.7748,
     "lng": -84.2963,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "e367ebeb-dc4e-5a59-8ee8-d86b25736442",
+    "slug": "decommissioned-org",
+    "flock_active_slug": "decommissioned-org",
+    "flock_slugs": [
+      "decommissioned-org"
+    ],
+    "flock_names": [
+      "Decommissioned Org"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "098c0089-e37c-50d0-bafc-0387298e7108",
+    "slug": "del-norte-county-ca-so",
+    "flock_active_slug": "del-norte-county-ca-so",
+    "flock_slugs": [
+      "del-norte-county-ca-so"
+    ],
+    "flock_names": [
+      "Del Norte County CA SO"
+    ],
+    "display_name": null,
+    "lat": 41.7434,
+    "lng": -124.1829,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5bb589eb-0d1f-50f1-9a05-55e6b12629fa",
+    "slug": "delano-ca-pd",
+    "flock_active_slug": "delano-ca-pd",
+    "flock_slugs": [
+      "delano-ca-pd"
+    ],
+    "flock_names": [
+      "Delano CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.7688,
+    "lng": -119.2471,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "43959383-1338-5d3c-94c2-d9aad1829694",
+    "slug": "delete",
+    "flock_active_slug": "delete",
+    "flock_slugs": [
+      "delete"
+    ],
+    "flock_names": [
+      "Delete"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "c03ecf42-93c9-5546-9a18-a929ea29ba77",
+    "slug": "demo",
+    "flock_active_slug": "demo",
+    "flock_slugs": [
+      "demo"
+    ],
+    "flock_names": [
+      "Demo",
+      "demo"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "00015f2d-ad5e-5b12-9811-04b7cb13827d",
+    "slug": "desert-hot-springs-ca-pd",
+    "flock_active_slug": "desert-hot-springs-ca-pd",
+    "flock_slugs": [
+      "desert-hot-springs-ca-pd"
+    ],
+    "flock_names": [
+      "Desert Hot Springs CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9611,
+    "lng": -116.5017,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ae6099b6-dbb6-520f-b490-73add6ae3107",
+    "slug": "dinuba-ca-pd",
+    "flock_active_slug": "dinuba-ca-pd",
+    "flock_slugs": [
+      "dinuba-ca-pd"
+    ],
+    "flock_names": [
+      "Dinuba CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.543,
+    "lng": -119.3868,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5fb54f1a-394c-521b-bb40-94ea865ead79",
+    "slug": "district-12-ca",
+    "flock_active_slug": "district-12-ca",
+    "flock_slugs": [
+      "district-12-ca"
+    ],
+    "flock_names": [
+      "District #12 (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "2957f546-0539-5aaa-afd6-364ff3fce1e6",
+    "slug": "dixon-ca-pd",
+    "flock_active_slug": "dixon-ca-pd",
+    "flock_slugs": [
+      "dixon-ca-pd"
+    ],
+    "flock_names": [
+      "Dixon CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.4455,
+    "lng": -121.8233,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b5a06458-86ec-5e2f-a673-172fdf4ac1af",
+    "slug": "dnu",
+    "flock_active_slug": "dnu",
+    "flock_slugs": [
+      "dnu"
+    ],
+    "flock_names": [
+      "DNU"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "df99bb2b-942a-5619-8d74-b4f0264efea7",
+    "slug": "dnu-glendale-pd-ca-condor",
+    "flock_active_slug": "dnu-glendale-pd-ca-condor",
+    "flock_slugs": [
+      "dnu-glendale-pd-ca-condor"
+    ],
+    "flock_names": [
+      "DNU - Glendale PD CA (Condor)"
+    ],
+    "display_name": null,
+    "lat": 34.1425,
+    "lng": -118.2551,
+    "state": "CA",
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "08b3a1c0-964c-5469-aaba-f76c8586a664",
+    "slug": "dnu-santa-clara-university-campus-safety-raven",
+    "flock_active_slug": "dnu-santa-clara-university-campus-safety-raven",
+    "flock_slugs": [
+      "dnu-santa-clara-university-campus-safety-raven"
+    ],
+    "flock_names": [
+      "DNU - Santa Clara University Campus Safety (Raven)"
+    ],
+    "display_name": null,
+    "lat": 37.3496,
+    "lng": -121.939,
+    "state": null,
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
+    "website": null,
+    "notes": "Santa Clara University is a private institution. Entry marked \"Do Not Use\" by Flock but still appears in sharing lists. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "2db45201-f8c3-5a62-9900-e2abcf268b30",
     "slug": "douglas-county-nv-so",
-    "flock_name": "douglas-county-nv-so",
-    "human_name": "douglas-county-nv-so",
+    "flock_active_slug": "douglas-county-nv-so",
+    "flock_slugs": [
+      "douglas-county-nv-so"
+    ],
+    "flock_names": [
+      "Douglas County NV SO"
+    ],
+    "display_name": null,
     "lat": 38.9536,
     "lng": -119.7674,
-    "public": true,
-    "federal": false,
     "state": "NV",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "e3bce61d-e4a4-59a0-a835-ef8070a7c064",
+    "slug": "downey-pd-ca",
+    "flock_active_slug": "downey-pd-ca",
+    "flock_slugs": [
+      "downey-pd-ca"
+    ],
+    "flock_names": [
+      "Downey PD CA"
+    ],
+    "display_name": null,
+    "lat": 33.9401,
+    "lng": -118.1332,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "19a23c27-bb4b-5dfe-880b-6220986f1fa6",
     "slug": "ds-towing",
-    "flock_name": "ds-towing",
-    "human_name": "ds-towing",
+    "flock_active_slug": "ds-towing",
+    "flock_slugs": [
+      "ds-towing"
+    ],
+    "flock_names": [
+      "D&S Towing"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": null,
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "9d74c984-25bf-54bd-9971-40285a9f2eeb",
+    "slug": "dublin-ca-pd",
+    "flock_active_slug": "dublin-ca-pd",
+    "flock_slugs": [
+      "dublin-ca-pd"
+    ],
+    "flock_names": [
+      "Dublin CA PD (ACSO)"
+    ],
+    "display_name": null,
+    "lat": 37.7022,
+    "lng": -121.9358,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f7d182f6-b252-53f8-aced-f246a52d3649",
+    "slug": "duplicate-please-delete",
+    "flock_active_slug": "duplicate-please-delete",
+    "flock_slugs": [
+      "duplicate-please-delete"
+    ],
+    "flock_names": [
+      "DUPLICATE PLEASE DELETE"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "ba6dffec-c362-5bc4-b042-eef688d730a2",
+    "slug": "east-bay-parks-ca-pd",
+    "flock_active_slug": "east-bay-parks-ca-pd",
+    "flock_slugs": [
+      "east-bay-parks-ca-pd"
+    ],
+    "flock_names": [
+      "East Bay Parks CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.82,
+    "lng": -122.26,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b0bd9add-ff5d-5af4-a468-0f03eb94214e",
+    "slug": "east-palo-alto-ca-pd",
+    "flock_active_slug": "east-palo-alto-ca-pd",
+    "flock_slugs": [
+      "east-palo-alto-ca-pd"
+    ],
+    "flock_names": [
+      "East Palo Alto CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4688,
+    "lng": -122.1411,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "38d99e7e-45b3-5c40-807b-6729c8b7e37c",
+    "slug": "el-cajon-ca-pd",
+    "flock_active_slug": "el-cajon-ca-pd",
+    "flock_slugs": [
+      "el-cajon-ca-pd"
+    ],
+    "flock_names": [
+      "El Cajon CA PD"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5460d54d-6a3d-531b-a007-de6e9491f686",
+    "slug": "el-centro-ca-pd",
+    "flock_active_slug": "el-centro-ca-pd",
+    "flock_slugs": [
+      "el-centro-ca-pd"
+    ],
+    "flock_names": [
+      "El Centro CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.792,
+    "lng": -115.5631,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "cb959829-2ddf-5780-841e-4d78cf1df75e",
+    "slug": "el-cerrito-ca-pd",
+    "flock_active_slug": "el-cerrito-ca-pd",
+    "flock_slugs": [
+      "el-cerrito-ca-pd"
+    ],
+    "flock_names": [
+      "El Cerrito CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9161,
+    "lng": -122.3122,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "64da8ade-ab72-5519-8f11-b65be44e0387",
+    "slug": "el-dorado-county-ca-so",
+    "flock_active_slug": "el-dorado-county-ca-so",
+    "flock_slugs": [
+      "el-dorado-county-ca-so"
+    ],
+    "flock_names": [
+      "El Dorado County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.7296,
+    "lng": -120.7985,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "33355e4c-36f3-5437-8c38-46dca8c24adc",
+    "slug": "el-monte-ca-pd",
+    "flock_active_slug": "el-monte-ca-pd",
+    "flock_slugs": [
+      "el-monte-ca-pd"
+    ],
+    "flock_names": [
+      "El Monte CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0686,
+    "lng": -118.0276,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0e444576-90a6-5c9d-8cf1-fbb6664f54b1",
+    "slug": "el-segundo-ca-pd",
+    "flock_active_slug": "el-segundo-ca-pd",
+    "flock_slugs": [
+      "el-segundo-ca-pd"
+    ],
+    "flock_names": [
+      "El Segundo CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9192,
+    "lng": -118.4165,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "16449917-ee53-5406-ade9-4b7361ec7ba2",
+    "slug": "elk-grove-ca-pd",
+    "flock_active_slug": "elk-grove-ca-pd",
+    "flock_slugs": [
+      "elk-grove-ca-pd"
+    ],
+    "flock_names": [
+      "Elk Grove CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.4088,
+    "lng": -121.3716,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "15b98a3b-bfa1-58d9-a3ae-5a7edf5e4792",
+    "slug": "emeryville-ca-pd",
+    "flock_active_slug": "emeryville-ca-pd",
+    "flock_slugs": [
+      "emeryville-ca-pd"
+    ],
+    "flock_names": [
+      "Emeryville CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8313,
+    "lng": -122.2852,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d7e16a10-5d8e-5ca4-934e-84cefe8840dc",
     "slug": "encino-ca",
-    "flock_name": "encino-ca",
-    "human_name": "encino-ca",
+    "flock_active_slug": "encino-ca",
+    "flock_slugs": [
+      "encino-ca"
+    ],
+    "flock_names": [
+      "Encino (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "7d2b8047-a15b-524a-bc77-627e8eeab00a",
+    "slug": "escalon-ca-pd",
+    "flock_active_slug": "escalon-ca-pd",
+    "flock_slugs": [
+      "escalon-ca-pd"
+    ],
+    "flock_names": [
+      "Escalon CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7974,
+    "lng": -120.9983,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b235e69b-8b4d-5708-96c2-905c00ad9922",
+    "slug": "escondido-ca-pd",
+    "flock_active_slug": "escondido-ca-pd",
+    "flock_slugs": [
+      "escondido-ca-pd"
+    ],
+    "flock_names": [
+      "Escondido CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.1192,
+    "lng": -117.0864,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c60df435-fd2c-5e19-88b3-5a63ff760218",
+    "slug": "fairfield-ca-pd",
+    "flock_active_slug": "fairfield-ca-pd",
+    "flock_slugs": [
+      "fairfield-ca-pd"
+    ],
+    "flock_names": [
+      "Fairfield CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.2494,
+    "lng": -122.04,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d7367d10-43b4-570f-b5a1-3e8d2a4a118b",
     "slug": "fairway-eighteen-by-hqt-development-ca",
-    "flock_name": "fairway-eighteen-by-hqt-development-ca",
-    "human_name": "fairway-eighteen-by-hqt-development-ca",
+    "flock_active_slug": "fairway-eighteen-by-hqt-development-ca",
+    "flock_slugs": [
+      "fairway-eighteen-by-hqt-development-ca"
+    ],
+    "flock_names": [
+      "Fairway Eighteen by HQT Development (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "db6a00fb-f7e5-571a-9a1a-4221e0a320f9",
+    "slug": "farmersville-ca-pd",
+    "flock_active_slug": "farmersville-ca-pd",
+    "flock_slugs": [
+      "farmersville-ca-pd"
+    ],
+    "flock_names": [
+      "Farmersville CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.2991,
+    "lng": -119.2068,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5557c1c6-7c12-5720-b9a3-09763bf45365",
     "slug": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
-    "flock_name": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
-    "human_name": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
+    "flock_active_slug": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
+    "flock_slugs": [
+      "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd"
+    ],
+    "flock_names": [
+      "[Federal] Loma Linda Healthcare System CA Veterans Affairs PD"
+    ],
+    "display_name": null,
     "lat": 34.0489,
     "lng": -117.2611,
-    "public": true,
-    "federal": true,
     "state": "CA",
     "agency_role": "police",
     "agency_type": "federal",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "federal",
+      "public"
+    ]
   },
   {
+    "agency_id": "5c953e17-7cdc-54c8-a702-acf43351f0f1",
     "slug": "fedex-corporation",
-    "flock_name": "fedex-corporation",
-    "human_name": "fedex-corporation",
+    "flock_active_slug": "fedex-corporation",
+    "flock_slugs": [
+      "fedex-corporation"
+    ],
+    "flock_names": [
+      "FedEx Corporation"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": null,
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
-    "slug": "flock-safety-vendor",
-    "flock_name": "Flock Safety (vendor)",
-    "human_name": "Flock Safety",
-    "lat": 33.849,
-    "lng": -84.3734,
-    "public": false,
-    "federal": false,
-    "state": "GA",
-    "agency_role": "vendor",
-    "agency_type": "private",
-    "website": "https://www.flocksafety.com",
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false,
-    "notes": "Private surveillance vendor headquartered in Atlanta, GA. Flock MSA §5.3 grants Flock independent authority to \"access, use, preserve and/or disclose\" agency footage to law enforcement, government officials, and third parties based on Flock's own \"good faith belief\" — including for Flock's own technical purposes. No agency approval or notification required. This provision survives contract termination (§7.3). The <a href=\"https://information.auditor.ca.gov/reports/2019-118/summary.html\" target=\"_blank\">CA State Auditor (Report 2019-118)</a> found that agencies' vendor contracts lacked necessary data security safeguards and recommended agencies update vendor contracts. The subsequent <a href=\"https://oag.ca.gov/system/files/media/2023-dle-06.pdf\" target=\"_blank\">AG Bulletin 2023-DLE-06</a> directed agencies to review vendor contracts for provisions allowing non-public access to ALPR data — §5.3 is exactly the type of provision both warned about. See <a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings §5</a>."
-  },
-  {
+    "agency_id": "a0a5200d-ae91-57da-8e6c-bc14c3f42b1e",
     "slug": "florence-al-pd",
-    "flock_name": "florence-al-pd",
-    "human_name": "florence-al-pd",
+    "flock_active_slug": "florence-al-pd",
+    "flock_slugs": [
+      "florence-al-pd"
+    ],
+    "flock_names": [
+      "Florence AL PD"
+    ],
+    "display_name": null,
     "lat": 34.7998,
     "lng": -87.6773,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "040a02b2-2734-5d96-9f70-2d4b27ee2001",
+    "slug": "fms-ca",
+    "flock_active_slug": "fms-ca",
+    "flock_slugs": [
+      "fms-ca"
+    ],
+    "flock_names": [
+      "FMS (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "66a47e2e-147b-55eb-ba49-6b49239dc935",
+    "slug": "folsom-ca-pd",
+    "flock_active_slug": "folsom-ca-pd",
+    "flock_slugs": [
+      "folsom-ca-pd"
+    ],
+    "flock_names": [
+      "Folsom CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.678,
+    "lng": -121.1761,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8d40ae56-8e48-570e-b485-f6c4a4464423",
+    "slug": "fontana-ca-pd",
+    "flock_active_slug": "fontana-ca-pd",
+    "flock_slugs": [
+      "fontana-ca-pd"
+    ],
+    "flock_names": [
+      "Fontana CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0922,
+    "lng": -117.435,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dead7dd4-476d-528d-92bd-89a198d5f518",
+    "slug": "foothill-deanza-ca-pd",
+    "flock_active_slug": "foothill-deanza-ca-pd",
+    "flock_slugs": [
+      "foothill-deanza-ca-pd"
+    ],
+    "flock_names": [
+      "Foothill-DeAnza CA PD"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bbd0ce35-d614-58bb-a262-3a82219901a0",
+    "slug": "foothilldeanza-ca-pd",
+    "flock_active_slug": "foothilldeanza-ca-pd",
+    "flock_slugs": [
+      "foothilldeanza-ca-pd"
+    ],
+    "flock_names": [
+      "Foothill-DeAnza CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3616,
+    "lng": -122.1281,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4b1b2934-07f1-5b73-8ef7-9ba21535e48c",
+    "slug": "fort-bragg-ca-pd",
+    "flock_active_slug": "fort-bragg-ca-pd",
+    "flock_slugs": [
+      "fort-bragg-ca-pd"
+    ],
+    "flock_names": [
+      "Fort Bragg CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.4457,
+    "lng": -123.8053,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "65f406c8-21a0-5d6c-b021-c7ee7a8ec74b",
     "slug": "fort-worth-tx-pd",
-    "flock_name": "fort-worth-tx-pd",
-    "human_name": "fort-worth-tx-pd",
+    "flock_active_slug": "fort-worth-tx-pd",
+    "flock_slugs": [
+      "fort-worth-tx-pd"
+    ],
+    "flock_names": [
+      "Fort Worth TX PD"
+    ],
+    "display_name": null,
     "lat": 32.7555,
     "lng": -97.3308,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "c7534013-784e-5c7b-8acb-b88b2ad8dfbe",
+    "slug": "foster-city-ca-pd",
+    "flock_active_slug": "foster-city-ca-pd",
+    "flock_slugs": [
+      "foster-city-ca-pd"
+    ],
+    "flock_names": [
+      "Foster City CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5585,
+    "lng": -122.2711,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "45b18cd2-8cf5-56c3-beb5-d3ff59fb351b",
     "slug": "foster-farms-inc-ca",
-    "flock_name": "foster-farms-inc-ca",
-    "human_name": "foster-farms-inc-ca",
+    "flock_active_slug": "foster-farms-inc-ca",
+    "flock_slugs": [
+      "foster-farms-inc-ca"
+    ],
+    "flock_names": [
+      "Foster Farms Inc. (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "dc80ea1b-fec8-5415-91f6-70fea8c607ed",
+    "slug": "fountain-valley-ca-pd",
+    "flock_active_slug": "fountain-valley-ca-pd",
+    "flock_slugs": [
+      "fountain-valley-ca-pd"
+    ],
+    "flock_names": [
+      "Fountain Valley CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7092,
+    "lng": -117.9536,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "418c6009-e224-5071-9158-50c8bfaf8034",
     "slug": "fountain-walk-ca",
-    "flock_name": "fountain-walk-ca",
-    "human_name": "fountain-walk-ca",
+    "flock_active_slug": "fountain-walk-ca",
+    "flock_slugs": [
+      "fountain-walk-ca"
+    ],
+    "flock_names": [
+      "Fountain Walk (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "80f246ff-0054-5b13-84e7-6bb6fc954b50",
+    "slug": "fowler-ca-pd",
+    "flock_active_slug": "fowler-ca-pd",
+    "flock_slugs": [
+      "fowler-ca-pd"
+    ],
+    "flock_names": [
+      "Fowler CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6307,
+    "lng": -119.6809,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f296ea7d-37b7-583c-aef6-5058b2df232d",
+    "slug": "fremont-ca-pd",
+    "flock_active_slug": "fremont-ca-pd",
+    "flock_slugs": [
+      "fremont-ca-pd"
+    ],
+    "flock_names": [
+      "Fremont CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5485,
+    "lng": -121.9886,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "54ec60dd-900e-55cb-9eaf-b9db3c9481c6",
+    "slug": "fresno-ca-pd",
+    "flock_active_slug": "fresno-ca-pd",
+    "flock_slugs": [
+      "fresno-ca-pd"
+    ],
+    "flock_names": [
+      "Fresno CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.7378,
+    "lng": -119.7871,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4398b153-1fbd-5ded-9f89-bc27c442cf94",
+    "slug": "fullerton-ca-pd",
+    "flock_active_slug": "fullerton-ca-pd",
+    "flock_slugs": [
+      "fullerton-ca-pd"
+    ],
+    "flock_names": [
+      "Fullerton CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8704,
+    "lng": -117.9242,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "813bae37-fafe-5daa-ae6d-22d15479c0c9",
+    "slug": "galt-ca-pd",
+    "flock_active_slug": "galt-ca-pd",
+    "flock_slugs": [
+      "galt-ca-pd"
+    ],
+    "flock_names": [
+      "Galt CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.2546,
+    "lng": -121.3,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b79270e4-262d-5069-ba04-0e4aa6298b3d",
+    "slug": "garden-grove-ca-pd",
+    "flock_active_slug": "garden-grove-ca-pd",
+    "flock_slugs": [
+      "garden-grove-ca-pd"
+    ],
+    "flock_names": [
+      "Garden Grove CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7743,
+    "lng": -117.9379,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "211a52aa-e418-5cb5-bfaa-9e969c7a152d",
     "slug": "ggtpc-ca",
-    "flock_name": "ggtpc-ca",
-    "human_name": "ggtpc-ca",
+    "flock_active_slug": "ggtpc-ca",
+    "flock_slugs": [
+      "ggtpc-ca"
+    ],
+    "flock_names": [
+      "GGTPC (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "cf1a9b74-20d6-5ca7-8c97-47db0f62db96",
+    "slug": "gilroy-ca-pd",
+    "flock_active_slug": "gilroy-ca-pd",
+    "flock_slugs": [
+      "gilroy-ca-pd"
+    ],
+    "flock_names": [
+      "Gilroy CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.0058,
+    "lng": -121.5683,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4ff77c1c-b4cf-59cc-89fd-10897c420245",
     "slug": "glen-cove-community-association-ca",
-    "flock_name": "glen-cove-community-association-ca",
-    "human_name": "glen-cove-community-association-ca",
+    "flock_active_slug": "glen-cove-community-association-ca",
+    "flock_slugs": [
+      "glen-cove-community-association-ca"
+    ],
+    "flock_names": [
+      "Glen Cove Community Association (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "a76648d4-dba1-53e2-b8f0-f68803d13bf4",
     "slug": "glen-cove-marina-ca",
-    "flock_name": "glen-cove-marina-ca",
-    "human_name": "glen-cove-marina-ca",
+    "flock_active_slug": "glen-cove-marina-ca",
+    "flock_slugs": [
+      "glen-cove-marina-ca"
+    ],
+    "flock_names": [
+      "Glen Cove Marina (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "9f648985-e0fa-595a-acd3-3d06bc7d84c6",
     "slug": "glencoe-al-pd",
-    "flock_name": "glencoe-al-pd",
-    "human_name": "glencoe-al-pd",
+    "flock_active_slug": "glencoe-al-pd",
+    "flock_slugs": [
+      "glencoe-al-pd"
+    ],
+    "flock_names": [
+      "Glencoe AL PD"
+    ],
+    "display_name": null,
     "lat": 34.0187,
     "lng": -86.0919,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "0f00be83-72aa-50be-95be-8973e9641cfd",
+    "slug": "glendale-ca-pd",
+    "flock_active_slug": "glendale-ca-pd",
+    "flock_slugs": [
+      "glendale-ca-pd"
+    ],
+    "flock_names": [
+      "Glendale CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1425,
+    "lng": -118.2551,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "939ef9db-dfdc-5abc-b689-da79c79d085c",
+    "slug": "glendora-ca-pd",
+    "flock_active_slug": "glendora-ca-pd",
+    "flock_slugs": [
+      "glendora-ca-pd"
+    ],
+    "flock_names": [
+      "Glendora (CA) PD"
+    ],
+    "display_name": null,
+    "lat": 34.1361,
+    "lng": -117.8653,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d3abc55d-1db8-50de-9e6f-031bca3e9a07",
     "slug": "gold-hills-ca",
-    "flock_name": "gold-hills-ca",
-    "human_name": "gold-hills-ca",
+    "flock_active_slug": "gold-hills-ca",
+    "flock_slugs": [
+      "gold-hills-ca"
+    ],
+    "flock_names": [
+      "Gold Hills (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "9d8d18a4-c601-5cc0-a010-a069da1d4820",
     "slug": "goodland-avenue-ca",
-    "flock_name": "goodland-avenue-ca",
-    "human_name": "goodland-avenue-ca",
+    "flock_active_slug": "goodland-avenue-ca",
+    "flock_slugs": [
+      "goodland-avenue-ca"
+    ],
+    "flock_names": [
+      "Goodland Avenue (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "68f7ba36-e76d-5e86-919f-f3e572a3e40d",
     "slug": "goshen-in-pd",
-    "flock_name": "goshen-in-pd",
-    "human_name": "goshen-in-pd",
+    "flock_active_slug": "goshen-in-pd",
+    "flock_slugs": [
+      "goshen-in-pd"
+    ],
+    "flock_names": [
+      "Goshen IN PD"
+    ],
+    "display_name": null,
     "lat": 41.5823,
     "lng": -85.8347,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "abd9ac18-4eff-57ec-9008-7c62a27c374c",
+    "slug": "goshen-village-ny-pd",
+    "flock_active_slug": "goshen-village-ny-pd",
+    "flock_slugs": [
+      "goshen-village-ny-pd"
+    ],
+    "flock_names": [
+      "Goshen Village NY PD"
+    ],
+    "display_name": null,
+    "lat": 41.3812,
+    "lng": -74.324,
+    "state": "NY",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f918e92d-ce22-5c49-96f3-241cc46df474",
     "slug": "grants-pass-or-pd",
-    "flock_name": "grants-pass-or-pd",
-    "human_name": "grants-pass-or-pd",
+    "flock_active_slug": "grants-pass-or-pd",
+    "flock_slugs": [
+      "grants-pass-or-pd"
+    ],
+    "flock_names": [
+      "Grants Pass OR PD"
+    ],
+    "display_name": null,
     "lat": 42.439,
     "lng": -123.3284,
-    "public": true,
-    "federal": false,
     "state": "OR",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "4936c402-8bf3-5c0a-9f55-f85aa0e5df48",
+    "slug": "grass-valley-ca-pd",
+    "flock_active_slug": "grass-valley-ca-pd",
+    "flock_slugs": [
+      "grass-valley-ca-pd"
+    ],
+    "flock_names": [
+      "Grass Valley CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.219,
+    "lng": -121.0611,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e9c8dd45-83aa-52bd-84a7-74f535d37604",
     "slug": "great-wolf-lodge-corporate",
-    "flock_name": "great-wolf-lodge-corporate",
-    "human_name": "great-wolf-lodge-corporate",
+    "flock_active_slug": "great-wolf-lodge-corporate",
+    "flock_slugs": [
+      "great-wolf-lodge-corporate"
+    ],
+    "flock_names": [
+      "Great Wolf Lodge - Corporate"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "270fd3ce-aefb-503a-82e0-36ea52c1ba28",
+    "slug": "greenfield-ca-pd",
+    "flock_active_slug": "greenfield-ca-pd",
+    "flock_slugs": [
+      "greenfield-ca-pd"
+    ],
+    "flock_names": [
+      "Greenfield CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.3208,
+    "lng": -121.2438,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6e00bdda-c3f3-5c16-81d8-22d6009bfb37",
+    "slug": "grover-beach-ca-pd",
+    "flock_active_slug": "grover-beach-ca-pd",
+    "flock_slugs": [
+      "grover-beach-ca-pd"
+    ],
+    "flock_names": [
+      "Grover Beach CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.1217,
+    "lng": -120.621,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d0843cde-d450-5617-b977-103218524b39",
+    "slug": "gustine-pd-ca",
+    "flock_active_slug": "gustine-pd-ca",
+    "flock_slugs": [
+      "gustine-pd-ca"
+    ],
+    "flock_names": [
+      "Gustine PD CA"
+    ],
+    "display_name": null,
+    "lat": 37.2577,
+    "lng": -120.9983,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "14c8d3ff-2f0c-5b4a-a82b-3b75e10d4bec",
+    "slug": "hanford-ca-pd",
+    "flock_active_slug": "hanford-ca-pd",
+    "flock_slugs": [
+      "hanford-ca-pd"
+    ],
+    "flock_names": [
+      "Hanford CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.3274,
+    "lng": -119.6457,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4cea309b-ec8b-5ba0-a4cd-7218383c9f01",
     "slug": "hardin-county-tn-so",
-    "flock_name": "hardin-county-tn-so",
-    "human_name": "hardin-county-tn-so",
+    "flock_active_slug": "hardin-county-tn-so",
+    "flock_slugs": [
+      "hardin-county-tn-so"
+    ],
+    "flock_names": [
+      "Hardin County TN SO"
+    ],
+    "display_name": null,
     "lat": 35.1987,
     "lng": -88.1826,
-    "public": true,
-    "federal": false,
     "state": "TN",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "97649e58-de88-55fd-856e-6dcf8f23f518",
     "slug": "haven-north-village",
-    "flock_name": "haven-north-village",
-    "human_name": "haven-north-village",
+    "flock_active_slug": "haven-north-village",
+    "flock_slugs": [
+      "haven-north-village"
+    ],
+    "flock_names": [
+      "Haven North Village"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": null,
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "9535f26d-b219-55da-bb80-7de676b4b0ed",
     "slug": "hawks-pointe-ca",
-    "flock_name": "hawks-pointe-ca",
-    "human_name": "hawks-pointe-ca",
+    "flock_active_slug": "hawks-pointe-ca",
+    "flock_slugs": [
+      "hawks-pointe-ca"
+    ],
+    "flock_names": [
+      "Hawks Pointe (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "38082941-85be-5f33-9a53-20afd458675a",
+    "slug": "hawthorne-ca-pd",
+    "flock_active_slug": "hawthorne-ca-pd",
+    "flock_slugs": [
+      "hawthorne-ca-pd"
+    ],
+    "flock_names": [
+      "Hawthorne CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9164,
+    "lng": -118.3526,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "831b5ef5-d075-5433-b2d0-60f3a4e95ecd",
+    "slug": "hayward-ca-pd",
+    "flock_active_slug": "hayward-ca-pd",
+    "flock_slugs": [
+      "hayward-ca-pd"
+    ],
+    "flock_names": [
+      "Hayward CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6688,
+    "lng": -122.0808,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ad35fbf9-4e02-5b42-b917-16bbe751564d",
+    "slug": "healdsburg-ca-pd",
+    "flock_active_slug": "healdsburg-ca-pd",
+    "flock_slugs": [
+      "healdsburg-ca-pd"
+    ],
+    "flock_names": [
+      "Healdsburg CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.6127,
+    "lng": -122.8694,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b6c359ce-910d-5e1c-b894-638cc3830c87",
     "slug": "helena-al-pd",
-    "flock_name": "helena-al-pd",
-    "human_name": "helena-al-pd",
+    "flock_active_slug": "helena-al-pd",
+    "flock_slugs": [
+      "helena-al-pd"
+    ],
+    "flock_names": [
+      "Helena AL PD"
+    ],
+    "display_name": null,
     "lat": 33.2968,
     "lng": -86.8436,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "13422e46-1750-5a1f-865c-a7219949a2ef",
+    "slug": "hemet-ca-pd",
+    "flock_active_slug": "hemet-ca-pd",
+    "flock_slugs": [
+      "hemet-ca-pd"
+    ],
+    "flock_names": [
+      "Hemet CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7475,
+    "lng": -116.9719,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ab72c709-a28e-5f83-b6ab-8dfe17c4cd40",
     "slug": "hendry-county-fl-so",
-    "flock_name": "hendry-county-fl-so",
-    "human_name": "hendry-county-fl-so",
+    "flock_active_slug": "hendry-county-fl-so",
+    "flock_slugs": [
+      "hendry-county-fl-so"
+    ],
+    "flock_names": [
+      "Hendry County FL SO"
+    ],
+    "display_name": null,
     "lat": 26.6834,
     "lng": -81.1437,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "8cfa53d1-ebc8-5d81-a3f0-ce26a8299bf3",
+    "slug": "hercules-ca-pd",
+    "flock_active_slug": "hercules-ca-pd",
+    "flock_slugs": [
+      "hercules-ca-pd"
+    ],
+    "flock_names": [
+      "Hercules CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.0172,
+    "lng": -122.2886,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e9d63958-c540-592f-aeb5-6fc9953296ef",
+    "slug": "hermosa-beach-pd-ca",
+    "flock_active_slug": "hermosa-beach-pd-ca",
+    "flock_slugs": [
+      "hermosa-beach-pd-ca"
+    ],
+    "flock_names": [
+      "Hermosa Beach PD CA"
+    ],
+    "display_name": null,
+    "lat": 33.8622,
+    "lng": -118.3995,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "06983d50-75a9-526c-9de2-fc7a4e530efd",
     "slug": "heron-bay-spyglass-hills-homeowners-association-ca",
-    "flock_name": "heron-bay-spyglass-hills-homeowners-association-ca",
-    "human_name": "heron-bay-spyglass-hills-homeowners-association-ca",
+    "flock_active_slug": "heron-bay-spyglass-hills-homeowners-association-ca",
+    "flock_slugs": [
+      "heron-bay-spyglass-hills-homeowners-association-ca"
+    ],
+    "flock_names": [
+      "Heron Bay Spyglass Hills Homeowners Association (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "c673daa5-68e3-565b-894d-638a7ff7704d",
     "slug": "hestia-lei-ca",
-    "flock_name": "hestia-lei-ca",
-    "human_name": "hestia-lei-ca",
+    "flock_active_slug": "hestia-lei-ca",
+    "flock_slugs": [
+      "hestia-lei-ca"
+    ],
+    "flock_names": [
+      "Hestia Lei (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "427dee70-92d1-5f3d-a2eb-d81f1a69251f",
     "slug": "hiddenbrooke-ca",
-    "flock_name": "hiddenbrooke-ca",
-    "human_name": "hiddenbrooke-ca",
+    "flock_active_slug": "hiddenbrooke-ca",
+    "flock_slugs": [
+      "hiddenbrooke-ca"
+    ],
+    "flock_names": [
+      "Hiddenbrooke (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "1a3173cf-12ce-5cb8-8b2e-d55f3c7a90dc",
     "slug": "highlands-hoa-ca",
-    "flock_name": "highlands-hoa-ca",
-    "human_name": "highlands-hoa-ca",
+    "flock_active_slug": "highlands-hoa-ca",
+    "flock_slugs": [
+      "highlands-hoa-ca"
+    ],
+    "flock_names": [
+      "Highlands HOA (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "630e2a4f-d617-5e89-bb13-9149c710e3ec",
+    "slug": "hillsborough-ca-pd",
+    "flock_active_slug": "hillsborough-ca-pd",
+    "flock_slugs": [
+      "hillsborough-ca-pd"
+    ],
+    "flock_names": [
+      "Hillsborough CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5741,
+    "lng": -122.3794,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d30e791e-779f-59ff-b24d-c5b05a3798ab",
     "slug": "hillside-il-pd",
-    "flock_name": "hillside-il-pd",
-    "human_name": "hillside-il-pd",
+    "flock_active_slug": "hillside-il-pd",
+    "flock_slugs": [
+      "hillside-il-pd"
+    ],
+    "flock_names": [
+      "Hillside IL PD"
+    ],
+    "display_name": null,
     "lat": 41.8778,
     "lng": -87.9015,
-    "public": true,
-    "federal": false,
     "state": "IL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "000dcf5b-5217-5ca6-aa52-9139bdfab38d",
     "slug": "holiday-gardens-ca",
-    "flock_name": "holiday-gardens-ca",
-    "human_name": "holiday-gardens-ca",
+    "flock_active_slug": "holiday-gardens-ca",
+    "flock_slugs": [
+      "holiday-gardens-ca"
+    ],
+    "flock_names": [
+      "Holiday Gardens (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "a3181593-1121-5cc0-aae2-beb7d164ed58",
+    "slug": "hollister-ca-pd",
+    "flock_active_slug": "hollister-ca-pd",
+    "flock_slugs": [
+      "hollister-ca-pd"
+    ],
+    "flock_names": [
+      "Hollister CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.8525,
+    "lng": -121.4016,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fdac9783-5c94-569a-a931-165dcb32a434",
     "slug": "home-depot-corporation",
-    "flock_name": "home-depot-corporation",
-    "human_name": "home-depot-corporation",
+    "flock_active_slug": "home-depot-corporation",
+    "flock_slugs": [
+      "home-depot-corporation"
+    ],
+    "flock_names": [
+      "Home Depot Corporation"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": null,
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "cdf53878-f007-5349-82c3-c198d69e4737",
     "slug": "houston-metro-transit-authority-tx",
-    "flock_name": "houston-metro-transit-authority-tx",
-    "human_name": "houston-metro-transit-authority-tx",
+    "flock_active_slug": "houston-metro-transit-authority-tx",
+    "flock_slugs": [
+      "houston-metro-transit-authority-tx"
+    ],
+    "flock_names": [
+      "Houston Metro Transit Authority (TX)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "030b796b-eb59-5d03-8f7f-b1d5ce1a005c",
     "slug": "houston-tx-pd",
-    "flock_name": "houston-tx-pd",
-    "human_name": "houston-tx-pd",
+    "flock_active_slug": "houston-tx-pd",
+    "flock_slugs": [
+      "houston-tx-pd"
+    ],
+    "flock_names": [
+      "Houston TX PD"
+    ],
+    "display_name": null,
     "lat": 29.7604,
     "lng": -95.3698,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "e881b333-fb53-5bec-9510-9d3c68095e89",
+    "slug": "humboldt-county-ca-so",
+    "flock_active_slug": "humboldt-county-ca-so",
+    "flock_slugs": [
+      "humboldt-county-ca-so"
+    ],
+    "flock_names": [
+      "Humboldt County CA SO"
+    ],
+    "display_name": null,
+    "lat": 40.745,
+    "lng": -123.8695,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "22be4e07-6927-58af-b2fe-b74885b935ec",
     "slug": "hunters-trail-ca",
-    "flock_name": "hunters-trail-ca",
-    "human_name": "hunters-trail-ca",
+    "flock_active_slug": "hunters-trail-ca",
+    "flock_slugs": [
+      "hunters-trail-ca"
+    ],
+    "flock_names": [
+      "Hunters Trail (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "27d3370c-1004-57a6-b76f-c2efedaefc53",
+    "slug": "huntington-beach-ca-pd",
+    "flock_active_slug": "huntington-beach-ca-pd",
+    "flock_slugs": [
+      "huntington-beach-ca-pd"
+    ],
+    "flock_names": [
+      "Huntington Beach CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6595,
+    "lng": -117.9988,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b9ffc1f3-6d5d-58c4-9b67-baadaa5fbb64",
     "slug": "huntsville-al-pd",
-    "flock_name": "huntsville-al-pd",
-    "human_name": "huntsville-al-pd",
+    "flock_active_slug": "huntsville-al-pd",
+    "flock_slugs": [
+      "huntsville-al-pd"
+    ],
+    "flock_names": [
+      "Huntsville AL PD"
+    ],
+    "display_name": null,
     "lat": 34.7304,
     "lng": -86.5861,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "55db20ff-e7cc-54e9-8115-34d66ff7e188",
+    "slug": "imperial-city-ca-pd",
+    "flock_active_slug": "imperial-city-ca-pd",
+    "flock_slugs": [
+      "imperial-city-ca-pd"
+    ],
+    "flock_names": [
+      "Imperial City CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.8473,
+    "lng": -115.5694,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "862d352e-a1e3-5445-b9ad-abb1a479b8bf",
+    "slug": "imperial-county-ca-so",
+    "flock_active_slug": "imperial-county-ca-so",
+    "flock_slugs": [
+      "imperial-county-ca-so"
+    ],
+    "flock_names": [
+      "Imperial County CA SO"
+    ],
+    "display_name": null,
+    "lat": 32.8473,
+    "lng": -115.5694,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3",
+    "slug": "indio-ca-pd",
+    "flock_active_slug": "indio-ca-pd",
+    "flock_slugs": [
+      "indio-ca-pd"
+    ],
+    "flock_names": [
+      "Indio CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7206,
+    "lng": -116.2156,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "981e7edd-d5e6-549a-9c63-9f5e6e6238a9",
+    "slug": "inglewood-ca-pd",
+    "flock_active_slug": "inglewood-ca-pd",
+    "flock_slugs": [
+      "inglewood-ca-pd"
+    ],
+    "flock_names": [
+      "Inglewood CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9617,
+    "lng": -118.3531,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "af06af64-75fc-584c-bae8-75df54671e05",
     "slug": "irondale-al-pd",
-    "flock_name": "irondale-al-pd",
-    "human_name": "irondale-al-pd",
+    "flock_active_slug": "irondale-al-pd",
+    "flock_slugs": [
+      "irondale-al-pd"
+    ],
+    "flock_names": [
+      "Irondale AL PD"
+    ],
+    "display_name": null,
     "lat": 33.5382,
     "lng": -86.7069,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "62bc6f36-2586-513f-b541-c9a4bcd1cfb7",
     "slug": "ironridge-at-portola-hills-ca",
-    "flock_name": "ironridge-at-portola-hills-ca",
-    "human_name": "ironridge-at-portola-hills-ca",
+    "flock_active_slug": "ironridge-at-portola-hills-ca",
+    "flock_slugs": [
+      "ironridge-at-portola-hills-ca"
+    ],
+    "flock_names": [
+      "IronRidge at Portola Hills (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "42ac4d61-32cd-5fa4-aa11-b6713123a5c7",
+    "slug": "irvine-ca-pd",
+    "flock_active_slug": "irvine-ca-pd",
+    "flock_slugs": [
+      "irvine-ca-pd"
+    ],
+    "flock_names": [
+      "Irvine CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6846,
+    "lng": -117.8265,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c1460b89-41f6-5f80-8e31-203920db6642",
+    "slug": "irwindale-ca-pd",
+    "flock_active_slug": "irwindale-ca-pd",
+    "flock_slugs": [
+      "irwindale-ca-pd"
+    ],
+    "flock_names": [
+      "Irwindale CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.107,
+    "lng": -117.9351,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fad50c3f-54b7-5bac-9093-b41b977dac71",
+    "slug": "jaime-le-training",
+    "flock_active_slug": "jaime-le-training",
+    "flock_slugs": [
+      "jaime-le-training"
+    ],
+    "flock_names": [
+      "Jaime LE Training"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "3ecbed4b-50ac-597f-bba9-52444f7189f7",
     "slug": "jasper-county-in-so",
-    "flock_name": "jasper-county-in-so",
-    "human_name": "jasper-county-in-so",
+    "flock_active_slug": "jasper-county-in-so",
+    "flock_slugs": [
+      "jasper-county-in-so"
+    ],
+    "flock_names": [
+      "Jasper County IN SO"
+    ],
+    "display_name": null,
     "lat": 40.9318,
     "lng": -87.0947,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "e67b2296-f7a6-5fcd-96d8-ea4b91c8c534",
     "slug": "jonesboro-ar-pd",
-    "flock_name": "jonesboro-ar-pd",
-    "human_name": "jonesboro-ar-pd",
+    "flock_active_slug": "jonesboro-ar-pd",
+    "flock_slugs": [
+      "jonesboro-ar-pd"
+    ],
+    "flock_names": [
+      "Jonesboro AR PD"
+    ],
+    "display_name": null,
     "lat": 35.8423,
     "lng": -90.7043,
-    "public": true,
-    "federal": false,
     "state": "AR",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "48636429-a55b-5204-806a-38b27f2f94dd",
+    "slug": "kensington-ca-pd",
+    "flock_active_slug": "kensington-ca-pd",
+    "flock_slugs": [
+      "kensington-ca-pd"
+    ],
+    "flock_names": [
+      "Kensington CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9103,
+    "lng": -122.2802,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7929aea5-907c-554a-be3f-2e9053c94df8",
+    "slug": "kerman-ca-pd",
+    "flock_active_slug": "kerman-ca-pd",
+    "flock_slugs": [
+      "kerman-ca-pd"
+    ],
+    "flock_names": [
+      "Kerman CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.7236,
+    "lng": -120.0596,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1360ff78-db4c-529a-b889-81746642325e",
+    "slug": "kern-county-ca-so",
+    "flock_active_slug": "kern-county-ca-so",
+    "flock_slugs": [
+      "kern-county-ca-so"
+    ],
+    "flock_names": [
+      "Kern County CA SO"
+    ],
+    "display_name": null,
+    "lat": 35.3733,
+    "lng": -118.9515,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b2a9efa4-a1a1-5962-9f3f-4d36a50cce99",
     "slug": "kerrigan-ranch-ii-ca",
-    "flock_name": "kerrigan-ranch-ii-ca",
-    "human_name": "kerrigan-ranch-ii-ca",
+    "flock_active_slug": "kerrigan-ranch-ii-ca",
+    "flock_slugs": [
+      "kerrigan-ranch-ii-ca"
+    ],
+    "flock_names": [
+      "Kerrigan Ranch II (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "e5ddd1d8-36a1-5879-9dd6-9b9b36fbda83",
+    "slug": "kings-county-ca-das-office",
+    "flock_active_slug": "kings-county-ca-das-office",
+    "flock_slugs": [
+      "kings-county-ca-das-office"
+    ],
+    "flock_names": [
+      "Kings County CA DAs Office"
+    ],
+    "display_name": null,
+    "lat": 36.0988,
+    "lng": -119.8159,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e1477d78-c4eb-51cb-956d-8fe1cf3ab242",
+    "slug": "kings-county-sheriffs-office-ca",
+    "flock_active_slug": "kings-county-sheriffs-office-ca",
+    "flock_slugs": [
+      "kings-county-sheriffs-office-ca"
+    ],
+    "flock_names": [
+      "Kings County Sheriff's Office CA"
+    ],
+    "display_name": null,
+    "lat": 36.3274,
+    "lng": -119.6457,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0eef94a0-897c-5598-902b-a289e5f23e28",
+    "slug": "kingsburg-ca-pd",
+    "flock_active_slug": "kingsburg-ca-pd",
+    "flock_slugs": [
+      "kingsburg-ca-pd"
+    ],
+    "flock_names": [
+      "Kingsburg CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.5136,
+    "lng": -119.5537,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4219823b-c553-51fd-9a9b-5618cb5f82b5",
+    "slug": "la-habra-ca-pd",
+    "flock_active_slug": "la-habra-ca-pd",
+    "flock_slugs": [
+      "la-habra-ca-pd"
+    ],
+    "flock_names": [
+      "La Habra CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9319,
+    "lng": -117.9462,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dbfeb93f-10ea-5aaf-8862-a6b186764b79",
+    "slug": "la-mesa-ca-pd",
+    "flock_active_slug": "la-mesa-ca-pd",
+    "flock_slugs": [
+      "la-mesa-ca-pd"
+    ],
+    "flock_names": [
+      "La Mesa CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.7679,
+    "lng": -117.0231,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7bcfacdc-986f-51c5-b5fb-fa8e89d4baa3",
     "slug": "la-paz-county-az-so",
-    "flock_name": "la-paz-county-az-so",
-    "human_name": "la-paz-county-az-so",
+    "flock_active_slug": "la-paz-county-az-so",
+    "flock_slugs": [
+      "la-paz-county-az-so"
+    ],
+    "flock_names": [
+      "La Paz County AZ SO"
+    ],
+    "display_name": null,
     "lat": 33.7312,
     "lng": -113.9836,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "727915ef-bda7-5399-8e79-0369d7bb7782",
+    "slug": "la-verne-ca-pd",
+    "flock_active_slug": "la-verne-ca-pd",
+    "flock_slugs": [
+      "la-verne-ca-pd"
+    ],
+    "flock_names": [
+      "La Verne CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1008,
+    "lng": -117.7678,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8cbeae6b-148f-5f0b-b524-a90475b8f2c2",
     "slug": "la-verne-live-oak-ca",
-    "flock_name": "la-verne-live-oak-ca",
-    "human_name": "la-verne-live-oak-ca",
+    "flock_active_slug": "la-verne-live-oak-ca",
+    "flock_slugs": [
+      "la-verne-live-oak-ca"
+    ],
+    "flock_names": [
+      "La Verne Live Oak (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "59158344-4894-55be-bc8a-de15bcb986f0",
+    "slug": "laguna-beach-ca-pd",
+    "flock_active_slug": "laguna-beach-ca-pd",
+    "flock_slugs": [
+      "laguna-beach-ca-pd"
+    ],
+    "flock_names": [
+      "Laguna Beach CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.5427,
+    "lng": -117.7854,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "16cc7aa1-493e-5033-9e5b-a315703c8c40",
+    "slug": "lake-county-ca-so",
+    "flock_active_slug": "lake-county-ca-so",
+    "flock_slugs": [
+      "lake-county-ca-so"
+    ],
+    "flock_names": [
+      "Lake County CA SO"
+    ],
+    "display_name": null,
+    "lat": 39.0429,
+    "lng": -122.7538,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "65131837-e542-51b5-9c61-28181333089f",
+    "slug": "lake-county-da-ca",
+    "flock_active_slug": "lake-county-da-ca",
+    "flock_slugs": [
+      "lake-county-da-ca"
+    ],
+    "flock_names": [
+      "Lake County DA CA"
+    ],
+    "display_name": null,
+    "lat": 39.0429,
+    "lng": -122.7538,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "80913cc4-83c1-5cbf-8002-39e41fc36521",
     "slug": "lake-havasu-city-az-pd",
-    "flock_name": "lake-havasu-city-az-pd",
-    "human_name": "lake-havasu-city-az-pd",
+    "flock_active_slug": "lake-havasu-city-az-pd",
+    "flock_slugs": [
+      "lake-havasu-city-az-pd"
+    ],
+    "flock_names": [
+      "Lake Havasu City AZ PD"
+    ],
+    "display_name": null,
     "lat": 34.4839,
     "lng": -114.3224,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "4d51cf25-3dd8-5b26-ae54-6c0b50511be2",
+    "slug": "lakeport-ca-pd",
+    "flock_active_slug": "lakeport-ca-pd",
+    "flock_slugs": [
+      "lakeport-ca-pd"
+    ],
+    "flock_names": [
+      "Lakeport CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.0432,
+    "lng": -122.9158,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "aecd81f3-fb7f-579a-895a-44d90a82a427",
+    "slug": "lancaster-ca-pd",
+    "flock_active_slug": "lancaster-ca-pd",
+    "flock_slugs": [
+      "lancaster-ca-pd"
+    ],
+    "flock_names": [
+      "Lancaster CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.6868,
+    "lng": -118.1542,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "852accd8-58d8-5121-8906-3c8bb117e303",
     "slug": "landmark-limited-group-of-companies",
-    "flock_name": "landmark-limited-group-of-companies",
-    "human_name": "landmark-limited-group-of-companies",
+    "flock_active_slug": "landmark-limited-group-of-companies",
+    "flock_slugs": [
+      "landmark-limited-group-of-companies"
+    ],
+    "flock_names": [
+      "Landmark Limited Group of Companies"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "03f39921-e81f-5d88-ba5a-cf79a6969ecb",
     "slug": "las-vegas-metro-nv-pd",
-    "flock_name": "las-vegas-metro-nv-pd",
-    "human_name": "las-vegas-metro-nv-pd",
+    "flock_active_slug": "las-vegas-metro-nv-pd",
+    "flock_slugs": [
+      "las-vegas-metro-nv-pd"
+    ],
+    "flock_names": [
+      "Las Vegas Metro NV PD"
+    ],
+    "display_name": null,
     "lat": 36.1699,
     "lng": -115.1398,
-    "public": true,
-    "federal": false,
     "state": "NV",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "lexington-sc-pd",
-    "flock_name": "lexington-sc-pd",
-    "human_name": "lexington-sc-pd",
-    "lat": 33.9816,
-    "lng": -81.2368,
-    "public": true,
-    "federal": false,
-    "state": "SC",
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
-  },
-  {
-    "slug": "longshore-cove-ca",
-    "flock_name": "longshore-cove-ca",
-    "human_name": "longshore-cove-ca",
-    "lat": null,
-    "lng": null,
-    "public": null,
-    "federal": false,
+    "agency_id": "7b4d182e-412e-59e3-9967-75d4f4f1bedf",
+    "slug": "lasd-ca-san-dimas-station",
+    "flock_active_slug": "lasd-ca-san-dimas-station",
+    "flock_slugs": [
+      "lasd-ca-san-dimas-station"
+    ],
+    "flock_names": [
+      "LASD CA - San Dimas Station"
+    ],
+    "display_name": null,
+    "lat": 34.1067,
+    "lng": -117.8087,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "lowes-corporation",
-    "flock_name": "lowes-corporation",
-    "human_name": "lowes-corporation",
+    "agency_id": "ad5d1953-7d8a-5cf5-b0c7-c7c12bd430d3",
+    "slug": "lassen-county-so-ca",
+    "flock_active_slug": "lassen-county-so-ca",
+    "flock_slugs": [
+      "lassen-county-so-ca"
+    ],
+    "flock_names": [
+      "Lassen County SO (CA)"
+    ],
+    "display_name": null,
+    "lat": 40.6736,
+    "lng": -120.7253,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7932e34a-0d6d-524b-9e26-543d66b8b93c",
+    "slug": "lathrop-ca-pd",
+    "flock_active_slug": "lathrop-ca-pd",
+    "flock_slugs": [
+      "lathrop-ca-pd"
+    ],
+    "flock_names": [
+      "Lathrop CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8227,
+    "lng": -121.2766,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "70d9a3e7-a4b3-5ecd-b578-24c2d48ba88d",
+    "slug": "lexington-sc-pd",
+    "flock_active_slug": "lexington-sc-pd",
+    "flock_slugs": [
+      "lexington-sc-pd"
+    ],
+    "flock_names": [
+      "Lexington SC PD"
+    ],
+    "display_name": null,
+    "lat": 33.9816,
+    "lng": -81.2368,
+    "state": "SC",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c0f0a490-a28c-5b8e-ac71-76e025e7eb56",
+    "slug": "lincoln-ca-pd",
+    "flock_active_slug": "lincoln-ca-pd",
+    "flock_slugs": [
+      "lincoln-ca-pd"
+    ],
+    "flock_names": [
+      "Lincoln CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.8916,
+    "lng": -121.293,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "094c575d-913f-5b3c-b633-90c27e848019",
+    "slug": "lindsay-public-safety-department-ca",
+    "flock_active_slug": "lindsay-public-safety-department-ca",
+    "flock_slugs": [
+      "lindsay-public-safety-department-ca"
+    ],
+    "flock_names": [
+      "Lindsay Public Safety Department CA"
+    ],
+    "display_name": null,
+    "lat": 36.203,
+    "lng": -119.0882,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ddaa717b-703e-5c02-8e9c-9563ebd8c802",
+    "slug": "livermore-ca-pd",
+    "flock_active_slug": "livermore-ca-pd",
+    "flock_slugs": [
+      "livermore-ca-pd"
+    ],
+    "flock_names": [
+      "Livermore CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6819,
+    "lng": -121.7681,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b983130e-fd65-5a8e-82bd-dcc8b2d5ebf3",
+    "slug": "livingston-ca-pd",
+    "flock_active_slug": "livingston-ca-pd",
+    "flock_slugs": [
+      "livingston-ca-pd"
+    ],
+    "flock_names": [
+      "Livingston CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3866,
+    "lng": -120.7233,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "342036b0-c959-5952-bfc1-f2e721024ec3",
+    "slug": "llc",
+    "flock_active_slug": "llc",
+    "flock_slugs": [
+      "llc"
+    ],
+    "flock_names": [
+      "LLC"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
+    "state": null,
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "389380ba-15bd-57ec-ba01-eeea7cf065ed",
+    "slug": "lodi-ca-pd",
+    "flock_active_slug": "lodi-ca-pd",
+    "flock_slugs": [
+      "lodi-ca-pd"
+    ],
+    "flock_names": [
+      "Lodi CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.1302,
+    "lng": -121.2724,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "490b8e5f-60a4-500f-921c-fba678d7d2bb",
+    "slug": "lompoc-ca-pd",
+    "flock_active_slug": "lompoc-ca-pd",
+    "flock_slugs": [
+      "lompoc-ca-pd"
+    ],
+    "flock_names": [
+      "Lompoc CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.6392,
+    "lng": -120.4579,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "980706f2-3871-5539-b697-f6718fd0cc87",
+    "slug": "longshore-cove-ca",
+    "flock_active_slug": "longshore-cove-ca",
+    "flock_slugs": [
+      "longshore-cove-ca"
+    ],
+    "flock_names": [
+      "Longshore Cove (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "ea91bafe-b935-5f29-bf40-896f155a1d1c",
+    "slug": "los-alamitos-pd-ca",
+    "flock_active_slug": "los-alamitos-pd-ca",
+    "flock_slugs": [
+      "los-alamitos-pd-ca"
+    ],
+    "flock_names": [
+      "Los Alamitos PD CA"
+    ],
+    "display_name": null,
+    "lat": 33.8031,
+    "lng": -118.0726,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e1a20804-c286-5bfd-8967-06a5293c5d2c",
+    "slug": "los-alto-hills-ca-pd",
+    "flock_active_slug": "los-alto-hills-ca-pd",
+    "flock_slugs": [
+      "los-alto-hills-ca-pd"
+    ],
+    "flock_names": [
+      "Los Alto Hills CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3796,
+    "lng": -122.1377,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "30c59ff7-8ee9-51ca-95a7-3dad69eba35f",
+    "slug": "los-altos-ca-pd",
+    "flock_active_slug": "los-altos-ca-pd",
+    "flock_slugs": [
+      "los-altos-ca-pd"
+    ],
+    "flock_names": [
+      "Los Altos CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3852,
+    "lng": -122.1141,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a17a8e7d-6ebb-50e2-ad83-14ecd689e810",
+    "slug": "los-angeles-ca-pd",
+    "flock_active_slug": "los-angeles-ca-pd",
+    "flock_slugs": [
+      "los-angeles-ca-pd"
+    ],
+    "flock_names": [
+      "Los Angeles CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0522,
+    "lng": -118.2437,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "943b3fc4-e976-51f5-b793-7f83c9ed9076",
+    "slug": "los-angeles-county-ca-sd",
+    "flock_active_slug": "los-angeles-county-ca-sd",
+    "flock_slugs": [
+      "los-angeles-county-ca-sd"
+    ],
+    "flock_names": [
+      "Los Angeles County CA SD"
+    ],
+    "display_name": null,
+    "lat": 34.0587,
+    "lng": -118.2114,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "94fd017f-e470-5a9f-b74f-8c73c4c26660",
+    "slug": "los-angeles-port-police-ca",
+    "flock_active_slug": "los-angeles-port-police-ca",
+    "flock_slugs": [
+      "los-angeles-port-police-ca"
+    ],
+    "flock_names": [
+      "Los Angeles Port Police CA"
+    ],
+    "display_name": null,
+    "lat": 33.7361,
+    "lng": -118.2639,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0f6fb381-e42b-5b54-8e4b-9fca368f3693",
+    "slug": "los-gatos-ca-pd",
+    "flock_active_slug": "los-gatos-ca-pd",
+    "flock_slugs": [
+      "los-gatos-ca-pd"
+    ],
+    "flock_names": [
+      "Town of Los Gatos CA"
+    ],
+    "display_name": null,
+    "lat": 37.2358,
+    "lng": -121.9624,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1d149e61-3d04-531d-87d2-8e2ec6e0844a",
+    "slug": "lowes-corporation",
+    "flock_active_slug": "lowes-corporation",
+    "flock_slugs": [
+      "lowes-corporation"
+    ],
+    "flock_names": [
+      "Lowe's Corporation"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": null,
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "1cec8612-4875-5e97-b85c-226bd1702c2c",
+    "slug": "madera-ca-pd",
+    "flock_active_slug": "madera-ca-pd",
+    "flock_slugs": [
+      "madera-ca-pd"
+    ],
+    "flock_names": [
+      "Madera CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.9613,
+    "lng": -120.0607,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e7331865-34fd-5831-8028-c63398d95e55",
+    "slug": "madera-county-so-ca",
+    "flock_active_slug": "madera-county-so-ca",
+    "flock_slugs": [
+      "madera-county-so-ca"
+    ],
+    "flock_names": [
+      "Madera County SO CA"
+    ],
+    "display_name": null,
+    "lat": 37.218,
+    "lng": -119.7631,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "99d9bd61-b63e-56a4-b58e-f81858136cd1",
     "slug": "mahoning-twp-pa-pd",
-    "flock_name": "mahoning-twp-pa-pd",
-    "human_name": "mahoning-twp-pa-pd",
+    "flock_active_slug": "mahoning-twp-pa-pd",
+    "flock_slugs": [
+      "mahoning-twp-pa-pd"
+    ],
+    "flock_names": [
+      "Mahoning Twp PA PD"
+    ],
+    "display_name": null,
     "lat": 40.9195,
     "lng": -75.6924,
-    "public": true,
-    "federal": false,
     "state": "PA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "32431759-b238-510c-928f-5328978003dd",
+    "slug": "mammoth-lakes-ca-pd",
+    "flock_active_slug": "mammoth-lakes-ca-pd",
+    "flock_slugs": [
+      "mammoth-lakes-ca-pd"
+    ],
+    "flock_names": [
+      "Mammoth Lakes CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6485,
+    "lng": -118.9721,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "731b41be-02b5-52e5-a7f7-3d00b5d034e9",
+    "slug": "manteca-ca-pd",
+    "flock_active_slug": "manteca-ca-pd",
+    "flock_slugs": [
+      "manteca-ca-pd"
+    ],
+    "flock_names": [
+      "Manteca CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7974,
+    "lng": -121.2161,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "681413b8-0ba8-5bcd-a4c6-3bb4f9cc3ee7",
     "slug": "mare-island-ca",
-    "flock_name": "mare-island-ca",
-    "human_name": "mare-island-ca",
+    "flock_active_slug": "mare-island-ca",
+    "flock_slugs": [
+      "mare-island-ca"
+    ],
+    "flock_names": [
+      "Mare Island (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "0649c75b-a49d-5ec7-a240-18692dea2047",
+    "slug": "marin-county-ca-da",
+    "flock_active_slug": "marin-county-ca-da",
+    "flock_slugs": [
+      "marin-county-ca-da"
+    ],
+    "flock_names": [
+      "Marin County CA DA"
+    ],
+    "display_name": null,
+    "lat": 38.075,
+    "lng": -122.73,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e1922365-80e2-5ec7-8580-95245cdad7f8",
+    "slug": "marin-county-ca-so",
+    "flock_active_slug": "marin-county-ca-so",
+    "flock_slugs": [
+      "marin-county-ca-so"
+    ],
+    "flock_names": [
+      "Marin County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.055,
+    "lng": -122.735,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4beba561-a7bd-5810-a241-ce69eb0c2c73",
+    "slug": "marina-ca-pd",
+    "flock_active_slug": "marina-ca-pd",
+    "flock_slugs": [
+      "marina-ca-pd"
+    ],
+    "flock_names": [
+      "Marina CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6844,
+    "lng": -121.8022,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "337d2d0a-e6e0-5920-b671-87b14aa321a2",
     "slug": "marshall-canyon-estates-ca",
-    "flock_name": "marshall-canyon-estates-ca",
-    "human_name": "marshall-canyon-estates-ca",
+    "flock_active_slug": "marshall-canyon-estates-ca",
+    "flock_slugs": [
+      "marshall-canyon-estates-ca"
+    ],
+    "flock_names": [
+      "Marshall Canyon Estates (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "c74c5b71-d041-5be4-b4b5-6e140c649a43",
+    "slug": "marysville-ca-pd",
+    "flock_active_slug": "marysville-ca-pd",
+    "flock_slugs": [
+      "marysville-ca-pd"
+    ],
+    "flock_names": [
+      "Marysville CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.1457,
+    "lng": -121.5914,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8a94dd8e-1e82-55b0-81d0-935bbf9ccc89",
     "slug": "matteson-il-pd",
-    "flock_name": "matteson-il-pd",
-    "human_name": "matteson-il-pd",
+    "flock_active_slug": "matteson-il-pd",
+    "flock_slugs": [
+      "matteson-il-pd"
+    ],
+    "flock_names": [
+      "Matteson IL PD"
+    ],
+    "display_name": null,
     "lat": 41.5089,
     "lng": -87.7131,
-    "public": true,
-    "federal": false,
     "state": "IL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "2d8a2244-adfe-5132-93bb-374be19d0f32",
+    "slug": "mcfarland-ca-pd",
+    "flock_active_slug": "mcfarland-ca-pd",
+    "flock_slugs": [
+      "mcfarland-ca-pd"
+    ],
+    "flock_names": [
+      "McFarland CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.6783,
+    "lng": -119.2293,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "52421068-08e8-5522-8cd4-26dabfe25eaa",
     "slug": "mchenry-county-conservation-district-il-pd",
-    "flock_name": "mchenry-county-conservation-district-il-pd",
-    "human_name": "mchenry-county-conservation-district-il-pd",
+    "flock_active_slug": "mchenry-county-conservation-district-il-pd",
+    "flock_slugs": [
+      "mchenry-county-conservation-district-il-pd"
+    ],
+    "flock_names": [
+      "McHenry County Conservation District IL PD"
+    ],
+    "display_name": null,
     "lat": 42.3233,
     "lng": -88.3501,
-    "public": true,
-    "federal": false,
     "state": "IL",
     "agency_role": "police",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "b7368687-c755-557e-b85e-d46a303a6852",
     "slug": "meadowood-ca",
-    "flock_name": "meadowood-ca",
-    "human_name": "meadowood-ca",
+    "flock_active_slug": "meadowood-ca",
+    "flock_slugs": [
+      "meadowood-ca"
+    ],
+    "flock_names": [
+      "Meadowood (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "b6388c0f-b716-5756-b1a7-18dc6ab75e91",
     "slug": "melrose-action-ca",
-    "flock_name": "melrose-action-ca",
-    "human_name": "melrose-action-ca",
+    "flock_active_slug": "melrose-action-ca",
+    "flock_slugs": [
+      "melrose-action-ca"
+    ],
+    "flock_names": [
+      "Melrose Action (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "c71beb26-95bc-5f26-b69f-8af96173cb66",
+    "slug": "mendocino-county-so-ca",
+    "flock_active_slug": "mendocino-county-so-ca",
+    "flock_slugs": [
+      "mendocino-county-so-ca"
+    ],
+    "flock_names": [
+      "Mendocino County SO-CA"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e940061b-0f3b-53ba-a1cb-a2e12672a989",
+    "slug": "mendocino-county-soca",
+    "flock_active_slug": "mendocino-county-soca",
+    "flock_slugs": [
+      "mendocino-county-soca"
+    ],
+    "flock_names": [
+      "Mendocino County SO-CA"
+    ],
+    "display_name": null,
+    "lat": 39.3076,
+    "lng": -123.7995,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e30ffc94-490f-502f-be3b-5a2b873c0bf1",
+    "slug": "mendota-ca-pd",
+    "flock_active_slug": "mendota-ca-pd",
+    "flock_slugs": [
+      "mendota-ca-pd"
+    ],
+    "flock_names": [
+      "Mendota CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.7536,
+    "lng": -120.3818,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0bece678-57a0-5cd0-bea2-22cca18ac358",
+    "slug": "menifee-ca-pd",
+    "flock_active_slug": "menifee-ca-pd",
+    "flock_slugs": [
+      "menifee-ca-pd"
+    ],
+    "flock_names": [
+      "Menifee CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6781,
+    "lng": -117.1464,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7212d59b-b991-5f9a-b1ac-b4c926d74d84",
+    "slug": "menlo-park-ca-pd",
+    "flock_active_slug": "menlo-park-ca-pd",
+    "flock_slugs": [
+      "menlo-park-ca-pd"
+    ],
+    "flock_names": [
+      "Menlo Park CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.453,
+    "lng": -122.1817,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fdbb9d9e-7030-50bf-b82f-e393edc99f86",
+    "slug": "merced-county-ca-so",
+    "flock_active_slug": "merced-county-ca-so",
+    "flock_slugs": [
+      "merced-county-ca-so"
+    ],
+    "flock_names": [
+      "Merced County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.3022,
+    "lng": -120.483,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e7b93869-9da4-5d24-b2d1-e173b8a79642",
     "slug": "mercury-insurance-ca",
-    "flock_name": "mercury-insurance-ca",
-    "human_name": "mercury-insurance-ca",
+    "flock_active_slug": "mercury-insurance-ca",
+    "flock_slugs": [
+      "mercury-insurance-ca"
+    ],
+    "flock_names": [
+      "Mercury Insurance (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "7d349876-8c78-56a8-b2b3-12e9606719f1",
     "slug": "mesa-verde-ca",
-    "flock_name": "mesa-verde-ca",
-    "human_name": "mesa-verde-ca",
+    "flock_active_slug": "mesa-verde-ca",
+    "flock_slugs": [
+      "mesa-verde-ca"
+    ],
+    "flock_names": [
+      "Mesa Verde (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "3fa6fc23-7bf6-5590-9865-6ef5de35d80f",
     "slug": "middlebury-in-pd",
-    "flock_name": "middlebury-in-pd",
-    "human_name": "middlebury-in-pd",
+    "flock_active_slug": "middlebury-in-pd",
+    "flock_slugs": [
+      "middlebury-in-pd"
+    ],
+    "flock_names": [
+      "Middlebury IN PD"
+    ],
+    "display_name": null,
     "lat": 41.6751,
     "lng": -85.7086,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "3ab7378e-0fad-5bec-bcce-2c4f81e1cd59",
     "slug": "midwick-collection-ca",
-    "flock_name": "midwick-collection-ca",
-    "human_name": "midwick-collection-ca",
+    "flock_active_slug": "midwick-collection-ca",
+    "flock_slugs": [
+      "midwick-collection-ca"
+    ],
+    "flock_names": [
+      "Midwick Collection (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "0046d4c9-07ce-5064-aa1c-0a02d26d0360",
+    "slug": "mill-valley-ca-pd",
+    "flock_active_slug": "mill-valley-ca-pd",
+    "flock_slugs": [
+      "mill-valley-ca-pd"
+    ],
+    "flock_names": [
+      "Mill Valley CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.906,
+    "lng": -122.5416,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "59e2385f-2649-5b82-9bf7-aee2e73b0af1",
+    "slug": "milpitas-ca-pd",
+    "flock_active_slug": "milpitas-ca-pd",
+    "flock_slugs": [
+      "milpitas-ca-pd"
+    ],
+    "flock_names": [
+      "Milpitas CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4323,
+    "lng": -121.8996,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fc4c4659-5262-572a-b3d0-6bf50591125e",
     "slug": "milton-ga-pd",
-    "flock_name": "milton-ga-pd",
-    "human_name": "milton-ga-pd",
+    "flock_active_slug": "milton-ga-pd",
+    "flock_slugs": [
+      "milton-ga-pd"
+    ],
+    "flock_names": [
+      "Milton GA PD"
+    ],
+    "display_name": null,
     "lat": 34.1326,
     "lng": -84.3008,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "f9c972d0-1a0d-5e7b-b9eb-e4e662598fd6",
     "slug": "miraleste-hills",
-    "flock_name": "miraleste-hills",
-    "human_name": "miraleste-hills",
+    "flock_active_slug": "miraleste-hills",
+    "flock_slugs": [
+      "miraleste-hills"
+    ],
+    "flock_names": [
+      "Miraleste Hills"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "05c21e46-75a4-579f-927e-9b69e81f29b2",
     "slug": "modesto-ca-pd",
-    "flock_name": "modesto-ca-pd",
-    "human_name": "modesto-ca-pd",
+    "flock_active_slug": "modesto-ca-pd",
+    "flock_slugs": [
+      "modesto-ca-pd"
+    ],
+    "flock_names": [
+      "Modesto CA PD"
+    ],
+    "display_name": null,
     "lat": 37.6391,
     "lng": -120.9969,
-    "public": true,
-    "federal": false,
     "state": "CA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "d9e44eea-4594-5748-af09-adef548b5c42",
+    "slug": "modoc-county-ca-so",
+    "flock_active_slug": "modoc-county-ca-so",
+    "flock_slugs": [
+      "modoc-county-ca-so"
+    ],
+    "flock_names": [
+      "Modoc County CA SO"
+    ],
+    "display_name": null,
+    "lat": 41.5885,
+    "lng": -120.7253,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "22cd299e-0742-5372-8e88-9918667f9f5a",
     "slug": "mohave-county-az-so",
-    "flock_name": "mohave-county-az-so",
-    "human_name": "mohave-county-az-so",
+    "flock_active_slug": "mohave-county-az-so",
+    "flock_slugs": [
+      "mohave-county-az-so"
+    ],
+    "flock_names": [
+      "Mohave County AZ SO"
+    ],
+    "display_name": null,
     "lat": 35.2047,
     "lng": -114.0285,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "c3560776-9492-50ab-b355-4eba892ca2bc",
     "slug": "monroe-ga-pd",
-    "flock_name": "monroe-ga-pd",
-    "human_name": "monroe-ga-pd",
+    "flock_active_slug": "monroe-ga-pd",
+    "flock_slugs": [
+      "monroe-ga-pd"
+    ],
+    "flock_names": [
+      "Monroe GA PD"
+    ],
+    "display_name": null,
     "lat": 33.7948,
     "lng": -83.7132,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "7c43fa8b-01d2-5d3a-9e7b-92bd1bf6435f",
+    "slug": "monrovia-ca-pd",
+    "flock_active_slug": "monrovia-ca-pd",
+    "flock_slugs": [
+      "monrovia-ca-pd"
+    ],
+    "flock_names": [
+      "Monrovia CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1442,
+    "lng": -118.002,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "853e0abd-afea-5c18-be2d-78a2e1ba4ce9",
     "slug": "monster-energy-corporate-office-ca",
-    "flock_name": "monster-energy-corporate-office-ca",
-    "human_name": "monster-energy-corporate-office-ca",
+    "flock_active_slug": "monster-energy-corporate-office-ca",
+    "flock_slugs": [
+      "monster-energy-corporate-office-ca"
+    ],
+    "flock_names": [
+      "Monster Energy Corporate Office (CA)"
+    ],
+    "display_name": null,
     "lat": 33.9425,
     "lng": -117.2297,
-    "public": false,
-    "federal": true,
     "state": "CA",
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "federal",
+      "private"
+    ]
   },
   {
+    "agency_id": "a3e03ffa-aa9d-548d-baf3-4647acc48d03",
+    "slug": "montclair-ca-pd",
+    "flock_active_slug": "montclair-ca-pd",
+    "flock_slugs": [
+      "montclair-ca-pd"
+    ],
+    "flock_names": [
+      "Montclair CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0775,
+    "lng": -117.6898,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4f6bc272-61fc-51e5-a0b4-e3de97e105d5",
+    "slug": "monte-sereno-ca-pd",
+    "flock_active_slug": "monte-sereno-ca-pd",
+    "flock_slugs": [
+      "monte-sereno-ca-pd"
+    ],
+    "flock_names": [
+      "City of Monte Sereno CA"
+    ],
+    "display_name": null,
+    "lat": 37.2363,
+    "lng": -121.9928,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "11cb11f9-469e-5be8-a6c7-e1e00ca4d9eb",
+    "slug": "montebello-ca-pd",
+    "flock_active_slug": "montebello-ca-pd",
+    "flock_slugs": [
+      "montebello-ca-pd"
+    ],
+    "flock_names": [
+      "Montebello CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0165,
+    "lng": -118.1138,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2815c8c8-6cb2-53ee-ae3c-efed33562c3d",
+    "slug": "monterey-ca-pd",
+    "flock_active_slug": "monterey-ca-pd",
+    "flock_slugs": [
+      "monterey-ca-pd"
+    ],
+    "flock_names": [
+      "Monterey CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6002,
+    "lng": -121.8947,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9b7b7208-5747-5e9c-bdcb-ed7b430686fd",
+    "slug": "monterey-county-ca-so",
+    "flock_active_slug": "monterey-county-ca-so",
+    "flock_slugs": [
+      "monterey-county-ca-so"
+    ],
+    "flock_names": [
+      "Monterey County CA SO"
+    ],
+    "display_name": null,
+    "lat": 36.61,
+    "lng": -121.88,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5d80780f-d47b-5f56-acf4-a457bbb421ac",
+    "slug": "monterey-county-district-attorneys-office",
+    "flock_active_slug": "monterey-county-district-attorneys-office",
+    "flock_slugs": [
+      "monterey-county-district-attorneys-office"
+    ],
+    "flock_names": [
+      "Monterey County District Attorney's Office"
+    ],
+    "display_name": null,
+    "lat": 36.24,
+    "lng": -121.32,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f4a842bc-4d80-5882-a96e-ecaf61376fd9",
+    "slug": "monterey-park-ca-pd",
+    "flock_active_slug": "monterey-park-ca-pd",
+    "flock_slugs": [
+      "monterey-park-ca-pd"
+    ],
+    "flock_names": [
+      "Monterey Park CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0625,
+    "lng": -118.1228,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "24f0f643-2aed-507a-be1f-caf34584912f",
+    "slug": "moraga-ca-pd",
+    "flock_active_slug": "moraga-ca-pd",
+    "flock_slugs": [
+      "moraga-ca-pd"
+    ],
+    "flock_names": [
+      "Moraga CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8349,
+    "lng": -122.1297,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9a214b33-798d-5cdd-a431-85742e891e5f",
+    "slug": "morgan-hill-ca-pd",
+    "flock_active_slug": "morgan-hill-ca-pd",
+    "flock_slugs": [
+      "morgan-hill-ca-pd"
+    ],
+    "flock_names": [
+      "Morgan Hill CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.1305,
+    "lng": -121.6544,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "13a62f9a-07fc-5d1c-863a-b7ecae793505",
     "slug": "mountain-house-ca",
-    "flock_name": "mountain-house-ca",
-    "human_name": "mountain-house-ca",
+    "flock_active_slug": "mountain-house-ca",
+    "flock_slugs": [
+      "mountain-house-ca"
+    ],
+    "flock_names": [
+      "Mountain House (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "38e41ebd-b217-5f82-8f31-d96b027968b6",
+    "slug": "murrieta-ca-pd",
+    "flock_active_slug": "murrieta-ca-pd",
+    "flock_slugs": [
+      "murrieta-ca-pd"
+    ],
+    "flock_names": [
+      "Murrieta CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.5539,
+    "lng": -117.2139,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1aadd012-9a3a-5b5a-b2e0-24ab5ec2685e",
+    "slug": "napa-ca-pd",
+    "flock_active_slug": "napa-ca-pd",
+    "flock_slugs": [
+      "napa-ca-pd"
+    ],
+    "flock_names": [
+      "Napa CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.2975,
+    "lng": -122.2869,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e9a5ef79-d14a-5bf4-91e2-99b75939f983",
+    "slug": "napa-county-ca-probation-department",
+    "flock_active_slug": "napa-county-ca-probation-department",
+    "flock_slugs": [
+      "napa-county-ca-probation-department"
+    ],
+    "flock_names": [
+      "Napa County (CA) Probation Department"
+    ],
+    "display_name": null,
+    "lat": 38.2975,
+    "lng": -122.2869,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ac7c00ba-76bb-5cc8-aaf4-cc4f2b0ca31a",
+    "slug": "napa-county-ca-so",
+    "flock_active_slug": "napa-county-ca-so",
+    "flock_slugs": [
+      "napa-county-ca-so"
+    ],
+    "flock_names": [
+      "Napa County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.32,
+    "lng": -122.295,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "23febb79-0d19-5c75-b964-46a43c1cd423",
+    "slug": "national-city-ca-pd",
+    "flock_active_slug": "national-city-ca-pd",
+    "flock_slugs": [
+      "national-city-ca-pd"
+    ],
+    "flock_names": [
+      "National City CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.6781,
+    "lng": -117.0992,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fb49463a-c0c0-5bc7-90a0-545bef9f3301",
     "slug": "navajo-county-az-so",
-    "flock_name": "navajo-county-az-so",
-    "human_name": "navajo-county-az-so",
+    "flock_active_slug": "navajo-county-az-so",
+    "flock_slugs": [
+      "navajo-county-az-so"
+    ],
+    "flock_names": [
+      "Navajo County AZ SO"
+    ],
+    "display_name": null,
     "lat": 34.5322,
     "lng": -110.2352,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "b6134b21-a8be-50ab-aff8-7516fbb803bd",
+    "slug": "ncric",
+    "flock_active_slug": "ncric",
+    "flock_slugs": [
+      "ncric"
+    ],
+    "flock_names": [
+      "NCRIC"
+    ],
+    "display_name": null,
+    "lat": 37.785,
+    "lng": -122.41,
+    "state": "CA",
+    "agency_role": "intelligence",
+    "agency_type": "fusion_center",
+    "website": null,
+    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>.<br><br><strong>Federal characteristics:</strong> NCRIC may not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f). It was created by the NC HIDTA Executive Board \u2014 not by statute or executive order. It is housed in the Phillip Burton Federal Building (GSA-managed), staffed primarily with federal analysts under DHS/ODNI grants, and governed by an 18-member board where 9 of 18 seats are held by federal agencies (ATF, DEA, FBI, IRS-CI, U.S. Marshals, DHS, Postal Inspection, U.S. Forest Service, U.S. Attorney NDCA). It operates under 28 CFR Part 23, a federal regulation. Its Flock transparency page states it will not share with \u201cfederal law enforcement\u201d \u2014 yet federal law enforcement agencies hold half the seats on its governing board.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "44163a0c-70d8-505f-b51b-a3a552320af8",
     "slug": "nephi-pd-ut",
-    "flock_name": "nephi-pd-ut",
-    "human_name": "nephi-pd-ut",
+    "flock_active_slug": "nephi-pd-ut",
+    "flock_slugs": [
+      "nephi-pd-ut"
+    ],
+    "flock_names": [
+      "Nephi PD UT"
+    ],
+    "display_name": null,
     "lat": 39.7105,
     "lng": -111.8363,
-    "public": true,
-    "federal": false,
     "state": "UT",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "30ad58b9-4925-5815-8213-036be93d86a9",
+    "slug": "nevada-city-ca-pd",
+    "flock_active_slug": "nevada-city-ca-pd",
+    "flock_slugs": [
+      "nevada-city-ca-pd"
+    ],
+    "flock_names": [
+      "Nevada City CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.2616,
+    "lng": -121.016,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8b59e382-0153-52e4-b127-fdfadbe7a54c",
+    "slug": "nevada-county-ca-so",
+    "flock_active_slug": "nevada-county-ca-so",
+    "flock_slugs": [
+      "nevada-county-ca-so"
+    ],
+    "flock_names": [
+      "Nevada County CA SO"
+    ],
+    "display_name": null,
+    "lat": 39.28,
+    "lng": -121.03,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e27f1b8b-4591-51db-8a36-db468464e1b9",
     "slug": "new-castle-county-de-pd",
-    "flock_name": "new-castle-county-de-pd",
-    "human_name": "new-castle-county-de-pd",
+    "flock_active_slug": "new-castle-county-de-pd",
+    "flock_slugs": [
+      "new-castle-county-de-pd"
+    ],
+    "flock_names": [
+      "New Castle County DE PD"
+    ],
+    "display_name": null,
     "lat": 39.5724,
     "lng": -75.6087,
-    "public": true,
-    "federal": false,
     "state": "DE",
     "agency_role": "police",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "5aad1905-8ff9-5a45-931a-7298f983153a",
+    "slug": "newark-ca-pd",
+    "flock_active_slug": "newark-ca-pd",
+    "flock_slugs": [
+      "newark-ca-pd"
+    ],
+    "flock_names": [
+      "Newark CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5316,
+    "lng": -122.0402,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "74177e29-6bac-5f35-8a72-d1fa6e6c4357",
     "slug": "newells-mobile-city-ca",
-    "flock_name": "newells-mobile-city-ca",
-    "human_name": "newells-mobile-city-ca",
+    "flock_active_slug": "newells-mobile-city-ca",
+    "flock_slugs": [
+      "newells-mobile-city-ca"
+    ],
+    "flock_names": [
+      "Newell's Mobile City (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "684c2432-b5ab-5c9e-9bc7-6dd9df1e3b2f",
+    "slug": "newport-beach-pd-ca",
+    "flock_active_slug": "newport-beach-pd-ca",
+    "flock_slugs": [
+      "newport-beach-pd-ca"
+    ],
+    "flock_names": [
+      "Newport Beach PD CA"
+    ],
+    "display_name": null,
+    "lat": 33.6189,
+    "lng": -117.9298,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "89bb3ead-5e04-51d3-a009-32d155e36a87",
+    "slug": "north-kern-cemetery-district-ca-pd",
+    "flock_active_slug": "north-kern-cemetery-district-ca-pd",
+    "flock_slugs": [
+      "north-kern-cemetery-district-ca-pd"
+    ],
+    "flock_names": [
+      "North Kern Cemetery District CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.49,
+    "lng": -119.27,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c375bce6-848b-5729-aa4c-28a6a21b685f",
+    "slug": "novato-ca-pd",
+    "flock_active_slug": "novato-ca-pd",
+    "flock_slugs": [
+      "novato-ca-pd"
+    ],
+    "flock_names": [
+      "Novato CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.1074,
+    "lng": -122.5697,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5f507ed1-8694-50cb-b6a5-f3261d6f6a3c",
     "slug": "oak-valley-ii-ca",
-    "flock_name": "oak-valley-ii-ca",
-    "human_name": "oak-valley-ii-ca",
+    "flock_active_slug": "oak-valley-ii-ca",
+    "flock_slugs": [
+      "oak-valley-ii-ca"
+    ],
+    "flock_names": [
+      "Oak Valley II (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "6f2b98a1-957a-5dc9-935c-7b8127a223d6",
+    "slug": "oakland-ca-pd",
+    "flock_active_slug": "oakland-ca-pd",
+    "flock_slugs": [
+      "oakland-ca-pd"
+    ],
+    "flock_names": [
+      "Oakland CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8044,
+    "lng": -122.2712,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e4335f88-2a8a-59cc-bab8-763f1cd586be",
+    "slug": "oakley-ca-pd",
+    "flock_active_slug": "oakley-ca-pd",
+    "flock_slugs": [
+      "oakley-ca-pd"
+    ],
+    "flock_names": [
+      "Oakley CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9974,
+    "lng": -121.7125,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4e689ee7-da7f-5530-bef1-c987d872e792",
+    "slug": "oceanside-ca-pd",
+    "flock_active_slug": "oceanside-ca-pd",
+    "flock_slugs": [
+      "oceanside-ca-pd"
+    ],
+    "flock_names": [
+      "Oceanside CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.1959,
+    "lng": -117.3795,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "81ba4320-6065-5064-a966-5b03022434ab",
     "slug": "ogden-dunes-in-pd",
-    "flock_name": "ogden-dunes-in-pd",
-    "human_name": "ogden-dunes-in-pd",
+    "flock_active_slug": "ogden-dunes-in-pd",
+    "flock_slugs": [
+      "ogden-dunes-in-pd"
+    ],
+    "flock_names": [
+      "Ogden Dunes IN PD"
+    ],
+    "display_name": null,
     "lat": 41.6226,
     "lng": -87.1919,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "olinda-ranch-community-ca",
-    "flock_name": "olinda-ranch-community-ca",
-    "human_name": "olinda-ranch-community-ca",
+    "agency_id": "56f9a46f-863a-5d77-b2c9-72403bb11a8e",
+    "slug": "old",
+    "flock_active_slug": "old",
+    "flock_slugs": [
+      "old"
+    ],
+    "flock_names": [
+      "Old"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
+    "state": null,
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "notes": "Not a public agency. Receives ALPR data from at least 2 agencies (Lodi PD, Merced County SO).",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "49b7e68a-8261-5236-85bc-9854e46387a9",
+    "slug": "olinda-ranch-community-ca",
+    "flock_active_slug": "olinda-ranch-community-ca",
+    "flock_slugs": [
+      "olinda-ranch-community-ca"
+    ],
+    "flock_names": [
+      "Olinda Ranch Community (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "c9751186-93a1-586a-96c0-92bfc49d6c54",
     "slug": "olivewood-community-association-ca",
-    "flock_name": "olivewood-community-association-ca",
-    "human_name": "olivewood-community-association-ca",
+    "flock_active_slug": "olivewood-community-association-ca",
+    "flock_slugs": [
+      "olivewood-community-association-ca"
+    ],
+    "flock_names": [
+      "Olivewood Community Association (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "10d8673e-60c9-5345-a1e1-eb25f18d157b",
+    "slug": "ontario-ca-pd",
+    "flock_active_slug": "ontario-ca-pd",
+    "flock_slugs": [
+      "ontario-ca-pd"
+    ],
+    "flock_names": [
+      "Ontario CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0633,
+    "lng": -117.6509,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f404cc12-352c-5e5c-969f-995c17d8640f",
     "slug": "ontario-oh-pd",
-    "flock_name": "ontario-oh-pd",
-    "human_name": "ontario-oh-pd",
+    "flock_active_slug": "ontario-oh-pd",
+    "flock_slugs": [
+      "ontario-oh-pd"
+    ],
+    "flock_names": [
+      "Ontario OH PD"
+    ],
+    "display_name": null,
     "lat": 40.7598,
     "lng": -82.5901,
-    "public": true,
-    "federal": false,
     "state": "OH",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "adae2f31-2d45-52bc-8c24-c07babbd4508",
     "slug": "orange-beach-al-pd",
-    "flock_name": "orange-beach-al-pd",
-    "human_name": "orange-beach-al-pd",
+    "flock_active_slug": "orange-beach-al-pd",
+    "flock_slugs": [
+      "orange-beach-al-pd"
+    ],
+    "flock_names": [
+      "Orange Beach AL PD"
+    ],
+    "display_name": null,
     "lat": 30.2944,
     "lng": -87.5836,
-    "public": true,
-    "federal": false,
     "state": "AL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "4f545e10-4f02-51d7-9f85-b670f74f352c",
+    "slug": "orange-ca-pd",
+    "flock_active_slug": "orange-ca-pd",
+    "flock_slugs": [
+      "orange-ca-pd"
+    ],
+    "flock_names": [
+      "Orange CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7878,
+    "lng": -117.8531,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2693f816-23d4-58ad-bdb7-0d851e03b3d6",
+    "slug": "orange-coast-college-campus-ca-pd",
+    "flock_active_slug": "orange-coast-college-campus-ca-pd",
+    "flock_slugs": [
+      "orange-coast-college-campus-ca-pd"
+    ],
+    "flock_names": [
+      "Orange Coast College Campus CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.6715,
+    "lng": -117.9129,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Orange Coast College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "74719b7b-43cb-57ec-a0bc-26515454b5dc",
+    "slug": "orange-county-ca-da-office",
+    "flock_active_slug": "orange-county-ca-da-office",
+    "flock_slugs": [
+      "orange-county-ca-da-office"
+    ],
+    "flock_names": [
+      "Orange County (CA) DA Office"
+    ],
+    "display_name": null,
+    "lat": 33.7878,
+    "lng": -117.8531,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a2c03da5-7700-5042-8d22-ab98c8a1c7f2",
+    "slug": "orange-county-fire-authority-ca",
+    "flock_active_slug": "orange-county-fire-authority-ca",
+    "flock_slugs": [
+      "orange-county-fire-authority-ca"
+    ],
+    "flock_names": [
+      "Orange County Fire Authority (CA)"
+    ],
+    "display_name": null,
+    "lat": 33.71,
+    "lng": -117.85,
+    "state": "CA",
+    "agency_role": "fire",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c45e5dc2-fd51-530a-8b09-3488758f9328",
     "slug": "orange-county-fl-so",
-    "flock_name": "orange-county-fl-so",
-    "human_name": "orange-county-fl-so",
+    "flock_active_slug": "orange-county-fl-so",
+    "flock_slugs": [
+      "orange-county-fl-so"
+    ],
+    "flock_names": [
+      "Orange County FL SO"
+    ],
+    "display_name": null,
     "lat": 28.5383,
     "lng": -81.3792,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "2c981ce6-8d54-565f-bb99-ac885eee8769",
+    "slug": "orange-county-so-ca",
+    "flock_active_slug": "orange-county-so-ca",
+    "flock_slugs": [
+      "orange-county-so-ca"
+    ],
+    "flock_names": [
+      "Orange County SO CA"
+    ],
+    "display_name": null,
+    "lat": 33.78,
+    "lng": -117.86,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "508e3f9d-bcc2-5540-b89f-73dd04f6676a",
+    "slug": "orange-cove-ca-pd",
+    "flock_active_slug": "orange-cove-ca-pd",
+    "flock_slugs": [
+      "orange-cove-ca-pd"
+    ],
+    "flock_names": [
+      "Orange Cove CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6236,
+    "lng": -119.3129,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5a4bfc03-5e3c-5d3b-8371-fe7beac76e1f",
     "slug": "orlando-fl-pd",
-    "flock_name": "orlando-fl-pd",
-    "human_name": "orlando-fl-pd",
+    "flock_active_slug": "orlando-fl-pd",
+    "flock_slugs": [
+      "orlando-fl-pd"
+    ],
+    "flock_names": [
+      "Orlando FL PD"
+    ],
+    "display_name": null,
     "lat": 28.5383,
     "lng": -81.3792,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "a7940cec-8bb3-5017-b27d-83ca4e7024ae",
+    "slug": "oroville-ca-pd",
+    "flock_active_slug": "oroville-ca-pd",
+    "flock_slugs": [
+      "oroville-ca-pd"
+    ],
+    "flock_names": [
+      "Oroville CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.5138,
+    "lng": -121.5564,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2e1e1b36-7a6b-5c97-8143-65347503186c",
+    "slug": "oxnard-ca-pd",
+    "flock_active_slug": "oxnard-ca-pd",
+    "flock_slugs": [
+      "oxnard-ca-pd"
+    ],
+    "flock_names": [
+      "Oxnard CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1975,
+    "lng": -119.1771,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1f3f9f30-3f02-5a90-9c13-b1a676bb8cb8",
+    "slug": "pacific-grove-ca-pd",
+    "flock_active_slug": "pacific-grove-ca-pd",
+    "flock_slugs": [
+      "pacific-grove-ca-pd"
+    ],
+    "flock_names": [
+      "Pacific Grove CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6177,
+    "lng": -121.9166,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3e018e17-0297-5a20-8959-c960ed0a14b3",
     "slug": "pacific-palisades-residents-association-ca",
-    "flock_name": "pacific-palisades-residents-association-ca",
-    "human_name": "pacific-palisades-residents-association-ca",
+    "flock_active_slug": "pacific-palisades-residents-association-ca",
+    "flock_slugs": [
+      "pacific-palisades-residents-association-ca"
+    ],
+    "flock_names": [
+      "Pacific Palisades Residents Association (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "2807c42c-e994-5089-bdcb-f8b0f15a6519",
+    "slug": "pacifica-ca-pd",
+    "flock_active_slug": "pacifica-ca-pd",
+    "flock_slugs": [
+      "pacifica-ca-pd"
+    ],
+    "flock_names": [
+      "Pacifica CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6138,
+    "lng": -122.4869,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "942d7467-8fdc-590a-850b-76df3b0f6167",
     "slug": "pacifica-san-juan",
-    "flock_name": "pacifica-san-juan",
-    "human_name": "pacifica-san-juan",
+    "flock_active_slug": "pacifica-san-juan",
+    "flock_slugs": [
+      "pacifica-san-juan"
+    ],
+    "flock_names": [
+      "Pacifica San Juan"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "871622eb-08da-5364-aaca-7c8e401a31bc",
+    "slug": "palm-springs-ca-pd",
+    "flock_active_slug": "palm-springs-ca-pd",
+    "flock_slugs": [
+      "palm-springs-ca-pd"
+    ],
+    "flock_names": [
+      "Palm Springs CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8303,
+    "lng": -116.5453,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "663b82ca-427a-5e74-83ce-823a973242d9",
+    "slug": "palo-alto-ca-pd",
+    "flock_active_slug": "palo-alto-ca-pd",
+    "flock_slugs": [
+      "palo-alto-ca-pd"
+    ],
+    "flock_names": [
+      "Palo Alto CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4419,
+    "lng": -122.143,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9ce29f9b-9f24-5a82-a3f2-7608d5a40501",
     "slug": "paradise-valley-az-pd",
-    "flock_name": "paradise-valley-az-pd",
-    "human_name": "paradise-valley-az-pd",
+    "flock_active_slug": "paradise-valley-az-pd",
+    "flock_slugs": [
+      "paradise-valley-az-pd"
+    ],
+    "flock_names": [
+      "Paradise Valley AZ PD"
+    ],
+    "display_name": null,
     "lat": 33.531,
     "lng": -111.9425,
-    "public": true,
-    "federal": false,
     "state": "AZ",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "b02faac8-de9c-5cbc-84ab-9c8047eccfea",
+    "slug": "pasadena-ca-pd",
+    "flock_active_slug": "pasadena-ca-pd",
+    "flock_slugs": [
+      "pasadena-ca-pd"
+    ],
+    "flock_names": [
+      "Pasadena CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1478,
+    "lng": -118.1445,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b257e032-9568-5909-a43e-1c7934119ad9",
     "slug": "peotone-il-pd",
-    "flock_name": "peotone-il-pd",
-    "human_name": "peotone-il-pd",
+    "flock_active_slug": "peotone-il-pd",
+    "flock_slugs": [
+      "peotone-il-pd"
+    ],
+    "flock_names": [
+      "Peotone IL PD"
+    ],
+    "display_name": null,
     "lat": 41.3345,
     "lng": -87.7856,
-    "public": true,
-    "federal": false,
     "state": "IL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "6923dc3e-4533-5c70-bdfc-073a1e360ac6",
     "slug": "peppertree-bend-ca",
-    "flock_name": "peppertree-bend-ca",
-    "human_name": "peppertree-bend-ca",
+    "flock_active_slug": "peppertree-bend-ca",
+    "flock_slugs": [
+      "peppertree-bend-ca"
+    ],
+    "flock_names": [
+      "Peppertree Bend (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "c6ffad8c-5885-5513-bcc0-b4db2ca7f415",
+    "slug": "petaluma-ca-pd",
+    "flock_active_slug": "petaluma-ca-pd",
+    "flock_slugs": [
+      "petaluma-ca-pd"
+    ],
+    "flock_names": [
+      "Petaluma CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.2324,
+    "lng": -122.6367,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b43d910e-99ca-56e2-8f1f-8f715885c247",
+    "slug": "piedmont-ca-pd",
+    "flock_active_slug": "piedmont-ca-pd",
+    "flock_slugs": [
+      "piedmont-ca-pd"
+    ],
+    "flock_names": [
+      "Piedmont CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8244,
+    "lng": -122.2316,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d5eacec5-3e5c-52b2-be12-07db63b34db2",
     "slug": "pittsboro-in-pd",
-    "flock_name": "pittsboro-in-pd",
-    "human_name": "pittsboro-in-pd",
+    "flock_active_slug": "pittsboro-in-pd",
+    "flock_slugs": [
+      "pittsboro-in-pd"
+    ],
+    "flock_names": [
+      "Pittsboro IN PD"
+    ],
+    "display_name": null,
     "lat": 39.8637,
     "lng": -86.4669,
-    "public": true,
-    "federal": false,
     "state": "IN",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "ee39b0f7-1dd6-5526-88ce-57e3dd7d8488",
+    "slug": "placentia-ca-pd",
+    "flock_active_slug": "placentia-ca-pd",
+    "flock_slugs": [
+      "placentia-ca-pd"
+    ],
+    "flock_names": [
+      "Placentia CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8722,
+    "lng": -117.8703,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "296ca8d3-956b-5f18-8743-2bd6c53e41f9",
+    "slug": "placer-county-ca-da-office",
+    "flock_active_slug": "placer-county-ca-da-office",
+    "flock_slugs": [
+      "placer-county-ca-da-office"
+    ],
+    "flock_names": [
+      "Placer County CA DA Office"
+    ],
+    "display_name": null,
+    "lat": 38.95,
+    "lng": -121.08,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d5302daa-76cc-5e29-b769-f9723a093309",
+    "slug": "placer-county-ca-so",
+    "flock_active_slug": "placer-county-ca-so",
+    "flock_slugs": [
+      "placer-county-ca-so"
+    ],
+    "flock_names": [
+      "Placer County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.9666,
+    "lng": -121.0958,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "59b1f730-2412-5790-92fd-a707e3ac23cd",
+    "slug": "pleasant-hill-ca-pd",
+    "flock_active_slug": "pleasant-hill-ca-pd",
+    "flock_slugs": [
+      "pleasant-hill-ca-pd"
+    ],
+    "flock_names": [
+      "Pleasant Hill CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.948,
+    "lng": -122.0608,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d9d1866d-0a26-5627-b886-855eeeded437",
+    "slug": "pleasanton-ca-pd",
+    "flock_active_slug": "pleasanton-ca-pd",
+    "flock_slugs": [
+      "pleasanton-ca-pd"
+    ],
+    "flock_names": [
+      "Pleasanton CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6624,
+    "lng": -121.8747,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "62f9d91a-99cb-5428-8312-38718e2196ed",
+    "slug": "pomona-ca-pd",
+    "flock_active_slug": "pomona-ca-pd",
+    "flock_slugs": [
+      "pomona-ca-pd"
+    ],
+    "flock_names": [
+      "Pomona CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0551,
+    "lng": -117.75,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a8cba160-1158-598a-bdfc-c138bc5d0379",
+    "slug": "port-hueneme-ca-pd",
+    "flock_active_slug": "port-hueneme-ca-pd",
+    "flock_slugs": [
+      "port-hueneme-ca-pd"
+    ],
+    "flock_names": [
+      "Port Hueneme CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1478,
+    "lng": -119.1951,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "50358086-9549-58ba-ab96-bb6984cd6ab0",
+    "slug": "port-of-stockton-ca-pd",
+    "flock_active_slug": "port-of-stockton-ca-pd",
+    "flock_slugs": [
+      "port-of-stockton-ca-pd"
+    ],
+    "flock_names": [
+      "Port of Stockton CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.945,
+    "lng": -121.32,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f57a9f4b-3015-5edd-93ed-7716591b86f8",
+    "slug": "porterville-ca-pd",
+    "flock_active_slug": "porterville-ca-pd",
+    "flock_slugs": [
+      "porterville-ca-pd"
+    ],
+    "flock_names": [
+      "Porterville CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.0653,
+    "lng": -119.0168,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "56464d81-cdfa-542c-ae8d-b2c30eb1c71d",
     "slug": "quiet-harbor",
-    "flock_name": "quiet-harbor",
-    "human_name": "quiet-harbor",
+    "flock_active_slug": "quiet-harbor",
+    "flock_slugs": [
+      "quiet-harbor"
+    ],
+    "flock_names": [
+      "Quiet Harbor"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "d66535a5-d9f6-5a8f-a7ed-48c00cfd91f3",
+    "slug": "redding-pd-ca",
+    "flock_active_slug": "redding-pd-ca",
+    "flock_slugs": [
+      "redding-pd-ca"
+    ],
+    "flock_names": [
+      "Redding PD - CA"
+    ],
+    "display_name": null,
+    "lat": 40.5865,
+    "lng": -122.3917,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dbb41fa5-9662-50ba-ae51-7061815de463",
+    "slug": "redlands-ca-pd",
+    "flock_active_slug": "redlands-ca-pd",
+    "flock_slugs": [
+      "redlands-ca-pd"
+    ],
+    "flock_names": [
+      "Redlands CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0556,
+    "lng": -117.1825,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "02126911-e73c-519e-b23b-8bc1cfb0d92d",
+    "slug": "redondo-beach-ca-pd",
+    "flock_active_slug": "redondo-beach-ca-pd",
+    "flock_slugs": [
+      "redondo-beach-ca-pd"
+    ],
+    "flock_names": [
+      "Redondo Beach CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8492,
+    "lng": -118.3884,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f94b9663-269f-51eb-b204-b6d4c8cee4de",
+    "slug": "redwood-city-ca-pd",
+    "flock_active_slug": "redwood-city-ca-pd",
+    "flock_slugs": [
+      "redwood-city-ca-pd"
+    ],
+    "flock_names": [
+      "Redwood City CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4852,
+    "lng": -122.2364,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2f9972d5-0838-5f56-9988-40c425e652e0",
+    "slug": "reedley-ca-pd",
+    "flock_active_slug": "reedley-ca-pd",
+    "flock_slugs": [
+      "reedley-ca-pd"
+    ],
+    "flock_names": [
+      "Reedley CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.5963,
+    "lng": -119.4504,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "16fa6eb0-e52b-5dc8-b2a5-4d9babbec252",
     "slug": "reflections-hoa-ca",
-    "flock_name": "reflections-hoa-ca",
-    "human_name": "reflections-hoa-ca",
+    "flock_active_slug": "reflections-hoa-ca",
+    "flock_slugs": [
+      "reflections-hoa-ca"
+    ],
+    "flock_names": [
+      "Reflections HOA (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "d0b9ceb5-ac4a-505b-b767-83abcc3f5347",
     "slug": "reno-nv-pd",
-    "flock_name": "reno-nv-pd",
-    "human_name": "reno-nv-pd",
+    "flock_active_slug": "reno-nv-pd",
+    "flock_slugs": [
+      "reno-nv-pd"
+    ],
+    "flock_names": [
+      "Reno NV PD"
+    ],
+    "display_name": null,
     "lat": 39.5296,
     "lng": -119.8138,
-    "public": true,
-    "federal": false,
     "state": "NV",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "76ffd436-962c-5842-92bc-1fb2c82f20dd",
+    "slug": "rialto-pd-ca",
+    "flock_active_slug": "rialto-pd-ca",
+    "flock_slugs": [
+      "rialto-pd-ca"
+    ],
+    "flock_names": [
+      "Rialto PD CA"
+    ],
+    "display_name": null,
+    "lat": 34.1064,
+    "lng": -117.3703,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "da68a0d1-cb53-5035-a69a-6e68e21fe5ef",
     "slug": "richland-county-sc-so",
-    "flock_name": "richland-county-sc-so",
-    "human_name": "richland-county-sc-so",
+    "flock_active_slug": "richland-county-sc-so",
+    "flock_slugs": [
+      "richland-county-sc-so"
+    ],
+    "flock_names": [
+      "Richland County SC SO"
+    ],
+    "display_name": null,
     "lat": 34.0007,
     "lng": -80.9451,
-    "public": true,
-    "federal": false,
     "state": "SC",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "6607f630-2279-5b12-b723-b94b16c81122",
+    "slug": "richmond-ca-pd",
+    "flock_active_slug": "richmond-ca-pd",
+    "flock_slugs": [
+      "richmond-ca-pd"
+    ],
+    "flock_names": [
+      "Richmond CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9358,
+    "lng": -122.3477,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fb63b4c3-2516-5d13-9633-c5319bec1ee1",
+    "slug": "richmond-housing-authority-ca-pd",
+    "flock_active_slug": "richmond-housing-authority-ca-pd",
+    "flock_slugs": [
+      "richmond-housing-authority-ca-pd"
+    ],
+    "flock_names": [
+      "Richmond Housing Authority CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9358,
+    "lng": -122.3477,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "09d7d905-9b6b-5352-8760-c9aa45a695f2",
+    "slug": "ridgecrest-ca-pd",
+    "flock_active_slug": "ridgecrest-ca-pd",
+    "flock_slugs": [
+      "ridgecrest-ca-pd"
+    ],
+    "flock_names": [
+      "Ridgecrest CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.6225,
+    "lng": -117.6709,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8d7fd470-fecf-5788-921d-7f82bc634a71",
+    "slug": "rio-hondo-college-pd-ca",
+    "flock_active_slug": "rio-hondo-college-pd-ca",
+    "flock_slugs": [
+      "rio-hondo-college-pd-ca"
+    ],
+    "flock_names": [
+      "Rio Hondo College PD CA"
+    ],
+    "display_name": null,
+    "lat": 34.0231,
+    "lng": -118.0359,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (Rio Hondo College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a55f9ea7-3fda-5ff3-a2b5-c3782b70d7b2",
+    "slug": "rio-vista-ca-pd",
+    "flock_active_slug": "rio-vista-ca-pd",
+    "flock_slugs": [
+      "rio-vista-ca-pd"
+    ],
+    "flock_names": [
+      "Rio Vista CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.1748,
+    "lng": -121.6925,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d7e600e3-b7e1-5f8e-b1a7-6166c6932df5",
+    "slug": "ripon-ca-pd",
+    "flock_active_slug": "ripon-ca-pd",
+    "flock_slugs": [
+      "ripon-ca-pd"
+    ],
+    "flock_names": [
+      "Ripon CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7416,
+    "lng": -121.1244,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "be4d4df1-462d-554f-b8fb-6139ed84e8a0",
     "slug": "ritchie-brothers-auctioneers",
-    "flock_name": "ritchie-brothers-auctioneers",
-    "human_name": "ritchie-brothers-auctioneers",
+    "flock_active_slug": "ritchie-brothers-auctioneers",
+    "flock_slugs": [
+      "ritchie-brothers-auctioneers"
+    ],
+    "flock_names": [
+      "Ritchie Brothers Auctioneers"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "bcd09a39-214a-55f3-b3b7-4e6e1ef26176",
+    "slug": "riv-co-arson-tf-ca-pd",
+    "flock_active_slug": "riv-co-arson-tf-ca-pd",
+    "flock_slugs": [
+      "riv-co-arson-tf-ca-pd"
+    ],
+    "flock_names": [
+      "RIV CO ARSON TF CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9806,
+    "lng": -117.3755,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "650ab346-a013-56f6-a970-1bf8a61acb18",
+    "slug": "riverside-county-ca-district-attorney",
+    "flock_active_slug": "riverside-county-ca-district-attorney",
+    "flock_slugs": [
+      "riverside-county-ca-district-attorney"
+    ],
+    "flock_names": [
+      "Riverside County CA District Attorney"
+    ],
+    "display_name": null,
+    "lat": 33.9806,
+    "lng": -117.3755,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dba49a24-b558-503f-b4b7-5c54450da30e",
+    "slug": "riverside-county-ca-sd",
+    "flock_active_slug": "riverside-county-ca-sd",
+    "flock_slugs": [
+      "riverside-county-ca-sd"
+    ],
+    "flock_names": [
+      "Riverside County CA SO"
+    ],
+    "display_name": null,
+    "lat": 33.9806,
+    "lng": -117.3755,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ae8c6210-8473-5a62-96af-7ea959cb19ff",
+    "slug": "riverside-county-ca-so",
+    "flock_active_slug": "riverside-county-ca-so",
+    "flock_slugs": [
+      "riverside-county-ca-so"
+    ],
+    "flock_names": [
+      "Riverside County CA SO"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8eb76a20-5443-5363-978b-807ae1b5d530",
+    "slug": "rocklin-ca-pd",
+    "flock_active_slug": "rocklin-ca-pd",
+    "flock_slugs": [
+      "rocklin-ca-pd"
+    ],
+    "flock_names": [
+      "Rocklin CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.7908,
+    "lng": -121.2358,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ccff4f65-09ac-5ed3-b1ba-36f43bcce935",
+    "slug": "rohnert-park-department-of-public-safety-ca",
+    "flock_active_slug": "rohnert-park-department-of-public-safety-ca",
+    "flock_slugs": [
+      "rohnert-park-department-of-public-safety-ca"
+    ],
+    "flock_names": [
+      "Rohnert Park Department of Public Safety (CA)"
+    ],
+    "display_name": null,
+    "lat": 38.3397,
+    "lng": -122.7011,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "366eac9d-3114-5e9e-a23a-a1ac15aedb7f",
     "slug": "rose-hills-memorial-park-mortuary-ca",
-    "flock_name": "rose-hills-memorial-park-mortuary-ca",
-    "human_name": "rose-hills-memorial-park-mortuary-ca",
+    "flock_active_slug": "rose-hills-memorial-park-mortuary-ca",
+    "flock_slugs": [
+      "rose-hills-memorial-park-mortuary-ca"
+    ],
+    "flock_names": [
+      "Rose Hills Memorial Park & Mortuary (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "26ed4286-4037-515f-a9f8-f411f8303bc0",
+    "slug": "roseville-ca-pd",
+    "flock_active_slug": "roseville-ca-pd",
+    "flock_slugs": [
+      "roseville-ca-pd"
+    ],
+    "flock_names": [
+      "Roseville CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.7521,
+    "lng": -121.288,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f314d73b-0427-5f5b-af2d-74b824eef8ab",
     "slug": "round-valley-indian-tribes-ca",
-    "flock_name": "round-valley-indian-tribes-ca",
-    "human_name": "round-valley-indian-tribes-ca",
+    "flock_active_slug": "round-valley-indian-tribes-ca",
+    "flock_slugs": [
+      "round-valley-indian-tribes-ca"
+    ],
+    "flock_names": [
+      "Round Valley Indian Tribes CA"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "3371578e-575d-5750-9a72-ffcdbcdd1e03",
     "slug": "rountree-road-neighborhood-ca",
-    "flock_name": "rountree-road-neighborhood-ca",
-    "human_name": "rountree-road-neighborhood-ca",
+    "flock_active_slug": "rountree-road-neighborhood-ca",
+    "flock_slugs": [
+      "rountree-road-neighborhood-ca"
+    ],
+    "flock_names": [
+      "Rountree Road Neighborhood (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "6a2741a1-b6d5-5537-9963-9f2fb2b2447e",
+    "slug": "sacramento-ca-da",
+    "flock_active_slug": "sacramento-ca-da",
+    "flock_slugs": [
+      "sacramento-ca-da"
+    ],
+    "flock_names": [
+      "Sacramento CA DA"
+    ],
+    "display_name": null,
+    "lat": 38.585,
+    "lng": -121.5,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bae9861d-a7ef-567d-b31b-a627075decf9",
+    "slug": "sacramento-ca-pd",
+    "flock_active_slug": "sacramento-ca-pd",
+    "flock_slugs": [
+      "sacramento-ca-pd"
+    ],
+    "flock_names": [
+      "Sacramento CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5816,
+    "lng": -121.4944,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "90910dc9-55ae-5362-93c3-d00246b75cac",
+    "slug": "sacramento-county-ca-so",
+    "flock_active_slug": "sacramento-county-ca-so",
+    "flock_slugs": [
+      "sacramento-county-ca-so"
+    ],
+    "flock_names": [
+      "Sacramento County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.57,
+    "lng": -121.47,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6c12c240-c390-5c0f-b570-8900c2366343",
+    "slug": "sacramento-county-parks-department-ca",
+    "flock_active_slug": "sacramento-county-parks-department-ca",
+    "flock_slugs": [
+      "sacramento-county-parks-department-ca"
+    ],
+    "flock_names": [
+      "Sacramento County Parks Department CA"
+    ],
+    "display_name": null,
+    "lat": 38.56,
+    "lng": -121.48,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "844ec58f-3abf-5a88-a280-2ba0f235264a",
+    "slug": "salinas-ca-pd",
+    "flock_active_slug": "salinas-ca-pd",
+    "flock_slugs": [
+      "salinas-ca-pd"
+    ],
+    "flock_names": [
+      "Salinas CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6777,
+    "lng": -121.6555,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3684a873-d18a-57d8-a30b-c1fe3b4c93a3",
+    "slug": "san-benito-county-so-ca",
+    "flock_active_slug": "san-benito-county-so-ca",
+    "flock_slugs": [
+      "san-benito-county-so-ca"
+    ],
+    "flock_names": [
+      "San Benito County SO CA"
+    ],
+    "display_name": null,
+    "lat": 36.8525,
+    "lng": -121.4016,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bc23d548-e468-55ce-845b-ddee21abe171",
+    "slug": "san-bernardino-ca-pd",
+    "flock_active_slug": "san-bernardino-ca-pd",
+    "flock_slugs": [
+      "san-bernardino-ca-pd"
+    ],
+    "flock_names": [
+      "San Bernardino CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1083,
+    "lng": -117.2898,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "eb8124e9-87f6-5e8b-b887-8a02105ea18e",
+    "slug": "san-bernardino-community-college-ca-pd",
+    "flock_active_slug": "san-bernardino-community-college-ca-pd",
+    "flock_slugs": [
+      "san-bernardino-community-college-ca-pd"
+    ],
+    "flock_names": [
+      "San Bernardino Community College CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0906,
+    "lng": -117.2746,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (San Bernardino Valley College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "79b569e0-f635-5cbe-9be7-bb5ed9d00482",
+    "slug": "san-bernardino-county-ca-human-services-law-enforcement",
+    "flock_active_slug": "san-bernardino-county-ca-human-services-law-enforcement",
+    "flock_slugs": [
+      "san-bernardino-county-ca-human-services-law-enforcement"
+    ],
+    "flock_names": [
+      "San Bernardino County CA Human Services [Law Enforcement]"
+    ],
+    "display_name": null,
+    "lat": 34.1083,
+    "lng": -117.2898,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0fafb2c6-af8b-5e57-abec-c9a469d32327",
+    "slug": "san-bernardino-county-ca-so",
+    "flock_active_slug": "san-bernardino-county-ca-so",
+    "flock_slugs": [
+      "san-bernardino-county-ca-so"
+    ],
+    "flock_names": [
+      "San Bernardino County CA SO"
+    ],
+    "display_name": null,
+    "lat": 34.1119,
+    "lng": -117.263,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "294a2f8e-cad6-5439-b849-ed2ff73ec216",
+    "slug": "san-bruno-ca-pd",
+    "flock_active_slug": "san-bruno-ca-pd",
+    "flock_slugs": [
+      "san-bruno-ca-pd"
+    ],
+    "flock_names": [
+      "San Bruno CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6305,
+    "lng": -122.4111,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ddca091b-bdea-5711-8eda-e1b175ebe7ad",
+    "slug": "san-diego-ca-pd",
+    "flock_active_slug": "san-diego-ca-pd",
+    "flock_slugs": [
+      "san-diego-ca-pd"
+    ],
+    "flock_names": [
+      "San Diego CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.7157,
+    "lng": -117.1611,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9997bf96-b2ff-595c-950f-27a68b2ba166",
+    "slug": "san-diego-county-ca-sd",
+    "flock_active_slug": "san-diego-county-ca-sd",
+    "flock_slugs": [
+      "san-diego-county-ca-sd"
+    ],
+    "flock_names": [
+      "San Diego County CA SD"
+    ],
+    "display_name": null,
+    "lat": 32.734,
+    "lng": -117.1933,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b66facad-4ee0-558e-8bfe-32d1894afad1",
+    "slug": "san-diego-harbor-ca-pd",
+    "flock_active_slug": "san-diego-harbor-ca-pd",
+    "flock_slugs": [
+      "san-diego-harbor-ca-pd"
+    ],
+    "flock_names": [
+      "San Diego Harbor CA PD"
+    ],
+    "display_name": null,
+    "lat": 32.7157,
+    "lng": -117.17,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2e9edae6-7b5a-5b86-bd0e-c3e06b3d96d0",
+    "slug": "san-fernando-ca-pd",
+    "flock_active_slug": "san-fernando-ca-pd",
+    "flock_slugs": [
+      "san-fernando-ca-pd"
+    ],
+    "flock_names": [
+      "San Fernando CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.2889,
+    "lng": -118.439,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "14b510e3-7bde-5474-8249-6ef49a16cfc5",
+    "slug": "san-francisco-ca-pd",
+    "flock_active_slug": "san-francisco-ca-pd",
+    "flock_slugs": [
+      "san-francisco-ca-pd"
+    ],
+    "flock_names": [
+      "San Francisco CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7749,
+    "lng": -122.4194,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0c16750f-dc42-5f60-9071-6ebb60654027",
+    "slug": "san-francisco-district-attorney-ca",
+    "flock_active_slug": "san-francisco-district-attorney-ca",
+    "flock_slugs": [
+      "san-francisco-district-attorney-ca"
+    ],
+    "flock_names": [
+      "San Francisco District Attorney CA"
+    ],
+    "display_name": null,
+    "lat": 37.78,
+    "lng": -122.415,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "77a78d80-60cc-5e45-b5bb-302caf18d07d",
+    "slug": "san-gabriel-ca-pd",
+    "flock_active_slug": "san-gabriel-ca-pd",
+    "flock_slugs": [
+      "san-gabriel-ca-pd"
+    ],
+    "flock_names": [
+      "San Gabriel CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0961,
+    "lng": -118.1058,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1b7f2e03-aea6-57dd-9a58-f75d98eb2c74",
+    "slug": "san-joaquin-ca-da",
+    "flock_active_slug": "san-joaquin-ca-da",
+    "flock_slugs": [
+      "san-joaquin-ca-da"
+    ],
+    "flock_names": [
+      "San Joaquin CA DA"
+    ],
+    "display_name": null,
+    "lat": 37.9577,
+    "lng": -121.2908,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a4056499-0fa5-5b2a-ab70-e2d4f994ad35",
+    "slug": "san-joaquin-county-ca-so",
+    "flock_active_slug": "san-joaquin-county-ca-so",
+    "flock_slugs": [
+      "san-joaquin-county-ca-so"
+    ],
+    "flock_names": [
+      "San Joaquin County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.975,
+    "lng": -121.275,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "afc27a65-11a4-5c6e-9c22-3d94e875a399",
+    "slug": "san-joaquin-delta-college-pd-ca",
+    "flock_active_slug": "san-joaquin-delta-college-pd-ca",
+    "flock_slugs": [
+      "san-joaquin-delta-college-pd-ca"
+    ],
+    "flock_names": [
+      "San Joaquin Delta College PD (CA)"
+    ],
+    "display_name": null,
+    "lat": 37.9891,
+    "lng": -121.327,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (San Joaquin Delta College). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
+    "slug": "san-jose-ca-pd",
+    "flock_active_slug": "san-jose-ca-pd",
+    "flock_slugs": [
+      "san-jose-ca-pd"
+    ],
+    "flock_names": [
+      "San Jose CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3382,
+    "lng": -121.8863,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8269106d-e127-5d07-97fe-d7963b813025",
+    "slug": "san-jose-evergreen-community-college-campus-pd-ca",
+    "flock_active_slug": "san-jose-evergreen-community-college-campus-pd-ca",
+    "flock_slugs": [
+      "san-jose-evergreen-community-college-campus-pd-ca"
+    ],
+    "flock_names": [
+      "San Jose - Evergreen Community College Campus PD CA"
+    ],
+    "display_name": null,
+    "lat": 37.313,
+    "lng": -121.8081,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (San Jose-Evergreen CCD). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fd81cdb7-d353-5d60-b5be-145011443df5",
+    "slug": "san-jose-state-university-ca",
+    "flock_active_slug": "san-jose-state-university-ca",
+    "flock_slugs": [
+      "san-jose-state-university-ca"
+    ],
+    "flock_names": [
+      "San Jose State University CA"
+    ],
+    "display_name": null,
+    "lat": 37.3352,
+    "lng": -121.8811,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public university (San Jose State University). Part of the <a href=\"https://www.calstate.edu/attend/campuses\" target=\"_blank\">California State University</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bdf7188e-c215-549a-bbfd-4c50ba5b0be0",
+    "slug": "san-juan-bautista-ca",
+    "flock_active_slug": "san-juan-bautista-ca",
+    "flock_slugs": [
+      "san-juan-bautista-ca"
+    ],
+    "flock_names": [
+      "San Juan Bautista CA"
+    ],
+    "display_name": null,
+    "lat": 36.8454,
+    "lng": -121.5383,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "484fbe20-7e66-5e78-b0d1-592e137257a3",
+    "slug": "san-leandro-ca-pd",
+    "flock_active_slug": "san-leandro-ca-pd",
+    "flock_slugs": [
+      "san-leandro-ca-pd"
+    ],
+    "flock_names": [
+      "San Leandro CA PD"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "25e82ba5-e684-517c-a175-5ab9342292db",
+    "slug": "san-leandro-pd-ca",
+    "flock_active_slug": "san-leandro-pd-ca",
+    "flock_slugs": [
+      "san-leandro-pd-ca"
+    ],
+    "flock_names": [
+      "San Leandro CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7249,
+    "lng": -122.1561,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "332407d3-a475-546c-88c0-b2046bb47ca7",
+    "slug": "san-luis-obispo-ca-pd",
+    "flock_active_slug": "san-luis-obispo-ca-pd",
+    "flock_slugs": [
+      "san-luis-obispo-ca-pd"
+    ],
+    "flock_names": [
+      "San Luis Obispo CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.2828,
+    "lng": -120.6596,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "06f1b20d-a403-5088-9d3a-d8df6edcb126",
+    "slug": "san-luis-obispo-county-ca-sheriff",
+    "flock_active_slug": "san-luis-obispo-county-ca-sheriff",
+    "flock_slugs": [
+      "san-luis-obispo-county-ca-sheriff"
+    ],
+    "flock_names": [
+      "San Luis Obispo County (CA) Sheriff"
+    ],
+    "display_name": null,
+    "lat": 35.295,
+    "lng": -120.67,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "22f8ebcd-32d7-5e6e-888d-e61c4173a5a3",
+    "slug": "san-marino-ca-pd",
+    "flock_active_slug": "san-marino-ca-pd",
+    "flock_slugs": [
+      "san-marino-ca-pd"
+    ],
+    "flock_names": [
+      "San Marino CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1215,
+    "lng": -118.1064,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "847ce8af-3e88-59ca-90f3-d621db6f31f6",
+    "slug": "san-mateo-ca-pd",
+    "flock_active_slug": "san-mateo-ca-pd",
+    "flock_slugs": [
+      "san-mateo-ca-pd"
+    ],
+    "flock_names": [
+      "San Mateo CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.563,
+    "lng": -122.3255,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6d11ec03-586d-570a-b110-56f9e37261ff",
+    "slug": "san-mateo-county-ca-so",
+    "flock_active_slug": "san-mateo-county-ca-so",
+    "flock_slugs": [
+      "san-mateo-county-ca-so"
+    ],
+    "flock_names": [
+      "San Mateo County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.49,
+    "lng": -122.23,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e0b44c96-8eee-5425-abe1-00ef89d519bd",
+    "slug": "san-pablo-ca-pd",
+    "flock_active_slug": "san-pablo-ca-pd",
+    "flock_slugs": [
+      "san-pablo-ca-pd"
+    ],
+    "flock_names": [
+      "San Pablo CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9621,
+    "lng": -122.3458,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "f17f02e4-77c4-50ca-a858-8e388e2b8e85",
+    "slug": "san-pasqual-ca-pd",
+    "flock_active_slug": "san-pasqual-ca-pd",
+    "flock_slugs": [
+      "san-pasqual-ca-pd"
+    ],
+    "flock_names": [
+      "San Pasqual CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.0947,
+    "lng": -116.9578,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8cc8d9b2-f3e3-5cef-a31b-a5e8990199b5",
+    "slug": "san-rafael-ca-pd",
+    "flock_active_slug": "san-rafael-ca-pd",
+    "flock_slugs": [
+      "san-rafael-ca-pd"
+    ],
+    "flock_names": [
+      "San Rafael CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9735,
+    "lng": -122.5311,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "70e82b2b-8338-517d-a602-8705d9a524e2",
+    "slug": "san-ramon-ca-pd",
+    "flock_active_slug": "san-ramon-ca-pd",
+    "flock_slugs": [
+      "san-ramon-ca-pd"
+    ],
+    "flock_names": [
+      "San Ramon CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7799,
+    "lng": -121.978,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dddefaf4-84f7-5857-8011-45b6eda02991",
+    "slug": "sand-city-ca-pd",
+    "flock_active_slug": "sand-city-ca-pd",
+    "flock_slugs": [
+      "sand-city-ca-pd"
+    ],
+    "flock_names": [
+      "Sand City CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.62,
+    "lng": -121.85,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e35b094f-0435-50b5-a03c-e644ad6144be",
+    "slug": "sanger-ca-pd",
+    "flock_active_slug": "sanger-ca-pd",
+    "flock_slugs": [
+      "sanger-ca-pd"
+    ],
+    "flock_names": [
+      "Sanger CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.708,
+    "lng": -119.556,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6dd1ac80-46a7-5e30-a512-bc0d51bfe013",
+    "slug": "santa-ana-ca-pd",
+    "flock_active_slug": "santa-ana-ca-pd",
+    "flock_slugs": [
+      "santa-ana-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Ana CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7455,
+    "lng": -117.8677,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "859a9edf-ef08-56b8-bb5c-db50aa11cad9",
     "slug": "santa-anita-oaks-ca",
-    "flock_name": "santa-anita-oaks-ca",
-    "human_name": "santa-anita-oaks-ca",
+    "flock_active_slug": "santa-anita-oaks-ca",
+    "flock_slugs": [
+      "santa-anita-oaks-ca"
+    ],
+    "flock_names": [
+      "Santa Anita Oaks (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "409e0107-b585-5909-bb57-7603baa9360c",
+    "slug": "santa-barbara-county-ca-so",
+    "flock_active_slug": "santa-barbara-county-ca-so",
+    "flock_slugs": [
+      "santa-barbara-county-ca-so"
+    ],
+    "flock_names": [
+      "Santa Barbara County CA SO"
+    ],
+    "display_name": null,
+    "lat": 34.444,
+    "lng": -119.715,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6f70fe45-e90c-558f-99bb-28df63a79ec1",
+    "slug": "santa-barbara-pd-ca",
+    "flock_active_slug": "santa-barbara-pd-ca",
+    "flock_slugs": [
+      "santa-barbara-pd-ca"
+    ],
+    "flock_names": [
+      "Santa Barbara PD CA"
+    ],
+    "display_name": null,
+    "lat": 34.4208,
+    "lng": -119.6982,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "033b31f5-8525-5ff8-af2b-2f53899bc6c9",
+    "slug": "santa-clara-ca-pd",
+    "flock_active_slug": "santa-clara-ca-pd",
+    "flock_slugs": [
+      "santa-clara-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Clara CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3541,
+    "lng": -121.9552,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1b719ab9-5230-5a7a-bcb4-a495a4e716eb",
+    "slug": "santa-clara-county-ca-so",
+    "flock_active_slug": "santa-clara-county-ca-so",
+    "flock_slugs": [
+      "santa-clara-county-ca-so"
+    ],
+    "flock_names": [
+      "Santa Clara County CA SO"
+    ],
+    "display_name": null,
+    "lat": 37.34,
+    "lng": -121.935,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6be9f842-1658-5490-8be4-14b77cc1e96d",
+    "slug": "santa-clara-da-ca",
+    "flock_active_slug": "santa-clara-da-ca",
+    "flock_slugs": [
+      "santa-clara-da-ca"
+    ],
+    "flock_names": [
+      "Santa Clara DA CA"
+    ],
+    "display_name": null,
+    "lat": 37.338,
+    "lng": -121.886,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8e97dede-dc5e-518a-bd9c-ca1acce1757a",
+    "slug": "santa-cruz-ca-pd",
+    "flock_active_slug": "santa-cruz-ca-pd",
+    "flock_slugs": [
+      "santa-cruz-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Cruz CA PD (deactivated)"
+    ],
+    "display_name": null,
+    "lat": 36.9741,
+    "lng": -122.0308,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a51bc7af-d8f6-50b5-8504-9b8ea53331d8",
+    "slug": "santa-cruz-ca-pd-deactivated",
+    "flock_active_slug": "santa-cruz-ca-pd-deactivated",
+    "flock_slugs": [
+      "santa-cruz-ca-pd-deactivated"
+    ],
+    "flock_names": [
+      "Santa Cruz CA PD (deactivated)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6c6b2202-9b87-5c04-b232-040a4f6e1468",
+    "slug": "santa-maria-ca-pd",
+    "flock_active_slug": "santa-maria-ca-pd",
+    "flock_slugs": [
+      "santa-maria-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Maria CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.953,
+    "lng": -120.4357,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4428f521-1969-5e78-9f02-2ff4495e7f72",
+    "slug": "santa-monica-ca-pd",
+    "flock_active_slug": "santa-monica-ca-pd",
+    "flock_slugs": [
+      "santa-monica-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Monica CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0195,
+    "lng": -118.4912,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bfd80134-387e-5eb1-b8b9-cc30a7db0861",
+    "slug": "santa-paula-ca-pd",
+    "flock_active_slug": "santa-paula-ca-pd",
+    "flock_slugs": [
+      "santa-paula-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Paula CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.3542,
+    "lng": -119.059,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9a02b7a4-b078-5f90-9323-a684dcda6674",
+    "slug": "santa-rosa-band-of-cahuilla-indians-ca",
+    "flock_active_slug": "santa-rosa-band-of-cahuilla-indians-ca",
+    "flock_slugs": [
+      "santa-rosa-band-of-cahuilla-indians-ca"
+    ],
+    "flock_names": [
+      "Santa Rosa Band of Cahuilla Indians CA"
+    ],
+    "display_name": null,
+    "lat": 33.56,
+    "lng": -116.78,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "ed2bac0c-c7d0-5c61-ac35-3eea1e073857",
+    "slug": "santa-rosa-ca-pd",
+    "flock_active_slug": "santa-rosa-ca-pd",
+    "flock_slugs": [
+      "santa-rosa-ca-pd"
+    ],
+    "flock_names": [
+      "Santa Rosa CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.4404,
+    "lng": -122.7141,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a057049d-8be7-595b-bb9f-8755d18ea194",
     "slug": "sarasota-county-fl-so",
-    "flock_name": "sarasota-county-fl-so",
-    "human_name": "sarasota-county-fl-so",
+    "flock_active_slug": "sarasota-county-fl-so",
+    "flock_slugs": [
+      "sarasota-county-fl-so"
+    ],
+    "flock_names": [
+      "Sarasota County FL SO"
+    ],
+    "display_name": null,
     "lat": 27.2356,
     "lng": -82.2787,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "98c98e27-7c96-5f33-9f93-9a658d56c4b3",
     "slug": "sarasota-fl-pd",
-    "flock_name": "sarasota-fl-pd",
-    "human_name": "sarasota-fl-pd",
+    "flock_active_slug": "sarasota-fl-pd",
+    "flock_slugs": [
+      "sarasota-fl-pd"
+    ],
+    "flock_names": [
+      "Sarasota FL PD"
+    ],
+    "display_name": null,
     "lat": 27.3364,
     "lng": -82.5307,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "d106645a-f234-5c31-9376-a2b483e2ccd5",
+    "slug": "sausalito-ca-pd",
+    "flock_active_slug": "sausalito-ca-pd",
+    "flock_slugs": [
+      "sausalito-ca-pd"
+    ],
+    "flock_names": [
+      "Sausalito CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8591,
+    "lng": -122.4852,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "56155ca3-fe36-5359-84bd-1feb3daa9d83",
+    "slug": "seal-beach-ca-pd",
+    "flock_active_slug": "seal-beach-ca-pd",
+    "flock_slugs": [
+      "seal-beach-ca-pd"
+    ],
+    "flock_names": [
+      "Seal Beach CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7414,
+    "lng": -118.1048,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e1fd4de4-56ea-5947-91a1-6d8c59bd1974",
+    "slug": "seaside-ca-pd",
+    "flock_active_slug": "seaside-ca-pd",
+    "flock_slugs": [
+      "seaside-ca-pd"
+    ],
+    "flock_names": [
+      "Seaside CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.6107,
+    "lng": -121.8514,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "bc17b741-df64-54cc-a3cc-62bd3fa08f65",
     "slug": "sedgwick-ks-pd",
-    "flock_name": "sedgwick-ks-pd",
-    "human_name": "sedgwick-ks-pd",
+    "flock_active_slug": "sedgwick-ks-pd",
+    "flock_slugs": [
+      "sedgwick-ks-pd"
+    ],
+    "flock_names": [
+      "Sedgwick KS PD"
+    ],
+    "display_name": null,
     "lat": 37.7166,
     "lng": -97.4274,
-    "public": true,
-    "federal": false,
     "state": "KS",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "03c310c0-6e05-5ad2-872a-d4e8b804358f",
+    "slug": "selma-ca-pd",
+    "flock_active_slug": "selma-ca-pd",
+    "flock_slugs": [
+      "selma-ca-pd"
+    ],
+    "flock_names": [
+      "Selma CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.5708,
+    "lng": -119.6121,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "45b455ec-b554-58dd-9cc9-e5e3bb290808",
     "slug": "senoia-ga-pd",
-    "flock_name": "senoia-ga-pd",
-    "human_name": "senoia-ga-pd",
+    "flock_active_slug": "senoia-ga-pd",
+    "flock_slugs": [
+      "senoia-ga-pd"
+    ],
+    "flock_names": [
+      "Senoia GA PD"
+    ],
+    "display_name": null,
     "lat": 33.3018,
     "lng": -84.5538,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "614102bf-56a4-5346-8883-fe06964c6503",
+    "slug": "sequoias-community-college-district-ca-pd",
+    "flock_active_slug": "sequoias-community-college-district-ca-pd",
+    "flock_slugs": [
+      "sequoias-community-college-district-ca-pd"
+    ],
+    "flock_names": [
+      "Sequoias Community College District CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.3302,
+    "lng": -119.2921,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (College of the Sequoias). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "6db175fe-bff6-58bc-a911-d688f797fda9",
+    "slug": "shafter-pd-ca",
+    "flock_active_slug": "shafter-pd-ca",
+    "flock_slugs": [
+      "shafter-pd-ca"
+    ],
+    "flock_names": [
+      "Shafter PD CA"
+    ],
+    "display_name": null,
+    "lat": 35.5005,
+    "lng": -119.2718,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0a4e711e-2f15-5549-aedd-f78cca464fc3",
+    "slug": "shasta-arson-task-force-ca",
+    "flock_active_slug": "shasta-arson-task-force-ca",
+    "flock_slugs": [
+      "shasta-arson-task-force-ca"
+    ],
+    "flock_names": [
+      "Shasta Arson Task Force CA"
+    ],
+    "display_name": null,
+    "lat": 40.5865,
+    "lng": -122.3917,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ]
+  },
+  {
+    "agency_id": "3a625802-0f41-55ae-9617-60dfc7c5f6d8",
+    "slug": "shasta-county-so",
+    "flock_active_slug": "shasta-county-so",
+    "flock_slugs": [
+      "shasta-county-so"
+    ],
+    "flock_names": [
+      "Shasta County SO"
+    ],
+    "display_name": null,
+    "lat": 40.5865,
+    "lng": -122.3917,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e4029280-c00b-58d0-b32e-4d944be14df8",
     "slug": "sherwood-village-anaheim-ca",
-    "flock_name": "sherwood-village-anaheim-ca",
-    "human_name": "sherwood-village-anaheim-ca",
+    "flock_active_slug": "sherwood-village-anaheim-ca",
+    "flock_slugs": [
+      "sherwood-village-anaheim-ca"
+    ],
+    "flock_names": [
+      "Sherwood Village-Anaheim (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "42ffc6f8-66bc-5d89-a53b-e3e030c26177",
     "slug": "shore-cliffs-ca",
-    "flock_name": "shore-cliffs-ca",
-    "human_name": "shore-cliffs-ca",
+    "flock_active_slug": "shore-cliffs-ca",
+    "flock_slugs": [
+      "shore-cliffs-ca"
+    ],
+    "flock_names": [
+      "Shore Cliffs (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "e087cf69-734d-5470-9f56-84a19ba42d9f",
+    "slug": "sierra-madre-ca-pd",
+    "flock_active_slug": "sierra-madre-ca-pd",
+    "flock_slugs": [
+      "sierra-madre-ca-pd"
+    ],
+    "flock_names": [
+      "Sierra Madre CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1617,
+    "lng": -118.0528,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fc97bf62-065b-507f-a327-4fd4c94453c6",
+    "slug": "signal-hill-ca-pd",
+    "flock_active_slug": "signal-hill-ca-pd",
+    "flock_slugs": [
+      "signal-hill-ca-pd"
+    ],
+    "flock_names": [
+      "Signal Hill CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.8042,
+    "lng": -118.1681,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e79b39d0-f790-5669-a217-9dc973a99e1a",
+    "slug": "simi-valley-ca-pd",
+    "flock_active_slug": "simi-valley-ca-pd",
+    "flock_slugs": [
+      "simi-valley-ca-pd"
+    ],
+    "flock_names": [
+      "Simi Valley CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.2694,
+    "lng": -118.7815,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b1b2a97d-0513-5ec3-86ef-3a6351dd2c58",
     "slug": "simon-property-group-hq-in",
-    "flock_name": "simon-property-group-hq-in",
-    "human_name": "simon-property-group-hq-in",
+    "flock_active_slug": "simon-property-group-hq-in",
+    "flock_slugs": [
+      "simon-property-group-hq-in"
+    ],
+    "flock_names": [
+      "Simon Property Group HQ (IN)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "1cb34efd-a1f4-55a7-8e18-afe3ad69412b",
+    "slug": "siskiyou-county-so-ca",
+    "flock_active_slug": "siskiyou-county-so-ca",
+    "flock_slugs": [
+      "siskiyou-county-so-ca"
+    ],
+    "flock_names": [
+      "Siskiyou County SO CA"
+    ],
+    "display_name": null,
+    "lat": 41.7354,
+    "lng": -122.6347,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "aa08a005-0a8d-51b3-9229-4e5f8a544e8d",
+    "slug": "solano-county-ca-so",
+    "flock_active_slug": "solano-county-ca-so",
+    "flock_slugs": [
+      "solano-county-ca-so"
+    ],
+    "flock_names": [
+      "Solano County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.27,
+    "lng": -122.015,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "81e727b4-f1d6-5aea-8cd4-db0cf88a7306",
+    "slug": "solano-county-da-ca",
+    "flock_active_slug": "solano-county-da-ca",
+    "flock_slugs": [
+      "solano-county-da-ca"
+    ],
+    "flock_names": [
+      "Solano County DA CA"
+    ],
+    "display_name": null,
+    "lat": 38.2494,
+    "lng": -122.04,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "99e640ed-c175-5ce6-90c8-5ea55dfa2ed3",
+    "slug": "solano-county-special-investigations-bureau",
+    "flock_active_slug": "solano-county-special-investigations-bureau",
+    "flock_slugs": [
+      "solano-county-special-investigations-bureau"
+    ],
+    "flock_names": [
+      "Solano County Special Investigations Bureau"
+    ],
+    "display_name": null,
+    "lat": 38.255,
+    "lng": -122.03,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4",
+    "slug": "soledad-ca-pd",
+    "flock_active_slug": "soledad-ca-pd",
+    "flock_slugs": [
+      "soledad-ca-pd"
+    ],
+    "flock_names": [
+      "Soledad CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.4247,
+    "lng": -121.3263,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2",
+    "slug": "sonoma-county-ca-so",
+    "flock_active_slug": "sonoma-county-ca-so",
+    "flock_slugs": [
+      "sonoma-county-ca-so"
+    ],
+    "flock_names": [
+      "Sonoma County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.511,
+    "lng": -122.9888,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c7d1aa56-2092-5b32-bba9-1a9765cfc18e",
+    "slug": "south-gate-ca-pd",
+    "flock_active_slug": "south-gate-ca-pd",
+    "flock_slugs": [
+      "south-gate-ca-pd"
+    ],
+    "flock_names": [
+      "South Gate CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9547,
+    "lng": -118.212,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5448e966-a286-5dac-a301-1ed74914217e",
+    "slug": "south-pasadena-ca-pd",
+    "flock_active_slug": "south-pasadena-ca-pd",
+    "flock_slugs": [
+      "south-pasadena-ca-pd"
+    ],
+    "flock_names": [
+      "South Pasadena CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.1161,
+    "lng": -118.1503,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8e9c1759-130e-5fe9-9ab4-6c4682ed81ec",
+    "slug": "south-san-francisco-ca-pd",
+    "flock_active_slug": "south-san-francisco-ca-pd",
+    "flock_slugs": [
+      "south-san-francisco-ca-pd"
+    ],
+    "flock_names": [
+      "South San Francisco CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.6547,
+    "lng": -122.4077,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "df046d0d-e4db-592a-89b0-646313b2ecb3",
     "slug": "south-sioux-city-ne-pd",
-    "flock_name": "south-sioux-city-ne-pd",
-    "human_name": "south-sioux-city-ne-pd",
+    "flock_active_slug": "south-sioux-city-ne-pd",
+    "flock_slugs": [
+      "south-sioux-city-ne-pd"
+    ],
+    "flock_names": [
+      "South Sioux City NE PD"
+    ],
+    "display_name": null,
     "lat": 42.4711,
     "lng": -96.4136,
-    "public": true,
-    "federal": false,
     "state": "NE",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "33f2410a-d3bc-59c8-9076-2f363c25b8ea",
     "slug": "sparks-police-department-nv",
-    "flock_name": "sparks-police-department-nv",
-    "human_name": "sparks-police-department-nv",
+    "flock_active_slug": "sparks-police-department-nv",
+    "flock_slugs": [
+      "sparks-police-department-nv"
+    ],
+    "flock_names": [
+      "Sparks Police Department - NV"
+    ],
+    "display_name": null,
     "lat": 39.5349,
     "lng": -119.7527,
-    "public": true,
-    "federal": true,
     "state": "NV",
     "agency_role": "police",
     "agency_type": "federal",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "federal",
+      "public"
+    ]
   },
   {
+    "agency_id": "db8b5934-0b06-5420-893c-9295c3aaf07d",
     "slug": "st-charles-county-mo-pd",
-    "flock_name": "st-charles-county-mo-pd",
-    "human_name": "st-charles-county-mo-pd",
+    "flock_active_slug": "st-charles-county-mo-pd",
+    "flock_slugs": [
+      "st-charles-county-mo-pd"
+    ],
+    "flock_names": [
+      "St. Charles County MO PD"
+    ],
+    "display_name": null,
     "lat": 38.7839,
     "lng": -90.4812,
-    "public": true,
-    "federal": false,
     "state": "MO",
     "agency_role": "police",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "ec6ab4f5-f3f8-5312-925f-9394a5877d27",
     "slug": "st-francois-county-mo-so",
-    "flock_name": "st-francois-county-mo-so",
-    "human_name": "st-francois-county-mo-so",
+    "flock_active_slug": "st-francois-county-mo-so",
+    "flock_slugs": [
+      "st-francois-county-mo-so"
+    ],
+    "flock_names": [
+      "St. Francois County MO SO"
+    ],
+    "display_name": null,
     "lat": 37.8214,
     "lng": -90.4193,
-    "public": true,
-    "federal": false,
     "state": "MO",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "8b8e35cd-c8ac-51a2-9f4f-2aa18b5d0028",
+    "slug": "st-helena-ca-pd",
+    "flock_active_slug": "st-helena-ca-pd",
+    "flock_slugs": [
+      "st-helena-ca-pd"
+    ],
+    "flock_names": [
+      "St. Helena CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5052,
+    "lng": -122.4703,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "08bd5589-6ad6-5be4-bea5-60bd90bf6883",
+    "slug": "stallion-springs-ca-pd",
+    "flock_active_slug": "stallion-springs-ca-pd",
+    "flock_slugs": [
+      "stallion-springs-ca-pd"
+    ],
+    "flock_names": [
+      "Stallion Springs CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.08,
+    "lng": -118.63,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "61659896-6870-5421-9b6c-8edf08f0e86b",
+    "slug": "stanford-university-ca-pd",
+    "flock_active_slug": "stanford-university-ca-pd",
+    "flock_slugs": [
+      "stanford-university-ca-pd"
+    ],
+    "flock_names": [
+      "Stanford University CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4275,
+    "lng": -122.1697,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "private",
+    "website": null,
+    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Stanford is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "9b86a732-064e-54d3-8b51-126061153dfb",
+    "slug": "stockton-ca-pd",
+    "flock_active_slug": "stockton-ca-pd",
+    "flock_slugs": [
+      "stockton-ca-pd"
+    ],
+    "flock_names": [
+      "Stockton CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9577,
+    "lng": -121.2908,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c",
+    "slug": "suisun-city-ca-pd",
+    "flock_active_slug": "suisun-city-ca-pd",
+    "flock_slugs": [
+      "suisun-city-ca-pd"
+    ],
+    "flock_names": [
+      "Suisun City CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.2383,
+    "lng": -122.04,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "132bc98f-aebb-52c5-b98b-6dbbec94ad46",
     "slug": "sumner-county-tn-so",
-    "flock_name": "sumner-county-tn-so",
-    "human_name": "sumner-county-tn-so",
+    "flock_active_slug": "sumner-county-tn-so",
+    "flock_slugs": [
+      "sumner-county-tn-so"
+    ],
+    "flock_names": [
+      "Sumner County TN SO"
+    ],
+    "display_name": null,
     "lat": 36.47,
     "lng": -86.4603,
-    "public": true,
-    "federal": false,
     "state": "TN",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "48ca1693-7f6e-5f8c-a4ab-5cb0c18c319e",
     "slug": "sundance-ca",
-    "flock_name": "sundance-ca",
-    "human_name": "sundance-ca",
+    "flock_active_slug": "sundance-ca",
+    "flock_slugs": [
+      "sundance-ca"
+    ],
+    "flock_names": [
+      "Sundance (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "7ef62d29-d50a-5f12-85fe-6061de259c8d",
+    "slug": "sunnyvale-ca-pd",
+    "flock_active_slug": "sunnyvale-ca-pd",
+    "flock_slugs": [
+      "sunnyvale-ca-pd"
+    ],
+    "flock_names": [
+      "Sunnyvale CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.3688,
+    "lng": -122.0363,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "d9342287-962b-509a-9861-e44e0172394e",
+    "slug": "sutter-county-ca-so",
+    "flock_active_slug": "sutter-county-ca-so",
+    "flock_slugs": [
+      "sutter-county-ca-so"
+    ],
+    "flock_names": [
+      "Sutter County CA SO"
+    ],
+    "display_name": null,
+    "lat": 39.1596,
+    "lng": -121.6947,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "884e9ea9-0bb4-516d-8115-721962e6e300",
     "slug": "sycamore-place-ca",
-    "flock_name": "sycamore-place-ca",
-    "human_name": "sycamore-place-ca",
+    "flock_active_slug": "sycamore-place-ca",
+    "flock_slugs": [
+      "sycamore-place-ca"
+    ],
+    "flock_names": [
+      "Sycamore Place (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "c381f451-5a62-51e2-bb73-cb592b9371ec",
+    "slug": "taft-ca-pd",
+    "flock_active_slug": "taft-ca-pd",
+    "flock_slugs": [
+      "taft-ca-pd"
+    ],
+    "flock_names": [
+      "Taft CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.1425,
+    "lng": -119.4566,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9d20e130-64d6-5b99-aaf0-28740d1fcc92",
     "slug": "tarpon-springs-fl-pd",
-    "flock_name": "tarpon-springs-fl-pd",
-    "human_name": "tarpon-springs-fl-pd",
+    "flock_active_slug": "tarpon-springs-fl-pd",
+    "flock_slugs": [
+      "tarpon-springs-fl-pd"
+    ],
+    "flock_names": [
+      "Tarpon Springs FL PD"
+    ],
+    "display_name": null,
     "lat": 28.1461,
     "lng": -82.7568,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "9873a872-c374-51e3-b9ea-6a6c427b932c",
+    "slug": "tehachapi-ca-pd",
+    "flock_active_slug": "tehachapi-ca-pd",
+    "flock_slugs": [
+      "tehachapi-ca-pd"
+    ],
+    "flock_names": [
+      "Tehachapi CA PD"
+    ],
+    "display_name": null,
+    "lat": 35.1322,
+    "lng": -118.449,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "2279723d-b2cf-59d8-8732-4fdefd822546",
+    "slug": "tehama-county-ca-so",
+    "flock_active_slug": "tehama-county-ca-so",
+    "flock_slugs": [
+      "tehama-county-ca-so"
+    ],
+    "flock_names": [
+      "Tehama County CA SO"
+    ],
+    "display_name": null,
+    "lat": 40.0258,
+    "lng": -122.1236,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c34885fe-6219-5859-9574-d45240dd1af9",
+    "slug": "temecula-ca-pd",
+    "flock_active_slug": "temecula-ca-pd",
+    "flock_slugs": [
+      "temecula-ca-pd"
+    ],
+    "flock_names": [
+      "Temecula CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.4936,
+    "lng": -117.1484,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "c7562b2e-899d-51ac-bbf0-4cde526babff",
+    "slug": "test-demo-1234",
+    "flock_active_slug": "test-demo-1234",
+    "flock_slugs": [
+      "test-demo-1234"
+    ],
+    "flock_names": [
+      "Test Demo 1234"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
+    "state": null,
+    "agency_role": "test",
+    "agency_type": "test",
+    "website": null,
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "2b9c0fdc-5497-5022-8ee4-5ae8cd221ddf",
     "slug": "texas-city-tx-pd",
-    "flock_name": "texas-city-tx-pd",
-    "human_name": "texas-city-tx-pd",
+    "flock_active_slug": "texas-city-tx-pd",
+    "flock_slugs": [
+      "texas-city-tx-pd"
+    ],
+    "flock_names": [
+      "Texas City TX PD"
+    ],
+    "display_name": null,
     "lat": 29.3838,
     "lng": -94.9027,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "344abfc1-75f0-51e5-bd7e-6ba54ac13609",
     "slug": "the-landing-at-wildflower-station-ca",
-    "flock_name": "the-landing-at-wildflower-station-ca",
-    "human_name": "the-landing-at-wildflower-station-ca",
+    "flock_active_slug": "the-landing-at-wildflower-station-ca",
+    "flock_slugs": [
+      "the-landing-at-wildflower-station-ca"
+    ],
+    "flock_names": [
+      "The Landing at Wildflower Station (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "890a202a-dd97-5136-8f4f-5fc64e60b29c",
     "slug": "the-lewis-group-of-companies",
-    "flock_name": "the-lewis-group-of-companies",
-    "human_name": "the-lewis-group-of-companies",
+    "flock_active_slug": "the-lewis-group-of-companies",
+    "flock_slugs": [
+      "the-lewis-group-of-companies"
+    ],
+    "flock_names": [
+      "The Lewis Group of Companies"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "4a508123-c296-5f67-b3c9-c1ccfa64db33",
+    "slug": "tiburon-ca-pd",
+    "flock_active_slug": "tiburon-ca-pd",
+    "flock_slugs": [
+      "tiburon-ca-pd"
+    ],
+    "flock_names": [
+      "Tiburon CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.8735,
+    "lng": -122.4567,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1e8076f1-9739-5576-aa76-10a687e68446",
     "slug": "tift-county-ga-so",
-    "flock_name": "tift-county-ga-so",
-    "human_name": "tift-county-ga-so",
+    "flock_active_slug": "tift-county-ga-so",
+    "flock_slugs": [
+      "tift-county-ga-so"
+    ],
+    "flock_names": [
+      "Tift County GA SO"
+    ],
+    "display_name": null,
     "lat": 31.471,
     "lng": -83.5088,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "ca08fcba-f0f8-5ecc-8fea-4338abcb187e",
     "slug": "tifton-ga-pd",
-    "flock_name": "tifton-ga-pd",
-    "human_name": "tifton-ga-pd",
+    "flock_active_slug": "tifton-ga-pd",
+    "flock_slugs": [
+      "tifton-ga-pd"
+    ],
+    "flock_names": [
+      "Tifton GA PD"
+    ],
+    "display_name": null,
     "lat": 31.4507,
     "lng": -83.5085,
-    "public": true,
-    "federal": false,
     "state": "GA",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "225a622c-c9c8-5b37-818c-cdd5cbdec38d",
     "slug": "titusville-fl-pd",
-    "flock_name": "titusville-fl-pd",
-    "human_name": "titusville-fl-pd",
+    "flock_active_slug": "titusville-fl-pd",
+    "flock_slugs": [
+      "titusville-fl-pd"
+    ],
+    "flock_names": [
+      "Titusville FL PD"
+    ],
+    "display_name": null,
     "lat": 28.6122,
     "lng": -80.8076,
-    "public": true,
-    "federal": false,
     "state": "FL",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "8dde57df-a338-5e82-ab54-c0ebc13d9720",
     "slug": "toluca-lake-ca",
-    "flock_name": "toluca-lake-ca",
-    "human_name": "toluca-lake-ca",
+    "flock_active_slug": "toluca-lake-ca",
+    "flock_slugs": [
+      "toluca-lake-ca"
+    ],
+    "flock_names": [
+      "Toluca Lake (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "311ff8a6-de97-5bdb-abba-9d5b9a21d66e",
     "slug": "tombstone-marshals-office-az",
-    "flock_name": "tombstone-marshals-office-az",
-    "human_name": "tombstone-marshals-office-az",
+    "flock_active_slug": "tombstone-marshals-office-az",
+    "flock_slugs": [
+      "tombstone-marshals-office-az"
+    ],
+    "flock_names": [
+      "Tombstone Marshals Office (AZ)"
+    ],
+    "display_name": null,
     "lat": 31.7129,
     "lng": -110.0676,
-    "public": true,
-    "federal": true,
     "state": "AZ",
     "agency_role": "police",
     "agency_type": "federal",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "federal",
+      "public"
+    ]
   },
   {
+    "agency_id": "a064cac6-6a2e-5c77-bd96-c106cb96bd61",
     "slug": "total-wine-more-md",
-    "flock_name": "total-wine-more-md",
-    "human_name": "total-wine-more-md",
+    "flock_active_slug": "total-wine-more-md",
+    "flock_slugs": [
+      "total-wine-more-md"
+    ],
+    "flock_names": [
+      "Total Wine & More (MD)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "tustin-fields-ca",
-    "flock_name": "tustin-fields-ca",
-    "human_name": "tustin-fields-ca",
+    "agency_id": "79d1a399-1db1-5b50-aaa9-b4bbc64d8dd2",
+    "slug": "town-of-los-gatos-ca",
+    "flock_active_slug": "town-of-los-gatos-ca",
+    "flock_slugs": [
+      "town-of-los-gatos-ca"
+    ],
+    "flock_names": [
+      "Town of Los Gatos CA"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e29c469f-b2b6-515e-8d3c-93b3075ad896",
+    "slug": "town-of-woodside-ca-smcso",
+    "flock_active_slug": "town-of-woodside-ca-smcso",
+    "flock_slugs": [
+      "town-of-woodside-ca-smcso"
+    ],
+    "flock_names": [
+      "Town of Woodside CA (SMCSO)"
+    ],
+    "display_name": null,
+    "lat": 37.4299,
+    "lng": -122.2539,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b9416bc1-b4d2-5852-9bad-c498f32961b0",
+    "slug": "tracy-ca-pd",
+    "flock_active_slug": "tracy-ca-pd",
+    "flock_slugs": [
+      "tracy-ca-pd"
+    ],
+    "flock_names": [
+      "Tracy CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7397,
+    "lng": -121.4252,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "72812ca1-c7b8-5c94-8327-508726647ad8",
+    "slug": "trinity-county-so-ca",
+    "flock_active_slug": "trinity-county-so-ca",
+    "flock_slugs": [
+      "trinity-county-so-ca"
+    ],
+    "flock_names": [
+      "Trinity County SO CA"
+    ],
+    "display_name": null,
+    "lat": 40.739,
+    "lng": -122.9423,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "babe8d1b-3500-5f2b-a064-c54430c60e74",
+    "slug": "truckee-ca-pd",
+    "flock_active_slug": "truckee-ca-pd",
+    "flock_slugs": [
+      "truckee-ca-pd"
+    ],
+    "flock_names": [
+      "Truckee CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.328,
+    "lng": -120.1833,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "8fb27794-b88c-5373-b6a1-da64ae2f059c",
+    "slug": "tulare-ca-pd",
+    "flock_active_slug": "tulare-ca-pd",
+    "flock_slugs": [
+      "tulare-ca-pd"
+    ],
+    "flock_names": [
+      "Tulare CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.2077,
+    "lng": -119.3473,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4cc1fd23-7711-52b8-be07-9d6e1ad7b364",
+    "slug": "tulare-county-ca-so",
+    "flock_active_slug": "tulare-county-ca-so",
+    "flock_slugs": [
+      "tulare-county-ca-so"
+    ],
+    "flock_names": [
+      "Tulare County CA SO"
+    ],
+    "display_name": null,
+    "lat": 36.23,
+    "lng": -119.32,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b1eec57c-0fcc-5546-bfb6-7005adc695d3",
+    "slug": "turlock-ca-pd",
+    "flock_active_slug": "turlock-ca-pd",
+    "flock_slugs": [
+      "turlock-ca-pd"
+    ],
+    "flock_names": [
+      "Turlock CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.4947,
+    "lng": -120.8466,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9eb7354b-b6ff-590b-b3bb-f097e0b30033",
+    "slug": "tustin-ca-pd",
+    "flock_active_slug": "tustin-ca-pd",
+    "flock_slugs": [
+      "tustin-ca-pd"
+    ],
+    "flock_names": [
+      "Tustin CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7458,
+    "lng": -117.8262,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "61d84379-7a54-5b45-8292-ef44a2e1a1f3",
+    "slug": "tustin-fields-ca",
+    "flock_active_slug": "tustin-fields-ca",
+    "flock_slugs": [
+      "tustin-fields-ca"
+    ],
+    "flock_names": [
+      "Tustin Fields (CA)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
-    "slug": "ulta-il",
-    "flock_name": "ulta-il",
-    "human_name": "ulta-il",
+    "agency_id": "6978140c-1211-52e1-8c04-94d5a9791efe",
+    "slug": "uc-irvine-campus-pd-ca",
+    "flock_active_slug": "uc-irvine-campus-pd-ca",
+    "flock_slugs": [
+      "uc-irvine-campus-pd-ca"
+    ],
+    "flock_names": [
+      "UC Irvine Campus PD CA"
+    ],
+    "display_name": null,
+    "lat": 33.6405,
+    "lng": -117.8443,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public university (UC Irvine). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "3f7eb8d2-ed50-5eac-9b8c-ac66584c00aa",
+    "slug": "ukiah-ca-pd",
+    "flock_active_slug": "ukiah-ca-pd",
+    "flock_slugs": [
+      "ukiah-ca-pd"
+    ],
+    "flock_names": [
+      "Ukiah CA PD"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "dde5fe3d-8dc6-5d4d-af6a-a28a62387cf6",
+    "slug": "ukiah-fire-ca-fd",
+    "flock_active_slug": "ukiah-fire-ca-fd",
+    "flock_slugs": [
+      "ukiah-fire-ca-fd"
+    ],
+    "flock_names": [
+      "Ukiah Fire CA FD"
+    ],
+    "display_name": null,
+    "lat": 39.1502,
+    "lng": -123.2078,
+    "state": "CA",
+    "agency_role": "fire",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "463bf304-0555-5d48-ba00-b4bb05816b67",
+    "slug": "ukiah-pd-ca",
+    "flock_active_slug": "ukiah-pd-ca",
+    "flock_slugs": [
+      "ukiah-pd-ca"
+    ],
+    "flock_names": [
+      "Ukiah CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.1502,
+    "lng": -123.2078,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e3faac7d-da12-5ca3-8d6b-9c11184d0919",
+    "slug": "ulta-il",
+    "flock_active_slug": "ulta-il",
+    "flock_slugs": [
+      "ulta-il"
+    ],
+    "flock_names": [
+      "Ulta (IL)"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": null,
     "agency_role": "business",
     "agency_type": "private",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "b3d62a9b-027b-58ce-a4ee-2378e02cd8f7",
     "slug": "ulysses-ks-pd",
-    "flock_name": "ulysses-ks-pd",
-    "human_name": "ulysses-ks-pd",
+    "flock_active_slug": "ulysses-ks-pd",
+    "flock_slugs": [
+      "ulysses-ks-pd"
+    ],
+    "flock_names": [
+      "Ulysses KS PD"
+    ],
+    "display_name": null,
     "lat": 37.5781,
     "lng": -101.3551,
-    "public": true,
-    "federal": false,
     "state": "KS",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "7f5089e9-3b53-5442-b628-865e85940409",
+    "slug": "union-city-ca-pd",
+    "flock_active_slug": "union-city-ca-pd",
+    "flock_slugs": [
+      "union-city-ca-pd"
+    ],
+    "flock_names": [
+      "Union City CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.5934,
+    "lng": -122.0439,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ecce0cdb-25b8-5f79-9108-3be60c1dc775",
+    "slug": "university-of-ca-santa-barbara-ca-pd",
+    "flock_active_slug": "university-of-ca-santa-barbara-ca-pd",
+    "flock_slugs": [
+      "university-of-ca-santa-barbara-ca-pd"
+    ],
+    "flock_names": [
+      "University of CA - Santa Barbara CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.414,
+    "lng": -119.8489,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public university (UC Santa Barbara). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "eaef691d-609c-566f-ad67-3a187a241852",
+    "slug": "university-of-california-berkeley",
+    "flock_active_slug": "university-of-california-berkeley",
+    "flock_slugs": [
+      "university-of-california-berkeley"
+    ],
+    "flock_names": [
+      "University of California, Berkeley"
+    ],
+    "display_name": null,
+    "lat": 37.872,
+    "lng": -122.259,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public university (UC Berkeley). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "89890ca4-4ace-50e7-a722-b23d22753898",
     "slug": "university-of-north-texas-at-denton-pd-tx",
-    "flock_name": "university-of-north-texas-at-denton-pd-tx",
-    "human_name": "university-of-north-texas-at-denton-pd-tx",
+    "flock_active_slug": "university-of-north-texas-at-denton-pd-tx",
+    "flock_slugs": [
+      "university-of-north-texas-at-denton-pd-tx"
+    ],
+    "flock_names": [
+      "University of North Texas at Denton PD (TX)"
+    ],
+    "display_name": null,
     "lat": 33.2148,
     "lng": -97.1331,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "campus_safety",
     "agency_type": "university",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review",
+      "public"
+    ]
   },
   {
+    "agency_id": "b1647bf6-e1ab-502c-be02-022861ee94ca",
+    "slug": "university-of-san-francisco-ca-pd",
+    "flock_active_slug": "university-of-san-francisco-ca-pd",
+    "flock_slugs": [
+      "university-of-san-francisco-ca-pd"
+    ],
+    "flock_names": [
+      "University of San Francisco CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.7767,
+    "lng": -122.4506,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "private",
+    "website": null,
+    "notes": "Private Jesuit university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. USF is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "c246371a-5810-5428-b861-52b526e54678",
+    "slug": "university-of-the-pacific-ca",
+    "flock_active_slug": "university-of-the-pacific-ca",
+    "flock_slugs": [
+      "university-of-the-pacific-ca"
+    ],
+    "flock_names": [
+      "University of the Pacific (CA)"
+    ],
+    "display_name": null,
+    "lat": 37.9812,
+    "lng": -121.3114,
+    "state": "CA",
+    "agency_role": "other",
+    "agency_type": "private",
+    "website": null,
+    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. UOP Chief of Police confirmed in writing that University of the Pacific is \"a private institution and therefore not subject to the CPRA.\" UOP was removed from SMPD\u2019s portal after a resident raised the issue; it remains on Stockton PD\u2019s portal. (<a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings, Source 29</a>)",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "11949eb7-26df-5b98-a23d-ac249879ec01",
+    "slug": "upland-ca-pd",
+    "flock_active_slug": "upland-ca-pd",
+    "flock_slugs": [
+      "upland-ca-pd"
+    ],
+    "flock_names": [
+      "Upland CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0975,
+    "lng": -117.6484,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b8c857d4-5045-5088-a4bc-67a87461caff",
+    "slug": "vacaville-ca-pd",
+    "flock_active_slug": "vacaville-ca-pd",
+    "flock_slugs": [
+      "vacaville-ca-pd"
+    ],
+    "flock_names": [
+      "Vacaville CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.3566,
+    "lng": -121.9877,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "18fbdbf6-7afe-5a4f-a63f-07de2c3029a5",
+    "slug": "vallejo-ca-pd",
+    "flock_active_slug": "vallejo-ca-pd",
+    "flock_slugs": [
+      "vallejo-ca-pd"
+    ],
+    "flock_names": [
+      "Vallejo CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.1041,
+    "lng": -122.2566,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1406641c-043e-5440-8311-1b12d05131f5",
     "slug": "valley-circle-estates-ca",
-    "flock_name": "valley-circle-estates-ca",
-    "human_name": "valley-circle-estates-ca",
+    "flock_active_slug": "valley-circle-estates-ca",
+    "flock_slugs": [
+      "valley-circle-estates-ca"
+    ],
+    "flock_names": [
+      "Valley Circle Estates (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "e2af06fe-90f6-56aa-adc6-4afeb0c38e9e",
     "slug": "valley-glen-neighborhood-watch-ca",
-    "flock_name": "valley-glen-neighborhood-watch-ca",
-    "human_name": "valley-glen-neighborhood-watch-ca",
+    "flock_active_slug": "valley-glen-neighborhood-watch-ca",
+    "flock_slugs": [
+      "valley-glen-neighborhood-watch-ca"
+    ],
+    "flock_names": [
+      "Valley Glen Neighborhood Watch (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "21325cff-0c27-5601-a897-ef4965469a6c",
     "slug": "valley-glen-vose-neighborhood-watch-ca",
-    "flock_name": "valley-glen-vose-neighborhood-watch-ca",
-    "human_name": "valley-glen-vose-neighborhood-watch-ca",
+    "flock_active_slug": "valley-glen-vose-neighborhood-watch-ca",
+    "flock_slugs": [
+      "valley-glen-vose-neighborhood-watch-ca"
+    ],
+    "flock_names": [
+      "VALLEY GLEN VOSE NEIGHBORHOOD WATCH (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "78e157c7-b826-5702-b5b3-d846c68ea601",
+    "slug": "ventura-ca-pd",
+    "flock_active_slug": "ventura-ca-pd",
+    "flock_slugs": [
+      "ventura-ca-pd"
+    ],
+    "flock_names": [
+      "Ventura CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.2805,
+    "lng": -119.2945,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b5b9bd9a-9242-5f99-8bc0-d4b96114a2d3",
+    "slug": "ventura-county-ca-so",
+    "flock_active_slug": "ventura-county-ca-so",
+    "flock_slugs": [
+      "ventura-county-ca-so"
+    ],
+    "flock_names": [
+      "Ventura County CA SO"
+    ],
+    "display_name": null,
+    "lat": 34.29,
+    "lng": -119.28,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "b592938c-c2c4-597c-b6cd-2bbb3b52447b",
+    "slug": "ventura-county-district-attorneys-office-ca",
+    "flock_active_slug": "ventura-county-district-attorneys-office-ca",
+    "flock_slugs": [
+      "ventura-county-district-attorneys-office-ca"
+    ],
+    "flock_names": [
+      "Ventura County District Attorney's Office CA"
+    ],
+    "display_name": null,
+    "lat": 34.2805,
+    "lng": -119.2945,
+    "state": "CA",
+    "agency_role": "da",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "a5b59684-abcc-5a43-949d-3aec089d30a4",
+    "slug": "vernon-ca-pd",
+    "flock_active_slug": "vernon-ca-pd",
+    "flock_slugs": [
+      "vernon-ca-pd"
+    ],
+    "flock_names": [
+      "Vernon CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9953,
+    "lng": -118.2298,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "ce304605-e2bb-5b09-b2bf-0c04b423dc92",
     "slug": "view-park-hoa-ca",
-    "flock_name": "view-park-hoa-ca",
-    "human_name": "view-park-hoa-ca",
+    "flock_active_slug": "view-park-hoa-ca",
+    "flock_slugs": [
+      "view-park-hoa-ca"
+    ],
+    "flock_names": [
+      "View Park HOA (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "a97028a3-2232-51da-94c3-9d73434149a9",
     "slug": "villa-del-mar-ca",
-    "flock_name": "villa-del-mar-ca",
-    "human_name": "villa-del-mar-ca",
+    "flock_active_slug": "villa-del-mar-ca",
+    "flock_slugs": [
+      "villa-del-mar-ca"
+    ],
+    "flock_names": [
+      "Villa Del Mar (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "518ec1a5-7eaa-5959-b698-ecc97e2aa4c6",
     "slug": "village-at-hiddenbrooke-ca",
-    "flock_name": "village-at-hiddenbrooke-ca",
-    "human_name": "village-at-hiddenbrooke-ca",
+    "flock_active_slug": "village-at-hiddenbrooke-ca",
+    "flock_slugs": [
+      "village-at-hiddenbrooke-ca"
+    ],
+    "flock_names": [
+      "Village at Hiddenbrooke (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "cadbc0e5-90bb-552a-8ed6-63c6bbe8ce42",
     "slug": "village-pointe-ca",
-    "flock_name": "village-pointe-ca",
-    "human_name": "village-pointe-ca",
+    "flock_active_slug": "village-pointe-ca",
+    "flock_slugs": [
+      "village-pointe-ca"
+    ],
+    "flock_names": [
+      "Village Pointe (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "e6d3f4c0-575b-5bc5-86d4-939b2cd50a3f",
+    "slug": "visalia-ca-pd",
+    "flock_active_slug": "visalia-ca-pd",
+    "flock_slugs": [
+      "visalia-ca-pd"
+    ],
+    "flock_names": [
+      "Visalia CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.3302,
+    "lng": -119.2921,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "458b707c-5b99-5ec3-95c8-f7c9ae95ee0d",
+    "slug": "walnut-creek-ca-pd",
+    "flock_active_slug": "walnut-creek-ca-pd",
+    "flock_slugs": [
+      "walnut-creek-ca-pd"
+    ],
+    "flock_names": [
+      "Walnut Creek CA PD"
+    ],
+    "display_name": null,
+    "lat": 37.9101,
+    "lng": -122.0652,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e7def38e-0798-58d3-81a3-43f1e46b242f",
     "slug": "washoe-county-nv-so",
-    "flock_name": "washoe-county-nv-so",
-    "human_name": "washoe-county-nv-so",
+    "flock_active_slug": "washoe-county-nv-so",
+    "flock_slugs": [
+      "washoe-county-nv-so"
+    ],
+    "flock_names": [
+      "Washoe County NV SO"
+    ],
+    "display_name": null,
     "lat": 39.5296,
     "lng": -119.8138,
-    "public": true,
-    "federal": false,
     "state": "NV",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
+    "agency_id": "bbb4b898-29a3-54f2-b36c-002472ed784c",
     "slug": "waterstone-community-association-ca",
-    "flock_name": "waterstone-community-association-ca",
-    "human_name": "waterstone-community-association-ca",
+    "flock_active_slug": "waterstone-community-association-ca",
+    "flock_slugs": [
+      "waterstone-community-association-ca"
+    ],
+    "flock_names": [
+      "Waterstone Community Association (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "3de0eb7e-fdc2-5be6-8b80-b5aecee3b5e3",
     "slug": "waterstone-hoa-ca",
-    "flock_name": "waterstone-hoa-ca",
-    "human_name": "waterstone-hoa-ca",
+    "flock_active_slug": "waterstone-hoa-ca",
+    "flock_slugs": [
+      "waterstone-hoa-ca"
+    ],
+    "flock_names": [
+      "Waterstone HOA (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": "CA",
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "33b64315-34e3-56d8-b0ba-fc370daf3169",
+    "slug": "watsonville-ca-pd",
+    "flock_active_slug": "watsonville-ca-pd",
+    "flock_slugs": [
+      "watsonville-ca-pd"
+    ],
+    "flock_names": [
+      "Watsonville CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.9102,
+    "lng": -121.7569,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "e75bd725-7d44-5c58-b7d4-6fd0784017d1",
+    "slug": "west-covina-ca-pd",
+    "flock_active_slug": "west-covina-ca-pd",
+    "flock_slugs": [
+      "west-covina-ca-pd"
+    ],
+    "flock_names": [
+      "West Covina CA PD"
+    ],
+    "display_name": null,
+    "lat": 34.0686,
+    "lng": -117.9394,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "1a7d1e5c-391d-5345-99a0-b51e735fc0a7",
+    "slug": "west-sacramento-ca-pd",
+    "flock_active_slug": "west-sacramento-ca-pd",
+    "flock_slugs": [
+      "west-sacramento-ca-pd"
+    ],
+    "flock_names": [
+      "West Sacramento CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5805,
+    "lng": -121.5302,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f",
+    "slug": "west-valley-mission-college-dist-campus-ca",
+    "flock_active_slug": "west-valley-mission-college-dist-campus-ca",
+    "flock_slugs": [
+      "west-valley-mission-college-dist-campus-ca"
+    ],
+    "flock_names": [
+      "West Valley Mission College Dist Campus (CA)"
+    ],
+    "display_name": null,
+    "lat": 37.263,
+    "lng": -121.9188,
+    "state": "CA",
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "notes": "Public community college (West Valley-Mission CCD). Part of the <a href=\"https://www.cccco.edu/Students/Find-a-College\" target=\"_blank\">California Community Colleges</a> system.",
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "88641902-bc0f-5740-baef-47f0c280b455",
+    "slug": "western-states-information-network-ca",
+    "flock_active_slug": "western-states-information-network-ca",
+    "flock_slugs": [
+      "western-states-information-network-ca"
+    ],
+    "flock_names": [
+      "Western States Information Network (CA)"
+    ],
+    "display_name": null,
+    "lat": 38.59,
+    "lng": -121.52,
+    "state": "CA",
+    "agency_role": "intelligence",
+    "agency_type": "fusion_center",
+    "website": "https://oag.ca.gov/bi/wsin",
+    "notes": "WSIN is a <strong>501(c)(3) nonprofit corporation</strong> (EIN 27-1453421), not a government agency. It is one of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers, 100% funded by BJA (DOJ) grants. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub \u2014 data shared with WSIN may be redistributed across five states and international partners.<br><br><strong>Not a public agency:</strong> WSIN incorporated as a California nonprofit in 2009 after separating from CA DOJ, which previously served as its fiscal agent. It employs 47 nonprofit employees (explicitly \u201cnot state positions\u201d). Its policy board is composed entirely of state/local officials from five states (no federal seats), but it operates under 28 CFR Part 23 (federal regulation) and is 100% federally funded (~$7.5M/yr from BJA). As a 501(c)(3) nonprofit, WSIN likely does not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f), which defines public agency as \u201cthe state, any city, county, or city and county, or any agency or political subdivision\u201d thereof.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "e9e62ca5-9bde-5fbd-a96e-e7ee780cfc20",
     "slug": "westfield-park-recreation-and-parkways",
-    "flock_name": "westfield-park-recreation-and-parkways",
-    "human_name": "westfield-park-recreation-and-parkways",
+    "flock_active_slug": "westfield-park-recreation-and-parkways",
+    "flock_slugs": [
+      "westfield-park-recreation-and-parkways"
+    ],
+    "flock_names": [
+      "Westfield Park Recreation and Parkways"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": null,
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "e1c69fca-7a58-547f-87ff-5fcb9e5ec3dc",
+    "slug": "westminster-ca-pd",
+    "flock_active_slug": "westminster-ca-pd",
+    "flock_slugs": [
+      "westminster-ca-pd"
+    ],
+    "flock_names": [
+      "Westminster CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.7514,
+    "lng": -117.994,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "47a01976-2030-52f3-9c3f-3347ce75fcf7",
+    "slug": "westmorland-ca-pd",
+    "flock_active_slug": "westmorland-ca-pd",
+    "flock_slugs": [
+      "westmorland-ca-pd"
+    ],
+    "flock_names": [
+      "Westmorland CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.0378,
+    "lng": -115.6222,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5bee2f78-b95b-530f-847b-588127e925db",
     "slug": "westpark-las-palmas-ca",
-    "flock_name": "westpark-las-palmas-ca",
-    "human_name": "westpark-las-palmas-ca",
+    "flock_active_slug": "westpark-las-palmas-ca",
+    "flock_slugs": [
+      "westpark-las-palmas-ca"
+    ],
+    "flock_names": [
+      "Westpark Las Palmas (CA)"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": null,
-    "federal": false,
     "state": "CA",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": true
+    "tags": [
+      "needs-review"
+    ]
   },
   {
+    "agency_id": "01183c44-3a5a-55a0-8601-cfe794ea28ff",
     "slug": "westwood-village",
-    "flock_name": "westwood-village",
-    "human_name": "westwood-village",
+    "flock_active_slug": "westwood-village",
+    "flock_slugs": [
+      "westwood-village"
+    ],
+    "flock_names": [
+      "Westwood Village"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": false,
     "state": null,
     "agency_role": "hoa",
     "agency_type": "community",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "private"
+    ]
   },
   {
+    "agency_id": "d8a94e88-50c9-5801-aa66-3716e0f4b648",
+    "slug": "wheatland-ca-pd",
+    "flock_active_slug": "wheatland-ca-pd",
+    "flock_slugs": [
+      "wheatland-ca-pd"
+    ],
+    "flock_names": [
+      "Wheatland CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.9986,
+    "lng": -121.4262,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "19f7b6cc-d156-57a7-9f61-a0e846b224f2",
+    "slug": "whittier-ca-pd",
+    "flock_active_slug": "whittier-ca-pd",
+    "flock_slugs": [
+      "whittier-ca-pd"
+    ],
+    "flock_names": [
+      "Whittier CA PD"
+    ],
+    "display_name": null,
+    "lat": 33.9792,
+    "lng": -118.0328,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "0cd01be2-9f1c-5cae-a15e-e83ae5de9e77",
     "slug": "wichita-falls-tx-pd",
-    "flock_name": "wichita-falls-tx-pd",
-    "human_name": "wichita-falls-tx-pd",
+    "flock_active_slug": "wichita-falls-tx-pd",
+    "flock_slugs": [
+      "wichita-falls-tx-pd"
+    ],
+    "flock_names": [
+      "Wichita Falls TX PD"
+    ],
+    "display_name": null,
     "lat": 33.9137,
     "lng": -98.4934,
-    "public": true,
-    "federal": false,
     "state": "TX",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "public"
+    ]
   },
   {
-    "slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
-    "flock_name": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
-    "human_name": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
+    "agency_id": "43d4e7c3-70a0-55fb-b84c-45c1c8bf7156",
+    "slug": "williams-ca-pd",
+    "flock_active_slug": "williams-ca-pd",
+    "flock_slugs": [
+      "williams-ca-pd"
+    ],
+    "flock_names": [
+      "Williams CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.1541,
+    "lng": -122.1497,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "48f57cd3-d6ca-5d95-aef9-ae970aad823f",
+    "slug": "willits-ca-pd",
+    "flock_active_slug": "willits-ca-pd",
+    "flock_slugs": [
+      "willits-ca-pd"
+    ],
+    "flock_names": [
+      "Willits CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.4096,
+    "lng": -123.3556,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "cf61829f-2b2f-5cec-863f-2d174bae940d",
+    "slug": "windsor-ca-pd",
+    "flock_active_slug": "windsor-ca-pd",
+    "flock_slugs": [
+      "windsor-ca-pd"
+    ],
+    "flock_names": [
+      "Windsor CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5469,
+    "lng": -122.8164,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "069764d3-6b36-5e35-ba95-2e4b38441b0e",
+    "slug": "winters-ca-pd",
+    "flock_active_slug": "winters-ca-pd",
+    "flock_slugs": [
+      "winters-ca-pd"
+    ],
+    "flock_names": [
+      "Winters CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.5249,
+    "lng": -121.9706,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "84006518-b4f2-528e-9094-f7a94132223f",
+    "slug": "woodlake-ca-pd",
+    "flock_active_slug": "woodlake-ca-pd",
+    "flock_slugs": [
+      "woodlake-ca-pd"
+    ],
+    "flock_names": [
+      "Woodlake CA PD"
+    ],
+    "display_name": null,
+    "lat": 36.4136,
+    "lng": -119.0987,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "950988b0-50de-5366-8f7d-46b0add309de",
+    "slug": "woodland-ca-pd",
+    "flock_active_slug": "woodland-ca-pd",
+    "flock_slugs": [
+      "woodland-ca-pd"
+    ],
+    "flock_names": [
+      "Woodland CA PD"
+    ],
+    "display_name": null,
+    "lat": 38.6785,
+    "lng": -121.7733,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "db169d30-d49b-5e8a-b46b-bf6e5d1eaf08",
+    "slug": "yolo-county-ca-so",
+    "flock_active_slug": "yolo-county-ca-so",
+    "flock_slugs": [
+      "yolo-county-ca-so"
+    ],
+    "flock_names": [
+      "Yolo County CA SO"
+    ],
+    "display_name": null,
+    "lat": 38.685,
+    "lng": -121.75,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "36d68f61-6c39-53ec-815e-c0853fca118d",
+    "slug": "yreka-ca-pd",
+    "flock_active_slug": "yreka-ca-pd",
+    "flock_slugs": [
+      "yreka-ca-pd"
+    ],
+    "flock_names": [
+      "Yreka CA PD"
+    ],
+    "display_name": null,
+    "lat": 41.7354,
+    "lng": -122.6347,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "4e68fcac-b7cc-558e-90e6-6599062aabd1",
+    "slug": "yuba-city-ca-pd",
+    "flock_active_slug": "yuba-city-ca-pd",
+    "flock_slugs": [
+      "yuba-city-ca-pd"
+    ],
+    "flock_names": [
+      "Yuba City CA PD"
+    ],
+    "display_name": null,
+    "lat": 39.1404,
+    "lng": -121.6169,
+    "state": "CA",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "363e5b17-3f6c-5150-9174-790ea45d45c0",
+    "slug": "yuba-county-ca-so",
+    "flock_active_slug": "yuba-county-ca-so",
+    "flock_slugs": [
+      "yuba-county-ca-so"
+    ],
+    "flock_names": [
+      "Yuba County Sheriffs Office"
+    ],
+    "display_name": null,
+    "lat": 39.2627,
+    "lng": -121.3502,
+    "state": "CA",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ]
+  },
+  {
+    "agency_id": "5b3abf70-5581-5412-8165-b9b12db5a69b",
+    "slug": "yuba-county-sheriffs-office",
+    "flock_active_slug": "yuba-county-sheriffs-office",
+    "flock_slugs": [
+      "yuba-county-sheriffs-office"
+    ],
+    "flock_names": [
+      "Yuba County Sheriffs Office"
+    ],
+    "display_name": null,
     "lat": null,
     "lng": null,
-    "public": false,
-    "federal": true,
+    "state": null,
+    "agency_role": "police",
+    "agency_type": "federal",
+    "website": null,
+    "tags": [
+      "federal",
+      "public"
+    ]
+  },
+  {
+    "agency_id": "7ed4d91c-73bc-5a97-838c-2c87fccbff9e",
+    "slug": "union-pacific-railroad-pd",
+    "flock_active_slug": "union-pacific-railroad-pd",
+    "flock_slugs": [
+      "union-pacific-railroad-pd"
+    ],
+    "flock_names": [
+      "Union Pacific Railroad PD"
+    ],
+    "display_name": null,
+    "lat": 41.2565,
+    "lng": -95.9345,
+    "state": "NE",
+    "agency_role": "police",
+    "agency_type": "private",
+    "website": null,
+    "notes": "Union Pacific Railroad Police is a <a href=\"https://en.wikipedia.org/wiki/Union_Pacific_Police_Department\" target=\"_blank\">private railroad police</a> force. While railroad police have some law enforcement authority under federal law (49 USC \u00a728101), Union Pacific is a private corporation. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.5(f)</a>.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "978d5b81-63f1-5f5d-bf83-4f108c15abcb",
+    "slug": "flock-safety-vendor",
+    "flock_active_slug": "flock-safety-vendor",
+    "flock_slugs": [
+      "flock-safety-vendor"
+    ],
+    "flock_names": [
+      "Flock Safety (vendor)"
+    ],
+    "display_name": "Flock Safety",
+    "lat": 33.849,
+    "lng": -84.3734,
+    "state": "GA",
+    "agency_role": "vendor",
+    "agency_type": "private",
+    "website": "https://www.flocksafety.com",
+    "notes": "Private surveillance vendor headquartered in Atlanta, GA. Flock MSA \u00a75.3 grants Flock independent authority to \"access, use, preserve and/or disclose\" agency footage to law enforcement, government officials, and third parties based on Flock's own \"good faith belief\" \u2014 including for Flock's own technical purposes. No agency approval or notification required. This provision survives contract termination (\u00a77.3). The <a href=\"https://information.auditor.ca.gov/reports/2019-118/summary.html\" target=\"_blank\">CA State Auditor (Report 2019-118)</a> found that agencies' vendor contracts lacked necessary data security safeguards and recommended agencies update vendor contracts. The subsequent <a href=\"https://oag.ca.gov/system/files/media/2023-dle-06.pdf\" target=\"_blank\">AG Bulletin 2023-DLE-06</a> directed agencies to review vendor contracts for provisions allowing non-public access to ALPR data \u2014 \u00a75.3 is exactly the type of provision both warned about. See <a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings \u00a75</a>.",
+    "tags": [
+      "private"
+    ]
+  },
+  {
+    "agency_id": "dea3892a-1d23-535d-ac5d-f3f8f975c712",
+    "slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
+    "flock_active_slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
+    "flock_slugs": [
+      "yuba-county-ca-so-hotlists-alerted-on-california-svs"
+    ],
+    "flock_names": [
+      "yuba-county-ca-so-hotlists-alerted-on-california-svs"
+    ],
+    "display_name": null,
+    "lat": null,
+    "lng": null,
     "state": "CA",
     "agency_role": "test",
     "agency_type": "test",
     "website": null,
-    "crawled": false,
-    "crawled_date": null,
-    "needs_review": false
+    "tags": [
+      "federal",
+      "private"
+    ]
   }
 ]

--- a/scripts/build_agency_registry.py
+++ b/scripts/build_agency_registry.py
@@ -10,13 +10,14 @@ After initial generation, re-running will merge new agencies into the
 existing registry without overwriting manual edits.
 
 Fields per entry:
-  slug          Flock transparency portal URL slug
-  flock_name    Display name on Flock's transparency portal
-  human_name    Cleaned human-readable name
+  agency_id          Stable unique identifier (UUID, never changes once assigned)
+  slug               Flock transparency portal URL slug (backward compat)
+  flock_active_slug  Current active Flock portal URL slug
+  flock_slugs        All known Flock portal URL slugs [active, ...old]
+  flock_names        All observed Flock display names [primary, ...variants]
+  display_name       Curated display name (null = use flock_names[0])
   lat           Latitude (null if unknown)
   lng           Longitude (null if unknown)
-  public        true/false — is this a public agency?
-  federal       true/false — is this a federal agency?
   state         Two-letter state code (null if unknown)
   agency_role   police|sheriff|da|fire|parks|campus_safety|corrections|
                 highway_patrol|state_parks|intelligence|fish_wildlife|
@@ -24,8 +25,11 @@ Fields per entry:
   agency_type   city|county|state|federal|university|tribal|private|
                 community|test|other
   website       Agency website URL (null if unknown)
-  crawled       Whether we have Flock portal data for this agency
-  needs_review  true if auto-classified with low confidence
+  tags          Classification tags: public|private|federal|needs-review|ag-lawsuit
+
+Derived at runtime (not stored):
+  crawled       lib.crawl_status() checks flock_slugs directories
+  crawled_date  Latest JSON filename in the crawled directory
 
 Usage:
   uv run python scripts/build_agency_registry.py           # initial build
@@ -36,6 +40,7 @@ import argparse
 import json
 import re
 import sys
+import uuid
 from pathlib import Path
 
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
@@ -65,7 +70,7 @@ def detect_state(name):
 
 
 # ── Classification rules ──
-# Each rule returns (agency_role, agency_type, public, federal, needs_review)
+# Each rule returns (agency_role, agency_type, tags)
 
 KNOWN_PRIVATE = [
     "University of the Pacific", "Stanford University",
@@ -80,116 +85,93 @@ TEST_NAMES = [
 
 
 def classify(name):
-    """Auto-classify an agency. Returns dict of classification fields."""
+    """Auto-classify an agency. Returns dict with agency_role, agency_type, tags."""
     n = name
 
     # DNU (Do Not Use) entries — deactivated device/org, but underlying agency may be real
     if n.startswith("DNU"):
-        # Check if the underlying entity is a known private institution
         is_private = any(p.lower() in n.lower() for p in KNOWN_PRIVATE)
-        return {
-            "agency_role": "decommissioned",
-            "agency_type": "decommissioned",
-            "public": not is_private,
-            "federal": False,
-            "needs_review": False,
-        }
+        return {"agency_role": "decommissioned", "agency_type": "decommissioned",
+                "tags": ["private"] if is_private else ["public"]}
 
     # Test / garbage entries
     if any(t.lower() in n.lower() for t in TEST_NAMES):
-        return {
-            "agency_role": "test",
-            "agency_type": "test",
-            "public": False,
-            "federal": False,
-            "needs_review": False,
-        }
+        return {"agency_role": "test", "agency_type": "test", "tags": ["private"]}
 
     # Known private institutions
     if any(p.lower() in n.lower() for p in KNOWN_PRIVATE):
         role = "campus_safety" if re.search(r"Campus|PD|Police", n, re.I) else "other"
-        return {
-            "agency_role": role,
-            "agency_type": "private",
-            "public": False,
-            "federal": False,
-            "needs_review": False,
-        }
+        return {"agency_role": role, "agency_type": "private", "tags": ["private"]}
 
     # HOA / community / business patterns
     if re.search(r"HOA|Association|Neighborhood Watch|Estates|Village\b(?!.*PD)", n, re.I):
-        return {"agency_role": "hoa", "agency_type": "community", "public": False, "federal": False, "needs_review": False}
+        return {"agency_role": "hoa", "agency_type": "community", "tags": ["private"]}
     if re.search(r"Corporation|Inc\.|Home Depot|Ulta|FedEx|Great Wolf|Total Wine|Mercury Insurance|Simon Property|Lewis Group|Autobody|Towing|Foster Farms", n, re.I):
-        return {"agency_role": "business", "agency_type": "private", "public": False, "federal": False, "needs_review": False}
+        return {"agency_role": "business", "agency_type": "private", "tags": ["private"]}
     if re.search(r"\bSchool\b(?!.*PD)", n, re.I):
-        return {"agency_role": "school", "agency_type": "other", "public": None, "federal": False, "needs_review": True}
+        return {"agency_role": "school", "agency_type": "other", "tags": ["needs-review"]}
 
     # Federal
     if re.search(r"\bFBI\b|Federal\b|US Marshal|DEA\b|ATF\b|ICE\b|CBP\b|Secret Service", n, re.I):
-        return {"agency_role": "police", "agency_type": "federal", "public": True, "federal": True, "needs_review": False}
+        return {"agency_role": "police", "agency_type": "federal", "tags": ["public", "federal"]}
 
     # State agencies
     if re.search(r"California Highway Patrol|CHP\b", n, re.I):
-        return {"agency_role": "highway_patrol", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "highway_patrol", "agency_type": "state", "tags": ["public"]}
     if re.search(r"California State Parks|State Parks\b", n, re.I):
-        return {"agency_role": "state_parks", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "state_parks", "agency_type": "state", "tags": ["public"]}
     if re.search(r"Cal Fire\b", n, re.I):
-        return {"agency_role": "fire", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "fire", "agency_type": "state", "tags": ["public"]}
     if re.search(r"Department of Corrections", n, re.I):
-        return {"agency_role": "corrections", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "corrections", "agency_type": "state", "tags": ["public"]}
     if re.search(r"Fish.*Wildlife", n, re.I):
-        return {"agency_role": "fish_wildlife", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "fish_wildlife", "agency_type": "state", "tags": ["public"]}
     if re.search(r"NCRIC|Fusion Center|Intelligence Center", n, re.I):
-        return {"agency_role": "intelligence", "agency_type": "state", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "intelligence", "agency_type": "state", "tags": ["public"]}
     if re.search(r"Department of Insurance", n, re.I):
-        return {"agency_role": "other", "agency_type": "state", "public": True, "federal": False, "needs_review": True}
+        return {"agency_role": "other", "agency_type": "state", "tags": ["public", "needs-review"]}
 
     # University / college
     if re.search(r"University|College|Campus", n, re.I):
-        return {"agency_role": "campus_safety", "agency_type": "university", "public": True, "federal": False, "needs_review": True}
+        return {"agency_role": "campus_safety", "agency_type": "university", "tags": ["public", "needs-review"]}
 
     # Tribal
     if re.search(r"Tribal|Rancheria|Reservation|Nation of", n, re.I):
-        return {"agency_role": "tribal", "agency_type": "tribal", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "tribal", "agency_type": "tribal", "tags": ["public"]}
 
     # Fire authority
     if re.search(r"\bFire\b.*Authority|\bFire\b.*District|\bFD\b|\bFire\b.*Department", n, re.I):
-        return {"agency_role": "fire", "agency_type": "county", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "fire", "agency_type": "county", "tags": ["public"]}
 
     # DA offices
     if re.search(r"\bDA\b|District Attorney|Attorney.s Office", n, re.I):
-        return {"agency_role": "da", "agency_type": "county", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "da", "agency_type": "county", "tags": ["public"]}
 
     # Sheriff
     if re.search(r"Sheriff|County.*SO\b|\bSO\b|\bSD\b", n, re.I):
-        return {"agency_role": "sheriff", "agency_type": "county", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "sheriff", "agency_type": "county", "tags": ["public"]}
 
     # County-level (non-sheriff, non-DA)
     if re.search(r"County\b", n, re.I):
         role = "police" if re.search(r"PD|Police", n, re.I) else "other"
-        return {"agency_role": role, "agency_type": "county", "public": True, "federal": False, "needs_review": role == "other"}
+        tags = ["public"] + (["needs-review"] if role == "other" else [])
+        return {"agency_role": role, "agency_type": "county", "tags": tags}
 
     # City police (most common)
     if re.search(r"\bPD\b|Police\b|Public Safety\b", n, re.I):
-        return {"agency_role": "police", "agency_type": "city", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "police", "agency_type": "city", "tags": ["public"]}
 
     # Port police / parks
     if re.search(r"Port Police|Parks.*PD|Parks.*Department", n, re.I):
-        return {"agency_role": "parks", "agency_type": "other", "public": True, "federal": False, "needs_review": False}
+        return {"agency_role": "parks", "agency_type": "other", "tags": ["public"]}
 
     # City of X (without PD)
     if re.search(r"^City of|^Town of", n, re.I):
-        return {"agency_role": "other", "agency_type": "city", "public": True, "federal": False, "needs_review": True}
+        return {"agency_role": "other", "agency_type": "city", "tags": ["public", "needs-review"]}
 
-    # Fallback
-    return {"agency_role": "other", "agency_type": "other", "public": None, "federal": False, "needs_review": True}
+    # Fallback — unknown public status
+    return {"agency_role": "other", "agency_type": "other", "tags": ["needs-review"]}
 
-
-def flock_name_to_human(name):
-    """Simple cleanup — don't over-expand, keep recognizable."""
-    s = name.strip()
-    s = re.sub(r"\s+", " ", s)
-    return s
 
 
 def main():
@@ -201,11 +183,21 @@ def main():
 
     data_dir = args.data_dir
 
+    # Safety: refuse to overwrite an existing registry without --merge
+    if not args.merge and REGISTRY_PATH.exists():
+        print("ERROR: registry already exists. Use --merge to add new agencies", file=sys.stderr)
+        print("       without --merge would destroy UUIDs, tags, and manual edits.", file=sys.stderr)
+        sys.exit(1)
+
     # Load existing registry for merge mode
     existing = {}
     if args.merge and REGISTRY_PATH.exists():
         for e in json.loads(REGISTRY_PATH.read_text()):
-            existing[e["slug"]] = e
+            existing[e["agency_id"]] = e
+            # Index by slug and flock_slugs so we can find existing entries
+            existing.setdefault(f"__slug__{e['slug']}", e["agency_id"])
+            for ps in e.get("flock_slugs", []):
+                existing.setdefault(f"__slug__{ps}", e["agency_id"])
 
     # Collect all entities from crawled data
     slug_to_flock_name = {}
@@ -220,11 +212,16 @@ def main():
         data = json.loads(jsons[-1].read_text())
         crawled_slugs[slug_dir.name] = jsons[-1].stem  # e.g. "2026-03-27"
 
-        for name, slug in zip(
-            data.get("shared_org_names", []),
-            data.get("shared_org_slugs", []),
-        ):
-            slug_to_flock_name[slug] = name
+        # Collect name→slug pairs from both outbound and inbound lists
+        for names_key, slugs_key in [
+            ("shared_org_names", "shared_org_slugs"),
+            ("orgs_sharing_with_names", "orgs_sharing_with_slugs"),
+        ]:
+            for name, slug in zip(
+                data.get(names_key, []),
+                data.get(slugs_key, []),
+            ):
+                slug_to_flock_name[slug] = name
 
     for slug in crawled_slugs:
         if slug not in slug_to_flock_name:
@@ -240,47 +237,56 @@ def main():
 
     # Build registry
     registry = []
+    seen_ids = set()
     new_count = 0
     kept_count = 0
 
     for slug in sorted(slug_to_flock_name.keys()):
-        # In merge mode, keep existing manual edits
-        if args.merge and slug in existing:
-            entry = existing[slug]
-            entry["crawled"] = slug in crawled_slugs
-            entry["crawled_date"] = crawled_slugs.get(slug)
-            registry.append(entry)
-            kept_count += 1
-            continue
-
         flock_name = slug_to_flock_name[slug]
+
+        # In merge mode, check if this slug maps to an existing agency
+        if args.merge:
+            existing_id = existing.get(f"__slug__{slug}")
+            if existing_id and existing_id in existing:
+                entry = existing[existing_id]
+                # Add new name if we haven't seen it
+                if flock_name not in entry.get("flock_names", []):
+                    entry.setdefault("flock_names", []).append(flock_name)
+                if existing_id not in seen_ids:
+                    registry.append(entry)
+                    seen_ids.add(existing_id)
+                    kept_count += 1
+                continue
+
         cls = classify(flock_name)
 
         entry = {
+            "agency_id": str(uuid.uuid5(uuid.NAMESPACE_DNS, "flock-registry:" + slug)),
             "slug": slug,
-            "flock_name": flock_name,
-            "human_name": flock_name_to_human(flock_name),
+            "flock_active_slug": slug,
+            "flock_slugs": [slug],
+            "flock_names": [flock_name],
+            "display_name": None,
             "lat": None,
             "lng": None,
-            "public": cls["public"],
-            "federal": cls["federal"],
             "state": detect_state(flock_name),
             "agency_role": cls["agency_role"],
             "agency_type": cls["agency_type"],
             "website": None,
-            "crawled": slug in crawled_slugs,
-            "crawled_date": crawled_slugs.get(slug),
-            "needs_review": cls["needs_review"],
+            "tags": sorted(cls["tags"]),
         }
         registry.append(entry)
+        seen_ids.add(slug)
         new_count += 1
 
     # In merge mode, preserve manually-added entries not in discovered data
     if args.merge:
-        registry_slugs = {e["slug"] for e in registry}
-        for slug, entry in existing.items():
-            if slug not in registry_slugs:
+        for aid, entry in existing.items():
+            if aid.startswith("__slug__"):
+                continue
+            if aid not in seen_ids:
                 registry.append(entry)
+                seen_ids.add(aid)
                 kept_count += 1
 
     # Save
@@ -289,17 +295,17 @@ def main():
 
     # Stats
     total = len(registry)
-    review = sum(1 for e in registry if e.get("needs_review"))
-    public = sum(1 for e in registry if e.get("public") is True)
-    private = sum(1 for e in registry if e.get("public") is False)
-    null_public = sum(1 for e in registry if e.get("public") is None)
+    review = sum(1 for e in registry if "needs-review" in e.get("tags", []))
+    public = sum(1 for e in registry if "public" in e.get("tags", []))
+    private = sum(1 for e in registry if "private" in e.get("tags", []))
+    null_public = total - public - private
     geocoded = sum(1 for e in registry if e.get("lat"))
 
     print(f"Registry: {total} agencies -> {REGISTRY_PATH}")
     if args.merge:
         print(f"  New:          {new_count}")
         print(f"  Kept:         {kept_count}")
-    print(f"  Crawled:      {sum(1 for e in registry if e['crawled'])}")
+    print(f"  Crawled:      {len(crawled_slugs)}")
     print(f"  Geocoded:     {geocoded}")
     print(f"  Public:       {public}")
     print(f"  Private:      {private}")
@@ -309,8 +315,10 @@ def main():
     if review:
         print(f"\n  Entries needing review:")
         for e in registry:
-            if e.get("needs_review"):
-                print(f"    {e['flock_name']}: role={e['agency_role']}, type={e['agency_type']}, public={e['public']}")
+            if "needs-review" in e.get("tags", []):
+                from lib import agency_display_name
+                name = agency_display_name(e)
+                print(f"    {name}: role={e['agency_role']}, type={e['agency_type']}, tags={e.get('tags', [])}")
 
 
 if __name__ == "__main__":

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -18,9 +18,12 @@ import json
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import agency_display_name, crawl_status, has_tag, load_registry
+
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
 DEFAULT_OUT = Path("docs/sharing_map.html")
-REGISTRY_PATH = Path("assets/agency_registry.json")
+
 
 
 # All geocoding comes from the agency registry. If an agency has no
@@ -42,14 +45,13 @@ def main():
     graph = json.loads(graph_path.read_text())
 
     # Load agency registry for classification data
-    registry_path = Path("assets/agency_registry.json")
     registry_by_slug = {}
-    alias_to_primary = {}  # alias_slug -> primary_slug
-    if registry_path.exists():
-        for e in json.loads(registry_path.read_text()):
-            registry_by_slug[e["slug"]] = e
-            for aka in e.get("also_known_as", []):
-                alias_to_primary[aka] = e["slug"]
+    alias_to_primary = {}  # flock_slug -> primary slug
+    for e in load_registry():
+        registry_by_slug[e["slug"]] = e
+        for ps in e.get("flock_slugs", []):
+            if ps != e["slug"]:
+                alias_to_primary[ps] = e["slug"]
 
     # Validate: warn about graph slugs not in registry
     not_in_registry = []
@@ -228,16 +230,17 @@ def main():
     # Build classification lookup for JS
     slug_info = {}
     for slug, reg in registry_by_slug.items():
+        is_crawled, crawled_date = crawl_status(reg, args.data_dir)
         slug_info[slug] = {
-            "public": reg.get("public"),
+            "public": True if has_tag(reg, "public") else (False if has_tag(reg, "private") else None),
             "state": reg.get("state"),
-            "name": reg.get("flock_name", slug),
+            "name": agency_display_name(reg, slug),
             "role": reg.get("agency_role"),
             "type": reg.get("agency_type"),
-            "crawled": reg.get("crawled", False),
-            "crawled_date": reg.get("crawled_date"),
+            "crawled": is_crawled,
+            "crawled_date": crawled_date,
             "notes": reg.get("notes"),
-            "ag_lawsuit": reg.get("ag_lawsuit", False),
+            "ag_lawsuit": has_tag(reg, "ag-lawsuit"),
         }
 
     # Add alias entries pointing to primary's info
@@ -258,7 +261,7 @@ def main():
     # a violation entity V, then A has an indirect violation "V via B"
     def is_violation_entity(slug):
         r = registry_by_slug.get(slug, {})
-        if r.get("public") is False:
+        if has_tag(r, "private"):
             return True
         if r.get("state") and r["state"] != "CA":
             return True
@@ -287,8 +290,8 @@ def main():
                         indirects.append({
                             "violation": second_hop,
                             "via": target,
-                            "via_name": registry_by_slug.get(target, {}).get("flock_name", target),
-                            "violation_name": registry_by_slug.get(second_hop, {}).get("flock_name", second_hop),
+                            "via_name": agency_display_name(registry_by_slug.get(target, {}), target),
+                            "violation_name": agency_display_name(registry_by_slug.get(second_hop, {}), second_hop),
                         })
         if indirects:
             # Deduplicate by violation slug

--- a/scripts/build_scoreboard.py
+++ b/scripts/build_scoreboard.py
@@ -10,9 +10,12 @@ Usage:
 """
 
 import json
+import sys
 from pathlib import Path
 
-REGISTRY_PATH = Path("assets/agency_registry.json")
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import agency_display_name, has_tag, load_registry
+
 GRAPH_PATH = Path("assets/transparency.flocksafety.com/.sharing_graph_full.json")
 DATA_DIR = Path("assets/transparency.flocksafety.com")
 OUT_PATH = Path("docs/data/scoreboard_data.json")
@@ -24,7 +27,7 @@ RANKED_STATE = "CA"
 def is_violation_entity(slug, registry_by_slug):
     """Match the violation logic from build_map.py."""
     r = registry_by_slug.get(slug, {})
-    if r.get("public") is False:
+    if has_tag(r, "private"):
         return "private"
     if r.get("state") and r["state"] != "CA":
         return "out_of_state"
@@ -51,8 +54,7 @@ def load_crawled_stats(slug):
 
 
 def main():
-    with open(REGISTRY_PATH) as f:
-        registry = json.load(f)
+    registry = load_registry()
     registry_by_slug = {a["slug"]: a for a in registry}
 
     with open(GRAPH_PATH) as f:
@@ -113,7 +115,7 @@ def main():
 
         agencies.append({
             "slug": slug,
-            "name": info.get("human_name", info.get("flock_name", slug)),
+            "name": agency_display_name(info, slug),
             "state": info.get("state", ""),
             "outbound": outbound_count,
             "inbound": inbound_count,
@@ -170,7 +172,7 @@ def main():
             info = registry_by_slug.get(slug, {})
             no_sharing_list.append({
                 "slug": slug,
-                "name": info.get("human_name", info.get("flock_name", slug)),
+                "name": agency_display_name(info, slug),
             })
 
     # ── Compute metadata for disclaimers ──

--- a/scripts/check_recipient_coords.py
+++ b/scripts/check_recipient_coords.py
@@ -13,8 +13,10 @@ import glob
 import json
 import os
 import sys
+from pathlib import Path
 
-REGISTRY = "assets/agency_registry.json"
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import has_tag, registry_by_slug
 PORTAL_DIR = "assets/transparency.flocksafety.com"
 
 # Flock test/placeholder slugs — not real agencies
@@ -33,8 +35,7 @@ JUNK_SLUGS = frozenset(
 
 
 def main() -> int:
-    with open(REGISTRY) as f:
-        registry = {a["slug"]: a for a in json.load(f)}
+    registry = registry_by_slug()
 
     # For each public agency, find the latest crawl JSON and collect recipients
     missing: dict[str, set[str]] = {}  # slug -> set of public senders
@@ -42,7 +43,7 @@ def main() -> int:
     for agency_dir in sorted(glob.glob(os.path.join(PORTAL_DIR, "*/"))):
         slug = os.path.basename(agency_dir.rstrip("/"))
         reg = registry.get(slug, {})
-        if not reg.get("public"):
+        if not has_tag(reg, "public"):
             continue
 
         jsons = sorted(glob.glob(os.path.join(agency_dir, "*.json")))

--- a/scripts/classify_agencies.py
+++ b/scripts/classify_agencies.py
@@ -21,7 +21,9 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-REGISTRY_PATH = Path("assets/agency_registry.json")
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import agency_display_name, has_tag, load_registry
+
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
 
 
@@ -31,11 +33,10 @@ def main():
     parser.add_argument("--out", type=Path)
     args = parser.parse_args()
 
-    if not REGISTRY_PATH.exists():
+    registry = load_registry()
+    if not registry:
         print("Error: agency registry not found. Run build_agency_registry.py first.", file=sys.stderr)
         sys.exit(1)
-
-    registry = json.loads(REGISTRY_PATH.read_text())
 
     # Collect sharing info — who shares with whom
     org_sources = {}
@@ -59,13 +60,11 @@ def main():
         slug = e["slug"]
         c = {
             "slug": slug,
-            "name": e.get("flock_name", slug),
-            "public": e.get("public"),
+            "name": agency_display_name(e, slug),
+            "tags": e.get("tags", []),
             "state": e.get("state"),
             "agency_type": e.get("agency_type"),
             "agency_role": e.get("agency_role"),
-            "federal": e.get("federal", False),
-            "needs_review": e.get("needs_review", False),
             "flags": [],
             "shared_by_count": len(org_sources.get(slug, set())),
             "shared_by": sorted(org_sources.get(slug, set())),
@@ -73,15 +72,15 @@ def main():
 
         if e.get("state") and e["state"] != "CA":
             c["flags"].append("OUT_OF_STATE")
-        if e.get("public") is False:
+        if has_tag(e, "private"):
             c["flags"].append("PRIVATE")
-        if e.get("federal"):
+        if has_tag(e, "federal"):
             c["flags"].append("FEDERAL")
         if e.get("agency_type") == "decommissioned":
             c["flags"].append("DECOMMISSIONED")
         if e.get("agency_type") == "test":
             c["flags"].append("TEST")
-        if e.get("needs_review"):
+        if has_tag(e, "needs-review"):
             c["flags"].append("NEEDS_REVIEW")
 
         classifications.append(c)
@@ -97,9 +96,9 @@ def main():
             "total": total,
             "california": sum(1 for c in classifications if c["state"] == "CA"),
             "out_of_state": sum(1 for c in classifications if c["state"] and c["state"] != "CA"),
-            "private": sum(1 for c in classifications if c["public"] is False),
-            "federal": sum(1 for c in classifications if c["federal"]),
-            "needs_review": sum(1 for c in classifications if c["needs_review"]),
+            "private": sum(1 for c in classifications if "private" in c["tags"]),
+            "federal": sum(1 for c in classifications if "federal" in c["tags"]),
+            "needs_review": sum(1 for c in classifications if "needs-review" in c["tags"]),
             "scopes": dict(scope_counts.most_common()),
             "roles": dict(role_counts.most_common()),
         },

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -918,21 +918,20 @@ def cmd_parse(args):
 
 def _load_registry():
     """Load agency registry as slug->entry lookup."""
-    registry_path = Path("assets/agency_registry.json")
-    if not registry_path.exists():
-        return {}
-    return {e["slug"]: e for e in json.loads(registry_path.read_text())}
+    from lib import load_registry
+    return {e["slug"]: e for e in load_registry()}
 
 
 def classify_entity_from_registry(slug, registry):
     """Classify an entity using the registry (single source of truth)."""
+    from lib import has_tag
     e = registry.get(slug, {})
     flags = []
-    if e.get("public") is False:
+    if has_tag(e, "private"):
         flags.append("PRIVATE")
     if e.get("state") and e["state"] != "CA":
         flags.append("OUT_OF_STATE")
-    if e.get("federal"):
+    if has_tag(e, "federal"):
         flags.append("FEDERAL")
     if e.get("agency_type") == "decommissioned":
         flags.append("DECOMMISSIONED")
@@ -940,7 +939,7 @@ def classify_entity_from_registry(slug, registry):
         flags.append("TEST")
     if e.get("agency_role") == "fire":
         flags.append("NON_LAW_ENFORCEMENT")
-    if e.get("needs_review"):
+    if has_tag(e, "needs-review"):
         flags.append("NEEDS_REVIEW")
     return flags
 

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -25,24 +25,95 @@ def load_registry():
     return _registry_cache
 
 
+def registry_by_id():
+    """Return agency_id -> registry entry lookup."""
+    return {e["agency_id"]: e for e in load_registry()}
+
+
 def registry_by_slug():
-    """Return slug -> registry entry lookup."""
+    """Return slug -> registry entry lookup. Backward compat."""
     return {e["slug"]: e for e in load_registry()}
 
 
-def flock_name_to_slug(name):
-    """Look up a Flock display name in the registry, return slug.
+DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
 
-    Returns None if the name isn't in the registry. New names should be
-    added to the registry via build_agency_registry.py, not derived here.
+
+def crawl_status(entry, data_dir=None):
+    """Derive crawled/crawled_date from the filesystem for a registry entry.
+
+    Checks all directories in ``flock_slugs`` and returns the most recent
+    crawl date found across any of them.
+
+    Returns (crawled: bool, crawled_date: str|None).
+    """
+    data_dir = data_dir or DEFAULT_DATA_DIR
+    latest = None
+    slugs = entry.get("flock_slugs", []) or []
+    # Always check the slug field as fallback (it's the directory name)
+    base_slug = entry.get("slug")
+    if base_slug and base_slug not in slugs:
+        slugs = list(slugs) + [base_slug]
+    for slug in slugs:
+        slug_dir = data_dir / slug
+        if slug_dir.is_dir():
+            jsons = sorted(slug_dir.glob("*.json"))
+            if jsons:
+                date = jsons[-1].stem  # e.g. "2026-04-10"
+                if latest is None or date > latest:
+                    latest = date
+    return (True, latest) if latest else (False, None)
+
+
+def has_tag(entry, tag):
+    """Check if a registry entry has a specific tag."""
+    return tag in entry.get("tags", [])
+
+
+
+def agency_active_slug(entry, fallback=None):
+    """Return the current active Flock portal slug for a registry entry."""
+    if entry.get("flock_active_slug"):
+        return entry["flock_active_slug"]
+    slugs = entry.get("flock_slugs", [])
+    if slugs:
+        return slugs[0]
+    return fallback or entry.get("slug", "?")
+
+
+def agency_display_name(entry, fallback=None):
+    """Return the best display name for a registry entry."""
+    if entry.get("display_name"):
+        return entry["display_name"]
+    names = entry.get("flock_names", [])
+    if names:
+        return names[0]
+    return fallback or entry.get("slug", "?")
+
+
+def resolve_agency(*, slug=None, name=None):
+    """Find a registry entry by Flock slug or display name.
+
+    Pass exactly one of ``slug`` or ``name``. Searches ``flock_slugs``
+    (including legacy slugs) and ``flock_names`` respectively.
+
+    Returns the full registry entry dict, or None if not found.
     """
     for e in load_registry():
-        if e.get("flock_name") == name:
-            return e["slug"]
-        for aka_name in e.get("also_known_as_names", []):
-            if aka_name == name:
-                return e["slug"]
+        if slug is not None:
+            if slug in e.get("flock_slugs", []) or slug == e.get("slug"):
+                return e
+        if name is not None:
+            if name in e.get("flock_names", []):
+                return e
     return None
+
+
+# Backward-compat wrappers — callers migrating to resolve_agency()
+
+def flock_name_to_slug(name):
+    """Look up a Flock display name, return active slug. Use resolve_agency() instead."""
+    entry = resolve_agency(name=name)
+    return agency_active_slug(entry) if entry else None
 
 
 # ── Text parsing utilities ──
@@ -60,8 +131,8 @@ _EXPECTS_CONTINUATION = re.compile(
 def parse_org_list(orgs_text):
     """Parse a comma-separated org list from Flock portal text.
 
-    Returns a list of display names. Use flock_name_to_slug() to resolve
-    each name to a registry slug.
+    Returns a list of display names. Use resolve_agency(name=n) to look
+    up each name in the registry.
     """
     if not orgs_text:
         return []

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -67,6 +67,13 @@ class TestMapData:
         assert uop.get("public") is False
         assert uop.get("type") == "private"
 
+    def test_public_field_is_tristate(self):
+        """public should be True, False, or None — never just a boolean for unknown."""
+        for slug, info in self.data["agencyInfo"].items():
+            assert info.get("public") in (True, False, None), (
+                f"{slug}: public={info.get('public')!r}, expected True/False/None"
+            )
+
     def test_ncric_exists(self):
         ncric = self.data["agencyInfo"].get("ncric", {})
         assert ncric.get("crawled") is True
@@ -107,28 +114,133 @@ class TestRegistry:
 
     def test_flock_is_private(self):
         flock = self.by_slug["flock-safety-vendor"]
-        assert flock["public"] is False
+        assert "private" in flock.get("tags", [])
         assert flock["agency_role"] == "vendor"
 
     def test_uop_is_private(self):
         uop = self.by_slug.get("university-of-the-pacific-ca", {})
-        assert uop.get("public") is False
+        assert "private" in uop.get("tags", [])
 
     def test_no_duplicate_slugs(self):
         slugs = [e["slug"] for e in self.registry]
         assert len(slugs) == len(set(slugs)), "Duplicate slugs found"
 
-    def test_crawled_have_dates(self):
-        for e in self.registry:
-            if e.get("crawled"):
-                assert e.get("crawled_date"), f"{e['slug']} crawled but no date"
+    def test_no_duplicate_agency_ids(self):
+        ids = [e["agency_id"] for e in self.registry]
+        assert len(ids) == len(set(ids)), "Duplicate agency_ids found"
 
-    def test_no_null_public_for_known_types(self):
-        """Entities with known types should have public set."""
+    def test_agency_id_is_uuid(self):
+        """agency_id should be a valid UUID."""
+        import uuid
+        for e in self.registry:
+            try:
+                uuid.UUID(e["agency_id"])
+            except ValueError:
+                assert False, f"{e['slug']} has invalid UUID: {e['agency_id']}"
+
+    def test_has_flock_slugs(self):
+        for e in self.registry:
+            assert "flock_slugs" in e, f"{e['agency_id']} missing flock_slugs"
+            assert len(e["flock_slugs"]) >= 1
+            assert "flock_active_slug" in e
+            assert e["flock_active_slug"] in e["flock_slugs"]
+
+    def test_has_flock_names(self):
+        for e in self.registry:
+            assert "flock_names" in e, f"{e['agency_id']} missing flock_names"
+            assert len(e["flock_names"]) >= 1
+
+    def test_no_crawled_fields_in_registry(self):
+        """crawled/crawled_date are derived at runtime, not stored."""
+        for e in self.registry:
+            assert "crawled" not in e, f"{e['agency_id']} has stale 'crawled' field"
+            assert "crawled_date" not in e, f"{e['agency_id']} has stale 'crawled_date' field"
+
+    def test_no_stale_boolean_fields(self):
+        """Old boolean fields should not exist in registry entries."""
+        stale = {"public", "federal", "needs_review", "ag_lawsuit", "crawled", "crawled_date",
+                 "also_known_as", "also_known_as_names", "flock_name", "human_name"}
+        for e in self.registry:
+            found = stale & set(e.keys())
+            assert not found, f"{e['agency_id']} has stale fields: {found}"
+
+    def test_tags_no_conflicts(self):
+        """No entry should have both public and private tags."""
+        for e in self.registry:
+            tags = e.get("tags", [])
+            assert not ("public" in tags and "private" in tags), (
+                f"{e['agency_id']} has both public and private tags"
+            )
+
+    def test_known_types_have_public_or_private_tag(self):
+        """Entities with known types should be tagged public or private."""
         known_types = {"city", "county", "state", "federal", "fusion_center", "university", "private", "tribal"}
         for e in self.registry:
             if e.get("agency_type") in known_types:
-                assert e.get("public") is not None, f"{e['slug']} type={e['agency_type']} but public=None"
+                tags = e.get("tags", [])
+                assert "public" in tags or "private" in tags, (
+                    f"{e['agency_id']} type={e['agency_type']} but no public/private tag"
+                )
+
+
+# ── Lib accessor tests (unit tests, no data dependencies) ──
+
+class TestLibAccessors:
+    """Verify lib.py accessor functions handle edge cases."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def add_scripts_to_path(self):
+        import sys
+        scripts_dir = str(Path(__file__).parent.parent / "scripts")
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+
+    def test_has_tag(self):
+        from lib import has_tag
+        assert has_tag({"tags": ["public", "federal"]}, "public") is True
+        assert has_tag({"tags": ["public"]}, "private") is False
+        assert has_tag({}, "public") is False
+        assert has_tag({"tags": []}, "public") is False
+
+    def test_agency_display_name(self):
+        from lib import agency_display_name
+        assert agency_display_name({"display_name": "Custom", "flock_names": ["Flock"]}) == "Custom"
+        assert agency_display_name({"flock_names": ["Flock Name"]}) == "Flock Name"
+        assert agency_display_name({}, "fallback") == "fallback"
+        assert agency_display_name({}) == "?"
+
+    def test_agency_active_slug(self):
+        from lib import agency_active_slug
+        assert agency_active_slug({"flock_active_slug": "active", "flock_slugs": ["active", "old"]}) == "active"
+        assert agency_active_slug({"flock_slugs": ["first", "second"]}) == "first"
+        assert agency_active_slug({}, "fallback") == "fallback"
+        assert agency_active_slug({}) == "?"
+
+    def test_resolve_agency_by_slug(self):
+        from lib import resolve_agency
+        entry = resolve_agency(slug="san-mateo-ca-pd")
+        assert entry is not None
+        assert "san-mateo-ca-pd" in entry["flock_slugs"]
+
+    def test_resolve_agency_by_name(self):
+        from lib import resolve_agency
+        entry = resolve_agency(name="San Mateo CA PD")
+        assert entry is not None
+        assert "San Mateo CA PD" in entry["flock_names"]
+
+    def test_resolve_agency_not_found(self):
+        from lib import resolve_agency
+        assert resolve_agency(slug="nonexistent-agency-xyz") is None
+        assert resolve_agency(name="Nonexistent Agency XYZ") is None
+
+    def test_resolve_returns_full_entry(self):
+        """resolve_agency should return a complete registry entry."""
+        from lib import resolve_agency
+        entry = resolve_agency(slug="san-mateo-ca-pd")
+        assert entry is not None
+        assert "agency_id" in entry
+        assert "flock_active_slug" in entry
+        assert "tags" in entry
 
 
 # ── HTML tests ──


### PR DESCRIPTION
## Summary

Replaces the fragile slug-as-identity model with a proper registry schema. This is the foundation for PRs 2-3 which will remove derived slugs from crawled JSON and switch the sharing graph/map/scoreboard to key by `agency_id`.

### Registry schema changes
- **`agency_id`**: stable UUID per agency (deterministic via uuid5, never changes)
- **`flock_slugs` / `flock_active_slug`**: track all known portal URL variants (confirmed + derived for now; PR 2 separates them)
- **`flock_names`**: all observed display name variants (consolidates `flock_name` + `also_known_as_names`)
- **`display_name`**: nullable curated name (replaces `human_name`, falls back to `flock_names[0]`)
- **`tags`**: replaces boolean fields (`public`/`federal`/`needs_review`/`ag_lawsuit`)
- **`crawled` / `crawled_date`**: removed from registry, derived at runtime from filesystem via `crawl_status()`

### New accessor API (`lib.py`)
- `resolve_agency(slug=..., name=...)` — unified lookup by slug or name, returns full entry
- `agency_display_name(entry)` / `agency_active_slug(entry)` — accessors with fallback chains
- `has_tag(entry, tag)` — tag-based classification checks
- `crawl_status(entry)` — filesystem-derived crawl state

### Other changes
- All scripts load registry through `lib.py` (no more direct file opens)
- `build_agency_registry.py` generates UUIDs and tags for new entries
- `build_map.py`, `build_scoreboard.py`, `classify_agencies.py`, `check_recipient_coords.py`, `flock_transparency.py` updated for new schema
- Dead code removed: `flock_name_to_human()`, `agency_is_public()`

## Test plan
- [x] 86 tests pass (10 new: accessor unit tests, stale field guards, tag conflict check, public tri-state regression guard)
- [x] `build_agency_registry.py --merge` succeeds (591 entries, 0 new)
- [x] `build_map.py` generates correct map data
- [x] `build_scoreboard.py` generates correct scoreboard data
- [x] Registry validates: all UUIDs valid, no duplicate IDs, no stale boolean fields, no tag conflicts