### PR TITLE
refactor: rename violations to flags (PR 3/3)

### DIFF
--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -259,9 +259,9 @@ def main():
             mismatch_map.setdefault(agency_slug, []).append(partner_slug)
             mismatch_map.setdefault(partner_slug, []).append(agency_slug)
 
-    # Compute indirect violations: if A shares with B, and B shares with
-    # a violation entity V, then A has an indirect violation "V via B"
-    def is_violation_entity(aid):
+    # Compute indirect flags: if A shares with B, and B shares with
+    # a flagged entity V, then A has an indirect flag "V via B"
+    def is_flagged_entity(aid):
         r = reg_by_id.get(aid, {})
         if has_tag(r, "private"):
             return True
@@ -276,40 +276,39 @@ def main():
     for aid, data in graph["agencies"].items():
         outbound_by_id[aid] = data.get("sharing_outbound_ids", [])
 
-    # For each agency, find indirect violations (depth 1: via intermediaries)
+    # For each agency, find indirect flags (depth 1: via intermediaries)
     # Output uses slugs for JS consumption
-    indirect_violations = {}  # slug -> [{"violation": slug, "via": slug}]
+    indirect_flags = {}  # slug -> [{"flagged": slug, "via": slug}]
     for aid, data in graph["agencies"].items():
         slug = id_to_slug.get(aid)
         if not slug:
             continue
         indirects = []
-        direct_violations = set()
+        direct_flags = set()
         for target_id in data.get("sharing_outbound_ids", []):
-            if is_violation_entity(target_id):
-                direct_violations.add(target_id)
+            if is_flagged_entity(target_id):
+                direct_flags.add(target_id)
         for target_id in data.get("sharing_outbound_ids", []):
             if target_id in outbound_by_id:
                 for second_hop_id in outbound_by_id[target_id]:
-                    if is_violation_entity(second_hop_id) and second_hop_id not in direct_violations:
+                    if is_flagged_entity(second_hop_id) and second_hop_id not in direct_flags:
                         indirects.append({
-                            "violation": id_to_slug.get(second_hop_id, second_hop_id),
+                            "flagged": id_to_slug.get(second_hop_id, second_hop_id),
                             "via": id_to_slug.get(target_id, target_id),
                             "via_name": agency_display_name(reg_by_id.get(target_id, {})),
-                            "violation_name": agency_display_name(reg_by_id.get(second_hop_id, {})),
+                            "flagged_name": agency_display_name(reg_by_id.get(second_hop_id, {})),
                         })
         if indirects:
-            # Deduplicate by violation slug
             seen = set()
             deduped = []
             for iv in indirects:
-                if iv["violation"] not in seen:
-                    seen.add(iv["violation"])
+                if iv["flagged"] not in seen:
+                    seen.add(iv["flagged"])
                     deduped.append(iv)
-            indirect_violations[slug] = deduped
+            indirect_flags[slug] = deduped
 
-    indirect_count = sum(len(v) for v in indirect_violations.values())
-    print(f"Indirect violations: {indirect_count} across {len(indirect_violations)} agencies")
+    indirect_count = sum(len(v) for v in indirect_flags.values())
+    print(f"Indirect flags: {indirect_count} across {len(indirect_flags)} agencies")
 
     print(f"Geocoded: {geocoded}/{len(graph['agencies'])}")
     if ungeocodable:
@@ -328,7 +327,7 @@ def main():
         "coords": slug_coords,
         "agencyInfo": slug_info,
         "mismatches": mismatch_map,
-        "indirectViolations": indirect_violations,
+        "indirectFlags": indirect_flags,
     }
     (docs_dir / "data" / "map_data.json").write_text(json.dumps(map_data) + "\n")
     print(f"Data written to {docs_dir}/data/map_data.json")
@@ -437,7 +436,7 @@ def _generate_html(marker_count):
     .legend {{
       display: none;
     }}
