### PR TITLE
ci(workflows): pass gh body via --body-file to avoid Argument list too long

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,26 +106,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BODY=$(cat /tmp/coord-check.txt)
           # Don't duplicate — check for an existing open issue
           EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
           if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "Updated from CI run:
-
-          \`\`\`
-          $BODY
-          \`\`\`"
+            {
+              echo "Updated from CI run:"
+              echo
+              echo '```'
+              cat /tmp/coord-check.txt
+              echo '```'
+            } > /tmp/coord-issue-body.md
+            gh issue comment "$EXISTING" --body-file /tmp/coord-issue-body.md
           else
+            {
+              echo "The following agencies receive data from public agencies but have no lat/lng in the registry:"
+              echo
+              echo '```'
+              cat /tmp/coord-check.txt
+              echo '```'
+              echo
+              echo "Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+            } > /tmp/coord-issue-body.md
             gh issue create \
               --title "Recipients missing coordinates in agency registry" \
               --label geocoding \
-              --body "The following agencies receive data from public agencies but have no lat/lng in the registry:
-
-          \`\`\`
-          $BODY
-          \`\`\`
-
-          Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+              --body-file /tmp/coord-issue-body.md
           fi
 
       - name: Screenshot pages
@@ -163,7 +168,8 @@ jobs:
             done
 
           # Build comment with inline images
-          BODY="<!-- page-preview -->
+          cat > /tmp/preview-body.md <<EOF
+          <!-- page-preview -->
           ## Page Preview
 
           ### index
@@ -182,9 +188,9 @@ jobs:
           ![report_alameda-ca-pd](${RAW}/report_alameda-ca-pd.png)
 
           *Updated $(date -u +%Y-%m-%dT%H:%M:%SZ)*
-          "
+          EOF
 
-          gh pr comment "${PR_NUM}" --body "${BODY}"
+          gh pr comment "${PR_NUM}" --body-file /tmp/preview-body.md
 
           # Return to PR branch for any subsequent steps
           git checkout "${{ github.head_ref }}"

--- a/.github/workflows/refresh-census-gazetteer.yml
+++ b/.github/workflows/refresh-census-gazetteer.yml
@@ -69,15 +69,18 @@ jobs:
 
           existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
           if [ -z "$existing" ]; then
-            gh pr create \
-              --title "chore: refresh Census gazetteer" \
-              --body "Automated quarterly refresh of Census gazetteer TSVs.
+            cat > /tmp/pr-body.md <<'EOF'
+          Automated quarterly refresh of Census gazetteer TSVs.
 
           Any changes here are driven by:
           - New annual Census place/county/cousub data
           - Re-running the geocoder against updated data
 
-          The geo cache tests pass, meaning cached lat/lng/name still match the new gazetteer (or have been updated)." \
+          The geo cache tests pass, meaning cached lat/lng/name still match the new gazetteer (or have been updated).
+          EOF
+            gh pr create \
+              --title "chore: refresh Census gazetteer" \
+              --body-file /tmp/pr-body.md \
               --head "$BRANCH" \
               --base main
           fi

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -110,25 +110,30 @@ jobs:
         run: |
           if ! uv run python scripts/check_recipient_coords.py > /tmp/coord-check.txt 2>&1; then
             cat /tmp/coord-check.txt
-            BODY=$(cat /tmp/coord-check.txt)
             EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
             if [ -n "$EXISTING" ]; then
-              gh issue comment "$EXISTING" --body "Updated from flock refresh:
-
-          \`\`\`
-          $BODY
-          \`\`\`"
+              {
+                echo "Updated from flock refresh:"
+                echo
+                echo '```'
+                cat /tmp/coord-check.txt
+                echo '```'
+              } > /tmp/coord-issue-body.md
+              gh issue comment "$EXISTING" --body-file /tmp/coord-issue-body.md
             else
