### PR TITLE
feat: per-agency sharing history with recent-change surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Build sharing graph, map, scoreboard, report data, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
+          uv run python scripts/build_history.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_scoreboard.py &
           uv run python scripts/build_report_data.py &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Build sharing graph, map, scoreboard, report data, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
+          uv run python scripts/build_history.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_scoreboard.py &
           uv run python scripts/build_report_data.py &

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Validate build outputs
         run: |
           uv run python scripts/build_sharing_graph.py
+          uv run python scripts/build_history.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_report_data.py &
           uv run python scripts/md_to_pdf.py &

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ docs/data/map_data.json
 docs/data/report_data.json
 docs/data/scoreboard_data.json
 docs/data/audit/
+docs/data/history/
+docs/data/agency_changelog.json
 docs/js/map.js
 assets/transparency.flocksafety.com/.sharing_graph_full.json
 assets/**/_pending/

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1610,6 +1610,11 @@
         visibleGroup.forEach(function(f) {
           html += `<li>${escapeHtml(f.name)}`;
           if (f.ag_lawsuit) html += ` <span class="flag-tag lawsuit">AG LAWSUIT</span>`;
+          if (f.days_since_added != null) {
+            const days = f.days_since_added;
+            const ago = days === 0 ? "today" : days === 1 ? "1 day ago" : `${days} days ago`;
+            html += ` <span class="flag-tag" style="background:#fef3c7;color:#92400e" title="Sharing first appeared on ${escapeHtml(f.added_on)}">NEW &mdash; started ${ago}</span>`;
+          }
           // Registry notes are curated HTML (may contain anchor tags);
           // inserted as-is. Editors of the registry must avoid script
           // content — there is no sanitizer.
@@ -1624,6 +1629,25 @@
         html += '</ul>';
         html += '</div>';
       });
+      html += '</div>';
+    }
+
+    // Previously-flagged recipients: entities the agency dropped from
+    // its sharing list. Surfaced so cleanup is visible (and so the
+    // record doesn't disappear when a portal update removes a row).
+    const removedFlagged = report.removed_flagged_recipients || [];
+    if (removedFlagged.length) {
+      html += '<div class="flag-section" style="margin-top:12px;border-left-color:#9ca3af">';
+      html += `<strong>${removedFlagged.length} previously flagged recipient${removedFlagged.length === 1 ? "" : "s"} removed</strong> &mdash; entities that were in this agency\'s sharing list at some point during our tracking window and have since been removed.`;
+      html += '<ul style="margin-top:6px">';
+      removedFlagged.forEach(function(r) {
+        const label = FLAG_LABELS[r.kind] || r.kind.toUpperCase();
+        html += `<li>${escapeHtml(r.name)} <span class="flag-tag kind-${escapeHtml(r.kind)}">${escapeHtml(label)}</span>`;
+        if (r.ag_lawsuit) html += ` <span class="flag-tag lawsuit">AG LAWSUIT</span>`;
+        html += ` <span class="muted" style="font-size:9.5pt">&mdash; removed on/around ${escapeHtml(r.removed_on)}</span>`;
+        html += '</li>';
+      });
+      html += '</ul>';
       html += '</div>';
     }
 

