### PR TITLE
fix(copy): El Cajon label, agenda links, drop 3rd-party ref

### DIFF
--- a/docs/js/meeting_banners.js
+++ b/docs/js/meeting_banners.js
@@ -21,6 +21,8 @@
       when: "Tue, Apr 21 2026",
       expires: "2026-04-22",
       links: [
+        { label: "Council agenda", url: "https://sunnyvaleca.legistar.com/MeetingDetail.aspx?ID=1351612&GUID=8D95399B-F698-47D0-A65E-09D6CBC92106" },
+        { label: "Flock agenda item", url: "https://sunnyvaleca.legistar.com/LegislationDetail.aspx?ID=7986124&GUID=6726AE42-4486-4796-B885-A7155BDDE804" },
         { label: "Flyer: No Flock in Sunnyvale", url: "https://tinyurl.com/no-flock-in-sunnyvale" },
       ],
     },
@@ -40,6 +42,7 @@
       when: "Tue, Apr 21 2026",
       expires: "2026-04-22",
       links: [
+        { label: "Council agenda", url: "https://www.elcerrito.gov/Calendar.aspx?EID=11171" },
         { label: "Flyer", url: "https://drive.proton.me/urls/RMFT9WY8N4#2EloSEBOnNtg" },
       ],
     },
@@ -49,6 +52,7 @@
       when: "Tue, Apr 21 2026",
       expires: "2026-04-22",
       links: [
+        { label: "Council agendas", url: "https://www.cityofepa.org/citycouncil/page/agenda-and-minutes" },
         { label: "Organizer doc", url: "https://docs.google.com/document/d/1l1sNmOQKw2kBzTw-Ww2nrugmMceaL9t7ZzJzI0A0ZRs/edit" },
       ],
     },

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -799,7 +799,7 @@
         extrasHtml: pvExtras,
         rankPillsHtml: pvPills,
       });
-      const hotlistCaveat = `A hit is a possible match, not a confirmed crime — NCIC matches can include false positives, and custom lists vary in how they're curated. More at <a href="https://haveibeenflocked.com/news/hotlist-mess" target="_blank" rel="noopener">haveibeenflocked.com/news/hotlist-mess</a>.`;
+      const hotlistCaveat = `A hit is a possible match, not a confirmed crime — NCIC matches can include false positives, and custom lists vary in how they're curated.`;
       html += metricBlockHtml({
         title: `${short}'s hotlist hits`,
         subtitle: "plate match against FBI NCIC or a custom list the operator has configured",

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -201,7 +201,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       tag += ' <span style="color:#dc2626;font-weight:bold" title="Not a &ldquo;public agency&rdquo; under CA Civil Code \u00a71798.90.5(f). Sharing ALPR data with non-agency recipients likely violates \u00a71798.90.55(b).">[PRIVATE ENTITY \u2014 not a public agency]</span>';
     }
     if (info.ag_lawsuit)
-      tag += ' <span style="color:#dc2626;font-weight:bold" title="CA Attorney General lawsuit for illegal out-of-state ALPR data sharing in violation of SB 34.">[OUT-OF-STATE \u2014 AG litigation]</span>';
+      tag += ' <span style="color:#dc2626;font-weight:bold" title="CA Attorney General lawsuit for illegally resharing ALPR data to out-of-state agencies in violation of SB 34.">[RESHARES OUT-OF-STATE \u2014 AG litigation]</span>';
     // Curated status flags from the registry (inactive, deactivated, dnu, duplicate, decommissioned)
     const FLAG_BADGES = {
       inactive: { color: '#6b7280', label: 'INACTIVE', title: 'Marked inactive on Flock\'s portal' },


### PR DESCRIPTION
## Summary

Three small copy edits surfaced while reviewing the sharing map and report for bias/accuracy:

- **El Cajon mislabeled.** AG-lawsuit agencies were tagged `[OUT-OF-STATE — AG litigation]`, but El Cajon (and the other AG-sued agencies) are CA agencies. The AG sued them *for* illegally resharing ALPR data to out-of-state agencies. Relabeled as `[RESHARES OUT-OF-STATE — AG litigation]`.
- **Meeting banners** for the Apr 21 meetings (Sunnyvale, El Cerrito, East Palo Alto) now link to each city's official council agenda alongside the organizer flyers/docs, so readers always have a neutral primary source. Sunnyvale additionally deep-links to the specific Flock data-retention item (Legistar item 26-0113). Alameda County already had its official agenda linked.
- **Hotlist caveat** on city reports no longer links out to `haveibeenflocked.com/news/hotlist-mess` — keeps the report unbiased and self-contained.

## Test plan

- [ ] Sharing map: open El Cajon tooltip, confirm new label reads "RESHARES OUT-OF-STATE — AG litigation".
- [ ] Report for a city with hotlist hits: confirm the caveat no longer includes the outbound link.
- [ ] Apr 21 meeting banner: confirm new "Council agenda" / "Flock agenda item" links resolve for each of Sunnyvale, El Cerrito, East Palo Alto.