### PR TITLE
feat(report): hotlist subscriptions, plain-language caveat, 30d labels

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -540,6 +540,7 @@
       });
       html += metricBlockHtml({
         title: `Searches performed by ${short}`,
+        subtitle: "last 30 days",
         concern: !notReported && (pctile >= 60 || lpctile >= 60),
         cellsHtml: rawCell + perCell,
         inlineConcernHtml: concernsForSection(report, "stat:searches_30d"),
@@ -592,7 +593,7 @@
       const rightCell = `<div class="metric-cell downstream-researchers">${topResearchersHtml(report.downstream_searches)}</div>`;
       html += metricBlockHtml({
         title: `Searches reaching ${short}'s data`,
-        subtitle: `${short} + its recipients`,
+        subtitle: `last 30 days · ${short} + its recipients`,
         titleTooltip: report.downstream_searches
           ? `${fmtInt(v || 0)} = searches this agency publishes + searches published by ${report.downstream_searches.recipients_with_data} of its ${report.downstream_searches.recipients_total} recipients.`
           : "",
@@ -799,13 +800,17 @@
         extrasHtml: pvExtras,
         rankPillsHtml: pvPills,
       });
-      const hotlistCaveat = `A hit is a possible match, not a confirmed crime — NCIC matches can include false positives, and custom lists vary in how they're curated.`;
+      const hotlistCaveat = `A hit is a notification, not a confirmed crime. Agencies subscribe to watchlists — FBI NCIC (stolen vehicles, felony wants, missing persons) or custom lists the operator maintains — and a camera pings when it sees a plate on one of them.`;
+      const subscribed = (report.stats && report.stats.hotlists_alerted_on) || [];
+      const subscribedHtml = subscribed.length
+        ? `<div class="hotlist-subscriptions"><span class="muted">Subscribed to:</span> ${subscribed.map(escapeHtml).join(", ")}</div>`
+        : "";
       html += metricBlockHtml({
         title: `${short}'s hotlist hits`,
-        subtitle: "plate match against FBI NCIC or a custom list the operator has configured",
+        subtitle: "last 30 days",
         concern: (pctile != null && pctile >= 60) || (per1kPct.hotlist_hits_30d != null && per1kPct.hotlist_hits_30d >= 60),
         cellsHtml: rawCell + perCell,
-        caveatHtml: hotlistCaveat,
+        caveatHtml: hotlistCaveat + subscribedHtml,
         inlineConcernHtml: concernsForSection(report, "stat:hotlist_hits_30d"),
       });
     }

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -423,6 +423,29 @@ def _place_name_from_agency(agency_name):
     return n
 
 
+def _clean_hotlists(raw):
+    """Parse the portal's `hotlists_alerted_on` string into a clean list.
+
+    The scraped value is a comma-separated label list (e.g. "California
+    SVS, NCMEC Amber Alert"), but at least one portal has bleed-through
+    from the adjacent section (newlines + stray numbers). Drop items
+    containing newlines or that are pure numeric, dedupe, preserve order.
+    """
+    if not raw or not isinstance(raw, str):
+        return []
+    out = []
+    seen = set()
+    for item in raw.split(","):
+        s = item.strip()
+        if not s or "\n" in s or s.replace(",", "").replace(".", "").isdigit():
+            continue
+        if s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
 def histogram(sorted_values, bins=20):
     """Bin a sorted numeric series for sparkline rendering.
 
@@ -931,6 +954,7 @@ def main():
         retention = gdata.get("data_retention_days")
         vehicles_30d = portal.get("vehicles_detected_30d")
         hotlist_hits = portal.get("hotlist_hits_30d")
+        hotlists_alerted_on = _clean_hotlists(portal.get("hotlists_alerted_on"))
         searches_30d = portal.get("searches_30d")
         outbound_count = gdata.get("sharing_outbound_count", 0)
         inbound_count = gdata.get("sharing_inbound_count", 0)
@@ -1489,6 +1513,7 @@ def main():
                 "retention_days": retention,
                 "vehicles_30d": vehicles_30d,
                 "hotlist_hits_30d": hotlist_hits,
+                "hotlists_alerted_on": hotlists_alerted_on,
                 "searches_30d": searches_30d,
                 "outbound_count": outbound_count,
                 "inbound_count": inbound_count,


### PR DESCRIPTION
## Summary

Clean up the hotlist block and clarify time windows on the searches blocks of per-agency `report.html`.

### Hotlist caveat + subscriptions
Old copy leaned on an external haveibeenflocked.com link. Replaced with a plain-language explanation: agencies subscribe to watchlists, a camera pings when it sees a plate on one.

Also ingest the portal's `hotlists_alerted_on` field (117 of 144 CA crawled agencies publish it) and render it as "Subscribed to: ..." under the caveat. Across the CA set, only 4 distinct labels appear:

| Count | Label |
|------:|-------|
| 117   | California SVS |
| 116   | NCMEC Amber Alert |
| 1     | NCIC (Shasta County SO) |
| 1     | Custom Hot Lists (Oakland PD) |

Build-time parser defends against one observed bleed-through case (newlines + stray numbers from the adjacent section).

### 30-day labels
"Searches performed by \<agency\>" and "Searches reaching \<agency\>'s data" didn't indicate the 30-day window. Added "last 30 days" subtitles to both. Hotlist block's long per-match subtitle also replaced with "last 30 days" — the caveat already covers the mechanism.

## Test plan
- [ ] Open `report.html?agency=san-mateo-ca-pd` — hotlist block shows caveat + "Subscribed to: California SVS, NCMEC Amber Alert"
- [ ] Open `report.html?agency=oakland-ca-pd` — subscriptions line includes "Custom Hot Lists"
- [ ] Open `report.html?agency=shasta-county-so` — subscriptions line shows "NCIC"
- [ ] Any crawled agency: both searches blocks show "last 30 days" in the subtitle line
- [ ] Any crawled agency with empty `hotlists_alerted_on` — subscriptions line is absent (caveat still shows)