### PR TITLE
feat: time-limited meeting banners (report + map)

### DIFF
--- a/docs/js/meeting_banners.js
+++ b/docs/js/meeting_banners.js
@@ -1,0 +1,138 @@
+// Time-limited per-agency meeting banners — shared across pages.
+//
+// Pages that want banner support:
+//   1. Add <script src="js/meeting_banners.js"></script> to the page head/body.
+//   2. Call window.renderMeetingBannerHtml([agency_id, slug, name]) and
+//      insert the returned HTML wherever the banner should appear.
+//
+// To add/remove a banner, edit the MEETING_BANNERS list below.
+// `match` accepts any mix of identifiers (slug, agency_id, display name);
+// agencies without a Flock portal still work via uuid or name.
+// `expires` is the first YYYY-MM-DD on which the banner hides — typically
+// the day after the meeting. Let entries self-expire, then remove.
+
+(function() {
+  "use strict";
+
+  const MEETING_BANNERS = [
+    {
+      match: ["sunnyvale-ca-pd", "7ef62d29-d50a-5f12-85fe-6061de259c8d", "Sunnyvale CA PD"],
+      meeting: "Sunnyvale City Council",
+      when: "Tue, Apr 21 2026",
+      expires: "2026-04-22",
+      links: [
+        { label: "Flyer: No Flock in Sunnyvale", url: "https://tinyurl.com/no-flock-in-sunnyvale" },
+      ],
+    },
+    {
+      match: ["alameda-county-ca-so", "9c1c5b61-7dec-5fce-a5ec-a3be9ed47c86", "Alameda County CA SO"],
+      meeting: "Alameda County Board of Supervisors",
+      when: "Tue, Apr 21 2026",
+      expires: "2026-04-22",
+      links: [
+        { label: "Board agenda (PDF)", url: "https://alamedacountyca.gov/board/bos_calendar/documents/GranicusAgenda_04_21_26.pdf" },
+        { label: "Organizer post", url: "https://www.instagram.com/p/DXP4JSfktwl/" },
+      ],
+    },
+    {
+      match: ["el-cerrito-ca-pd", "cb959829-2ddf-5780-841e-4d78cf1df75e", "El Cerrito CA PD"],
+      meeting: "El Cerrito City Council",
+      when: "Tue, Apr 21 2026",
+      expires: "2026-04-22",
+      links: [
+        { label: "Flyer", url: "https://drive.proton.me/urls/RMFT9WY8N4#2EloSEBOnNtg" },
+      ],
+    },
+    {
+      match: ["east-palo-alto-ca-pd", "b0bd9add-ff5d-5af4-a468-0f03eb94214e", "East Palo Alto CA PD"],
+      meeting: "East Palo Alto City Council",
+      when: "Tue, Apr 21 2026",
+      expires: "2026-04-22",
+      links: [
+        { label: "Organizer doc", url: "https://docs.google.com/document/d/1l1sNmOQKw2kBzTw-Ww2nrugmMceaL9t7ZzJzI0A0ZRs/edit" },
+      ],
+    },
+  ];
+
+  const STYLES = `
+    .meeting-banner {
+      background: #fffbeb;
+      border: 1px solid #f59e0b;
+      border-left: 5px solid #f59e0b;
+      border-radius: 6px;
+      padding: 10px 14px;
+      margin: 0 0 14px 0;
+    }
+    .meeting-banner-title {
+      font-weight: bold;
+      font-size: 10.5px;
+      color: #92400e;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .meeting-banner-when {
+      font-size: 13px;
+      color: #78350f;
+      font-weight: 600;
+      margin: 3px 0 8px 0;
+    }
+    .meeting-banner-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px 16px;
+    }
+    .meeting-banner-links a {
+      font-size: 12.5px;
+      color: #b45309;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    .meeting-banner-links a:hover { text-decoration: underline; }
+  `;
+
+  function injectStyles() {
+    if (document.getElementById("meeting-banner-style")) return;
+    const s = document.createElement("style");
+    s.id = "meeting-banner-style";
+    s.textContent = STYLES;
+    document.head.appendChild(s);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", injectStyles);
+  } else {
+    injectStyles();
+  }
+
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  window.activeMeetingBanner = function(identifiers) {
+    const today = new Date().toISOString().slice(0, 10);
+    const idSet = new Set((identifiers || []).filter(Boolean));
+    for (const b of MEETING_BANNERS) {
+      if (today >= b.expires) continue;
+      if (b.match.some(m => idSet.has(m))) return b;
+    }
+    return null;
+  };
+
+  window.renderMeetingBannerHtml = function(identifiers) {
+    const b = window.activeMeetingBanner(identifiers);
+    if (!b) return "";
+    let html = '<div class="meeting-banner" role="note">';
+    html += '<div class="meeting-banner-title">Upcoming public meeting</div>';
+    html += '<div class="meeting-banner-when">' + esc(b.meeting) + " \u00b7 " + esc(b.when) + "</div>";
+    html += '<div class="meeting-banner-links">';
+    b.links.forEach(function(l) {
+      html += '<a href="' + esc(l.url) + '" target="_blank" rel="noopener noreferrer">' + esc(l.label) + " \u2192</a>";
+    });
+    html += "</div></div>";
+    return html;
+  };
+})();

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -75,6 +75,9 @@
     outbound: "Agencies it shares to",
   };
 
