### PR TITLE
fix(report): county display + suppress broken county-local peer pills

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -445,7 +445,12 @@
   // display name.
   function shortAgencyName(report) {
     const geo = report.geo || {};
-    if (geo.name) return geo.name;
+    if (geo.name) {
+      if (geo.kind === "county" && !/\bCounty$/i.test(geo.name)) {
+        return geo.name + " County";
+      }
+      return geo.name;
+    }
     let n = report.name || "";
     n = n.replace(/\s+(CA|NV|AZ|OR|WA|ID|UT|NY|TX|FL|NH|MA|CT|NJ|PA|MD|VA|NC|SC|GA|OH|MI|IL|IN|KY|TN|AL|MS|LA|AR|OK|MO|KS|NE|IA|MN|WI|ND|SD|MT|WY|CO|NM|AK|HI|ME|VT|RI|DE|WV|DC)\s+(PD|SO|SD|DA|FD|DPS|Police|Sheriff|Police Department|Sheriff'?s? Office|District Attorney)\b.*$/i, "").trim();
     return n || report.name || "This agency";

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -1101,10 +1101,20 @@ def main():
 
             # Compute the local peer pool once for this agency. The same
             # pool is reused for raw and per-capita rankings.
-            source_county = _county_fips_from_geo(reg.get("geo"))
-            local_peers, local_scope = local_peers_for(
-                aid, lat, lng, source_county
-            )
+            #
+            # County-scope agencies (sheriffs) are skipped: their "same
+            # county" pool is the city PDs they overlay, which is
+            # structurally apples-to-oranges — the sheriff's jurisdiction
+            # covers unincorporated areas + overlays every city, so raw
+            # numbers trivially dominate and per-capita uses a denominator
+            # that already contains every peer's population.
+            if atype == "county":
+                local_peers, local_scope = [], None
+            else:
+                source_county = _county_fips_from_geo(reg.get("geo"))
+                local_peers, local_scope = local_peers_for(
+                    aid, lat, lng, source_county
+                )
 
             for metric, v in metric_values.items():
                 series, fallback, peer_type = peer_series(metric, atype)


### PR DESCRIPTION
## Summary

Two inconsistencies on per-agency `report.html` for county-scope agencies.

### 1. "vs county" pill was apples-to-oranges for sheriffs
The local peer pool for any agency is "crawled agencies sharing the same 5-digit county FIPS." For a city, that's the other cities plus the sheriff — reasonable. For the sheriff itself, the pool is the city PDs it overlays:

- Sheriffs patrol unincorporated areas + overlay every city, so raw camera/search/vehicle counts trivially dominate → sheriff looks like an outlier by construction.
- Per-capita denominator is the whole-county population, which already contains every peer's population → weird average, not like-for-like.

Skipped at the data-build layer for `agency_type == "county"`. All 18 CA sheriff reports now emit empty `percentiles_local` / `peer_sample_local`; the frontend's existing null-check suppresses the pill automatically. Statewide (same-type) comparison is unchanged.

### 2. Prose said "Alameda", not "Alameda County"
`shortAgencyName` pulled `geo.name` directly. For `kind === "county"` that's the base Census name (e.g. `"Alameda"`), so cells read "Alameda's cameras" instead of "Alameda County's cameras". Append " County" when missing. Cousubs left alone (suffix varies by state).

## Test plan
- [ ] Open `report.html?agency=alameda-county-ca-so` — header/metric titles read "Alameda County", not "Alameda"
- [ ] Same report — no "vs county" pills on any metric (only "vs state")
- [ ] Open `report.html?agency=san-mateo-ca-pd` — "vs county" pills still render as before