### PR TITLE
fix(crawl): prioritize uncrawled agencies, include level-1 discoveries

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -193,6 +193,24 @@ def has_prior_success(slug, data_dir):
     return any(slug_dir.glob("*.json"))
 
 
+def latest_capture_date(slug, data_dir):
+    """Return the latest successful capture date for a slug, or None.
+
+    A capture exists when a parsed .json is present — .txt alone can be a
+    failure stub. None means never successfully captured.
+    """
+    slug_dir = data_dir / slug
+    if not slug_dir.is_dir():
+        return None
+    jsons = sorted(slug_dir.glob("*.json"))
+    if not jsons:
+        return None
+    try:
+        return datetime.strptime(jsons[-1].stem, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
 # ═══════════════════════════════════════════════════════════
 # Parsing: raw DOM text -> structured JSON
 # ═══════════════════════════════════════════════════════════
@@ -829,10 +847,25 @@ def cmd_crawl(args):
                                     if guessed:
                                         discovered_from_existing.append(guessed)
 
-                new_slugs = [s for s in slugs if s not in visited]
-                # Prioritize agencies that have succeeded before (stale refresh)
-                # over never-tried ones (unlikely to suddenly appear)
-                new_slugs.sort(key=lambda s: (0 if has_prior_success(s, data_dir) else 1))
+                # Eligible candidates this level = the current seed list plus
+                # anything discovered in the outbound of fresh neighbors. Merging
+                # `discovered_from_existing` here is what lets a known-but-never-
+                # crawled agency (e.g. a newly seeded registry entry that first
+                # appears in some peer's outbound list) get picked up on the same
+                # level it's discovered, instead of waiting for a deeper run.
+                candidates = dedupe(list(slugs) + discovered_from_existing)
+                new_slugs = [s for s in candidates if s not in visited]
+                # Crawl order: never-crawled first (fills gaps like newly-seeded
+                # registry entries), then previously-captured agencies sorted by
+                # oldest capture (refresh the stalest first). Both tiers sort
+                # together via a (tier, date) key — tier 0 = uncrawled, tier 1
+                # = by oldest capture date.
+                def _order(s):
+                    last = latest_capture_date(s, data_dir)
+                    if last is None:
+                        return (0, date.min)
+                    return (1, last)
+                new_slugs.sort(key=_order)
                 if args.batch:
                     new_slugs = new_slugs[:int(batch_remaining)]
 


### PR DESCRIPTION
## Summary
Two bugs combined to keep `sunnyvale-ca-pd` (just added to the registry) from ever being crawled by the hourly refresh, even after adding it to `RELATED_SLUGS`:

1. **Level-1 discoveries weren't eligible for crawl.** The candidate pool at each depth level was only the level's seed list. Sunnyvale appears in the outbound of several level-1 neighbors (atherton, albany, belmont, etc.), so it got surfaced into `discovered_from_existing` — but then had to wait until *next* level to be crawlable. With `max-depth=1` there is no next level. Now `discovered_from_existing` is merged into the candidate set for the same level.
2. **Sort was backwards.** Previous order put prior-successful agencies first and never-tried last — so newly seeded registry entries always lost to stale refreshes for the limited batch slots. Flipped to `(tier, date)` with `tier 0 = never crawled` and `tier 1 = oldest refresh first`.

Also adds `latest_capture_date()` helper alongside `has_prior_success()`.

## Effect on the hourly action
`--all --batch 3 --max-age 7` will now always pull Sunnyvale (and any other uncrawled registered agency reachable within depth-1) ahead of stale refreshes — until nothing uncrawled remains, at which point it reverts to oldest-refresh-first.

## Test plan
- [x] `uv run pytest tests/test_flock_transparency_headings.py tests/test_meeting_banners.py` — pass
- [x] Sort verified on current data: `sunnyvale-ca-pd` (None) sorts ahead of fresh agencies (2026-04-10..17)
- [ ] Watch the next `workflow_dispatch` of `refresh-flock-data.yml` — should pick up sunnyvale in the first batch