### PR TITLE
fix: geocode 3 Calistoga-recipient agencies missing coords

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -17411,10 +17411,8 @@
       "needs-review"
     ],
     "geo": {
-      "kind": "manual",
-      "state": "CA",
-      "lat": 38.0694,
-      "lng": -122.2336
+      "kind": "state-only",
+      "state": "CA"
     },
     "flags": []
   },
@@ -17486,8 +17484,10 @@
       "needs-review"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "manual",
+      "state": "CA",
+      "lat": 38.0694,
+      "lng": -122.2336
     },
     "flags": []
   },

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -4248,8 +4248,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "manual",
+      "state": "CA",
+      "lat": 35.305,
+      "lng": -120.6625
     }
   },
   {
@@ -17409,8 +17411,10 @@
       "needs-review"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "manual",
+      "state": "CA",
+      "lat": 38.0694,
+      "lng": -122.2336
     },
     "flags": []
   },
@@ -18024,6 +18028,14 @@
     "tags": [
       "needs-review"
     ],
+    "geo": {
+      "kind": "place",
+      "fips": "0631708",
+      "name": "Half Moon Bay",
+      "state": "CA",
+      "lat": 37.467319,
+      "lng": -122.440485
+    },
     "flags": []
   },
   {


### PR DESCRIPTION
## Summary
- `check_recipient_coords.py` flagged Cal Maritime (CA), Cal Poly CA PD, and City of Half Moon Bay (SMCSO) after the Calistoga crawl — all three were being shared to without a mappable location.
- HMB had no `state` at all, so the geocoder skipped it. Seeded `state: CA` then ran `geocode_agencies.py --slug city-of-half-moon-bay --apply`, which auto-upgraded to `kind: "place"` with FIPS `0631708`.
- Cal Maritime (CSU Maritime Academy in Vallejo) and Cal Poly (SLO campus, since the slug/name don't disambiguate Pomona) get `kind: "manual"` lat/lng — neither name resolves to a Census place.

## Test plan
- [x] `scripts/check_recipient_coords.py` now reports "All public-agency recipients have coordinates."
- [x] `tests/test_geo_cache.py` passes (validates the new HMB FIPS/coord match the gazetteer)