--- a/scripts/build_history.py
+++ b/scripts/build_history.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Build per-agency change history from dated transparency snapshots.
+
+For each agency with ≥1 snapshot, writes docs/data/history/<slug>.json
+containing an events list computed by diffing consecutive snapshots.
+
+Also writes docs/data/history/index.json — a lightweight directory of
+which agencies have history and how much.
+
+Reads:
+  - assets/transparency.flocksafety.com/<slug>/*.json
+  - assets/agency_registry.json (for display names / agency_id)
+
+Writes:
+  - docs/data/history/<slug>.json (one per agency)
+  - docs/data/history/index.json
+
+Usage:
+  uv run python scripts/build_history.py
+"""
+
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+RECENT_WINDOW_DAYS = 90
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import portal_jsons, registry_by_slug, resolve_agency
+
+DATA_DIR = Path("assets/transparency.flocksafety.com")
+OUT_DIR = Path("docs/data/history")
+
+# Rename-map: normalize legacy scraper field names to current names so a
+# field rename doesn't produce a false "everything changed" event.
+FIELD_ALIASES = {
+    "shared_org_names": "sharing_outbound",
+    "orgs_sharing_with_names": "sharing_inbound",
+}
+
+# Observational / identity fields — not policy, don't track.
+SKIP_FIELDS = {
+    "archived_date",
+    "crawled_slug",
+    "crawled_name",
+    "vehicles_detected_30d",
+    "hotlist_hits_30d",
+    "searches_30d",
+    "shared_org_slugs",
+    "orgs_sharing_with_slugs",
+    "crawled_at",
+    # High-churn audit-log payload: list of per-search records with
+    # timestamps. Diffing this as a set would produce noisy add/remove
+    # events on every scrape. Consumers that want audit-log analysis
+    # should read the raw portal JSON directly.
+    "search_audit_csv",
+}
+
+SCALAR_FIELDS = {"data_retention_days", "camera_count"}
+
+SET_FIELDS = {"sharing_outbound", "sharing_inbound"}
+
+# Fields stored as a comma-separated string but semantically a set.
+COMMA_SET_FIELDS = {"hotlists_alerted_on"}
+
+TEXT_FIELDS = {
+    "access_policy",
+    "hotlist_policy",
+    "acceptable_use_policy",
+    "prohibited_uses",
+    "whats_detected",
+    "whats_not_detected",
+    "sharing_with_partners",
+    "sharing_restrictions",
+    "sb54",
+    "sharing_info",
+    "success_stories",
+    "policy_info",
+    "alpr_policy",
+    "additional_info",
+}
+
+
+_UNKNOWN_FIELDS_WARNED: set[str] = set()
+
+
+def _split_comma_set(val):
+    if not val:
+        return []
+    return sorted({p.strip() for p in val.split(",") if p.strip()})
+
+
+def _normalize(snapshot: dict) -> dict:
+    out = {}
+    for key, val in snapshot.items():
+        if key in SKIP_FIELDS:
+            continue
+        out[FIELD_ALIASES.get(key, key)] = val
+    return out
+
+
+def _diff_pair(prev: dict, curr: dict, prev_date: str, curr_date: str) -> list[dict]:
+    events = []
+    prev_n = _normalize(prev)
+    curr_n = _normalize(curr)
+    keys = sorted(set(prev_n) | set(curr_n))
+    for key in keys:
+        before = prev_n.get(key)
+        after = curr_n.get(key)
+        if before == after:
+            continue
+        if key in SCALAR_FIELDS:
+            events.append({
+                "date": curr_date,
+                "prev_date": prev_date,
+                "field": key,
+                "kind": "scalar",
+                "before": before,
+                "after": after,
+            })
+        elif key in SET_FIELDS:
+            before_set = set(before or [])
+            after_set = set(after or [])
+            added = sorted(after_set - before_set)
+            removed = sorted(before_set - after_set)
+            if not added and not removed:
+                continue
+            events.append({
+                "date": curr_date,
+                "prev_date": prev_date,
+                "field": key,
+                "kind": "set",
+                "added": added,
+                "removed": removed,
+            })
+        elif key in COMMA_SET_FIELDS:
+            before_set = set(_split_comma_set(before))
+            after_set = set(_split_comma_set(after))
+            added = sorted(after_set - before_set)
+            removed = sorted(before_set - after_set)
+            if not added and not removed:
+                continue
+            events.append({
+                "date": curr_date,
+                "prev_date": prev_date,
+                "field": key,
+                "kind": "set",
+                "added": added,
+                "removed": removed,
+            })
+        elif key in TEXT_FIELDS:
+            events.append({
+                "date": curr_date,
+                "prev_date": prev_date,
+                "field": key,
+                "kind": "text",
+                "before": before or "",
+                "after": after or "",
+            })
+        else:
+            # Unclassified field changed — emit once per (script-run, field)
+            # so scraper schema drift is visible in CI logs without drowning
+            # output when a field churns across many agencies.
+            if key not in _UNKNOWN_FIELDS_WARNED:
+                _UNKNOWN_FIELDS_WARNED.add(key)
+                print(f"  WARN: unclassified field '{key}' changed — "
+                      f"add to SCALAR/SET/COMMA_SET/TEXT/SKIP_FIELDS in "
+                      f"build_history.py to track",
+                      file=sys.stderr)
+    return events
+
+
+def build_agency_history(slug_dir: Path, reg_by_slug: dict) -> dict | None:
+    jsons = portal_jsons(slug_dir)
+    if not jsons:
+        return None
+
+    snapshots = [p.stem for p in jsons]
+    entry = reg_by_slug.get(slug_dir.name, {})
+
+    latest = json.loads(jsons[-1].read_text())
+    display_name = entry.get("display_name") or latest.get("crawled_name") or slug_dir.name
+
+    events = []
+    for i in range(1, len(jsons)):
+        prev = json.loads(jsons[i - 1].read_text())
+        curr = json.loads(jsons[i].read_text())
+        events.extend(_diff_pair(prev, curr, jsons[i - 1].stem, jsons[i].stem))
+
+    events.sort(key=lambda e: (e["date"], e["field"]), reverse=True)
+
+    return {
+        "slug": slug_dir.name,
+        "agency_id": entry.get("agency_id"),
+        "display_name": display_name,
+        "first_seen": snapshots[0],
+        "last_seen": snapshots[-1],
+        "snapshots": snapshots,
+        "events": events,
+    }
+
+
+def _resolve_name(name: str) -> dict:
+    """Return {name, slug, agency_id} for a sharing target, with nulls on miss."""
+    entry = resolve_agency(name=name)
+    if entry:
+        return {"name": name, "slug": entry.get("slug"), "agency_id": entry.get("agency_id")}
+    return {"name": name, "slug": None, "agency_id": None}
+
+
+def _build_changelog(all_histories: list[dict], oldest_snapshot: str | None) -> dict:
+    """Flatten recent events into a per-source-slug map for map-client use.
+
+    Only events with date >= today - RECENT_WINDOW_DAYS are included.
+    Sharing targets are resolved to slug+agency_id so the map can draw
+    edges (including ghost edges to former targets).
+    """
+    today = date.today()
+    cutoff = today - timedelta(days=RECENT_WINDOW_DAYS)
+    cutoff_str = cutoff.isoformat()
+
+    by_slug: dict[str, dict] = {}
+
+    for hist in all_histories:
+        slug = hist["slug"]
+        entry = {
+            "display_name": hist["display_name"],
+            "agency_id": hist["agency_id"],
+            "sharing_outbound_added": [],
+            "sharing_outbound_removed": [],
+            "sharing_inbound_added": [],
+            "sharing_inbound_removed": [],
+            "policy_events": [],
+        }
+        has_any = False
+        for ev in hist["events"]:
+            if ev["date"] < cutoff_str:
+                continue
+            field = ev["field"]
+            if field in ("sharing_outbound", "sharing_inbound") and ev["kind"] == "set":
+                added_key = f"{field}_added"
+                removed_key = f"{field}_removed"
+                for name in ev.get("added", []):
+                    entry[added_key].append({**_resolve_name(name), "date": ev["date"]})
+                    has_any = True
+                for name in ev.get("removed", []):
+                    entry[removed_key].append({**_resolve_name(name), "date": ev["date"]})
+                    has_any = True
+            else:
+                entry["policy_events"].append({
+                    "date": ev["date"],
+                    "field": field,
+                    "kind": ev["kind"],
+                    **({"before": ev["before"], "after": ev["after"]}
+                       if ev["kind"] in ("scalar", "text")
+                       else {"added": ev.get("added", []), "removed": ev.get("removed", [])}),
+                })
+                has_any = True
+        if has_any:
+            by_slug[slug] = entry
+
+    tracking_days = None
+    if oldest_snapshot:
+        try:
+            tracking_days = (today - date.fromisoformat(oldest_snapshot)).days
+        except ValueError:
+            pass
+
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_days": RECENT_WINDOW_DAYS,
+        "cutoff_date": cutoff_str,
+        "oldest_snapshot": oldest_snapshot,
+        "tracking_days": tracking_days,
+        "window_complete": tracking_days is not None and tracking_days >= RECENT_WINDOW_DAYS,
+        "by_slug": by_slug,
+    }
+
+
+def main():
+    if not DATA_DIR.is_dir():
+        print(f"No data directory at {DATA_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    reg_by_slug = registry_by_slug()
+    index = {}
+    total_events = 0
+    all_histories = []
+    oldest_snapshot = None
+
+    for slug_dir in sorted(DATA_DIR.iterdir()):
+        if not slug_dir.is_dir() or slug_dir.name.startswith("."):
+            continue
+        history = build_agency_history(slug_dir, reg_by_slug)
+        if history is None:
+            continue
+        out_path = OUT_DIR / f"{slug_dir.name}.json"
+        out_path.write_text(json.dumps(history, indent=2) + "\n")
+        index[slug_dir.name] = {
+            "agency_id": history["agency_id"],
+            "display_name": history["display_name"],
+            "first_seen": history["first_seen"],
+            "last_seen": history["last_seen"],
+            "snapshots": len(history["snapshots"]),
+            "events": len(history["events"]),
+        }
+        total_events += len(history["events"])
+        all_histories.append(history)
+        if oldest_snapshot is None or history["first_seen"] < oldest_snapshot:
+            oldest_snapshot = history["first_seen"]
+
+    index_path = OUT_DIR / "index.json"
+    index_path.write_text(json.dumps({
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "agencies": index,
+    }, indent=2) + "\n")
+
+    changelog = _build_changelog(all_histories, oldest_snapshot)
+    changelog_path = Path("docs/data/agency_changelog.json")
+    changelog_path.parent.mkdir(parents=True, exist_ok=True)
+    changelog_path.write_text(json.dumps(changelog, indent=2) + "\n")
+
+    print(f"Wrote history for {len(index)} agencies ({total_events} events total) to {OUT_DIR}/")
+    print(f"Wrote {RECENT_WINDOW_DAYS}d changelog for {len(changelog['by_slug'])} agencies to {changelog_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -26,6 +26,7 @@ import math
 import re
 import sys
 from collections import defaultdict
+from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -39,6 +40,7 @@ from lib import (
     load_registry,
     portal_jsons,
     registry_by_id,
+    resolve_agency,
 )
 from gazetteer import (
     county_fips_for_place,
@@ -51,7 +53,57 @@ from gazetteer import (
 
 GRAPH_PATH = Path("assets/transparency.flocksafety.com/.sharing_graph_full.json")
 DATA_DIR = Path("assets/transparency.flocksafety.com")
+HISTORY_DIR = Path("docs/data/history")
 OUT_PATH = Path("docs/data/report_data.json")
+RECENT_ADD_WINDOW_DAYS = 90
+
+
+def _load_sharing_history(reg_entry):
+    """Return (outbound_added_by_aid, outbound_removed_events) from history files.
+
+    outbound_added_by_aid: {target_agency_id: iso_date} — most recent add date
+    outbound_removed_events: [{agency_id, name, date, kind}] — one per removal event
+    """
+    slugs = list(reg_entry.get("flock_slugs") or [])
+    base = reg_entry.get("slug")
+    if base and base not in slugs:
+        slugs.append(base)
+    added_by_aid = {}
+    removed_events = []
+    for slug in slugs:
+        hist_path = HISTORY_DIR / f"{slug}.json"
+        if not hist_path.exists():
+            continue
+        try:
+            hist = json.loads(hist_path.read_text())
+        except json.JSONDecodeError:
+            continue
+        for ev in hist.get("events", []):
+            if ev.get("field") != "sharing_outbound" or ev.get("kind") != "set":
+                continue
+            ev_date = ev.get("date", "")
+            for name in ev.get("added", []):
+                target = resolve_agency(name=name)
+                if target:
+                    aid = target["agency_id"]
+                    prev = added_by_aid.get(aid)
+                    if prev is None or ev_date > prev:
+                        added_by_aid[aid] = ev_date
+            for name in ev.get("removed", []):
+                target = resolve_agency(name=name)
+                if target:
+                    removed_events.append({
+                        "agency_id": target["agency_id"],
+                        "name": name,
+                        "date": ev_date,
+                    })
+                else:
+                    removed_events.append({
+                        "agency_id": None,
+                        "name": name,
+                        "date": ev_date,
+                    })
+    return added_by_aid, removed_events
 
 RANKED_STATE = "CA"
 # 25 miles, expressed in km (the native unit of dist_km). Matches the
@@ -1375,19 +1427,67 @@ def main():
         # XSS surface. Source is the curated agency_registry.json (not
         # user input), but anyone editing the registry must avoid script
         # content — there's no sanitizer layer.
+        # Pull per-agency sharing history so we can annotate flagged
+        # recipients with "sharing started N days ago" (for recently-added
+        # flagged targets) and surface a "previously shared with X,
+        # removed DATE" list for flagged targets the agency has since
+        # dropped. Build_history.py must have run first.
+        added_on_by_aid, removed_events = _load_sharing_history(reg)
+        today = date.today()
+
         flagged_recipients = []
         for target_id in outbound_ids:
             kind = is_flagged_entity(target_id, reg_by_id)
             if kind:
                 tr = reg_by_id.get(target_id, {})
-                flagged_recipients.append({
+                entry_out = {
                     "agency_id": target_id,
                     "slug": id_to_slug.get(target_id, target_id),
                     "name": agency_display_name(tr, id_to_slug.get(target_id, target_id)),
                     "kind": kind,
                     "ag_lawsuit": has_tag(tr, "ag-lawsuit"),
                     "notes": tr.get("notes"),
-                })
+                }
+                added_on = added_on_by_aid.get(target_id)
+                if added_on:
+                    try:
+                        days_since = (today - date.fromisoformat(added_on)).days
+                        if days_since <= RECENT_ADD_WINDOW_DAYS:
+                            entry_out["added_on"] = added_on
+                            entry_out["days_since_added"] = days_since
+                    except ValueError:
+                        pass
+                flagged_recipients.append(entry_out)
+
+        # Removed-flagged: targets that were in sharing at some point,
+        # have since been removed, and would be flagged by current
+        # registry classification. Dedupe by agency_id keeping the most
+        # recent removal date.
+        current_outbound_set = set(outbound_ids)
+        removed_flagged_by_aid = {}
+        for ev in removed_events:
+            aid_r = ev["agency_id"]
+            if not aid_r or aid_r in current_outbound_set:
+                continue
+            kind = is_flagged_entity(aid_r, reg_by_id)
+            if not kind:
+                continue
+            existing = removed_flagged_by_aid.get(aid_r)
+            if existing is None or ev["date"] > existing["removed_on"]:
+                tr = reg_by_id.get(aid_r, {})
+                removed_flagged_by_aid[aid_r] = {
+                    "agency_id": aid_r,
+                    "slug": id_to_slug.get(aid_r, aid_r),
+                    "name": agency_display_name(tr, id_to_slug.get(aid_r, aid_r)),
+                    "kind": kind,
+                    "ag_lawsuit": has_tag(tr, "ag-lawsuit"),
+                    "removed_on": ev["date"],
+                }
+        removed_flagged_recipients = sorted(
+            removed_flagged_by_aid.values(),
+            key=lambda x: x["removed_on"],
+            reverse=True,
+        )
 
         # ── Inferred inbound (for uncrawled agencies mostly) ──
         inbound_source_ids = set(inbound_ids) | inbound_inferred_by_id.get(aid, set())
@@ -1561,6 +1661,7 @@ def main():
             "checklist_sb34": checklist_sb34,
             "checklist_transparency": checklist_transparency,
             "flagged_recipients": flagged_recipients,
+            "removed_flagged_recipients": removed_flagged_recipients,
             "outbound": outbound_list,
             "inbound": inbound_list,
             "regional": regional,

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -12,12 +12,19 @@ function safeSlug(s) { return SLUG_RE.test(s) ? s : ''; }
 // from sharing_map.html before this script. Call window.renderMeetingBannerHtml.
 
 // Load data
-fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
+Promise.all([
+  fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()),
+  fetch('data/agency_changelog.json?v=CACHE_BUST').then(r => r.ok ? r.json() : null).catch(() => null),
+]).then(([data, changelog]) => {
   const markers = data.markers;
   const coords = data.coords;
   const agencyInfo = data.agencyInfo;
   const mismatches = data.mismatches;
   const indirectFlags = data.indirectFlags || {};
+  const changelogBySlug = (changelog && changelog.by_slug) || {};
+  const changelogMeta = changelog || { window_days: 90, tracking_days: null, window_complete: false };
+  let showChanges = localStorage.getItem('smalpr-show-changes') !== 'false';
+  let currentSelectionSlug = null;
 
   const map = L.map('map').setView([37.5, -121.5], 7);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', {
@@ -285,6 +292,7 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
   function showAgency(m) {
     lineLayer.clearLayers();
     clearTempMarkers();
+    currentSelectionSlug = m.slug;
 
     // Reveal hidden markers connected to the selected agency
     const connectedSlugs = new Set([
@@ -356,6 +364,45 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
         });
         L.marker([topLat + 0.4, m.lng], { icon: overflowIcon }).addTo(lineLayer);
       }
+    }
+
+    // Overlay recent sharing changes for the selected agency (last 90d)
+    const chg = showChanges ? changelogBySlug[m.slug] : null;
+    if (chg) {
+      (chg.sharing_outbound_added || []).forEach(it => {
+        if (it.slug && coords[it.slug]) {
+          L.polyline([[m.lat, m.lng], coords[it.slug]], {
+            color: '#16a34a', weight: 4, opacity: 0.55,
+          }).addTo(lineLayer).bindTooltip(
+            'Started sharing on/around ' + it.date,
+            { direction: 'top', sticky: true }
+          );
+        }
+      });
+      (chg.sharing_outbound_removed || []).forEach(it => {
+        if (it.slug && coords[it.slug]) {
+          const tCoord = coords[it.slug];
+          L.polyline([[m.lat, m.lng], tCoord], {
+            color: '#9ca3af', weight: 1.5, opacity: 0.6, dashArray: '6 5',
+          }).addTo(lineLayer).bindTooltip(
+            'Stopped sharing on/around ' + it.date,
+            { direction: 'top', sticky: true }
+          );
+          const xIcon = L.divIcon({
+            html: '<div style="font-size:18px;font-weight:bold;color:#dc2626;text-shadow:0 0 2px #fff,0 0 2px #fff,0 0 2px #fff;line-height:1">\u2716</div>',
+            className: '',
+            iconSize: [20, 20],
+            iconAnchor: [10, 10],
+          });
+          const tName = (agencyInfo[it.slug] || {}).name || it.name;
+          L.marker(tCoord, { icon: xIcon, zIndexOffset: 500 })
+            .addTo(lineLayer)
+            .bindTooltip(
+              escapeHtml(tName) + ' \u2014 sharing stopped on/around ' + it.date,
+              { direction: 'top', offset: [0, -8], sticky: true }
+            );
+        }
+      });
     }
 
     let inConnected = 0;
@@ -882,6 +929,50 @@ fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()).then(data => {
       searchResults.style.display = 'none';
     }
   });
+
+  // Change-overlay toggle in the legend
+  const legendEl = document.querySelector('.legend');
+  if (legendEl) {
+    const divider = document.createElement('div');
+    divider.style.cssText = 'border-top:1px solid #e5e7eb;margin:6px 0 4px';
+    legendEl.appendChild(divider);
+
+    const addedItem = document.createElement('div');
+    addedItem.className = 'legend-item';
+    addedItem.innerHTML = '<div style="width:20px;height:3px;background:#16a34a"></div> Sharing started (last 90d)';
+    legendEl.appendChild(addedItem);
+
+    const removedItem = document.createElement('div');
+    removedItem.className = 'legend-item';
+    removedItem.innerHTML = '<div style="width:20px;height:2px;background:repeating-linear-gradient(90deg,#9ca3af 0,#9ca3af 4px,transparent 4px,transparent 7px)"></div> <span style="color:#dc2626;font-weight:bold;margin:0 2px">\u2716</span> Sharing stopped (last 90d)';
+    legendEl.appendChild(removedItem);
+
+    const toggleWrap = document.createElement('label');
+    toggleWrap.className = 'legend-item';
+    toggleWrap.style.cssText = 'cursor:pointer;user-select:none';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = showChanges;
+    cb.style.cssText = 'margin:0 6px 0 0';
+    toggleWrap.appendChild(cb);
+    toggleWrap.appendChild(document.createTextNode('Show recent changes'));
+    cb.addEventListener('change', () => {
+      showChanges = cb.checked;
+      localStorage.setItem('smalpr-show-changes', String(showChanges));
+      if (currentSelectionSlug) {
+        const md = markerDataBySlug[currentSelectionSlug];
+        if (md) showAgency(md);
+      }
+    });
+    legendEl.appendChild(toggleWrap);
+
+    if (!changelogMeta.window_complete && changelogMeta.tracking_days != null) {
+      const note = document.createElement('div');
+      note.style.cssText = 'font-size:10px;color:#6b7280;margin-top:2px;font-style:italic;line-height:1.3';
+      note.textContent = 'Only ' + changelogMeta.tracking_days + ' days tracked so far — window will grow to 90.';
+      legendEl.appendChild(note);
+    }
+  }
 
   // Auto-select agency from URL hash (e.g. #san-mateo-ca-pd)
   const hashSlug = decodeURIComponent(window.location.hash.replace('#', ''));


### PR DESCRIPTION
## Summary
Adds `scripts/build_history.py` (new) which diffs consecutive dated transparency snapshots per agency and writes:
- `docs/data/history/<slug>.json` — full event timeline per agency (scalar / set / text changes across sharing lists, retention, policy texts, etc.)
- `docs/data/history/index.json` — lightweight directory of who has history
- `docs/data/agency_changelog.json` — 90-day aggregate used by the map client

### Per-agency report surfaces (`docs/js/report.js`)
- "**NEW — started N days ago**" badge on recently-added flagged recipients
- "**previously flagged recipients removed**" section listing flagged entities that were in the sharing list and have since been dropped (de-duped by most-recent removal, filtered to those not currently present)

### Sharing map surfaces (`scripts/map.js`)
- Green solid lines from the selected agency to recently-added targets
- Gray dashed lines + red-X markers to recently-removed targets
- Legend toggle to hide/show; persists in `localStorage`
- "Partial window" notice when `tracking_days < 90`

### Plumbing
- Wired into `ci.yml`, `deploy.yml`, and `refresh-flock-data.yml` sequentially before the parallel builders so `build_report_data.py` can read history output.
- `build_report_data.py` tolerates missing history files — pre-wiring deploys degrade cleanly.
- `.gitignore` picks up `docs/data/history/` and `docs/data/agency_changelog.json` (both pure build outputs).

### Design notes
- Uses the `portal_jsons()` helper from `scripts/lib.py` — no private date-pattern regex in this script. Same helper PR #125 introduced.
- Schema-drift detector: any unclassified field that changes between snapshots emits a one-time `WARN` to stderr naming the field and pointing at the classification lists. Used during development to catch and classify `sb54`, `sharing_info`, `success_stories`, `policy_info`, `alpr_policy`, `additional_info` (text); `crawled_at`, `search_audit_csv` (skip).
- XSS surface: all new JS injection paths `escapeHtml()` user-facing strings (names, kinds, dates). `policy_events` is populated in the changelog but not yet rendered in UI — future consumer must escape.

### Narrow UI slice, intentionally
The data layer captures more than is surfaced today — the full per-agency event timeline (retention changes, policy flip-flops, access-policy rewrites) sits in `history/<slug>.json` ready for follow-up renderers. This PR ships the plumbing plus the two narrowest user-facing surfaces.

## Test plan
- [ ] CI runs `build_history.py` ahead of `build_report_data.py` and both succeed.
- [ ] Smoke test (`test_map_smoke.py`) still passes — no new body-level positioned overlays introduced (all additions are children of `.legend` or Leaflet overlays inside `#map`).
- [ ] PR preview screenshots render the new report sections and map overlays on an agency with recent changes.
- [ ] `docs/data/history/<slug>.json` and `docs/data/agency_changelog.json` are excluded from git (verify `git status` is clean after a local build).