### PR TITLE
Toolbar agency-search autocomplete on report pages

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1948,7 +1948,10 @@
 
     fetch("data/report_data.json?v=" + Date.now())
       .then(function(r) { return r.json(); })
-      .then(function(data) { render(data, slug); })
+      .then(function(data) {
+        render(data, slug);
+        wireAgencySearch(data, slug);
+      })
       .catch(function(err) {
         document.getElementById("report").innerHTML = `
           <div class="error-box">
@@ -1956,6 +1959,103 @@
             <p>${escapeHtml(err.message || String(err))}</p>
           </div>`;
       });
+  }
+
+  // Toolbar "Jump to another agency" search. Filters by case-
+  // insensitive substring, ranks exact > startsWith > contains, caps
+  // at 12 results. Navigating follows report.html?agency=<slug>.
+  // Keyboard: ↓/↑ to move highlight, Enter to open, Esc to close.
+  function wireAgencySearch(data, currentSlug) {
+    const input = document.getElementById("agency-search-input");
+    const results = document.getElementById("agency-search-results");
+    if (!input || !results) return;
+    const index = Object.entries(data.reports || {}).map(function(entry) {
+      const [slug, r] = entry;
+      return {
+        slug: slug,
+        name: r.name || slug,
+        state: r.state || "",
+        _nameLower: (r.name || slug).toLowerCase(),
+      };
+    });
+    let highlightIdx = -1;
+
+    function doSearch(q) {
+      q = q.trim().toLowerCase();
+      if (!q) { results.classList.remove("open"); results.innerHTML = ""; highlightIdx = -1; return; }
+      const matches = [];
+      for (let i = 0; i < index.length; i++) {
+        const e = index[i];
+        if (e.slug === currentSlug) continue;
+        const n = e._nameLower;
+        let score = 0;
+        if (n === q) score = 100;
+        else if (n.startsWith(q)) score = 50;
+        else if (n.includes(q)) score = 10;
+        if (score > 0) matches.push({ e: e, score: score });
+      }
+      matches.sort(function(a, b) {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.e._nameLower.localeCompare(b.e._nameLower);
+      });
+      const shown = matches.slice(0, 12);
+      if (!shown.length) {
+        results.innerHTML = '<div class="sr-empty">No matching agencies</div>';
+      } else {
+        results.innerHTML = shown.map(function(m) {
+          const state = m.e.state ? `<span class="sr-state">${escapeHtml(m.e.state)}</span>` : "";
+          return `<a href="report.html?agency=${encodeURIComponent(m.e.slug)}" data-slug="${escapeHtml(m.e.slug)}">${escapeHtml(m.e.name)}${state}</a>`;
+        }).join("");
+      }
+      results.classList.add("open");
+      highlightIdx = -1;
+    }
+
+    function updateHighlight() {
+      const links = results.querySelectorAll("a");
+      links.forEach(function(a, i) { a.classList.toggle("hl", i === highlightIdx); });
+      if (highlightIdx >= 0 && links[highlightIdx]) {
+        links[highlightIdx].scrollIntoView({ block: "nearest" });
+      }
+    }
+
+    input.addEventListener("input", function() { doSearch(input.value); });
+    input.addEventListener("keydown", function(e) {
+      const links = results.querySelectorAll("a");
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (!results.classList.contains("open")) doSearch(input.value);
+        if (links.length) {
+          highlightIdx = Math.min(highlightIdx + 1, links.length - 1);
+          updateHighlight();
+        }
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (links.length) {
+          highlightIdx = Math.max(highlightIdx - 1, 0);
+          updateHighlight();
+        }
+      } else if (e.key === "Enter") {
+        if (highlightIdx >= 0 && links[highlightIdx]) {
+          e.preventDefault();
+          window.location.href = links[highlightIdx].href;
+        } else if (links.length === 1) {
+          e.preventDefault();
+          window.location.href = links[0].href;
+        }
+      } else if (e.key === "Escape") {
+        results.classList.remove("open");
+        input.blur();
+      }
+    });
+    input.addEventListener("focus", function() {
+      if (input.value.trim()) doSearch(input.value);
+    });
+    document.addEventListener("click", function(e) {
+      if (!e.target.closest("#agency-search")) {
+        results.classList.remove("open");
+      }
+    });
   }
 
   // (Previously: opened every <details> on beforeprint so the PDF

--- a/docs/report.html
+++ b/docs/report.html
@@ -47,6 +47,64 @@
   }
   .toolbar a:hover, .toolbar button:hover { background: #eff6ff; }
   .toolbar .spacer { flex: 1; }
+  .toolbar .agency-search {
+    position: relative;
+    flex: 0 1 300px;
+    min-width: 180px;
+  }
+  .toolbar .agency-search input {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    box-sizing: border-box;
+    background: white;
+  }
+  .toolbar .agency-search input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37,99,235,0.15);
+  }
+  .toolbar .agency-search .search-results {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 100;
+    display: none;
+  }
+  .toolbar .agency-search .search-results.open { display: block; }
+  .toolbar .agency-search .search-results a {
+    display: block;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 0;
+    text-decoration: none;
+    color: #111;
+    font-size: 13px;
+  }
+  .toolbar .agency-search .search-results a:hover,
+  .toolbar .agency-search .search-results a.hl {
+    background: #eff6ff;
+  }
+  .toolbar .agency-search .search-results .sr-state {
+    color: #6b7280;
+    font-size: 11px;
+    margin-left: 6px;
+  }
+  .toolbar .agency-search .search-results .sr-empty {
+    padding: 6px 10px;
+    color: #6b7280;
+    font-size: 13px;
+  }
 
   .page {
     max-width: 7.5in;
@@ -855,6 +913,10 @@
 <div class="toolbar">
   <a href="sharing_map.html" title="Back to the interactive map">&larr; Back to Map</a>
   <a href="index.html">Investigation home</a>
+  <div class="agency-search" id="agency-search">
+    <input type="text" id="agency-search-input" placeholder="Jump to another agency&hellip;" autocomplete="off" spellcheck="false">
+    <div class="search-results" id="agency-search-results" role="listbox"></div>
+  </div>
   <div class="spacer"></div>
   <button id="print-btn">Print / Save as PDF</button>
 </div>


### PR DESCRIPTION
## Summary

Adds a "Jump to another agency" input to the report toolbar so readers can hop between reports without bouncing back through the sharing map. Lives inside `.toolbar`, which is already `display:none` in print, so nothing shows up on paper.

Filters by substring against `report_data.json` (~1,030 agencies), ranks exact > startsWith > contains, caps at 12 results. Keyboard nav (↓/↑/Enter/Esc) and click both navigate to `report.html?agency=<slug>`.

## Test plan

- [x] Local test: type "oak" → Oakland CA PD ranks above Oak Valley II / La Verne Live Oak; ↓ highlights next row; Enter opens.
- [ ] Confirm search is hidden in Print / Save as PDF preview.
- [ ] Confirm behavior on a narrow mobile viewport (the input flexes to available space).
- [ ] Confirm clicking outside the dropdown closes it.