### PR TITLE
Report copy tweaks + reach peer pills + mini-map right float

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -597,14 +597,42 @@
         value: v,
         rankPillsHtml: pills,
       });
-      // Right cell: reach metrics
+      // Right cell: reach metrics + state/local comparison pills so
+      // the reader sees how this agency's geographic reach stacks up.
+      const reachPcts = report.reach_percentiles || {};
+      const reachMeds = report.reach_medians || {};
+      const reachPctsLocal = report.reach_percentiles_local || {};
+      const reachMedsLocal = report.reach_medians_local || {};
+      const reachSampleLocal = report.reach_peer_samples_local || {};
+      function reachPillsFor(kind, value) {
+        return rankPillsForMetric({
+          pctile: reachPcts[kind],
+          med: reachMeds[kind] != null ? kmToMi(reachMeds[kind]) : null,
+          lpctile: reachPctsLocal[kind],
+          lmed: reachMedsLocal[kind] != null ? kmToMi(reachMedsLocal[kind]) : null,
+          lsamp: reachSampleLocal[kind],
+          value: value, agencyType: report.agency_type, meta,
+          sparkMetricKey: null,
+        });
+      }
       const bits = [];
       if (report.outbound_avg_km != null) {
-        bits.push(`<div><strong>${fmtNum(kmToMi(report.outbound_avg_km), 0)}</strong> <span class="muted">miles — average distance to a recipient</span></div>`);
+        const avgMi = kmToMi(report.outbound_avg_km);
+        bits.push(
+          `<div><strong>${fmtNum(avgMi, 0)}</strong> <span class="muted">mi &mdash; avg distance to a recipient</span>` +
+          reachPillsFor("avg", avgMi) +
+          `</div>`
+        );
       }
       if (report.farthest_outbound) {
-        const farMi = fmtNum(kmToMi(report.farthest_outbound.distance_km), 0);
-        bits.push(`<div><strong>${farMi}</strong> <span class="muted">miles — farthest:</span> ${escapeHtml(report.farthest_outbound.name)}${report.farthest_outbound.state && report.farthest_outbound.state !== report.state ? ` (${escapeHtml(report.farthest_outbound.state)})` : ""}</div>`);
+        const farMi = kmToMi(report.farthest_outbound.distance_km);
+        const stateSuffix = report.farthest_outbound.state && report.farthest_outbound.state !== report.state
+          ? ` (${escapeHtml(report.farthest_outbound.state)})` : "";
+        bits.push(
+          `<div><strong>${fmtNum(farMi, 0)}</strong> <span class="muted">mi &mdash; farthest:</span> ${escapeHtml(report.farthest_outbound.name)}${stateSuffix}` +
+          reachPillsFor("far", farMi) +
+          `</div>`
+        );
       }
       const reachCell = `<div class="metric-cell reach"><div class="cell-label">Reach</div><div class="reach-lines">${bits.join("")}</div></div>`;
       html += metricBlockHtml({
@@ -1883,7 +1911,15 @@
     html += '<div style="flex:1">';
     html += `<p><strong>Source:</strong> Flock Safety transparency portals, compiled by the sm-alpr project.</p>`;
     if (popSrc) {
-      html += `<p><strong>Population data:</strong> ${escapeHtml(popSrc.source || "U.S. Census Bureau")}.</p>`;
+      // Link the ACS product + Census Bureau so readers can click
+      // through to source. Print CSS strips underlines so the PDF
+      // stays clean — the source text still appears verbatim.
+      const vintage = popSrc.vintage || 2023;
+      const acsUrl = "https://www.census.gov/programs-surveys/acs";
+      const censusUrl = "https://www.census.gov/";
+      html += `<p><strong>Population data:</strong> ` +
+        `<a href="${acsUrl}" target="_blank" rel="noopener">ACS 5-Year Estimates (${vintage})</a>` +
+        `, <a href="${censusUrl}" target="_blank" rel="noopener">U.S. Census Bureau</a>.</p>`;
     }
     html += `<p><strong>Interactive map:</strong> <a href="${escapeHtml(mapUrlAbs)}">${escapeHtml(mapUrlAbs)}</a></p>`;
     html += `<p><strong>This report:</strong> <a href="${escapeHtml(thisUrlAbs)}">${escapeHtml(thisUrlAbs)}</a></p>`;

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -312,11 +312,11 @@
     if (pctile == null) return "";
     let cls = "";
     let phrase;
-    if (pctile >= 90) { phrase = "higher than nearly all"; cls = "concern strong"; }
-    else if (pctile >= 75) { phrase = "higher than most"; cls = "concern"; }
-    else if (pctile >= 60) { phrase = "above average"; cls = "concern-mild"; }
-    else if (pctile >= 40) { phrase = "near median"; cls = ""; }
-    else { phrase = "below median"; cls = ""; }
+    if (pctile >= 90) { phrase = "higher than nearly all peers"; cls = "concern strong"; }
+    else if (pctile >= 75) { phrase = "higher than most peers"; cls = "concern"; }
+    else if (pctile >= 60) { phrase = "above peer average"; cls = "concern-mild"; }
+    else if (pctile >= 40) { phrase = "near peer median"; cls = ""; }
+    else { phrase = "below peer median"; cls = ""; }
     const spark = inlinePillSparkSvg(hist, value);
     const medHtml = med != null ? ` <span class="pill-med">med ${fmtNumSmart(med)}</span>` : "";
     return `<span class="rank-pill ${cls}">` +
@@ -339,12 +339,12 @@
     let html = '<div class="rank-pill-row">';
     if (pctile != null) {
       html += rankPillHtml({
-        scopeLabel: "STATE",
+        scopeLabel: "vs state",
         pctile: pctile, median: med, hist: hist, value: value,
       });
     }
     if (lpctile != null) {
-      const scopeLabel = lsamp && lsamp.scope === "county" ? "COUNTY" : "25 mi";
+      const scopeLabel = lsamp && lsamp.scope === "county" ? "vs county" : "vs 25 mi";
       html += rankPillHtml({
         scopeLabel: scopeLabel,
         pctile: lpctile, median: lmed, hist: hist, value: value,
@@ -1144,7 +1144,7 @@
     if (!items.length) return "";
 
     let html = `<h2>SB 34 Compliance Concerns</h2>`;
-    html += `<p class="muted">Signals tied to California Civil Code &sect;1798.90.51&ndash;.55. Red items indicate potential compliance concerns a council member may want to raise.</p>`;
+    html += `<p class="muted">Signals tied to California Civil Code &sect;1798.90.51&ndash;.55. Red items indicate potential compliance concerns a council member may want to raise with their agency.</p>`;
     // Pass the current report through so inline data-concern callouts
     // can be attached to specific checklist items.
     // (Opt `report` consumed by renderChecklistItems below.)
@@ -1254,50 +1254,43 @@
     });
     html += '</ul>';
 
-    // One-line summary of the items we hid because they're near-
-    // universal (this agency does them AND > 90% of peers do them).
-    // Names the items so the reader knows what was skipped, without
-    // reserving full UI real estate for each.
-    if (hiddenPassItems.length) {
-      const names = hiddenPassItems.map(function(i) { return labelFor(i); }).join(", ");
-      html += `<p class="muted baseline-note" style="font-size:9pt; margin:4px 0 0 0">` +
-        `<strong>Also passing</strong> (\u2265 90% of peers also pass &mdash; baseline, not distinguishing): ${escapeHtml(names)}.` +
-        `</p>`;
-    }
+    // (Previously: a "Also passing — ≥ 90% of peers also pass" blurb
+    // listed the items we hid as near-universal baseline. Removed —
+    // the checklist already shows only distinguishing signals, so
+    // naming the hidden baseline items just added noise.)
     return html;
   }
 
-  // Phrases peer stats concretely, always leading with the "how many
-  // agencies pass" number. Uncrawled agencies are excluded from the
-  // denominator (we can't verify what isn't public) — that context is
-  // included as a separate sentence when relevant. For SB 34 items
-  // (non-compact), also renders a statewide line underneath so the
-  // reader sees if the concern is type-specific or CA-wide.
+  // Phrases peer stats concretely, using a per-check action phrase
+  // (e.g. "publish an access policy", "avoid out-of-state sharing")
+  // so the reader sees the specific behavior instead of an abstract
+  // "pass". Falls back to "do this" if no peer_phrase is set.
+  // Uncrawled agencies are excluded from the denominator — we can't
+  // verify what isn't public. For SB 34 items (non-compact), adds a
+  // statewide line when the type-scoped numbers differ.
   function formatPeerStat(item, peerTypeLabel, compact) {
     const applicable = item.peer_applicable != null ? item.peer_applicable : item.peer_total;
-    const total = item.peer_total;
     const pass = item.peer_count;
-    const fail = applicable - pass;
+    const phrase = item.peer_phrase || "do this";
 
     if (applicable === 0) {
       return `No ${peerTypeLabel} publish enough info to evaluate.`;
     }
 
     const passPct = pct(pass, applicable);
-    const failPct = pct(fail, applicable);
 
     if (compact) {
-      return `${pass}/${applicable} peers pass (${passPct}%).`;
+      return `${passPct}% of peers ${escapeHtml(phrase)} (${pass}/${applicable}).`;
     }
 
-    let line = `<strong>${pass} of ${applicable} ${peerTypeLabel}</strong> pass (${passPct}%).`;
+    let line = `<strong>${passPct}%</strong> of ${applicable} ${peerTypeLabel} ${escapeHtml(phrase)} (${pass}/${applicable}).`;
 
     if (item.state_applicable != null && item.state_total != null) {
       const sApp = item.state_applicable;
       const sPass = item.state_count;
       if (sApp > applicable) {
         const sPct = pct(sPass, sApp);
-        line += ` <span class="muted">Statewide: ${sPass}/${sApp} (${sPct}%).</span>`;
+        line += ` <span class="muted">Statewide: ${sPct}% (${sPass}/${sApp}).</span>`;
       }
     }
     return line;
@@ -1865,7 +1858,10 @@
       "A council member should ask to see the <em>text</em> of the policy and compare it item-by-item against &sect;1798.90.51\u2013.55."
     );
     qs.push("How many users currently have access to the city's Flock pages? Are there any inactive users who still have access? What is the process for revoking accounts when personnel leave the department?");
-    qs.push("Does the Flock contract contain an independent disclosure clause (such as &sect;5.3 in the standard MSA)?");
+    qs.push(
+      "Does the Flock contract contain an independent disclosure clause (such as &sect;5.3 in the standard MSA)? " +
+      "<span class=\"muted\">Such clauses let Flock (the company) access and share the city's ALPR data outside the protections of the city's configured sharing settings.</span>"
+    );
 
     return qs;
   }
@@ -1892,7 +1888,9 @@
     html += `<p><strong>Interactive map:</strong> <a href="${escapeHtml(mapUrlAbs)}">${escapeHtml(mapUrlAbs)}</a></p>`;
     html += `<p><strong>This report:</strong> <a href="${escapeHtml(thisUrlAbs)}">${escapeHtml(thisUrlAbs)}</a></p>`;
     html += `<p><strong>Report generated:</strong> ${new Date().toLocaleDateString("en-US", {year: "numeric", month: "long", day: "numeric"})}</p>`;
-    html += `<p>This report reflects data at the time of the last portal crawl. Sharing relationships and stats may have changed.</p>`;
+    const crawlDate = report.crawled_date;
+    const crawlPhrase = crawlDate ? `the ${escapeHtml(crawlDate)} portal crawl` : "the last portal crawl";
+    html += `<p>This report reflects data from ${crawlPhrase}. Sharing relationships and stats may have changed since.</p>`;
     html += '</div>';
     // QR code block (right column)
     html += '<div style="flex:0 0 auto;text-align:center">';

--- a/docs/report.html
+++ b/docs/report.html
@@ -386,14 +386,16 @@
   /* Mini regional map — inline SVG showing subject agency surrounded
      by geocoded outbound recipients. Floated left so the surrounding
      sharing-section text (reach metrics, flagged recipients) wraps
-     along the right side rather than consuming a full page-width
-     strip. Caps the map width at ~55% so there's room for the text
-     without the map getting too small to read. The next h3 (inbound)
-     clears the float so the inbound list starts on its own baseline. */
+     along the left side rather than consuming a full page-width
+     strip. Right-floated so the reader's eye stays on the
+     left-aligned prose. Caps the map width at ~55% so there's room
+     for the text without the map getting too small to read. The
+     next h3 (inbound) clears the float so the inbound list starts
+     on its own baseline. */
   .mini-map-wrap {
-    float: left;
+    float: right;
     max-width: 55%;
-    margin: 4px 16px 8px 0;
+    margin: 4px 0 8px 16px;
   }
   .mini-map {
     max-width: 100%;

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -126,6 +126,7 @@ SB34_CHECKLIST = [
         "label_fail": "Shares with at least one private entity",
         "label_unknown": "Private sharing not verifiable (no public transparency page)",
         "detail": "CA Civil Code \u00a71798.90.55(b) restricts ALPR sharing to public agencies.",
+        "peer_phrase": "share only with public agencies",
     },
     {
         "id": "no_out_of_state_sharing",
@@ -133,6 +134,7 @@ SB34_CHECKLIST = [
         "label_fail": "Shares with at least one out-of-state entity",
         "label_unknown": "Out-of-state sharing not verifiable (no public transparency page)",
         "detail": "CA Civil Code \u00a71798.90.55(b) and AG Bulletin 2023-DLE-06 prohibit out-of-state sharing.",
+        "peer_phrase": "avoid out-of-state sharing",
     },
     {
         "id": "no_federal_sharing",
@@ -140,6 +142,7 @@ SB34_CHECKLIST = [
         "label_fail": "Shares with at least one federal agency",
         "label_unknown": "Federal sharing not verifiable (no public transparency page)",
         "detail": "Federal agencies are not \u201cagencies of the state\u201d under \u00a71798.90.5(f).",
+        "peer_phrase": "avoid sharing with federal agencies",
     },
     {
         "id": "no_fusion_center_sharing",
@@ -147,6 +150,7 @@ SB34_CHECKLIST = [
         "label_fail": "Shares with at least one fusion center",
         "label_unknown": "Fusion-center sharing not verifiable (no public transparency page)",
         "detail": "Fusion centers (e.g., NCRIC) re-distribute ALPR data to their member networks. Their status as \u201cpublic agencies\u201d under \u00a71798.90.5(f) varies by charter; NCRIC in particular has federal staffing and funding ties. Sharing with a fusion center forwards this agency's data to every member of that center.",
+        "peer_phrase": "avoid sharing with fusion centers",
     },
     {
         "id": "no_ag_lawsuit_sharing",
@@ -154,6 +158,7 @@ SB34_CHECKLIST = [
         "label_fail": "Shares with an agency the CA AG has sued for illegal sharing",
         "label_unknown": "Cannot verify (no public transparency page)",
         "detail": "The CA Attorney General has sued specific CA agencies for illegal out-of-state ALPR sharing in violation of SB 34. Sending data to those agencies continues the same illegal flow.",
+        "peer_phrase": "avoid sharing with AG-sued agencies",
     },
     {
         "id": "published_policy",
@@ -161,6 +166,7 @@ SB34_CHECKLIST = [
         "label_fail": "Does not publish an ALPR usage and privacy policy",
         "label_unknown": "Policy publication not verifiable (no public transparency page)",
         "detail": "\u00a71798.90.51(a) requires conspicuously posting a usage and privacy policy.",
+        "peer_phrase": "publish an ALPR policy",
     },
     {
         "id": "documented_audit",
@@ -168,26 +174,27 @@ SB34_CHECKLIST = [
         "label_fail": "No documented audit process",
         "label_unknown": "Audit process not verifiable (no public transparency page)",
         "detail": "\u00a71798.90.51(b)(5) requires audit provisions for ALPR access.",
+        "peer_phrase": "document an audit process",
     },
 ]
 
 # Transparency checks — what they publish on the Flock portal.
 # Same pass/fail/unknown label structure as SB34_CHECKLIST above.
 TRANSPARENCY_CHECKLIST = [
-    {"id": "has_portal",       "label_pass": "Has a public Flock transparency page",   "label_fail": "No public Flock transparency page"},
-    {"id": "camera_count",     "label_pass": "Reports camera count",                    "label_fail": "Does not report camera count"},
-    {"id": "retention",        "label_pass": "Reports data retention days",              "label_fail": "Does not report data retention"},
-    {"id": "vehicles_30d",     "label_pass": "Reports 30-day vehicle detections",        "label_fail": "Does not report 30-day vehicle detections"},
-    {"id": "hotlist_hits",     "label_pass": "Reports 30-day hotlist hits",              "label_fail": "Does not report 30-day hotlist hits"},
-    {"id": "searches_30d",     "label_pass": "Reports 30-day search counts",             "label_fail": "Does not report 30-day search counts"},
-    {"id": "policy_link",      "label_pass": "Links to a full ALPR/department policy",    "label_fail": "No link to a full policy document"},
-    {"id": "access_policy",    "label_pass": "Publishes access policy",                  "label_fail": "Does not publish access policy"},
-    {"id": "hotlist_policy",   "label_pass": "Publishes hotlist policy",                  "label_fail": "Does not publish hotlist policy"},
-    {"id": "acceptable_use",   "label_pass": "Publishes acceptable-use policy",          "label_fail": "Does not publish acceptable-use policy"},
-    {"id": "prohibited_uses",  "label_pass": "Publishes prohibited-uses statement",       "label_fail": "Does not publish prohibited-uses statement"},
-    {"id": "sb54_statement",   "label_pass": "Publishes SB 54 compliance statement",     "label_fail": "Does not publish SB 54 compliance statement"},
-    {"id": "outbound_list",    "label_pass": "Publishes full outbound sharing list",     "label_fail": "Does not publish outbound sharing list"},
-    {"id": "inbound_list",     "label_pass": "Publishes full inbound sharing list",      "label_fail": "Does not publish inbound sharing list"},
+    {"id": "has_portal",       "label_pass": "Has a public Flock transparency page",   "label_fail": "No public Flock transparency page", "peer_phrase": "have a public transparency page"},
+    {"id": "camera_count",     "label_pass": "Reports camera count",                    "label_fail": "Does not report camera count", "peer_phrase": "report their camera count"},
+    {"id": "retention",        "label_pass": "Reports data retention days",              "label_fail": "Does not report data retention", "peer_phrase": "report their data-retention policy"},
+    {"id": "vehicles_30d",     "label_pass": "Reports 30-day vehicle detections",        "label_fail": "Does not report 30-day vehicle detections", "peer_phrase": "report 30-day vehicle detections"},
+    {"id": "hotlist_hits",     "label_pass": "Reports 30-day hotlist hits",              "label_fail": "Does not report 30-day hotlist hits", "peer_phrase": "report 30-day hotlist hits"},
+    {"id": "searches_30d",     "label_pass": "Reports 30-day search counts",             "label_fail": "Does not report 30-day search counts", "peer_phrase": "report 30-day search counts"},
+    {"id": "policy_link",      "label_pass": "Links to a full ALPR/department policy",    "label_fail": "No link to a full policy document", "peer_phrase": "link to a full policy document"},
+    {"id": "access_policy",    "label_pass": "Publishes access policy",                  "label_fail": "Does not publish access policy", "peer_phrase": "publish an access policy"},
+    {"id": "hotlist_policy",   "label_pass": "Publishes hotlist policy",                  "label_fail": "Does not publish hotlist policy", "peer_phrase": "publish a hotlist policy"},
+    {"id": "acceptable_use",   "label_pass": "Publishes acceptable-use policy",          "label_fail": "Does not publish acceptable-use policy", "peer_phrase": "publish an acceptable-use policy"},
+    {"id": "prohibited_uses",  "label_pass": "Publishes prohibited-uses statement",       "label_fail": "Does not publish prohibited-uses statement", "peer_phrase": "publish a prohibited-uses statement"},
+    {"id": "sb54_statement",   "label_pass": "Publishes SB 54 compliance statement",     "label_fail": "Does not publish SB 54 compliance statement", "peer_phrase": "publish an SB 54 statement"},
+    {"id": "outbound_list",    "label_pass": "Publishes full outbound sharing list",     "label_fail": "Does not publish outbound sharing list", "peer_phrase": "publish an outbound sharing list"},
+    {"id": "inbound_list",     "label_pass": "Publishes full inbound sharing list",      "label_fail": "Does not publish inbound sharing list", "peer_phrase": "publish an inbound sharing list"},
 ]
 
 
@@ -958,6 +965,11 @@ def main():
                         "label_fail": item.get("label_fail") or item.get("label"),
                         "label_unknown": item.get("label_unknown")
                             or (item.get("label_fail") or item.get("label")),
+                        # Short third-person-plural phrase naming the
+                        # action, used in "XX% of peers <peer_phrase>"
+                        # so the peer stat reads as a specific behavior
+                        # rather than an abstract "pass".
+                        "peer_phrase": item.get("peer_phrase"),
                         "detail": item.get("detail"),
                         "value": checklist_results.get(cid),  # True/False/None
                         # For sharing-based failures, list of entity names

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -653,6 +653,13 @@ def main():
     # totals from it. Peer percentiles come from this series.
     downstream_series_by_type = defaultdict(list)
     downstream_series_all = []
+    # Reach series: average / farthest km across outbound recipients.
+    # Included so the reach cell can show "this agency vs peer" on
+    # the same pill treatment we use for cameras, searches, etc.
+    reach_avg_series_by_type = defaultdict(list)
+    reach_avg_series_all = []
+    reach_far_series_by_type = defaultdict(list)
+    reach_far_series_all = []
     searches_by_aid = {}
     for a in ca_crawled:
         s = a["portal"].get("searches_30d")
@@ -694,7 +701,28 @@ def main():
                 downstream_total += int(searches_by_aid[t_id])
         downstream_series_by_type[a["type"]].append(downstream_total)
         downstream_series_all.append(downstream_total)
+        # Reach: avg + farthest km over geocoded outbound recipients.
+        # Same calc the per-report loop uses later; duplicated here so
+        # it contributes to the peer series without requiring a third
+        # pass through the data.
         a_lat, a_lng = agency_coords(a["reg"])
+        reach_avg_km = None
+        reach_far_km = None
+        if a_lat is not None and a_lng is not None:
+            dists = []
+            for tid in a["graph"].get("sharing_outbound_ids", []):
+                tr = reg_by_id.get(tid, {})
+                tlat, tlng = agency_coords(tr)
+                if tlat is None or tlng is None:
+                    continue
+                dists.append(dist_km(a_lat, a_lng, tlat, tlng))
+            if dists:
+                reach_avg_km = round(sum(dists) / len(dists), 1)
+                reach_far_km = round(max(dists), 1)
+                reach_avg_series_by_type[a["type"]].append(reach_avg_km)
+                reach_avg_series_all.append(reach_avg_km)
+                reach_far_series_by_type[a["type"]].append(reach_far_km)
+                reach_far_series_all.append(reach_far_km)
         a_county_fips = _county_fips_from_geo(a["reg"].get("geo"))
         crawled_agency_metrics.append({
             "agency_id": a["agency_id"],
@@ -708,6 +736,8 @@ def main():
             # "cameras" key to mirror the other metric-keyed dicts.
             "density": {"cameras": density} if density is not None else {},
             "downstream_searches": downstream_total,
+            "reach_avg_km": reach_avg_km,
+            "reach_far_km": reach_far_km,
         })
     for metric in list(series_all.keys()):
         series_all[metric].sort()
@@ -723,6 +753,12 @@ def main():
     downstream_series_all.sort()
     for t in downstream_series_by_type:
         downstream_series_by_type[t].sort()
+    reach_avg_series_all.sort()
+    for t in reach_avg_series_by_type:
+        reach_avg_series_by_type[t].sort()
+    reach_far_series_all.sort()
+    for t in reach_far_series_by_type:
+        reach_far_series_by_type[t].sort()
     # Index crawled_agency_metrics by agency_id for O(1) lookup below.
     crawled_metrics_by_aid = {m["agency_id"]: m for m in crawled_agency_metrics}
 
@@ -754,6 +790,18 @@ def main():
         if len(s) >= MIN_PEER_SAMPLE:
             return s, False, atype
         return density_series_all, True, "all"
+
+    def peer_reach_series(kind, atype):
+        """Return (series, is_fallback, peer_type) for reach km.
+        kind = 'avg' or 'far'."""
+        if kind == "avg":
+            by_type, all_series = reach_avg_series_by_type, reach_avg_series_all
+        else:
+            by_type, all_series = reach_far_series_by_type, reach_far_series_all
+        s = by_type.get(atype, [])
+        if len(s) >= MIN_PEER_SAMPLE:
+            return s, False, atype
+        return all_series, True, "all"
 
     def peer_downstream_series(atype):
         """Return (series, is_fallback, peer_type) for downstream-search totals."""
@@ -802,6 +850,11 @@ def main():
         key = "rates" if per_capita else "values"
         s = sorted(p[key].get(metric) for p in peers if p[key].get(metric) is not None)
         return s
+
+    def local_reach_series(peers, kind):
+        """Sorted series of peer reach_avg_km or reach_far_km."""
+        k = "reach_avg_km" if kind == "avg" else "reach_far_km"
+        return sorted(p[k] for p in peers if p.get(k) is not None)
 
     # ── Build graph-wide flag classification cache ──
     outbound_by_id = {aid: d.get("sharing_outbound_ids", []) for aid, d in graph_agencies.items()}
@@ -1030,6 +1083,13 @@ def main():
         percentile_downstream_local = None
         median_downstream_local = None
         peer_sample_downstream_local = None
+        # Reach (avg + farthest km) vs peers.
+        reach_percentiles = {}
+        reach_medians = {}
+        reach_peer_samples = {}
+        reach_percentiles_local = {}
+        reach_medians_local = {}
+        reach_peer_samples_local = {}
         if state == RANKED_STATE and crawled:
             metric_values = {
                 "cameras": cameras,
@@ -1118,6 +1178,31 @@ def main():
                             "size": len(l_ds),
                             "scope": local_scope,
                         }
+
+            # ── Reach (avg/far km) peer comparison ──
+            cm_reach = crawled_metrics_by_aid.get(aid)
+            if cm_reach is not None:
+                for kind, val in (("avg", cm_reach.get("reach_avg_km")),
+                                  ("far", cm_reach.get("reach_far_km"))):
+                    if val is None:
+                        continue
+                    rseries, rfb, rpt = peer_reach_series(kind, atype)
+                    reach_percentiles[kind] = percentile_of(val, rseries)
+                    reach_medians[kind] = median(rseries)
+                    reach_peer_samples[kind] = {
+                        "size": len(rseries),
+                        "type": rpt,
+                        "fallback": rfb,
+                    }
+                    if local_scope:
+                        l_rseries = local_reach_series(local_peers, kind)
+                        if l_rseries:
+                            reach_percentiles_local[kind] = percentile_of(val, l_rseries)
+                            reach_medians_local[kind] = median(l_rseries)
+                            reach_peer_samples_local[kind] = {
+                                "size": len(l_rseries),
+                                "scope": local_scope,
+                            }
 
             # ── Camera density (cameras per sq mi) ──
             # Name-based fallback for land area on manual-geocoded entries,
@@ -1380,6 +1465,15 @@ def main():
             "percentile_downstream_local": percentile_downstream_local,
             "median_downstream_local": median_downstream_local,
             "peer_sample_downstream_local": peer_sample_downstream_local,
+            # Reach (outbound distance) peer comparisons. Keyed by
+            # "avg" (mean distance across geocoded recipients) and
+            # "far" (single farthest recipient). Both state + local.
+            "reach_percentiles": reach_percentiles,
+            "reach_medians": reach_medians,
+            "reach_peer_samples": reach_peer_samples,
+            "reach_percentiles_local": reach_percentiles_local,
+            "reach_medians_local": reach_medians_local,
+            "reach_peer_samples_local": reach_peer_samples_local,
             "stats": {
                 "cameras": cameras,
                 "retention_days": retention,


### PR DESCRIPTION
## Summary

Small batch of report-page improvements:

**Copy disambiguation**
- Rank pills: scope label "STATE" / "COUNTY" / "25 mi" → "vs state" / "vs county" / "vs 25 mi" and phrases now say "higher than most **peers**" etc. so the comparator is explicit rather than reading as the subject.
- Peer-stat: "XX% of peers pass" → "XX% of peers publish an access policy" (specific to each check). New `peer_phrase` field per SB34/transparency check.
- "may want to raise" → "...raise with their agency"
- Footer crawl-date now includes the actual date; population-source line links to ACS / Census.
- Drop the "Also passing (≥90% of peers...)" baseline blurb — redundant.
- Flock-contract §5.3 question gets a one-line muted explanation.

**Reach peer pills** (main new feature)
- `outbound_avg_km` and `outbound_farthest_km` now have state + local peer series aggregated in `build_report_data.py`.
- Each reach line (avg, farthest) carries its own rank pills so the reader sees how this agency's geographic spread compares to peers.

**Mini-map**
- Right-floated instead of left so the text column stays on the page's left margin.

## Test plan

- [x] Rebuild + tests pass.
- [x] SMPD report visually verified: pills show "vs state / vs county" with clearer phrases; reach pills render below each distance line; map right-floats with text flowing left.
- [ ] Confirm print rendering still looks right (links are suppressed via existing print CSS).