### PR TITLE
feat(ci): lint findings doc for source-number collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Lint findings source numbering
+        run: python3 scripts/lint_findings.py
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,11 @@ The PDF generator (`scripts/md_to_pdf.py`) parses the findings markdown by split
 - Pushing changes to `docs/SMPD_ALPR_Findings.md` or `scripts/md_to_pdf.py`
   triggers a GitHub release with the built PDF attached.
 - The Pages site links to the latest release download.
+
+**Source-numbering integrity:**
+- Every source row must have a unique `| N |` number; every inline `[N]`
+  in prose must resolve to an existing source row.
+- Parallel PRs can auto-merge into duplicate source numbers without a git
+  conflict (no line-level overlap), so CI runs `scripts/lint_findings.py`
+  on every PR to catch that. Run it locally before pushing when adding a
+  source row: `python3 scripts/lint_findings.py`.

--- a/scripts/lint_findings.py
+++ b/scripts/lint_findings.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Lint docs/SMPD_ALPR_Findings.md for source-numbering integrity.
+
+Parallel PRs each adding a new source row can auto-merge into duplicate
+numbered rows without a git conflict. Run this in CI to catch that — and
+to catch inline [N] references that don't resolve to any source row.
+
+Usage:
+  python scripts/lint_findings.py              # check the canonical doc
+  python scripts/lint_findings.py PATH         # check a specific file
+
+Exits 0 on success, 1 on any error.
+"""
+
+import re
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+
+DEFAULT_DOC = Path(__file__).resolve().parent.parent / "docs" / "SMPD_ALPR_Findings.md"
+
+SOURCE_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|")
+# [N] inline ref: 1–3 digits in brackets NOT followed by `(` (a markdown
+# link). Catches [49], [35]; skips [text](url), ![alt](src), 4-digit years
+# like "[2025]" used as editorial brackets in quotes.
+INLINE_REF_RE = re.compile(r"\[(\d{1,3})\](?!\()")
+
+
+def extract_source_section(text: str) -> tuple[list[str], int]:
+    """Return (lines_in_section, start_line_number). Start is 1-indexed for
+    error reporting."""
+    lines = text.splitlines()
+    start = None
+    end = len(lines)
+    for i, line in enumerate(lines):
+        if line.startswith("## Source Documents"):
+            start = i + 1  # skip the heading itself
+            continue
+        if start is not None and line.startswith("## "):
+            end = i
+            break
+    if start is None:
+        print("ERROR: '## Source Documents' heading not found", file=sys.stderr)
+        sys.exit(1)
+    return lines[start:end], start + 1  # +1 so reported lines are 1-indexed
+
+
+def main() -> int:
+    doc_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_DOC
+    if not doc_path.exists():
+        print(f"ERROR: {doc_path} not found", file=sys.stderr)
+        return 1
+
+    text = doc_path.read_text(encoding="utf-8")
+    section_lines, section_start = extract_source_section(text)
+
+    # Source rows: N -> list of 1-indexed line numbers where it appears.
+    rows: dict[int, list[int]] = defaultdict(list)
+    for offset, line in enumerate(section_lines):
+        m = SOURCE_ROW_RE.match(line)
+        if m:
+            rows[int(m.group(1))].append(section_start + offset)
+
+    errors: list[str] = []
+
+    # Duplicate source numbers.
+    for n, line_nums in sorted(rows.items()):
+        if len(line_nums) > 1:
+            locs = ", ".join(f"line {ln}" for ln in line_nums)
+            errors.append(f"duplicate source #{n} ({locs})")
+
+    # Orphan inline references: [N] in prose that doesn't resolve.
+    known = set(rows.keys())
+    orphans: dict[int, list[int]] = defaultdict(list)
+    for i, line in enumerate(text.splitlines(), start=1):
+        for m in INLINE_REF_RE.finditer(line):
+            n = int(m.group(1))
+            if n not in known:
+                orphans[n].append(i)
+    for n, line_nums in sorted(orphans.items()):
+        sample = line_nums[0]
+        extra = f" (+{len(line_nums) - 1} more)" if len(line_nums) > 1 else ""
+        errors.append(f"inline [{n}] has no source row (first at line {sample}{extra})")
+
+    if errors:
+        print(f"lint_findings: {len(errors)} error(s) in {doc_path}:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"lint_findings: OK — {len(rows)} source rows, all inline refs resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Parallel PRs each adding a new source row to `docs/SMPD_ALPR_Findings.md` can auto-merge into **duplicate `| N |` rows without any git conflict** — there's nothing at the line level for git to flag. We almost shipped this with #114 and #136 (same #49, only caught because #114 was stale and I manually noticed).

Adds `scripts/lint_findings.py`:
- Parses the Source Documents section and reports duplicate row numbers.
- Scans prose for `[N]` inline refs and reports orphans (no matching source row).
- Regex caps refs at 1–3 digits, so editorial brackets like `[2025]` in quoted text aren't false positives.

Wired into `ci.yml` as a fast early step (stdlib only, runs in milliseconds). Fails the PR before the heavier build work begins.

`CLAUDE.md` gains a short note explaining the invariant and the local command.

## Test plan
- [ ] CI runs the lint step on this PR and passes (48 rows, all refs resolve).
- [ ] Synthetic test locally — inject a duplicate `| 49 |` row, confirm exit 1.
- [ ] Synthetic test locally — inject `[999]` ref, confirm orphan error with correct line number.