### PR TITLE
fix(flock_transparency): skip missing slug dir in depth-crawl discovery

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -837,6 +837,8 @@ def cmd_crawl(args):
                 for s in slugs:
                     if s in visited:
                         slug_dir = data_dir / s
+                        if not slug_dir.is_dir():
+                            continue
                         jsons = portal_jsons(slug_dir)
                         if jsons:
                             stored = json.loads(jsons[-1].read_text())

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -837,6 +837,10 @@ def cmd_crawl(args):
                 for s in slugs:
                     if s in visited:
                         slug_dir = data_dir / s
+                        # No dir means this slug is in `visited` via failed_slugs
+                        # (never successfully captured). Nothing to harvest from.
+                        # Whether it gets crawled is decided below at `new_slugs`;
+                        # skipping here only opts out of the outbound-sharing read.
                         if not slug_dir.is_dir():
                             continue
                         jsons = portal_jsons(slug_dir)


### PR DESCRIPTION
## Summary
- Nightly `flock_transparency.py crawl --all-agencies` crashed with `FileNotFoundError: assets/transparency.flocksafety.com/san-jose-state-university-ca` after capturing the last seed slug.
- Root cause: the depth-crawl discovery loop (`cmd_crawl`, ~L837) iterates every seed slug already in `visited` and calls `portal_jsons(slug_dir)` to read its stored outbound sharing list. `visited` is populated from both `hashes` (successful captures, dir exists) and `failed_slugs` (never-captured, no dir). On the first previously-failed seed the read blew up.
- Fix: guard the read site with `slug_dir.is_dir()` and `continue`. Matches the existing pattern at the three other read sites in the same module ([L173-174](scripts/flock_transparency.py#L173-L174), [L190-191](scripts/flock_transparency.py#L190-L191), [L202-203](scripts/flock_transparency.py#L202-L203)). The write path at [L604-605](scripts/flock_transparency.py#L604-L605) already `mkdir`s when a capture succeeds, so "no dir" genuinely means "nothing to read."

## Test plan
- [x] `python3 -m pytest tests/test_flock_transparency_headings.py tests/test_flock_csv.py tests/test_audit_log.py tests/test_diff_scrapes.py` — 36 passed
- [ ] Next scheduled crawl completes without FileNotFoundError on previously-failed slugs