### PR TITLE
feat(workflow): add slugs input for spot crawls

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -6,11 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       batch_size:
-        description: 'Number of agencies to refresh'
+        description: 'Number of agencies to refresh (ignored when slugs set)'
         default: '3'
       max_age:
-        description: 'Re-crawl if older than N days'
+        description: 'Re-crawl if older than N days (ignored when slugs set)'
         default: '7'
+      slugs:
+        description: 'Specific slug(s) to crawl, space-separated. Bypasses --all/--batch/--max-age when set.'
+        default: ''
 
 concurrency:
   group: flock-refresh
@@ -61,11 +64,18 @@ jobs:
 
       - name: Crawl oldest agencies
         run: |
-          uv run python scripts/flock_transparency.py crawl \
-            --all \
-            --batch ${{ inputs.batch_size || '3' }} \
-            --max-age ${{ inputs.max_age || '7' }} \
-            --delay 1
+          if [ -n "${{ inputs.slugs }}" ]; then
+            # shellcheck disable=SC2086
+            uv run python scripts/flock_transparency.py crawl \
+              ${{ inputs.slugs }} \
+              --delay 1
+          else
+            uv run python scripts/flock_transparency.py crawl \
+              --all \
+              --batch ${{ inputs.batch_size || '3' }} \
+              --max-age ${{ inputs.max_age || '7' }} \
+              --delay 1
+          fi
 
       - name: Parse new data
         run: uv run python scripts/flock_transparency.py parse


### PR DESCRIPTION
## Summary
Adds an optional `slugs` input to `workflow_dispatch` for [refresh-flock-data.yml](.github/workflows/refresh-flock-data.yml). When set, the action crawls those specific slugs directly and skips the normal `--all/--batch/--max-age` flow.

Lets me spot-crawl a newly seeded registry entry (e.g. `sunnyvale-ca-pd`) that the priority queue hasn't reached yet, without waiting on the alphabetic tier-0 flood.

Empty default preserves the existing hourly cron behavior.

## Usage
Actions → Refresh Flock Transparency Data → Run workflow:
- **slugs**: `sunnyvale-ca-pd` (space-separated for multiple)
- Other inputs ignored when `slugs` is set.

## Test plan
- [x] YAML syntax check — `gh workflow view` equivalent (committed, next UI load renders input)
- [ ] After merge: dispatch with `slugs=sunnyvale-ca-pd`, confirm portal gets captured