+  // Meeting banner data + helpers live in docs/js/meeting_banners.js
+  // (loaded from report.html before this script).
+
   function escapeHtml(s) {
     return String(s == null ? "" : s)
       .replace(/&/g, "&amp;")
@@ -127,6 +130,7 @@
     document.title = `${report.name} — ALPR Scorecard`;
 
     let html = "";
+    html += renderMeetingBanner(report);
     html += renderHeader(report);
     html += renderStats(report, meta);
     html += renderSB34Checklist(report, meta);
@@ -150,6 +154,12 @@
         <p class="muted">Example slugs: ${agencyList.map(s => `<a href="?agency=${escapeHtml(s)}">${escapeHtml(s)}</a>`).join(", ")}${agencyList.length >= 10 ? ", ..." : ""}</p>
       </div>
     `;
+  }
+
+  // ── Meeting banner (time-limited, per-agency) ──
+  function renderMeetingBanner(report) {
+    if (typeof window.renderMeetingBannerHtml !== "function") return "";
+    return window.renderMeetingBannerHtml([report.agency_id, report.slug, report.name]);
   }
 
   // ── Header ──

--- a/docs/report.html
+++ b/docs/report.html
@@ -929,6 +929,7 @@
 </div>
 
 <script src="js/qrcode.min.js"></script>
+<script src="js/meeting_banners.js"></script>
 <script src="js/report.js"></script>
 <script data-goatcounter="https://none-below.goatcounter.com/count"
         async src="https://gc.zgo.at/count.js"></script>

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -522,6 +522,7 @@ def _generate_html(marker_count):
 <div id="edge-bottom" class="edge-indicator"></div>
 <div class="offmap-panel" id="offmap"></div>
 <script src="data/map_data.json" type="application/json" id="mapData"></script>
+<script src="js/meeting_banners.js?v=JSCACHEBUST"></script>
 <script src="js/map.js?v=JSCACHEBUST"></script>
 <script data-goatcounter="https://none-below.goatcounter.com/count"
         async src="https://gc.zgo.at/count.js"></script>

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -72,6 +72,7 @@ RELATED_SLUGS = DEFAULT_SLUGS + [
     "south-san-francisco-ca-pd", "atherton-ca-pd", "hillsborough-ca-pd",
     "menlo-park-ca-pd", "east-palo-alto-ca-pd", "burlingame-ca-pd",
     "san-bruno-ca-pd", "pacifica-ca-pd", "colma-ca-pd", "brisbane-ca-pd",
+    "sunnyvale-ca-pd",
 ]
 
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -8,6 +8,9 @@ function escapeHtml(s) {
 const SLUG_RE = /^[a-z0-9][a-z0-9\-]*$/;
 function safeSlug(s) { return SLUG_RE.test(s) ? s : ''; }
 
+// Meeting-banner data + helpers live in docs/js/meeting_banners.js, loaded
+// from sharing_map.html before this script. Call window.renderMeetingBannerHtml.
+
 // Load data
 fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
   const markers = data.markers;
@@ -414,7 +417,11 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
     const status = m.crawled ? ('Crawled' + (crawlDate ? ' ' + crawlDate : '')) : 'No transparency page found (inferred from other portals)';
     const statusColor = m.crawled ? '#16a34a' : '#f97316';
     const shareUrl = window.location.href.split('#')[0] + '#' + m.slug;
-    let html = '<h3>' + escapeHtml(agencyInfo[m.slug]?.name || m.slug) + ' <a href="' + escapeHtml(shareUrl) + '" data-share-url="' + escapeHtml(shareUrl) + '" style="font-size:14px;text-decoration:none" title="Copy link">\ud83d\udd17</a></h3>';
+    const mInfoForBanner = agencyInfo[m.slug] || {};
+    let html = (typeof window.renderMeetingBannerHtml === 'function')
+      ? window.renderMeetingBannerHtml([m.agency_id, m.slug, mInfoForBanner.name])
+      : '';
+    html += '<h3>' + escapeHtml(agencyInfo[m.slug]?.name || m.slug) + ' <a href="' + escapeHtml(shareUrl) + '" data-share-url="' + escapeHtml(shareUrl) + '" style="font-size:14px;text-decoration:none" title="Copy link">\ud83d\udd17</a></h3>';
     html += '<p class="stat"><a href="report.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb;font-weight:600">View full report \u2192</a>';
     if (m.crawled) {
       html += ' &middot; <a href="https://transparency.flocksafety.com/' + safeSlug(m.slug) + '" target="_blank" style="color:#2563eb">Transparency portal \u2197</a>';

--- a/tests/test_meeting_banners.py
+++ b/tests/test_meeting_banners.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Tests for the shared meeting-banner module (docs/js/meeting_banners.js).
+
+Validates both the banner data shape (field types, date formats) and the
+integration points on pages that consume it.
+"""
+
+import http.server
+import json
+import re
+import threading
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+DOCS_DIR = Path("docs")
+BANNER_JS = DOCS_DIR / "js" / "meeting_banners.js"
+
+
+def _parse_banners():
+    """Extract MEETING_BANNERS from the JS source into a Python list.
+
+    We purposely parse the literal JS object rather than shelling out to a
+    JS runtime — the data is a pure literal and keeps the test dependency-
+    free. If this ever grows dynamic logic, switch to playwright-based
+    evaluation (see `TestBrowser` below).
+    """
+    src = BANNER_JS.read_text()
+    m = re.search(r"const MEETING_BANNERS\s*=\s*(\[.*?\n  \]);", src, re.DOTALL)
+    assert m, "Could not find MEETING_BANNERS array in meeting_banners.js"
+    body = m.group(1)
+    # Strip line comments (`// ...`) but not `://` in URLs. JS block
+    # comments (`/* ... */`) aren't used in the banner data currently.
+    body = re.sub(r"(?<!:)//[^\n]*", "", body)
+    # Strip trailing commas.
+    body = re.sub(r",(\s*[\]}])", r"\1", body)
+    # Quote unquoted keys (match/meeting/when/expires/links/label/url).
+    body = re.sub(r"([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*:", r'\1"\2":', body)
+    return json.loads(body)
+
+
+class TestBannerData:
+    """Validate the shape and contents of MEETING_BANNERS entries."""
+
+    @pytest.fixture(autouse=True)
+    def load(self):
+        assert BANNER_JS.exists(), f"{BANNER_JS} missing"
+        self.banners = _parse_banners()
+
+    def test_is_list(self):
+        assert isinstance(self.banners, list)
+
+    def test_entries_have_required_fields(self):
+        for i, b in enumerate(self.banners):
+            for field in ("match", "meeting", "when", "expires", "links"):
+                assert field in b, f"banner[{i}] missing {field}: {b}"
+
+    def test_match_is_nonempty_string_list(self):
+        for i, b in enumerate(self.banners):
+            assert isinstance(b["match"], list) and b["match"], f"banner[{i}] match must be non-empty list"
+            for m in b["match"]:
+                assert isinstance(m, str) and m, f"banner[{i}] match entries must be non-empty strings"
+
+    def test_expires_is_iso_date(self):
+        for i, b in enumerate(self.banners):
+            try:
+                datetime.strptime(b["expires"], "%Y-%m-%d")
+            except ValueError:
+                pytest.fail(f"banner[{i}] expires {b['expires']!r} is not YYYY-MM-DD")
+
+    def test_links_have_label_and_url(self):
+        for i, b in enumerate(self.banners):
+            assert isinstance(b["links"], list) and b["links"], f"banner[{i}] needs at least one link"
+            for j, lnk in enumerate(b["links"]):
+                assert lnk.get("label"), f"banner[{i}].links[{j}] missing label"
+                url = lnk.get("url", "")
+                assert url.startswith(("http://", "https://")), (
+                    f"banner[{i}].links[{j}] url must be absolute http(s): {url!r}"
+                )
+
+    def test_matches_registry_identifiers(self):
+        """Each banner should match a real registry entry by slug/agency_id/name.
+
+        Catches typos in identifiers before they ship as dead banners.
+        """
+        reg = json.loads(Path("assets/agency_registry.json").read_text())
+        known = set()
+        for e in reg:
+            if e.get("slug"):
+                known.add(e["slug"])
+            if e.get("agency_id"):
+                known.add(e["agency_id"])
+            for s in e.get("flock_slugs", []):
+                known.add(s)
+            for n in e.get("flock_names", []):
+                known.add(n)
+            if e.get("display_name"):
+                known.add(e["display_name"])
+        for i, b in enumerate(self.banners):
+            hits = [m for m in b["match"] if m in known]
+            assert hits, (
+                f"banner[{i}] ({b['meeting']}) has no identifiers matching the registry: "
+                f"{b['match']}"
+            )
+
+
+class TestIntegration:
+    """Verify pages that use banners include the shared script."""
+
+    def test_report_html_includes_banner_script(self):
+        html = (DOCS_DIR / "report.html").read_text()
+        assert "js/meeting_banners.js" in html, "report.html must include meeting_banners.js"
+
+    def test_sharing_map_includes_banner_script(self):
+        html = (DOCS_DIR / "sharing_map.html").read_text()
+        assert "js/meeting_banners.js" in html, "sharing_map.html must include meeting_banners.js"
+
+    def test_report_js_delegates_to_shared_helper(self):
+        js = (DOCS_DIR / "js" / "report.js").read_text()
+        assert "window.renderMeetingBannerHtml" in js, (
+            "report.js should call the shared window.renderMeetingBannerHtml helper"
+        )
+
+    def test_map_js_delegates_to_shared_helper(self):
+        js = (DOCS_DIR / "js" / "map.js").read_text()
+        assert "renderMeetingBannerHtml" in js, (
+            "map.js should call the shared renderMeetingBannerHtml helper"
+        )
+
+
+def _serve_docs():
+    handler = http.server.SimpleHTTPRequestHandler
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    server.timeout = 0.5
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port
+
+
+class TestBrowser:
+    """End-to-end: load the banner module in a real browser and exercise
+    activeMeetingBanner / renderMeetingBannerHtml with fixed 'today' dates.
+
+    Skips cleanly if playwright isn't installed (keeps the non-browser
+    tests useful on minimal CI).
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def serve(self, request):
+        import os
+        os.chdir(DOCS_DIR)
+        server, port = _serve_docs()
+        request.cls.port = port
+        yield
+        server.shutdown()
+        os.chdir(Path(__file__).parent.parent)
+
+    @pytest.fixture(scope="class")
+    def browser(self):
+        pytest.importorskip("playwright.sync_api")
+        from playwright.sync_api import sync_playwright
+        pw = sync_playwright().start()
+        b = pw.chromium.launch()
+        yield b
+        b.close()
+        pw.stop()
+
+    def _load(self, browser, today_iso):
+        """Load a minimal page that imports meeting_banners.js with Date frozen."""
+        page = browser.new_page()
+        # Freeze Date so expiration logic is deterministic. Override before
+        # the module loads so `new Date()` inside it sees the frozen clock.
+        page.add_init_script(f"""
+          (function() {{
+            const fixed = new Date('{today_iso}T12:00:00Z');
+            const OrigDate = Date;
+            function MockDate(...args) {{
+              if (args.length === 0) return new OrigDate(fixed);
+              return new OrigDate(...args);
+            }}
+            MockDate.prototype = OrigDate.prototype;
+            MockDate.now = () => fixed.getTime();
+            MockDate.parse = OrigDate.parse;
+            MockDate.UTC = OrigDate.UTC;
+            window.Date = MockDate;
+          }})();
+        """)
+        page.goto(f"http://127.0.0.1:{self.port}/report.html?agency=_banner_test",
+                  wait_until="domcontentloaded")
+        # Wait until the banner helper is defined.
+        page.wait_for_function("typeof window.renderMeetingBannerHtml === 'function'")
+        return page
+
+    def test_sunnyvale_banner_shows_before_expiry(self, browser):
+        page = self._load(browser, "2026-04-20")
+        html = page.evaluate("window.renderMeetingBannerHtml(['sunnyvale-ca-pd'])")
+        assert "Sunnyvale City Council" in html
+        assert "no-flock-in-sunnyvale" in html
+        page.close()
+
+    def test_banner_hides_after_expiry(self, browser):
+        page = self._load(browser, "2026-04-22")
+        html = page.evaluate("window.renderMeetingBannerHtml(['sunnyvale-ca-pd'])")
+        assert html == ""
+        page.close()
+
+    def test_banner_matches_by_agency_id(self, browser):
+        page = self._load(browser, "2026-04-20")
+        html = page.evaluate(
+            "window.renderMeetingBannerHtml(['7ef62d29-d50a-5f12-85fe-6061de259c8d'])"
+        )
+        assert "Sunnyvale" in html
+        page.close()
+
+    def test_banner_matches_by_display_name(self, browser):
+        page = self._load(browser, "2026-04-20")
+        html = page.evaluate("window.renderMeetingBannerHtml(['El Cerrito CA PD'])")
+        assert "El Cerrito" in html
+        page.close()
+
+    def test_unknown_identifiers_return_empty(self, browser):
+        page = self._load(browser, "2026-04-20")
+        html = page.evaluate("window.renderMeetingBannerHtml(['not-a-real-slug'])")
+        assert html == ""
+        page.close()
+
+    def test_null_and_empty_idents_are_tolerated(self, browser):
+        page = self._load(browser, "2026-04-20")
+        html = page.evaluate("window.renderMeetingBannerHtml([null, '', undefined])")
+        assert html == ""
+        page.close()


### PR DESCRIPTION
## Summary
- New shared module [docs/js/meeting_banners.js](docs/js/meeting_banners.js) renders an amber action banner on agency pages that have an upcoming public ALPR meeting. Added to both the report and the sharing-map info panel via `window.renderMeetingBannerHtml([agency_id, slug, name])`.
- Banner entries match on any of slug / agency_id / display_name, so agencies without a Flock portal can still be targeted. Entries self-expire by `YYYY-MM-DD`.
- 4 banners seeded for **Tue Apr 21 2026**: Sunnyvale, Alameda County BoS, El Cerrito, East Palo Alto. All expire `2026-04-22`.
- Drive-by: added `sunnyvale-ca-pd` to `RELATED_SLUGS` — the portal works at that slug but never got reached.

## Adding banners later
One-line `<script src="js/meeting_banners.js">` on any page, then call `window.renderMeetingBannerHtml([...])`. CSS is auto-injected. To retire a banner, delete its entry (or let `expires` fire).

## Test plan
- [x] `uv run pytest tests/test_meeting_banners.py` — 16 tests pass (data shape, registry identifier matching to catch typos, script-include integration, browser tests with frozen `Date()` covering pre-expiry render, post-expiry hide, match by slug/uuid/name, empty input)
- [x] `uv run pytest tests/test_map_smoke.py` — all 51 pass, no regressions
- [x] Manually verified banner appears on each of the 4 agency reports and on the sharing-map info panel when their dot is clicked; no banner on unrelated agencies (e.g. SMPD).