### PR TITLE
ci(refresh): use REFRESH_PAT secret for checkout + PR creation

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -32,6 +32,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # Using a PAT (if configured) makes git push + gh pr create attribute
+          # to the PAT owner, so the resulting pull_request event's
+          # triggering_actor is a human. Without this, GITHUB_TOKEN-authored
+          # events get triggering_actor=github-actions[bot], which trips the
+          # "approval required for non-committers" setting on every run.
+          token: ${{ secrets.REFRESH_PAT || github.token }}
 
       - name: Set up refresh branch
         run: |
@@ -171,7 +177,10 @@ jobs:
       - name: Create or update PR
         if: steps.commit.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the PAT (if set) so the PR is created by a human identity,
+          # which keeps the next CI run on this PR from requiring manual
+          # approval. Falls back to GITHUB_TOKEN when PAT isn't configured.
+          GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           existing=$(gh pr list --head flock-refresh --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then


### PR DESCRIPTION
## Why
Every CI run on the `flock-refresh` PR is gated at `action_required` because the `pull_request` event's `triggering_actor` is `github-actions[bot]` (the `GITHUB_TOKEN` identity). The repo's "allow current and previous committers to run CI" setting evaluates **human committers only** — bots never count, even ones with hundreds of merged commits. Compare two CI runs on `flock-refresh`:

| Run | `triggering_actor` | Result |
|-----|-------------------|--------|
| #24792556653 | zero-below (you manually pushed) | success |
| #24854077770 | github-actions[bot] | action_required |

## What
- `actions/checkout@v6` now takes `token: ${{ secrets.REFRESH_PAT || github.token }}`, so git-push credentials carry the PAT owner's identity.
- `Create or update PR` step's `GH_TOKEN` is `secrets.REFRESH_PAT || secrets.GITHUB_TOKEN`, so `gh pr create` / `gh pr comment` attribute the resulting event to the PAT owner.
- The other `GH_TOKEN` env vars (geocoding issue, commit status) stay on `GITHUB_TOKEN` — neither triggers a workflow run so they don't hit the approval gate.
- Fallback: if `REFRESH_PAT` isn't set yet, the workflow keeps working exactly as today. Safe to land before the secret is created.

## Setup (after merging)
See the PR comment for the step-by-step walkthrough for creating the PAT and adding it as a repo secret.

## Test plan
- [x] YAML parses
- [ ] Create PAT + add `REFRESH_PAT` secret
- [ ] Manually dispatch `refresh-flock-data` workflow
- [ ] Confirm resulting CI run's `triggering_actor` is the PAT owner and CI runs without approval