+              {
+                echo "The following agencies receive data from public agencies but have no lat/lng in the registry:"
+                echo
+                echo '```'
+                cat /tmp/coord-check.txt
+                echo '```'
+                echo
+                echo "Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+              } > /tmp/coord-issue-body.md
               gh issue create \
                 --title "Recipients missing coordinates in agency registry" \
                 --label geocoding \
-                --body "The following agencies receive data from public agencies but have no lat/lng in the registry:
-
-          \`\`\`
-          $BODY
-          \`\`\`
-
-          Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+                --body-file /tmp/coord-issue-body.md
             fi
           else
             cat /tmp/coord-check.txt
@@ -162,17 +167,11 @@ jobs:
 
       - name: Generate diff summary
         if: steps.commit.outputs.has_changes == 'true'
-        id: diff
         run: |
           slugs=$(git diff HEAD~1 --name-only -- 'assets/transparency.flocksafety.com/' \
             | sed 's|assets/transparency.flocksafety.com/||' | cut -d/ -f1 | sort -u)
-          summary=$(uv run python scripts/diff_scrapes.py $slugs)
-          echo "$summary"
-          {
-            echo 'DIFF_SUMMARY<<EOF'
-            echo "$summary"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          uv run python scripts/diff_scrapes.py $slugs > /tmp/diff-summary.txt
+          cat /tmp/diff-summary.txt
 
       - name: Create or update PR
         if: steps.commit.outputs.has_changes == 'true'
@@ -181,32 +180,33 @@ jobs:
           # which keeps the next CI run on this PR from requiring manual
           # approval. Falls back to GITHUB_TOKEN when PAT isn't configured.
           GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
+          BATCH_SIZE: ${{ inputs.batch_size || '3' }}
         run: |
           existing=$(gh pr list --head flock-refresh --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh pr comment "$existing" --body "$(cat <<'EOF'
-          ### Refresh batch — ${{ inputs.batch_size || '3' }} agencies
-
-          ```
-          ${{ steps.diff.outputs.DIFF_SUMMARY }}
-          ```
-          EOF
-          )"
+            {
+              echo "### Refresh batch — ${BATCH_SIZE} agencies"
+              echo
+              echo '```'
+              cat /tmp/diff-summary.txt
+              echo '```'
+            } > /tmp/pr-body.md
+            gh pr comment "$existing" --body-file /tmp/pr-body.md
           else
+            {
+              echo "Automated rolling refresh of Flock Safety transparency portal data."
+              echo
+              echo "This PR accumulates hourly batches. Merge when ready — the next run will create a fresh branch from main."
+              echo
+              echo "### Initial batch"
+              echo
+              echo '```'
+              cat /tmp/diff-summary.txt
+              echo '```'
+            } > /tmp/pr-body.md
             gh pr create \
               --title "chore: refresh flock transparency data" \
-              --body "$(cat <<EOF
-          Automated rolling refresh of Flock Safety transparency portal data.
-
-          This PR accumulates hourly batches. Merge when ready — the next run will create a fresh branch from main.
-
-          ### Initial batch
-
-          \`\`\`
-          ${{ steps.diff.outputs.DIFF_SUMMARY }}
-          \`\`\`
-          EOF
-          )" \
+              --body-file /tmp/pr-body.md \
               --head flock-refresh \
               --base main
           fi


### PR DESCRIPTION
## Summary
- Every `gh pr comment` / `gh pr create` / `gh issue comment` call that embedded a multiline body via `--body "$(cat <<EOF ...)"` was at risk of `E2BIG`: the heredoc expands into a single argv entry for `execve()`, and Linux caps that at ~128KB. The hourly flock-refresh chore has been hitting this — the old parser bug (fixed in #125) amplified it by producing huge OCR-dump diffs, but the shell pattern itself was always fragile.
- Rewrote every such call to write the body to `/tmp/*.md` and pass `--body-file`, which reads from disk and has no argv limit.
- Dropped the `DIFF_SUMMARY` step-output round-trip from `refresh-flock-data.yml` — step output has its own size cap and the value only hops between two adjacent steps. Generate into `/tmp/diff-summary.txt` and read it directly in the next step.

## Covers
- `.github/workflows/ci.yml` — geocoding issue create/comment, page-preview PR comment
- `.github/workflows/refresh-flock-data.yml` — geocoding issue create/comment, PR create/comment
- `.github/workflows/refresh-census-gazetteer.yml` — PR create (consistency, body is small today but same pattern)

## Test plan
- [x] `python -c 'import yaml; yaml.safe_load(...)'` on all three workflows
- [x] Eyeballed the rendered shell for each step — heredocs resolve to column-0 content after YAML strips block indent
- [ ] Confirm next hourly `flock-refresh` run posts a clean PR comment (no more E2BIG)
- [ ] Confirm next PR triggers the page-preview comment correctly