-    #violation-banner {{
+    #flag-banner {{
       font-size: 11px !important;
       padding: 6px 10px !important;
       left: 10px !important;
@@ -471,8 +470,8 @@ def _generate_html(marker_count):
     cursor: pointer; white-space: nowrap;
     display: none;
   }}
-  .edge-indicator.has-violation {{ background: #dc2626; }}
-  #violation-banner {{
+  .edge-indicator.has-flag {{ background: #dc2626; }}
+  #flag-banner {{
     position: absolute; top: 58px; left: 50%; transform: translateX(-60%);
     z-index: 1000; background: #dc2626; color: white;
     padding: 8px 16px; border-radius: 8px; font-size: 13px; font-weight: bold;
@@ -492,7 +491,7 @@ def _generate_html(marker_count):
   <button id="search-btn">\U0001f50d</button>
 </div>
 <div id="search-results"></div>
-<div id="violation-banner"></div>
+<div id="flag-banner"></div>
 <button class="info-toggle" id="infoToggle" onclick="
   var p = document.getElementById('info');
   p.classList.toggle('collapsed');
@@ -505,8 +504,8 @@ def _generate_html(marker_count):
 </div>
 <div class="legend">
   <div class="legend-item"><div class="legend-dot" style="background:#2563eb"></div> Public agency</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#f97316"></div> Shares with non-conforming entity</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#dc2626"></div> Non-conforming entity (private/out-of-state/fusion center)</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#f97316"></div> Shares with flagged entity</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#dc2626"></div> Flagged entity (private/out-of-state/federal)</div>
   <div class="legend-item"><div class="legend-dot" style="background:#06b6d4"></div> Selected</div>
   <div class="legend-item"><div class="legend-dot" style="background:#8b5cf6"></div> No transparency page found</div>
   <div class="legend-item"><div style="width:20px;height:2px;background:#2563eb"></div> Shares with (outbound)</div>

--- a/scripts/build_scoreboard.py
+++ b/scripts/build_scoreboard.py
@@ -24,8 +24,8 @@ OUT_PATH = Path("docs/data/scoreboard_data.json")
 RANKED_STATE = "CA"
 
 
-def is_violation_entity(aid, reg_by_id):
-    """Match the violation logic from build_map.py."""
+def is_flagged_entity(aid, reg_by_id):
+    """Match the flag logic from build_map.py."""
     r = reg_by_id.get(aid, {})
     if has_tag(r, "private"):
         return "private"
@@ -61,7 +61,7 @@ def main():
     with open(GRAPH_PATH) as f:
         graph = json.load(f)
 
-    # Build outbound lookup for indirect violation computation
+    # Build outbound lookup for indirect flag computation
     outbound_by_id = {}
     for aid, data in graph["agencies"].items():
         outbound_by_id[aid] = data.get("sharing_outbound_ids", [])
@@ -81,11 +81,11 @@ def main():
         private = 0
         federal = 0
         universities = 0
-        non_conforming = 0
+        flagged = 0
 
-        direct_violations = set()
+        direct_flags = set()
         for target_id in outbound_ids:
-            v = is_violation_entity(target_id, reg_by_id)
+            v = is_flagged_entity(target_id, reg_by_id)
             if v == "out_of_state":
                 out_of_state += 1
             elif v == "private":
@@ -93,22 +93,22 @@ def main():
             elif v == "federal":
                 federal += 1
             if v:
-                non_conforming += 1
-                direct_violations.add(target_id)
+                flagged += 1
+                direct_flags.add(target_id)
 
             tr = reg_by_id.get(target_id, {})
             if tr.get("agency_type") == "university":
                 universities += 1
 
-        # Indirect violations: targets' outbound that are violation entities
-        indirect_violations = 0
+        # Indirect flags: targets' outbound that are flagged entities
+        indirect_flags = 0
         indirect_seen = set()
         for target_id in outbound_ids:
             if target_id in outbound_by_id:
                 for second_hop in outbound_by_id[target_id]:
-                    if second_hop not in direct_violations and second_hop not in indirect_seen:
-                        if is_violation_entity(second_hop, reg_by_id):
-                            indirect_violations += 1
+                    if second_hop not in direct_flags and second_hop not in indirect_seen:
+                        if is_flagged_entity(second_hop, reg_by_id):
+                            indirect_flags += 1
                             indirect_seen.add(second_hop)
 
         # Load crawled portal stats
@@ -121,12 +121,12 @@ def main():
             "state": info.get("state", ""),
             "outbound": outbound_count,
             "inbound": inbound_count,
-            "non_conforming": non_conforming,
+            "flagged": flagged,
             "out_of_state": out_of_state,
             "private": private,
             "federal": federal,
             "universities": universities,
-            "indirect_violations": indirect_violations,
+            "indirect_flags": indirect_flags,
             "cameras": data.get("camera_count") or 0,
             "retention_days": data.get("data_retention_days"),
             "vehicles_30d": crawled_stats.get("vehicles_detected_30d"),
@@ -197,16 +197,16 @@ def main():
             "key": "out_of_state",
         },
         {
-            "id": "non_conforming",
-            "title": "Most Direct Non-Conforming Shares",
+            "id": "flagged",
+            "title": "Most Flagged Sharing Partners",
             "subtitle": "Direct shares with private, out-of-state, or federal entities",
-            "key": "non_conforming",
+            "key": "flagged",
         },
         {
             "id": "indirect",
-            "title": "Most Indirect Non-Conforming Shares",
-            "subtitle": "Non-conforming exposure through sharing partners' networks",
-            "key": "indirect_violations",
+            "title": "Most Indirect Flagged Shares",
+            "subtitle": "Flagged exposure through sharing partners' networks",
+            "key": "indirect_flags",
         },
         {
             "id": "cameras",

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -903,6 +903,15 @@ def cmd_parse(args):
 
             portal_data = parse_portal_text(raw_text, slug, datestamp, bold_headings=bold_headings)
 
+            # Preserve crawled_at from existing JSON (set during crawl, not recoverable from .txt)
+            if json_path.exists():
+                try:
+                    existing = json.loads(json_path.read_text())
+                    if "crawled_at" in existing:
+                        portal_data["crawled_at"] = existing["crawled_at"]
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
             # Extract embedded CSVs from HTML if available
             if page_html is not None:
                 for csv_name, csv_rows in extract_csvs_from_html(

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,5 +1,5 @@
 // Feature flags
-const SHOW_SHARES_WITH_TAGS = false; // [SHARES WITH NON-CONFORMING ENTITY] and [SHARES WITH SUED AGENCY]
+const SHOW_SHARES_WITH_TAGS = false; // [SHARES WITH FLAGGED ENTITY] and [SHARES WITH SUED AGENCY]
 
 // Sanitization helpers
 function escapeHtml(s) {
@@ -14,7 +14,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
   const coords = data.coords;
   const agencyInfo = data.agencyInfo;
   const mismatches = data.mismatches;
-  const indirectViolations = data.indirectViolations || {};
+  const indirectFlags = data.indirectFlags || {};
 
   const map = L.map('map').setView([37.5, -121.5], 7);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', {
@@ -38,8 +38,8 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
         const slug = cm.options.slug;
         if (!slug) { gray++; return; }
         const info = agencyInfo[slug] || {};
-        if (isViolation(slug)) red++;
-        else if (hasOutboundViolation(cm._markerData || {})) orange++;
+        if (isFlagged(slug)) red++;
+        else if (hasOutboundFlags(cm._markerData || {})) orange++;
         else if (info.crawled || cm.options.fillColor === '#2563eb') blue++;
         else gray++;
       });
@@ -91,7 +91,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       const slug = cm.options.slug;
       const info = agencyInfo[slug] || {};
       let name = info.name || slug;
-      if (isViolation(slug)) name = '\u26a0 ' + name;
+      if (isFlagged(slug)) name = '\u26a0 ' + name;
       return name;
     }).sort();
     e.layer.bindTooltip(names.join('<br>'), { direction: 'top' }).openTooltip();
@@ -109,7 +109,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     return 4;  // uncrawled: same base size as small cities
   }
 
-  function isViolation(slug) {
+  function isFlagged(slug) {
     const info = agencyInfo[slug] || {};
     if (info.public === false && info.type !== 'test') return true;  // private entity
     if (info.state && info.state !== 'CA') return true;               // out-of-state
@@ -120,14 +120,14 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     return false;
   }
 
-  // Does this agency share with any violation entities?
-  function hasOutboundViolation(m) {
-    return (m.outbound_slugs || []).some(s => isViolation(s));
+  // Does this agency share with any flagged entities?
+  function hasOutboundFlags(m) {
+    return (m.outbound_slugs || []).some(s => isFlagged(s));
   }
 
   function defaultColor(m) {
-    if (isViolation(m.slug)) return { fill: '#dc2626', border: '#991b1b', opacity: 0.8 };
-    if (hasOutboundViolation(m)) return { fill: '#f97316', border: '#c2410c', opacity: 0.7 };
+    if (isFlagged(m.slug)) return { fill: '#dc2626', border: '#991b1b', opacity: 0.8 };
+    if (hasOutboundFlags(m)) return { fill: '#f97316', border: '#c2410c', opacity: 0.7 };
     if (m.crawled) return { fill: '#2563eb', border: '#1e40af', opacity: 0.6 };
     return { fill: '#8b5cf6', border: '#6d28d9', opacity: 0.5 };
   }
@@ -186,12 +186,12 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     // Flag agencies under AG lawsuit
     if (info.ag_lawsuit)
       tag += ' <span style="color:#dc2626;font-weight:bold" title="CA Attorney General lawsuit for illegal out-of-state ALPR data sharing in violation of SB 34">[AG LAWSUIT \u2014 illegal sharing]</span>';
-    // Check if this agency re-shares to violations (from marker data)
+    // Check if this agency re-shares to flagged entities (from marker data)
     const mData = (typeof markerDataBySlug !== 'undefined') && markerDataBySlug[s];
-    if (SHOW_SHARES_WITH_TAGS && mData && !isViolation(s)) {
-      const hasOutboundViol = (mData.outbound_slugs || []).some(t => isViolation(t));
+    if (SHOW_SHARES_WITH_TAGS && mData && !isFlagged(s)) {
+      const hasOutboundViol = (mData.outbound_slugs || []).some(t => isFlagged(t));
       if (hasOutboundViol)
-        tag += ' <span style="color:#d97706;font-weight:bold" title="This agency shares data with non-conforming entities (private, federal, test)">[SHARES WITH NON-CONFORMING ENTITY]</span>';
+        tag += ' <span style="color:#d97706;font-weight:bold" title="This agency shares data with flagged entities (private, federal, test)">[SHARES WITH FLAGGED ENTITY]</span>';
     }
     // Flag agencies sharing with a sued agency
     if (SHOW_SHARES_WITH_TAGS && mData && !info.ag_lawsuit) {
@@ -215,18 +215,18 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
   // Non-public (private, test, decommissioned) only appear when an agency is selected.
   markers.forEach(m => {
     const col = defaultColor(m);
-    const radius = isViolation(m.slug) ? Math.max(6, defaultRadius(m)) : defaultRadius(m);
+    const radius = isFlagged(m.slug) ? Math.max(6, defaultRadius(m)) : defaultRadius(m);
     const circle = L.circleMarker([m.lat, m.lng], {
       radius: radius,
       fillColor: col.fill,
       color: col.border,
-      weight: isViolation(m.slug) ? 2 : 1,
+      weight: isFlagged(m.slug) ? 2 : 1,
       fillOpacity: col.opacity,
       slug: m.slug,
     });
     const info = agencyInfo[m.slug] || {};
     circle._markerData = m;
-    const tipName = (info.name || m.slug) + (isViolation(m.slug) ? ' \u26a0' : '');
+    const tipName = (info.name || m.slug) + (isFlagged(m.slug) ? ' \u26a0' : '');
     circle.bindTooltip(tipName, { direction: 'top', offset: [0, -8], sticky: true });
     circle.on('click', (e) => { L.DomEvent.stopPropagation(e); showAgency(m); });
     markersBySlug[m.slug] = circle;
@@ -239,7 +239,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     e.markers.forEach(cm => {
       const slug = cm.options.slug;
       const info = agencyInfo[slug] || {};
-      const tipName = (info.name || slug) + (isViolation(slug) ? ' \u26a0' : '');
+      const tipName = (info.name || slug) + (isFlagged(slug) ? ' \u26a0' : '');
       cm.bindTooltip(tipName, { direction: 'top', offset: [0, -8], sticky: true });
     });
   });
@@ -271,31 +271,31 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     });
 
     let outConnected = 0;
-    let outViolations = 0;
+    let outFlags = 0;
     let outNotMapped = 0;
-    const unmappedViolations = [];
+    const unmappedFlagged = [];
     (m.outbound_slugs || []).forEach(target => {
-      if (isViolation(target)) outViolations++;
+      if (isFlagged(target)) outFlags++;
       if (coords[target]) {
-        const lineColor = isViolation(target) ? '#dc2626' : '#2563eb';
-        const lineWeight = isViolation(target) ? 2 : 1.5;
+        const lineColor = isFlagged(target) ? '#dc2626' : '#2563eb';
+        const lineWeight = isFlagged(target) ? 2 : 1.5;
         L.polyline([[m.lat, m.lng], coords[target]], { color: lineColor, weight: lineWeight, opacity: 0.4 }).addTo(lineLayer);
         outConnected++;
-      } else if (isViolation(target)) {
-        unmappedViolations.push(target);
+      } else if (isFlagged(target)) {
+        unmappedFlagged.push(target);
       } else {
         outNotMapped++;
       }
     });
 
-    // Place unmapped violations as warning markers along the top edge
-    if (unmappedViolations.length > 0) {
-      const spread = Math.min(unmappedViolations.length, 20);
+    // Place unmapped flagged entities as warning markers along the top edge
+    if (unmappedFlagged.length > 0) {
+      const spread = Math.min(unmappedFlagged.length, 20);
       const startLng = m.lng - 2.5;
       const lngStep = 5.0 / Math.max(spread - 1, 1);
       const topLat = m.lat + 3.5;
 
-      unmappedViolations.slice(0, 20).forEach((slug, i) => {
+      unmappedFlagged.slice(0, 20).forEach((slug, i) => {
         const vLat = topLat + (Math.random() - 0.5) * 0.3;
         const vLng = startLng + i * lngStep + (Math.random() - 0.5) * 0.2;
         const vInfo = agencyInfo[slug] || {};
@@ -318,10 +318,10 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
         }).addTo(lineLayer);
       });
 
-      if (unmappedViolations.length > 20) {
+      if (unmappedFlagged.length > 20) {
         // Overflow indicator
         const overflowIcon = L.divIcon({
-          html: '<div style="background:#dc2626;color:white;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:bold;white-space:nowrap">+' + (unmappedViolations.length - 20) + ' more</div>',
+          html: '<div style="background:#dc2626;color:white;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:bold;white-space:nowrap">+' + (unmappedFlagged.length - 20) + ' more</div>',
           className: '',
           iconSize: [80, 20],
           iconAnchor: [40, 10],
@@ -365,12 +365,12 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       }
     });
 
-    // Show violation summary as a fixed banner at top of map
-    const bannerEl = document.getElementById('violation-banner');
-    const myIndirectCount = (indirectViolations[m.slug] || []).length;
-    const totalViolations = outViolations + myIndirectCount;
-    if (totalViolations > 0) {
-      let bannerText = '\u26a0 ' + outViolations + ' direct violation' + (outViolations !== 1 ? 's' : '');
+    // Show flag summary as a fixed banner at top of map
+    const bannerEl = document.getElementById('flag-banner');
+    const myIndirectCount = (indirectFlags[m.slug] || []).length;
+    const totalFlags = outFlags + myIndirectCount;
+    if (totalFlags > 0) {
+      let bannerText = '\u26a0 ' + outFlags + ' direct flag' + (outFlags !== 1 ? 's' : '');
       if (myIndirectCount > 0) {
         bannerText += ' + ' + myIndirectCount + ' indirect (via intermediaries)';
       }
@@ -414,27 +414,27 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
 
     if (m.outbound_slugs && m.outbound_slugs.length) {
       const sorted = sortOutbound(m.outbound_slugs, m.lat, m.lng);
-      const directViol = sorted.filter(s => isViolation(s));
-      const clean = sorted.filter(s => !isViolation(s));
-      const myIndirects = indirectViolations[m.slug] || [];
+      const directFlagged = sorted.filter(s => isFlagged(s));
+      const clean = sorted.filter(s => !isFlagged(s));
+      const myIndirects = indirectFlags[m.slug] || [];
 
-      // Direct violations first
-      if (directViol.length) {
-        html += '<div class="sharing-list"><strong style="color:#dc2626">\u26a0 Direct violations (' + directViol.length + '):</strong>';
-        directViol.forEach(function(s) {
+      // Direct flags first
+      if (directFlagged.length) {
+        html += '<div class="sharing-list"><strong style="color:#dc2626">\u26a0 Direct flags (' + directFlagged.length + '):</strong>';
+        directFlagged.forEach(function(s) {
           html += '<div style="cursor:pointer" data-slug="' + escapeHtml(s) + '" onclick="clickSlug(this.dataset.slug)">' + slugLabel(s) + (inferredOut.has(s) ? inferTag : '') + '</div>';
         });
         html += '</div>';
       }
 
-      // Indirect violations
+      // Indirect flags
       if (myIndirects.length) {
         html += '<div class="sharing-list" style="border-top:1px solid #fecaca;padding-top:6px">';
-        html += '<strong style="color:#dc2626">\u26a0 Indirect violations (' + myIndirects.length + '):</strong>';
+        html += '<strong style="color:#dc2626">\u26a0 Indirect flags (' + myIndirects.length + '):</strong>';
         html += '<p class="stat" style="font-size:11px;color:#92400e;margin:2px 0 4px 0">Data reaches these entities through intermediaries.</p>';
         myIndirects.forEach(function(iv) {
-          html += '<div style="cursor:pointer;padding:2px 0" data-slug="' + escapeHtml(iv.violation) + '" onclick="clickSlug(this.dataset.slug)">';
-          html += slugLabel(iv.violation);
+          html += '<div style="cursor:pointer;padding:2px 0" data-slug="' + escapeHtml(iv.flagged) + '" onclick="clickSlug(this.dataset.slug)">';
+          html += slugLabel(iv.flagged);
           html += ' <span style="color:#6b7280;font-size:11px">via </span>';
           html += '<span style="cursor:pointer;color:#2563eb;font-size:11px" data-slug="' + escapeHtml(iv.via) + '" onclick="event.stopPropagation();clickSlug(this.dataset.slug)">' + escapeHtml(iv.via_name) + '</span>';
           html += '</div>';
@@ -527,9 +527,9 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       if (!c) return;
       if (!shouldShowByDefault(mm.slug)) return;
       const col = defaultColor(mm);
-      const radius = isViolation(mm.slug) ? Math.max(5, defaultRadius(mm)) : defaultRadius(mm);
+      const radius = isFlagged(mm.slug) ? Math.max(5, defaultRadius(mm)) : defaultRadius(mm);
       c.setRadius(radius);
-      c.setStyle({ fillColor: col.fill, fillOpacity: col.opacity, weight: isViolation(mm.slug) ? 2 : 1, color: col.border });
+      c.setStyle({ fillColor: col.fill, fillOpacity: col.opacity, weight: isFlagged(mm.slug) ? 2 : 1, color: col.border });
       markerLayer.addLayer(c);
     });
   }
@@ -543,7 +543,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     lineLayer.clearLayers();
     clearTempMarkers();
     resetMarkers();
-    document.getElementById('violation-banner').style.display = 'none';
+    document.getElementById('flag-banner').style.display = 'none';
     document.getElementById('info').innerHTML =
       '<h3>Flock ALPR Sharing Map</h3>' +
       '<p class="stat">Click an agency to see its sharing web.</p>' +
@@ -558,7 +558,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
 
     markers.forEach(m => {
       if (bounds.contains([m.lat, m.lng])) return;
-      const viol = isViolation(m.slug);
+      const viol = isFlagged(m.slug);
       if (m.lng < bounds.getWest()) { left++; if (viol) leftViol = true; }
       if (m.lng > bounds.getEast()) { right++; if (viol) rightViol = true; }
       if (m.lat > bounds.getNorth()) { top++; if (viol) topViol = true; }
@@ -569,7 +569,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       const el = document.getElementById(id);
       if (count > 0) {
         el.textContent = arrow + ' ' + count;
-        el.className = 'edge-indicator' + (hasViol ? ' has-violation' : '');
+        el.className = 'edge-indicator' + (hasViol ? ' has-flag' : '');
         el.style.display = '';
       } else {
         el.style.display = 'none';
@@ -638,20 +638,20 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     }
   };
 
-  // Place off-map violations as markers in the ocean west of California
+  // Place off-map flagged entities as markers in the ocean west of California
   document.getElementById('offmap').style.display = 'none';  // hide the old panel
 
   // Only show entities that RECEIVE data from CA agencies but have no map location
   // (test accounts, decommissioned entries, etc.) — not out-of-state sources
   const offmapEntities = Object.entries(agencyInfo).filter(([slug]) => {
-    if (!isViolation(slug)) return false;
+    if (!isFlagged(slug)) return false;
     if (coords[slug]) return false;
     // Must be a recipient — some agency shares outbound to this entity
     return recipientSlugs.has(slug);
   }).sort((a, b) => sortPriority(a[1]) - sortPriority(b[1]));
 
   if (offmapEntities.length) {
-    // Place all off-map violations at a single point in the ocean.
+    // Place all off-map flagged entities at a single point in the ocean.
     // MarkerCluster will group them into one clickable cluster.
     const offmapLat = 37.5;
     const offmapLng = -126.0;

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -78,9 +78,9 @@ class TestMapData:
         ncric = self.data["agencyInfo"].get("ncric", {})
         assert ncric.get("crawled") is True
 
-    def test_indirect_violations_computed(self):
-        assert "indirectViolations" in self.data
-        assert len(self.data["indirectViolations"]) > 50
+    def test_indirect_flags_computed(self):
+        assert "indirectFlags" in self.data
+        assert len(self.data["indirectFlags"]) > 50
 
     def test_no_garbled_entries(self):
         """No ncmec-amber-alert parser artifacts."""
@@ -263,8 +263,8 @@ class TestHTML:
     def test_has_info_panel(self):
         assert 'id="info"' in self.html
 
-    def test_has_violation_banner(self):
-        assert 'id="violation-banner"' in self.html
+    def test_has_flag_banner(self):
+        assert 'id="flag-banner"' in self.html
 
     def test_has_search_box(self):
         assert 'id="search-input"' in self.html
@@ -304,7 +304,7 @@ def _boxes_overlap(a, b):
 # Add new elements here as they're created.
 _UI_ELEMENTS = [
     "#search-box",
-    "#violation-banner",
+    "#flag-banner",
     ".info-panel",
     ".legend",
     ".back-link",
@@ -408,7 +408,7 @@ class TestLayout:
             )
 
         # -- All elements visible and in viewport --
-        hidden_by_default = {"#violation-banner"}
+        hidden_by_default = {"#flag-banner"}
         for sel in _UI_ELEMENTS:
             el = page.query_selector(sel)
             if not el:
@@ -435,8 +435,8 @@ class TestLayout:
         page.close()
 
     @pytest.mark.parametrize("vp", VIEWPORTS, ids=lambda v: v["name"])
-    def test_violation_banner_after_click(self, browser, vp):
-        """After selecting an agency with violations, banner should not overlap search and be fully visible."""
+    def test_flag_banner_after_click(self, browser, vp):
+        """After selecting an agency with flags, banner should not overlap search and be fully visible."""
         page = browser.new_page(viewport={"width": vp["width"], "height": vp["height"]})
         page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html#san-mateo-ca-pd", wait_until="networkidle")
         page.wait_for_selector("#map", state="visible", timeout=10000)
@@ -444,14 +444,14 @@ class TestLayout:
         page.wait_for_timeout(500)
 
         search = page.query_selector("#search-box")
-        banner = page.query_selector("#violation-banner")
+        banner = page.query_selector("#flag-banner")
 
-        # Banner must be visible when an agency with violations is selected
-        assert banner is not None, "Violation banner element not found"
-        assert banner.is_visible(), f"Violation banner not visible at {vp['name']} after selecting agency with violations"
+        # Banner must be visible when an agency with flags is selected
+        assert banner is not None, "Flag banner element not found"
+        assert banner.is_visible(), f"Flag banner not visible at {vp['name']} after selecting agency with flags"
 
         box_b = banner.bounding_box()
-        assert box_b is not None, f"Violation banner has no bounding box at {vp['name']}"
+        assert box_b is not None, f"Flag banner has no bounding box at {vp['name']}"
 
         # Banner must be fully within viewport
         assert box_b["x"] >= 0, f"Banner clipped on left at {vp['name']}: x={box_b['x']}"
@@ -468,7 +468,7 @@ class TestLayout:
             box_s = search.bounding_box()
             if box_s:
                 assert not _boxes_overlap(box_s, box_b), (
-                    f"Search box overlaps violation banner at {vp['name']}: "
+                    f"Search box overlaps flag banner at {vp['name']}: "
                     f"search={box_s}, banner={box_b}"
                 )
         page.close()

--- a/tests/test_scoreboard.py
+++ b/tests/test_scoreboard.py
@@ -177,7 +177,7 @@ class TestScoreboardData:
 
     def test_spicy_categories_first(self):
         ids = [c["id"] for c in self.data["categories"]]
-        assert ids[:5] == ["out_of_state", "non_conforming", "indirect", "cameras", "outbound"]
+        assert ids[:5] == ["out_of_state", "flagged", "indirect", "cameras", "outbound"]
 
     def test_has_meta(self):
         assert "meta" in self.data


### PR DESCRIPTION
## Summary

Renames "violation" and "non-conforming" terminology to "flag" / "flagged" throughout. Less conclusory language for public-facing tools — "flag" indicates something worth examining rather than asserting a legal conclusion.

### Renames
- `is_violation_entity` -> `is_flagged_entity` (build_map.py, build_scoreboard.py)
- `isViolation` -> `isFlagged`, `hasOutboundViolation` -> `hasOutboundFlags` (map.js)
- `indirectViolations` -> `indirectFlags` (Python, JS, JSON output key)
- `non_conforming` -> `flagged` (scoreboard category id + data key)
- `violation-banner` -> `flag-banner` (HTML element id + CSS)
- All UI text: "Direct violations" -> "Direct flags", "Non-conforming entity" -> "Flagged entity"

### Preserved
- AG lawsuit tooltip text references "violation of SB 34" — that's a factual description of the lawsuit, not our terminology

## Test plan
- [x] 86 tests pass
- [x] Map and scoreboard rebuild correctly
- [x] No remaining "violation" or "non-conforming" references except AG lawsuit text