### PR TITLE
feat(contracts): nationwide map of terminated ALPR contracts (preview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/data/scoreboard_data.json
 docs/data/audit/
 docs/data/history/
 docs/data/agency_changelog.json
+docs/data/contract_map_data.json
 docs/js/map.js
 assets/transparency.flocksafety.com/.sharing_graph_full.json
 assets/**/_pending/

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -27819,7 +27819,7 @@
   },
   {
     "agency_id": "b78b4a4c-e8ea-5a96-9edd-585d0b0d1ce1",
-    "slug": "oak-park-il-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -27843,7 +27843,7 @@
   },
   {
     "agency_id": "a597ac19-0e62-585c-82a0-f9c7b87c55e8",
-    "slug": "evanston-il-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -27868,9 +27868,13 @@
   {
     "agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "slug": "austin-tx-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "austin-tx-pd",
+    "flock_slugs": [
+      "austin-tx-pd"
+    ],
+    "flock_names": [
+      "Austin Police Department"
+    ],
     "display_name": "Austin Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -27892,9 +27896,13 @@
   {
     "agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "slug": "denver-co-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "denver-co-pd",
+    "flock_slugs": [
+      "denver-co-pd"
+    ],
+    "flock_names": [
+      "Denver Police Department"
+    ],
     "display_name": "Denver Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -27916,9 +27924,13 @@
   {
     "agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "slug": "charlottesville-va-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "charlottesville-va-pd",
+    "flock_slugs": [
+      "charlottesville-va-pd"
+    ],
+    "flock_names": [
+      "Charlottesville Police Department"
+    ],
     "display_name": "Charlottesville Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -27940,9 +27952,13 @@
   {
     "agency_id": "4cec1b92-d54e-5ef1-aebb-11d93521b4a5",
     "slug": "staunton-va-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "staunton-va-pd",
+    "flock_slugs": [
+      "staunton-va-pd"
+    ],
+    "flock_names": [
+      "Staunton Police Department"
+    ],
     "display_name": "Staunton Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -27964,9 +27980,9 @@
   {
     "agency_id": "86e9b8be-f02d-50c0-a0f8-9ed7b2b378a4",
     "slug": "flagstaff-az-pd",
-    "flock_active_slug": "flagstaff-az-pd-inactive",
+    "flock_active_slug": "flagstaff-az-pd",
     "flock_slugs": [
-      "flagstaff-az-pd-inactive"
+      "flagstaff-az-pd"
     ],
     "flock_names": [
       "Flagstaff Police Department"
@@ -27991,7 +28007,7 @@
   },
   {
     "agency_id": "a6ee05fe-842e-512c-9cae-13bb118682c0",
-    "slug": "cambridge-ma-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28016,9 +28032,13 @@
   {
     "agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
     "slug": "eugene-or-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "eugene-or-pd",
+    "flock_slugs": [
+      "eugene-or-pd"
+    ],
+    "flock_names": [
+      "Eugene Police Department"
+    ],
     "display_name": "Eugene Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -28039,7 +28059,7 @@
   },
   {
     "agency_id": "d22f3264-52b5-5139-ad7c-849564e02eb1",
-    "slug": "ithaca-ny-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28064,9 +28084,13 @@
   {
     "agency_id": "2cc3a31d-7f98-5714-bc85-927815444575",
     "slug": "tompkins-county-ny-so",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "tompkins-county-ny-so",
+    "flock_slugs": [
+      "tompkins-county-ny-so"
+    ],
+    "flock_names": [
+      "Tompkins County Sheriff's Office"
+    ],
     "display_name": "Tompkins County Sheriff's Office",
     "agency_role": "sheriff",
     "agency_type": "county",
@@ -28088,9 +28112,13 @@
   {
     "agency_id": "b994e41b-23e6-5392-ba7b-821af80978f0",
     "slug": "hillsborough-nc-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "hillsborough-nc-pd",
+    "flock_slugs": [
+      "hillsborough-nc-pd"
+    ],
+    "flock_names": [
+      "Hillsborough Police Department"
+    ],
     "display_name": "Hillsborough Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -28111,7 +28139,7 @@
   },
   {
     "agency_id": "40521632-8a29-5e5d-a064-1b57410743b5",
-    "slug": "coralville-ia-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28136,9 +28164,13 @@
   {
     "agency_id": "5b70f7bd-e72b-5f98-b6f2-58a611e13ed3",
     "slug": "lynnwood-wa-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "lynnwood-wa-pd",
+    "flock_slugs": [
+      "lynnwood-wa-pd"
+    ],
+    "flock_names": [
+      "Lynnwood Police Department"
+    ],
     "display_name": "Lynnwood Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -28159,7 +28191,7 @@
   },
   {
     "agency_id": "80fc5e77-78d4-5499-abf4-9cda8cfb284d",
-    "slug": "olympia-wa-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28183,7 +28215,7 @@
   },
   {
     "agency_id": "64f3e786-cdc0-575d-ad89-b15f8695ebe8",
-    "slug": "redmond-wa-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28208,9 +28240,13 @@
   {
     "agency_id": "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712",
     "slug": "oshkosh-wi-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "oshkosh-wi-pd",
+    "flock_slugs": [
+      "oshkosh-wi-pd"
+    ],
+    "flock_names": [
+      "Oshkosh Police Department"
+    ],
     "display_name": "Oshkosh Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -28232,9 +28268,13 @@
   {
     "agency_id": "50dc11c1-7f4e-557f-b65c-6666d43832a0",
     "slug": "windsor-ct-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [],
+    "flock_active_slug": "windsor-ct-pd",
+    "flock_slugs": [
+      "windsor-ct-pd"
+    ],
+    "flock_names": [
+      "Windsor Police Department"
+    ],
     "display_name": "Windsor Police Department",
     "agency_role": "police",
     "agency_type": "city",
@@ -28255,7 +28295,7 @@
   },
   {
     "agency_id": "356e30e5-12d3-5ff7-b563-6de8c10c553b",
-    "slug": "columbus-oh-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28279,7 +28319,7 @@
   },
   {
     "agency_id": "5b574464-e076-5bc0-8c62-e3052ecf8723",
-    "slug": "el-paso-tx-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],
@@ -28303,7 +28343,7 @@
   },
   {
     "agency_id": "97f69d1e-5db1-5a4d-a95a-7314e28d0ad1",
-    "slug": "bloomington-in-pd",
+    "slug": null,
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [],

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -27788,5 +27788,541 @@
       "state": "CA"
     },
     "flags": []
+  },
+  {
+    "agency_id": "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
+    "slug": "mountain-view-ca-pd",
+    "flock_active_slug": "mountain-view-ca-pd",
+    "flock_slugs": [
+      "mountain-view-ca-pd"
+    ],
+    "flock_names": [
+      "Mountain View Police Department"
+    ],
+    "display_name": "Mountain View Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "0649670",
+      "name": "Mountain View",
+      "state": "CA",
+      "lat": 37.399686,
+      "lng": -122.079269
+    }
+  },
+  {
+    "agency_id": "b78b4a4c-e8ea-5a96-9edd-585d0b0d1ce1",
+    "slug": "oak-park-il-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Oak Park Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "1754885",
+      "name": "Oak Park",
+      "state": "IL",
+      "lat": 41.887164,
+      "lng": -87.78994
+    }
+  },
+  {
+    "agency_id": "a597ac19-0e62-585c-82a0-f9c7b87c55e8",
+    "slug": "evanston-il-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Evanston Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "1724582",
+      "name": "Evanston",
+      "state": "IL",
+      "lat": 42.046391,
+      "lng": -87.694352
+    }
+  },
+  {
+    "agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
+    "slug": "austin-tx-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Austin Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4805000",
+      "name": "Austin",
+      "state": "TX",
+      "lat": 30.298622,
+      "lng": -97.754134
+    }
+  },
+  {
+    "agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
+    "slug": "denver-co-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Denver Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "0820000",
+      "name": "Denver",
+      "state": "CO",
+      "lat": 39.76185,
+      "lng": -104.881105
+    }
+  },
+  {
+    "agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
+    "slug": "charlottesville-va-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Charlottesville Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5114968",
+      "name": "Charlottesville",
+      "state": "VA",
+      "lat": 38.037658,
+      "lng": -78.485381
+    }
+  },
+  {
+    "agency_id": "4cec1b92-d54e-5ef1-aebb-11d93521b4a5",
+    "slug": "staunton-va-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Staunton Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5175216",
+      "name": "Staunton",
+      "state": "VA",
+      "lat": 38.157978,
+      "lng": -79.061876
+    }
+  },
+  {
+    "agency_id": "86e9b8be-f02d-50c0-a0f8-9ed7b2b378a4",
+    "slug": "flagstaff-az-pd",
+    "flock_active_slug": "flagstaff-az-pd-inactive",
+    "flock_slugs": [
+      "flagstaff-az-pd-inactive"
+    ],
+    "flock_names": [
+      "Flagstaff Police Department"
+    ],
+    "display_name": "Flagstaff Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "0423620",
+      "name": "Flagstaff",
+      "state": "AZ",
+      "lat": 35.185212,
+      "lng": -111.620698
+    }
+  },
+  {
+    "agency_id": "a6ee05fe-842e-512c-9cae-13bb118682c0",
+    "slug": "cambridge-ma-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Cambridge Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "2511000",
+      "name": "Cambridge",
+      "state": "MA",
+      "lat": 42.376043,
+      "lng": -71.11868
+    }
+  },
+  {
+    "agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
+    "slug": "eugene-or-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Eugene Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4123850",
+      "name": "Eugene",
+      "state": "OR",
+      "lat": 44.056848,
+      "lng": -123.119019
+    }
+  },
+  {
+    "agency_id": "d22f3264-52b5-5139-ad7c-849564e02eb1",
+    "slug": "ithaca-ny-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Ithaca Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "3638077",
+      "name": "Ithaca",
+      "state": "NY",
+      "lat": 42.443937,
+      "lng": -76.503055
+    }
+  },
+  {
+    "agency_id": "2cc3a31d-7f98-5714-bc85-927815444575",
+    "slug": "tompkins-county-ny-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Tompkins County Sheriff's Office",
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "36109",
+      "name": "Tompkins",
+      "state": "NY",
+      "lat": 42.453006,
+      "lng": -76.473483
+    }
+  },
+  {
+    "agency_id": "b994e41b-23e6-5392-ba7b-821af80978f0",
+    "slug": "hillsborough-nc-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Hillsborough Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "3731620",
+      "name": "Hillsborough",
+      "state": "NC",
+      "lat": 36.077903,
+      "lng": -79.097979
+    }
+  },
+  {
+    "agency_id": "40521632-8a29-5e5d-a064-1b57410743b5",
+    "slug": "coralville-ia-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Coralville Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "1916230",
+      "name": "Coralville",
+      "state": "IA",
+      "lat": 41.698795,
+      "lng": -91.5968
+    }
+  },
+  {
+    "agency_id": "5b70f7bd-e72b-5f98-b6f2-58a611e13ed3",
+    "slug": "lynnwood-wa-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Lynnwood Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5340840",
+      "name": "Lynnwood",
+      "state": "WA",
+      "lat": 47.828979,
+      "lng": -122.300672
+    }
+  },
+  {
+    "agency_id": "80fc5e77-78d4-5499-abf4-9cda8cfb284d",
+    "slug": "olympia-wa-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Olympia Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5351300",
+      "name": "Olympia",
+      "state": "WA",
+      "lat": 47.040604,
+      "lng": -122.895
+    }
+  },
+  {
+    "agency_id": "64f3e786-cdc0-575d-ad89-b15f8695ebe8",
+    "slug": "redmond-wa-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Redmond Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5357535",
+      "name": "Redmond",
+      "state": "WA",
+      "lat": 47.677924,
+      "lng": -122.115336
+    }
+  },
+  {
+    "agency_id": "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712",
+    "slug": "oshkosh-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Oshkosh Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5560500",
+      "name": "Oshkosh",
+      "state": "WI",
+      "lat": 44.023168,
+      "lng": -88.56226
+    }
+  },
+  {
+    "agency_id": "50dc11c1-7f4e-557f-b65c-6666d43832a0",
+    "slug": "windsor-ct-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Windsor Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "cousub",
+      "fips": "0911087000",
+      "name": "Windsor",
+      "state": "CT",
+      "lat": 41.871037,
+      "lng": -72.675082
+    }
+  },
+  {
+    "agency_id": "356e30e5-12d3-5ff7-b563-6de8c10c553b",
+    "slug": "columbus-oh-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Columbus Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
+    }
+  },
+  {
+    "agency_id": "5b574464-e076-5bc0-8c62-e3052ecf8723",
+    "slug": "el-paso-tx-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "El Paso Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4824000",
+      "name": "El Paso",
+      "state": "TX",
+      "lat": 31.84778,
+      "lng": -106.431106
+    }
+  },
+  {
+    "agency_id": "97f69d1e-5db1-5a4d-a95a-7314e28d0ad1",
+    "slug": "bloomington-in-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [],
+    "display_name": "Bloomington Police Department",
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "notes": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "1805860",
+      "name": "Bloomington",
+      "state": "IN",
+      "lat": 39.1637,
+      "lng": -86.524264
+    }
   }
 ]

--- a/data/contracts/README.md
+++ b/data/contracts/README.md
@@ -69,6 +69,7 @@ added there first — see the workflow below.
   "outlet": "San Francisco Chronicle",
   "author": "Jane Doe",
   "published_date": "2025-06-15",
+  "quote": "This program does not best reflect our community's priorities.",
   "summary": null,
   "tags": []
 }
@@ -76,6 +77,10 @@ added there first — see the workflow below.
 
 - `id`: stable slug. Convention: `<outlet-slug>-<YYYY-MM-DD>-<shortkey>`.
 - `url`, `title`, `outlet`, `published_date` required.
+- `quote` optional — a verbatim one-liner to highlight in the UI
+  (official statement, council-member remark, etc.). Use direct quotes
+  only; editorial paraphrases do not belong here. Rendered as a
+  pull-quote below the title in the agency side panel.
 - `author`, `summary`, `tags` optional.
 
 ## Adding a new case

--- a/data/contracts/README.md
+++ b/data/contracts/README.md
@@ -1,0 +1,116 @@
+# ALPR Contract Status — curated data
+
+Hand-curated data powering `docs/contracts.html`: a nationwide map of agencies
+that have canceled, paused, are reviewing, or are considering ending their
+ALPR contracts. Vendor-agnostic — tracks Flock, Motorola Vigilant, Axon Fusus,
+Rekor, etc.
+
+**Agency identity lives in `assets/agency_registry.json`** (central registry
+for all tools in this repo). Contract-map events reference agencies by their
+registry `agency_id` (UUID). An agency that isn't yet in the registry must be
+added there first — see the workflow below.
+
+## Files in this directory
+
+- `events.json` — flat list of timeline events (signed / canceled / etc.).
+- `articles.json` — article metadata. Referenced by events via `article_ids`.
+
+## Schema
+
+### events.json
+
+```json
+{
+  "agency_id": "8e97dede-dc5e-518a-bd9c-ca1acce1757a",
+  "type": "canceled",
+  "date": "2026-01-13",
+  "vendor": "flock",
+  "cameras_affected": null,
+  "article_ids": ["santacruzlocal-2026-01-13"],
+  "reasons": ["federal-access", "unauthorized-access"],
+  "notes": "6-1 council vote. First CA city to terminate."
+}
+```
+
+- `agency_id`: **registry UUID** from `assets/agency_registry.json`. Build
+  fails loudly if the id isn't present in the registry.
+- `type`: one of `signed`, `considering`, `reviewing`, `paused`, `canceled`,
+  `reinstated`.
+- `date`: `YYYY-MM-DD` preferred. `YYYY-MM` and `YYYY` also accepted. Null
+  for events with no pinnable date.
+- `vendor`: which ALPR vendor this event is about. An agency using both
+  Flock and Vigilant will have vendor-tagged events for each.
+- `cameras_affected`: optional integer — how many cameras the event touches
+  (e.g. "canceled their 500 cameras"). Editorial; pulled from the article.
+- `article_ids`: zero or more article ids from `articles.json`. Build fails
+  if any id is missing.
+- `reasons`: zero or more reason codes. Rendered as colored chips in the UI.
+  Build fails on unknown codes. Known codes:
+  - `federal-access` — ICE/CBP/DHS access or unreviewed federal sharing
+  - `unauthorized-access` — out-of-state or third-party agencies ran
+    searches without approval (e.g. Mountain View's 250+ unauthorized
+    agencies)
+  - `vendor-misconduct` — Flock's own conduct (e.g. Cambridge's unauthorized
+    installs, Oshkosh's heatmap misrepresentation)
+  - `broad-disclosure` — contract language allows disclosure to any gov
+    entity or third party (e.g. Hillsborough)
+  - `sanctuary-conflict` — conflicts with the jurisdiction's sanctuary
+    ordinance (e.g. Oak Park)
+  - `data-breach` — actual breach or unauthorized exposure
+  - `privacy-general` — catchall for general privacy concerns
+
+### articles.json
+
+```json
+{
+  "id": "sfchron-2025-06-15-sfpd-drops-flock",
+  "url": "https://www.sfchronicle.com/...",
+  "title": "San Francisco police will stop using Flock cameras",
+  "outlet": "San Francisco Chronicle",
+  "author": "Jane Doe",
+  "published_date": "2025-06-15",
+  "summary": null,
+  "tags": []
+}
+```
+
+- `id`: stable slug. Convention: `<outlet-slug>-<YYYY-MM-DD>-<shortkey>`.
+- `url`, `title`, `outlet`, `published_date` required.
+- `author`, `summary`, `tags` optional.
+
+## Adding a new case
+
+1. **Agency missing from registry?** Add it. Two paths:
+   - Edit `scripts/seed_contract_registry.py` and add a row to `SEEDS`,
+     then run `uv run python scripts/seed_contract_registry.py`. This
+     auto-geocodes via the Census gazetteer. Idempotent — re-running with
+     the same slug is a no-op.
+   - Or edit `assets/agency_registry.json` directly (follow the shape of
+     existing entries). Use `uv run python scripts/geocode_agencies.py
+     --apply` to backfill `geo`.
+2. **Add the article** to `articles.json` with a stable `id`.
+3. **Add one or more events** to `events.json` — one per reported state
+   change — each referencing the agency's registry `agency_id` and the
+   article `id`.
+4. Run `uv run python scripts/build_contract_map.py`. It validates
+   references and regenerates `docs/data/contract_map_data.json`.
+
+## Derived status
+
+The build script computes the "current" status per agency/vendor from the
+most recent event. The map marker reflects the most serious status across
+all vendors for that agency (ordering: `canceled > paused > reviewing >
+considering > reinstated > signed`).
+
+## Flock transparency enrichment
+
+When a registry entry has `flock_active_slug` set and there's crawled data
+under `assets/transparency.flocksafety.com/<slug>/`, the build script
+attaches a `flock_snapshot` to the agency payload: live camera count,
+30-day activity stats, and a link to the Flock portal. If two snapshots
+are at least 14 days apart, the older one is also included as
+`flock_snapshot_prior` so the UI can show "cameras dropped from X to Y".
+
+Cancellations on agencies whose Flock portals are still up are especially
+interesting — the UI shows the live portal alongside the cancellation
+event.

--- a/data/contracts/articles.json
+++ b/data/contracts/articles.json
@@ -266,6 +266,18 @@
     "outlet": "The Ithaca Voice",
     "author": null,
     "published_date": "2026-03-05",
+    "quote": null,
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "ithacacom-2026-03-exit",
+    "url": "https://www.ithaca.com/news/ithaca/flock-safety-set-to-exit-ithaca-following-common-council-vote/article_a71585bc-3ee7-4015-9a75-f934ec3ada45.html",
+    "title": "Flock Safety Set to Exit Ithaca Following Common Council Vote",
+    "outlet": "ithaca.com",
+    "author": null,
+    "published_date": "2026-03-05",
+    "quote": "I don't know that I could live with myself if I allowed something to exist in our community that directly or indirectly led to someone's civil liberties being violated.",
     "summary": null,
     "tags": []
   },

--- a/data/contracts/articles.json
+++ b/data/contracts/articles.json
@@ -1,0 +1,392 @@
+[
+  {
+    "id": "eff-2025-06-austin-cancel",
+    "url": "https://www.eff.org/deeplinks/2025/06/victory-austin-organizers-cancel-citys-flock-alpr-contract",
+    "title": "Victory! Austin Organizers Cancel City's Flock ALPR Contract",
+    "outlet": "Electronic Frontier Foundation",
+    "author": null,
+    "published_date": "2025-06-04",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "kut-2025-06-04-austin-ends",
+    "url": "https://www.kut.org/austin/2025-06-04/austin-tx-automatic-license-reader-program-police-data-privacy-flock",
+    "title": "Austin's license plate reader program will end this month",
+    "outlet": "KUT (Austin NPR)",
+    "author": null,
+    "published_date": "2025-06-04",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "kut-2026-02-12-austin-loophole",
+    "url": "https://www.kut.org/crime-justice/2026-02-12/austin-tx-apd-flock-cameras-license-plate-readers",
+    "title": "Austin ended its license plate reader program. Then the police department found a loophole.",
+    "outlet": "KUT (Austin NPR)",
+    "author": null,
+    "published_date": "2026-02-12",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "oakpark-2025-08-07-terminates",
+    "url": "https://www.oakpark.com/2025/08/07/oak-park-terminates-flock-license-plate-reader-contract/",
+    "title": "Oak Park terminates Flock license plate reader contract",
+    "outlet": "Wednesday Journal (Oak Park)",
+    "author": null,
+    "published_date": "2025-08-07",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "oakpark-2025-08-28-state-broke-law",
+    "url": "https://www.oakpark.com/2025/08/28/state-says-flock-safety-broke-the-law/",
+    "title": "After Oak Park cut ties, state says Flock Safety broke the law",
+    "outlet": "Wednesday Journal (Oak Park)",
+    "author": null,
+    "published_date": "2025-08-28",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "abc7-2025-08-27-evanston-oakpark",
+    "url": "https://abc7chicago.com/post/evanston-oak-park-end-contracts-flock-safety-license-plate-reader-company-investigation-illinois/17678137/",
+    "title": "Evanston, Oak Park end contracts with Flock Safety, license plate reader company under investigation in Illinois",
+    "outlet": "ABC7 Chicago",
+    "author": null,
+    "published_date": "2025-08-27",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "patch-2025-08-27-evanston-deactivates",
+    "url": "https://patch.com/illinois/evanston/evanston-deactivates-license-plate-cameras-terminates-contract-flock-safety",
+    "title": "Evanston Deactivates License Plate Cameras, Terminates Contract With Flock Safety",
+    "outlet": "Evanston Patch",
+    "author": null,
+    "published_date": "2025-08-27",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "hillsboroughnc-2025-10-cancel",
+    "url": "https://www.hillsboroughnc.gov/Home/Components/News/News/856/14",
+    "title": "Hillsborough Cancels Contract for License Plate Reader Cameras",
+    "outlet": "Town of Hillsborough",
+    "author": null,
+    "published_date": "2025-10-28",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "dth-2025-11-11-hillsborough",
+    "url": "https://dailytarheel.com/article/city-hillsborough-flock-safety-cameras-20251111",
+    "title": "Hillsborough cancels license plate reader cameras due to data privacy concerns",
+    "outlet": "Daily Tar Heel",
+    "author": null,
+    "published_date": "2025-11-11",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "cambridgema-2025-12-statement",
+    "url": "https://www.cambridgema.gov/news/2025/12/statementontheflocksafetyalprcontracttermination",
+    "title": "Statement on the Flock Safety ALPR Contract Termination",
+    "outlet": "City of Cambridge",
+    "author": null,
+    "published_date": "2025-12-11",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "bostoncom-2025-12-11-cambridge",
+    "url": "https://www.boston.com/news/local-news/2025/12/11/cambridge-ends-contract-for-license-plate-cameras-after-breach-of-trust/",
+    "title": "Cambridge ends contract for license plate cameras after 'breach of trust'",
+    "outlet": "Boston.com",
+    "author": null,
+    "published_date": "2025-12-11",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "lookout-2025-12-05-eugene",
+    "url": "https://lookouteugene-springfield.com/story/justice/2025/12/05/eugene-announces-termination-of-flock-contract/",
+    "title": "Eugene, Springfield announce end of Flock cameras",
+    "outlet": "Lookout Eugene-Springfield",
+    "author": null,
+    "published_date": "2025-12-05",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "opb-2025-12-06-eugene-springfield",
+    "url": "https://www.opb.org/article/2025/12/06/eugene-springfield-end-flock-cameras/",
+    "title": "Eugene and Springfield both announce end of Flock camera usage",
+    "outlet": "OPB",
+    "author": null,
+    "published_date": "2025-12-06",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "29news-2025-12-17-cville",
+    "url": "https://www.29news.com/2025/12/17/charlottesville-ends-flock-camera-pilot-program-over-privacy-concerns/",
+    "title": "Charlottesville ends Flock camera pilot program over privacy concerns",
+    "outlet": "29News",
+    "author": null,
+    "published_date": "2025-12-17",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "wvtf-2026-01-15-cville-staunton",
+    "url": "https://www.wvtf.org/news/2026-01-15/charlottesville-and-staunton-cancel-license-plate-reading-technology",
+    "title": "Charlottesville and Staunton cancel license plate reading technology",
+    "outlet": "WVTF",
+    "author": null,
+    "published_date": "2026-01-15",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "staunton-2025-12-19-terminate",
+    "url": "https://www.ci.staunton.va.us/Home/Components/News/News/2564/71",
+    "title": "City to Terminate Contract with Flock Safety for License Plate Readers",
+    "outlet": "City of Staunton",
+    "author": null,
+    "published_date": "2025-12-19",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "flagstaff-2025-12-20-removed",
+    "url": "https://www.flagstaff.az.gov/m/newsflash/home/detail/2229",
+    "title": "Flock Safety cameras removed",
+    "outlet": "City of Flagstaff",
+    "author": null,
+    "published_date": "2025-12-20",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "azfamily-2025-12-20-flagstaff",
+    "url": "https://www.azfamily.com/2025/12/20/flagstaff-cancels-controversial-contract-flock-safety-cameras/",
+    "title": "Flagstaff cancels controversial contract for Flock Safety cameras",
+    "outlet": "AZ Family",
+    "author": null,
+    "published_date": "2025-12-20",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "santacruzlocal-2026-01-13",
+    "url": "https://santacruzlocal.org/2026/01/13/santa-cruz-leaders-vote-to-terminate-contract-with-flock/",
+    "title": "Santa Cruz leaders vote to terminate contract with Flock",
+    "outlet": "Santa Cruz Local",
+    "author": null,
+    "published_date": "2026-01-13",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "kqed-2026-01-santa-cruz-first",
+    "url": "https://www.kqed.org/news/12069705/santa-cruz-the-first-in-california-to-terminate-its-contract-with-flock-safety",
+    "title": "Santa Cruz the First in California to Terminate Its Contract With Flock Safety",
+    "outlet": "KQED",
+    "author": null,
+    "published_date": "2026-01-14",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "littlevillage-2026-02-coralville",
+    "url": "https://littlevillagemag.com/flock-alpr-cameras-removed-coralville/",
+    "title": "Coralville City Council ends Flock contract signed by police chief after backlash",
+    "outlet": "Little Village",
+    "author": null,
+    "published_date": "2026-02-10",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "yahoo-2026-02-lynnwood",
+    "url": "https://www.yahoo.com/news/articles/lynnwood-votes-end-contract-flock-202509113.html",
+    "title": "Lynnwood votes to end contract with Flock license plate reader cameras",
+    "outlet": "Yahoo News",
+    "author": null,
+    "published_date": "2026-02-18",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "denverite-2026-02-24-fires-flock",
+    "url": "https://denverite.com/2026/02/24/denver-ends-flock-contract-axon-alpr/",
+    "title": "Denver fires Flock, prepares to switch to new roadway surveillance system",
+    "outlet": "Denverite",
+    "author": null,
+    "published_date": "2026-02-24",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "9news-2026-02-24-denver-removes",
+    "url": "https://www.9news.com/article/news/local/denver-removes-flock-license-plate-reader-cameras/73-eaf91d0a-3b90-45f5-8338-dbb9f79a8712",
+    "title": "Denver removes all 110 Flock license plate reader cameras as contract expires",
+    "outlet": "9News",
+    "author": null,
+    "published_date": "2026-02-24",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "mvgov-2026-02-25-terminates",
+    "url": "https://www.mountainview.gov/Home/Components/News/News/1211/284",
+    "title": "City Council Terminates ALPR Contract with Flock Safety",
+    "outlet": "City of Mountain View",
+    "author": null,
+    "published_date": "2026-02-25",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "kqed-2026-02-mv-shuts-off",
+    "url": "https://www.kqed.org/news/12072077/as-california-cities-grow-wary-of-flock-safety-cameras-mountain-views-shuts-its-off",
+    "title": "As California Cities Grow Wary of Flock Safety Cameras, Mountain View Shuts Its Off",
+    "outlet": "KQED",
+    "author": null,
+    "published_date": "2026-02-26",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "ithacavoice-2026-03-ends",
+    "url": "https://ithacavoice.org/2026/03/city-ends-use-of-ai-powered-license-plate-cameras/",
+    "title": "City ends use of AI powered license plate cameras",
+    "outlet": "The Ithaca Voice",
+    "author": null,
+    "published_date": "2026-03-05",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "ithacacom-tompkins-terminates",
+    "url": "https://www.ithaca.com/news/tompkins_county/county-legislature-terminates-agreement-with-flock-safety/article_2d808fd9-54e5-449d-aadd-561317125a19.html",
+    "title": "County Legislature Terminates Agreement With Flock Safety",
+    "outlet": "ithaca.com",
+    "author": null,
+    "published_date": "2026-03-18",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "laist-2026-03-south-pas",
+    "url": "https://laist.com/news/south-pasadena-cancels-flock-safety-contract-privacy-concerns",
+    "title": "South Pasadena cancels contract with Flock Safety, citing privacy concerns",
+    "outlet": "LAist",
+    "author": null,
+    "published_date": "2026-03-19",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "jolt-2025-12-olympia",
+    "url": "https://www.thejoltnews.com/stories/olympia-to-remove-flock-cameras-amid-federal-data-misuse-concerns,27268",
+    "title": "Olympia to remove Flock cameras amid federal data misuse concerns",
+    "outlet": "The JOLT News",
+    "author": null,
+    "published_date": "2025-12-03",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "waretail-2025-12-olympia-redmond",
+    "url": "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns/",
+    "title": "Olympia and Redmond halt Flock safety camera use amid privacy and data-access concerns",
+    "outlet": "Washington Retail Association",
+    "author": null,
+    "published_date": "2025-12-05",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "carscoops-2026-02-termination",
+    "url": "https://www.carscoops.com/2026/02/flock-safety-alpr-contract-termination/",
+    "title": "Why More Cities Are Suddenly Pulling The Plug On Flock Safety Cameras",
+    "outlet": "CarScoops",
+    "author": null,
+    "published_date": "2026-02-20",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "fox11-2026-04-oshkosh-rescind",
+    "url": "https://fox11online.com/news/local/oshkosh-common-council-flock-surveillance-cameras-new-information-special-meeting-reconsider-contract-privacy-police-public-safety",
+    "title": "Oshkosh Common Council votes to rescind Flock camera contract, 1 day after approving it",
+    "outlet": "Fox11 (WLUK)",
+    "author": null,
+    "published_date": "2026-04-22",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "wosu-2026-03-columbus",
+    "url": "https://www.wosu.org/politics-government/2026-03-16/columbus-city-council-reevaluating-policy-around-use-of-flock-cameras",
+    "title": "Columbus City Council reevaluating policy around use of Flock cameras",
+    "outlet": "WOSU",
+    "author": null,
+    "published_date": "2026-03-16",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "lnm-2026-03-berkeley-delay",
+    "url": "https://localnewsmatters.org/2026/03/25/berkeley-city-council-delays-vote-whether-to-expand-flock-safety-surveillance-system/",
+    "title": "Berkeley City Council delays vote whether to expand Flock Safety surveillance system",
+    "outlet": "Local News Matters",
+    "author": null,
+    "published_date": "2026-03-25",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "elpasomatters-2026-03-reconsider",
+    "url": "https://elpasomatters.org/2026/03/02/flock-safety-license-plate-reader-cameras-contract-el-paso-texas-city-council/",
+    "title": "El Paso City Council may reconsider Flock Safety camera contract",
+    "outlet": "El Paso Matters",
+    "author": null,
+    "published_date": "2026-03-02",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "ids-2026-03-bloomington",
+    "url": "https://www.idsnews.com/article/2026/03/bloomington-city-council-flock-cameras-resolution-hopewell-affordable-housing",
+    "title": "Bloomington City Council passes Flock limits resolution",
+    "outlet": "Indiana Daily Student",
+    "author": null,
+    "published_date": "2026-03-19",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "lnm-2026-02-alameda-county",
+    "url": "https://localnewsmatters.org/2026/02/11/alameda-county-flock-cameras-privacy-debate/",
+    "title": "Supporters, critics debate Flock cameras as Alameda County reviews contract extension",
+    "outlet": "Local News Matters",
+    "author": null,
+    "published_date": "2026-02-11",
+    "summary": null,
+    "tags": []
+  },
+  {
+    "id": "vpm-2026-02-27-richmond-extends",
+    "url": "https://www.vpm.org/news/2026-02-27/rick-edwards-rpd-flock-safety-license-plate-cameras-keener-atf",
+    "title": "Richmond police extend contract with Flock Safety for license plate readers",
+    "outlet": "VPM News",
+    "author": null,
+    "published_date": "2026-02-27",
+    "summary": null,
+    "tags": []
+  }
+]

--- a/data/contracts/events.json
+++ b/data/contracts/events.json
@@ -6,8 +6,8 @@
     "vendor": "flock",
     "cameras_affected": 40,
     "article_ids": ["eff-2025-06-austin-cancel", "kut-2025-06-04-austin-ends"],
-    "reasons": ["federal-access", "sanctuary-conflict", "privacy-general"],
-    "notes": "Council ended the ALPR program after community pressure. 40 fixed cameras plus ~500 mobile cams. APD later found a loophole accessing neighbor agencies' Flock data."
+    "reasons": ["federal-access-risk", "sanctuary-conflict", "privacy-general"],
+    "notes": "Council ended the ALPR program after community pressure. 40 fixed cameras plus ~500 mobile cams. Council and residents cited risks of data sharing with ICE and TX AG (abortion enforcement). APD later found a loophole accessing neighbor agencies' Flock data."
   },
   {
     "agency_id": "b78b4a4c-e8ea-5a96-9edd-585d0b0d1ce1",
@@ -46,7 +46,7 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["lookout-2025-12-05-eugene", "opb-2025-12-06-eugene-springfield"],
-    "reasons": ["federal-access", "privacy-general"],
+    "reasons": ["federal-access-risk", "privacy-general"],
     "notes": "Eugene PD announced immediate termination. Springfield PD followed within the hour."
   },
   {
@@ -56,7 +56,7 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["lookout-2025-12-05-eugene", "opb-2025-12-06-eugene-springfield"],
-    "reasons": ["federal-access", "privacy-general"],
+    "reasons": ["federal-access-risk", "privacy-general"],
     "notes": "Announced termination same day as Eugene PD."
   },
   {
@@ -66,7 +66,7 @@
     "vendor": "flock",
     "cameras_affected": 15,
     "article_ids": ["jolt-2025-12-olympia", "waretail-2025-12-olympia-redmond"],
-    "reasons": ["federal-access", "sanctuary-conflict", "privacy-general"],
+    "reasons": ["federal-access-risk", "sanctuary-conflict", "privacy-general"],
     "notes": "Two-year pilot suspended; hoods installed over all 15 cameras. Interim Chief cited sanctuary-city status and data-access risks."
   },
   {
@@ -76,8 +76,8 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["waretail-2025-12-olympia-redmond"],
-    "reasons": ["federal-access", "privacy-general"],
-    "notes": "Paused alongside Olympia amid WA-wide privacy debate."
+    "reasons": ["federal-access-risk", "privacy-general"],
+    "notes": "Paused alongside Olympia amid WA-wide privacy debate. Sourced from aggregator — primary coverage not yet verified."
   },
   {
     "agency_id": "a6ee05fe-842e-512c-9cae-13bb118682c0",
@@ -86,7 +86,7 @@
     "vendor": "flock",
     "cameras_affected": 16,
     "article_ids": ["cambridgema-2025-12-statement", "bostoncom-2025-12-11-cambridge"],
-    "reasons": ["vendor-misconduct", "federal-access"],
+    "reasons": ["vendor-misconduct"],
     "notes": "City cited 'breach of trust' after discovering Flock installed two cameras without authorization. 16 cameras deactivated late October; formal termination Dec 11."
   },
   {
@@ -116,7 +116,7 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["flagstaff-2025-12-20-removed", "azfamily-2025-12-20-flagstaff"],
-    "reasons": ["federal-access", "privacy-general"],
+    "reasons": ["federal-access-risk", "privacy-general"],
     "notes": "Unanimous council vote. Flock portal for Flagstaff marked inactive post-cancellation."
   },
   {
@@ -185,9 +185,9 @@
     "date": "2026-03-04",
     "vendor": "flock",
     "cameras_affected": 22,
-    "article_ids": ["ithacavoice-2026-03-ends"],
-    "reasons": ["federal-access", "sanctuary-conflict"],
-    "notes": "Unanimous Common Council vote to decommission 22 ALPRs. Mayor cited civil liberties concerns about immigration use."
+    "article_ids": ["ithacavoice-2026-03-ends", "ithacacom-2026-03-exit"],
+    "reasons": ["federal-access-risk", "sanctuary-conflict"],
+    "notes": "Unanimous Common Council vote to decommission 22 ALPRs. Resolution sponsored by Alderperson Robin Trumble. Residents and council cited Ithaca's sanctuary status and risk of data sharing with federal agencies including ICE; no Ithaca-specific federal-access incident has been demonstrated."
   },
   {
     "agency_id": "2cc3a31d-7f98-5714-bc85-927815444575",
@@ -196,8 +196,8 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["ithacacom-tompkins-terminates"],
-    "reasons": ["federal-access"],
-    "notes": "County legislature followed the City of Ithaca in terminating."
+    "reasons": ["federal-access-risk", "sanctuary-conflict"],
+    "notes": "County legislature followed the City of Ithaca in terminating, same sanctuary-related rationale."
   },
   {
     "agency_id": "5448e966-a286-5dac-a301-1ed74914217e",
@@ -226,7 +226,7 @@
     "vendor": "flock",
     "cameras_affected": null,
     "article_ids": ["wosu-2026-03-columbus"],
-    "reasons": ["privacy-general", "federal-access"],
+    "reasons": ["privacy-general"],
     "notes": "Council working on an updated comprehensive policy governing Flock use."
   },
   {

--- a/data/contracts/events.json
+++ b/data/contracts/events.json
@@ -1,0 +1,282 @@
+[
+  {
+    "agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
+    "type": "canceled",
+    "date": "2025-06-04",
+    "vendor": "flock",
+    "cameras_affected": 40,
+    "article_ids": ["eff-2025-06-austin-cancel", "kut-2025-06-04-austin-ends"],
+    "reasons": ["federal-access", "sanctuary-conflict", "privacy-general"],
+    "notes": "Council ended the ALPR program after community pressure. 40 fixed cameras plus ~500 mobile cams. APD later found a loophole accessing neighbor agencies' Flock data."
+  },
+  {
+    "agency_id": "b78b4a4c-e8ea-5a96-9edd-585d0b0d1ce1",
+    "type": "canceled",
+    "date": "2025-08-05",
+    "vendor": "flock",
+    "cameras_affected": 8,
+    "article_ids": ["oakpark-2025-08-07-terminates", "oakpark-2025-08-28-state-broke-law"],
+    "reasons": ["federal-access", "sanctuary-conflict"],
+    "notes": "5-2 board vote. Trustees cited conflicts with village sanctuary ordinance. IL Sec. of State audit two weeks later found Flock had shared data with CBP in violation of state law."
+  },
+  {
+    "agency_id": "a597ac19-0e62-585c-82a0-f9c7b87c55e8",
+    "type": "canceled",
+    "date": "2025-08-26",
+    "vendor": "flock",
+    "cameras_affected": 19,
+    "article_ids": ["abc7-2025-08-27-evanston-oakpark", "patch-2025-08-27-evanston-deactivates"],
+    "reasons": ["federal-access", "data-breach"],
+    "notes": "Deactivated 19 cameras after IL Sec. of State confirmed Flock had shared Evanston data with CBP in a pilot Flock leadership said they were unaware of. Contract termination effective Sept 26."
+  },
+  {
+    "agency_id": "b994e41b-23e6-5392-ba7b-821af80978f0",
+    "type": "canceled",
+    "date": "2025-10-27",
+    "vendor": "flock",
+    "cameras_affected": 10,
+    "article_ids": ["hillsboroughnc-2025-10-cancel", "dth-2025-11-11-hillsborough"],
+    "reasons": ["broad-disclosure"],
+    "notes": "Board of Commissioners terminated after closer review of contract language permitting disclosure to any government entity or third party on Flock's 'good faith belief.'"
+  },
+  {
+    "agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
+    "type": "canceled",
+    "date": "2025-12-05",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["lookout-2025-12-05-eugene", "opb-2025-12-06-eugene-springfield"],
+    "reasons": ["federal-access", "privacy-general"],
+    "notes": "Eugene PD announced immediate termination. Springfield PD followed within the hour."
+  },
+  {
+    "agency_id": "bf2b80b2-d258-558f-b1f1-fa17fb8b4af4",
+    "type": "canceled",
+    "date": "2025-12-05",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["lookout-2025-12-05-eugene", "opb-2025-12-06-eugene-springfield"],
+    "reasons": ["federal-access", "privacy-general"],
+    "notes": "Announced termination same day as Eugene PD."
+  },
+  {
+    "agency_id": "80fc5e77-78d4-5499-abf4-9cda8cfb284d",
+    "type": "paused",
+    "date": "2025-12-03",
+    "vendor": "flock",
+    "cameras_affected": 15,
+    "article_ids": ["jolt-2025-12-olympia", "waretail-2025-12-olympia-redmond"],
+    "reasons": ["federal-access", "sanctuary-conflict", "privacy-general"],
+    "notes": "Two-year pilot suspended; hoods installed over all 15 cameras. Interim Chief cited sanctuary-city status and data-access risks."
+  },
+  {
+    "agency_id": "64f3e786-cdc0-575d-ad89-b15f8695ebe8",
+    "type": "paused",
+    "date": "2025-12-05",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["waretail-2025-12-olympia-redmond"],
+    "reasons": ["federal-access", "privacy-general"],
+    "notes": "Paused alongside Olympia amid WA-wide privacy debate."
+  },
+  {
+    "agency_id": "a6ee05fe-842e-512c-9cae-13bb118682c0",
+    "type": "canceled",
+    "date": "2025-12-11",
+    "vendor": "flock",
+    "cameras_affected": 16,
+    "article_ids": ["cambridgema-2025-12-statement", "bostoncom-2025-12-11-cambridge"],
+    "reasons": ["vendor-misconduct", "federal-access"],
+    "notes": "City cited 'breach of trust' after discovering Flock installed two cameras without authorization. 16 cameras deactivated late October; formal termination Dec 11."
+  },
+  {
+    "agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
+    "type": "canceled",
+    "date": "2025-12-17",
+    "vendor": "flock",
+    "cameras_affected": 10,
+    "article_ids": ["29news-2025-12-17-cville", "wvtf-2026-01-15-cville-staunton"],
+    "reasons": ["federal-access", "privacy-general"],
+    "notes": "One-year pilot ended. VA Center for Investigative Journalism found ~3,000 immigration-related queries of VA Flock cameras between Jun 2024 and Jun 2025."
+  },
+  {
+    "agency_id": "4cec1b92-d54e-5ef1-aebb-11d93521b4a5",
+    "type": "canceled",
+    "date": "2025-12-19",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["staunton-2025-12-19-terminate", "wvtf-2026-01-15-cville-staunton"],
+    "reasons": ["vendor-misconduct", "privacy-general"],
+    "notes": "City terminated citing Flock CEO's activist remarks and privacy concerns."
+  },
+  {
+    "agency_id": "86e9b8be-f02d-50c0-a0f8-9ed7b2b378a4",
+    "type": "canceled",
+    "date": "2025-12-20",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["flagstaff-2025-12-20-removed", "azfamily-2025-12-20-flagstaff"],
+    "reasons": ["federal-access", "privacy-general"],
+    "notes": "Unanimous council vote. Flock portal for Flagstaff marked inactive post-cancellation."
+  },
+  {
+    "agency_id": "8e97dede-dc5e-518a-bd9c-ca1acce1757a",
+    "type": "canceled",
+    "date": "2026-01-13",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["santacruzlocal-2026-01-13", "kqed-2026-01-santa-cruz-first"],
+    "reasons": ["federal-access", "unauthorized-access", "data-breach"],
+    "notes": "6-1 vote. First CA city to terminate. Followed reports that data from Santa Cruz, Capitola, and Watsonville had been accessed by outside agencies for federal purposes."
+  },
+  {
+    "agency_id": "40521632-8a29-5e5d-a064-1b57410743b5",
+    "type": "canceled",
+    "date": "2026-02-10",
+    "vendor": "flock",
+    "cameras_affected": 2,
+    "article_ids": ["littlevillage-2026-02-coralville"],
+    "reasons": ["privacy-general"],
+    "notes": "Council reversed a contract signed unilaterally by the police chief after community backlash."
+  },
+  {
+    "agency_id": "5b70f7bd-e72b-5f98-b6f2-58a611e13ed3",
+    "type": "canceled",
+    "date": "2026-02-18",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["yahoo-2026-02-lynnwood"],
+    "reasons": ["privacy-general"],
+    "notes": "Unanimous council vote."
+  },
+  {
+    "agency_id": "50dc11c1-7f4e-557f-b65c-6666d43832a0",
+    "type": "paused",
+    "date": "2026-02-20",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["carscoops-2026-02-termination"],
+    "reasons": ["privacy-general"],
+    "notes": "Town Council voted 8-1 to shut off cameras pending revisions aligned with a new ALPR privacy and security policy."
+  },
+  {
+    "agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
+    "type": "canceled",
+    "date": "2026-02-24",
+    "vendor": "flock",
+    "cameras_affected": 110,
+    "article_ids": ["denverite-2026-02-24-fires-flock", "9news-2026-02-24-denver-removes"],
+    "reasons": ["federal-access"],
+    "notes": "Contract expired; 110+ cameras removed. Denver replaced Flock with Axon ALPR (~50 cameras) by a single-vote council margin."
+  },
+  {
+    "agency_id": "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
+    "type": "canceled",
+    "date": "2026-02-24",
+    "vendor": "flock",
+    "cameras_affected": 30,
+    "article_ids": ["mvgov-2026-02-25-terminates", "kqed-2026-02-mv-shuts-off"],
+    "reasons": ["unauthorized-access", "privacy-general"],
+    "notes": "Unanimous vote. Police audit found National/Statewide Lookup enabled from day one; 250+ unapproved agencies ran ~600,000 searches on MV data Dec 2024–Dec 2025. Cameras off since Feb 2."
+  },
+  {
+    "agency_id": "d22f3264-52b5-5139-ad7c-849564e02eb1",
+    "type": "canceled",
+    "date": "2026-03-04",
+    "vendor": "flock",
+    "cameras_affected": 22,
+    "article_ids": ["ithacavoice-2026-03-ends"],
+    "reasons": ["federal-access", "sanctuary-conflict"],
+    "notes": "Unanimous Common Council vote to decommission 22 ALPRs. Mayor cited civil liberties concerns about immigration use."
+  },
+  {
+    "agency_id": "2cc3a31d-7f98-5714-bc85-927815444575",
+    "type": "canceled",
+    "date": "2026-03-18",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["ithacacom-tompkins-terminates"],
+    "reasons": ["federal-access"],
+    "notes": "County legislature followed the City of Ithaca in terminating."
+  },
+  {
+    "agency_id": "5448e966-a286-5dac-a301-1ed74914217e",
+    "type": "canceled",
+    "date": "2026-03-19",
+    "vendor": "flock",
+    "cameras_affected": 14,
+    "article_ids": ["laist-2026-03-south-pas"],
+    "reasons": ["unauthorized-access", "federal-access"],
+    "notes": "4-1 vote to end one of two contracts and let the other expire in ~5 months. Triggered by reports that data from Santa Cruz / Mountain View / Oxnard had been obtained by out-of-state agencies via a Flock software feature."
+  },
+  {
+    "agency_id": "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712",
+    "type": "paused",
+    "date": "2026-04-22",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["fox11-2026-04-oshkosh-rescind"],
+    "reasons": ["vendor-misconduct", "privacy-general"],
+    "notes": "Council voted 7-0 to rescind a renewal approved the day before, after Chief Smith said Flock had misrepresented that the cameras do not collect heat maps of travelers."
+  },
+  {
+    "agency_id": "356e30e5-12d3-5ff7-b563-6de8c10c553b",
+    "type": "reviewing",
+    "date": "2026-03-16",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["wosu-2026-03-columbus"],
+    "reasons": ["privacy-general", "federal-access"],
+    "notes": "Council working on an updated comprehensive policy governing Flock use."
+  },
+  {
+    "agency_id": "eca5a0e5-4ab4-5868-a688-c03da1dff9b1",
+    "type": "reviewing",
+    "date": "2026-03-25",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["lnm-2026-03-berkeley-delay"],
+    "reasons": ["privacy-general"],
+    "notes": "Council deferred a proposed expansion of Flock-based surveillance (cameras, drones, investigative software)."
+  },
+  {
+    "agency_id": "5b574464-e076-5bc0-8c62-e3052ecf8723",
+    "type": "reviewing",
+    "date": "2026-03-02",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["elpasomatters-2026-03-reconsider"],
+    "reasons": ["privacy-general"],
+    "notes": "Council debate on contract renewal amid privacy and surveillance concerns."
+  },
+  {
+    "agency_id": "97f69d1e-5db1-5a4d-a95a-7314e28d0ad1",
+    "type": "reviewing",
+    "date": "2026-03-19",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["ids-2026-03-bloomington"],
+    "reasons": ["privacy-general"],
+    "notes": "Unanimous passage of a Flock limits resolution."
+  },
+  {
+    "agency_id": "9c1c5b61-7dec-5fce-a5ec-a3be9ed47c86",
+    "type": "reviewing",
+    "date": "2026-02-11",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["lnm-2026-02-alameda-county"],
+    "reasons": ["privacy-general"],
+    "notes": "Board considering whether to extend ~$300K Flock contract covering unincorporated communities."
+  },
+  {
+    "agency_id": "7b9dbf06-a73b-532d-ba54-751ba8d15fe8",
+    "type": "signed",
+    "date": "2026-02-27",
+    "vendor": "flock",
+    "cameras_affected": null,
+    "article_ids": ["vpm-2026-02-27-richmond-extends"],
+    "reasons": [],
+    "notes": "Richmond PD extended Flock contract despite regional debate — contrast point for the map."
+  }
+]

--- a/docs/contracts.html
+++ b/docs/contracts.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://gc.zgo.at; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org data:; connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://unpkg.com https://gc.zgo.at https://none-below.goatcounter.com;">
+<title>ALPR Contract Status Map</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, system-ui, sans-serif; color: #1f2937; }
+  #map { height: calc(100vh - 30px); width: 100%; background: #f1f5f9; margin-top: 30px; }
+
+  .draft-banner {
+    position: fixed; top: 0; left: 0; right: 0; height: 30px;
+    background: repeating-linear-gradient(
+      -45deg, #fde68a 0 14px, #fbbf24 14px 28px
+    );
+    border-bottom: 1px solid #d97706;
+    z-index: 2000; display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 600; color: #78350f; letter-spacing: 0.2px;
+    padding: 0 12px;
+  }
+  .draft-banner a { color: #78350f; text-decoration: underline; margin-left: 8px; }
+
+  .gate-overlay {
+    position: fixed; inset: 0; z-index: 3000;
+    background: #0f172a; color: #e2e8f0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    padding: 20px; text-align: center;
+  }
+  .gate-overlay h1 { font-size: 20px; margin: 0 0 12px; }
+  .gate-overlay p { max-width: 440px; margin: 0 0 16px; font-size: 14px; color: #94a3b8; line-height: 1.5; }
+  .gate-overlay input {
+    padding: 10px 12px; border-radius: 6px; border: 1px solid #334155;
+    background: #1e293b; color: #e2e8f0; font-size: 14px; width: 240px;
+  }
+  .gate-overlay button {
+    margin-top: 10px; padding: 10px 18px; border-radius: 6px;
+    background: #2563eb; color: #fff; border: none; cursor: pointer;
+    font-size: 14px; font-weight: 600;
+  }
+  .gate-overlay .gate-error { color: #f87171; font-size: 13px; margin-top: 10px; min-height: 18px; }
+
+  .back-link {
+    position: absolute; top: 42px; left: 12px; z-index: 1000;
+    background: #fff; padding: 6px 10px; border-radius: 6px;
+    text-decoration: none; color: #1a2744; font-size: 13px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  }
+  .back-link:hover { background: #f1f5f9; }
+
+  .page-title {
+    position: absolute; top: 42px; left: 50%; transform: translateX(-50%);
+    z-index: 1000; background: #fff; padding: 8px 16px; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+    font-weight: 600; font-size: 14px; color: #1a2744;
+  }
+
+  .search-wrap {
+    position: absolute; top: 86px; left: 50%; transform: translateX(-50%);
+    z-index: 1000; width: min(340px, calc(100% - 24px));
+  }
+  #search-box {
+    width: 100%; padding: 8px 12px; border: 1px solid #cbd5e1;
+    border-radius: 6px; font-size: 14px; background: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  }
+  #search-results {
+    background: #fff; border: 1px solid #cbd5e1; border-top: none;
+    border-radius: 0 0 6px 6px; max-height: 280px; overflow-y: auto;
+    display: none;
+  }
+  #search-results .result {
+    padding: 8px 12px; cursor: pointer; font-size: 13px;
+    border-bottom: 1px solid #f1f5f9;
+  }
+  #search-results .result:hover { background: #eff6ff; }
+  #search-results .result small { color: #6b7280; }
+
+  .info-panel {
+    position: absolute; top: 30px; right: 0; bottom: 0; width: min(420px, 100%);
+    background: #fff; border-left: 1px solid #e5e7eb; z-index: 1000;
+    overflow-y: auto; padding: 20px; display: none;
+    box-shadow: -2px 0 8px rgba(0,0,0,0.08);
+  }
+  .info-panel.open { display: block; }
+  .info-panel .close-btn {
+    position: absolute; top: 12px; right: 12px; background: none;
+    border: none; font-size: 20px; cursor: pointer; color: #6b7280;
+    line-height: 1; padding: 4px 8px;
+  }
+  .info-panel h2 { margin: 0 0 4px; font-size: 18px; color: #1a2744; padding-right: 32px; }
+  .info-panel .locality { color: #6b7280; font-size: 13px; margin-bottom: 14px; }
+  .info-panel .section-title {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;
+    color: #6b7280; margin: 18px 0 8px; font-weight: 600;
+  }
+  .status-chip {
+    display: inline-block; padding: 3px 8px; border-radius: 10px;
+    font-size: 12px; font-weight: 600; margin-right: 6px; margin-bottom: 4px;
+    color: #fff;
+  }
+  .status-chip.canceled { background: #dc2626; }
+  .status-chip.paused { background: #ea580c; }
+  .status-chip.reviewing { background: #f59e0b; color: #1f2937; }
+  .status-chip.considering { background: #fbbf24; color: #1f2937; }
+  .status-chip.reinstated { background: #2563eb; }
+  .status-chip.signed { background: #6b7280; }
+  .vendor-row {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 13px; margin-bottom: 4px;
+  }
+  .vendor-name { text-transform: capitalize; color: #374151; font-weight: 500; }
+
+  .flock-snapshot {
+    background: #f8fafc; border-radius: 6px; padding: 12px;
+    font-size: 13px; border-left: 3px solid #2563eb;
+  }
+  .flock-snapshot .stat { display: inline-block; margin-right: 14px; color: #374151; }
+  .flock-snapshot .stat b { color: #0f172a; font-size: 15px; }
+  .flock-snapshot .delta-down { color: #dc2626; font-weight: 600; }
+  .flock-snapshot .delta-same { color: #6b7280; }
+  .flock-snapshot .portal-link { margin-top: 8px; display: inline-block; font-size: 12px; }
+
+  .timeline { list-style: none; padding: 0; margin: 0; }
+  .timeline li {
+    display: flex; gap: 10px; padding: 8px 0;
+    border-bottom: 1px solid #f1f5f9;
+  }
+  .timeline li:last-child { border-bottom: none; }
+  .timeline .event-dot {
+    width: 10px; height: 10px; border-radius: 50%; margin-top: 5px;
+    flex-shrink: 0;
+  }
+  .timeline .event-dot.canceled { background: #dc2626; }
+  .timeline .event-dot.paused { background: #ea580c; }
+  .timeline .event-dot.reviewing { background: #f59e0b; }
+  .timeline .event-dot.considering { background: #fbbf24; }
+  .timeline .event-dot.reinstated { background: #2563eb; }
+  .timeline .event-dot.signed { background: #6b7280; }
+  .timeline .event-body { flex: 1; font-size: 13px; }
+  .timeline .event-head {
+    font-weight: 600; color: #0f172a; text-transform: capitalize;
+  }
+  .timeline .event-date { color: #6b7280; font-weight: normal; font-size: 12px; margin-left: 6px; }
+  .timeline .event-vendor { color: #6b7280; font-size: 11px; }
+  .timeline .event-notes { margin-top: 2px; color: #374151; line-height: 1.4; }
+  .timeline .event-cameras { font-size: 12px; color: #6b7280; margin-top: 2px; }
+  .timeline .event-articles { margin-top: 4px; font-size: 12px; }
+  .timeline .event-reasons { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 4px; }
+
+  .reason-chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 2px 8px 2px 2px; border-radius: 10px;
+    font-size: 11px; font-weight: 600; color: #fff;
+    line-height: 1.5;
+  }
+  .reason-chip .reason-icon {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: rgba(255,255,255,0.25);
+    font-size: 10px; font-weight: 700; font-family: ui-monospace, SFMono-Regular, monospace;
+  }
+
+  .reason-legend {
+    position: absolute; bottom: 16px; right: 16px; z-index: 1000;
+    background: #fff; padding: 10px 12px; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15); font-size: 11px;
+    max-width: 260px;
+  }
+  .reason-legend-title {
+    font-weight: 600; color: #1a2744; margin-bottom: 6px;
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px;
+  }
+  .reason-legend .reason-chip { margin-bottom: 3px; }
+
+  .articles { list-style: none; padding: 0; margin: 0; }
+  .articles li { padding: 6px 0; border-bottom: 1px solid #f1f5f9; font-size: 13px; }
+  .articles li:last-child { border-bottom: none; }
+  .articles .outlet { color: #6b7280; font-size: 12px; }
+  .articles a { color: #2563eb; text-decoration: none; }
+  .articles a:hover { text-decoration: underline; }
+
+  .legend {
+    position: absolute; bottom: 16px; left: 16px; z-index: 1000;
+    background: #fff; padding: 10px 12px; border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15); font-size: 12px;
+  }
+  .legend-row { display: flex; align-items: center; gap: 8px; margin: 3px 0; }
+  .legend-dot {
+    width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0;
+  }
+  .legend-x {
+    width: 14px; height: 14px; display: inline-flex; align-items: center;
+    justify-content: center; font-weight: 900; color: #dc2626; flex-shrink: 0;
+  }
+
+  .empty-state {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    background: #fff; padding: 20px 28px; border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1); text-align: center;
+    font-size: 14px; color: #6b7280; max-width: 360px;
+  }
+
+  @media (max-width: 720px) {
+    .legend, .reason-legend { display: none; }
+    .info-panel { width: 100%; }
+    .page-title { font-size: 12px; padding: 6px 10px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="draft-banner" id="draft-banner">
+  PREVIEW — sample data, not for citation. Data is being actively curated and may be inaccurate or incomplete.
+</div>
+
+<div class="gate-overlay" id="gate-overlay">
+  <h1>Preview access</h1>
+  <p>This page is a work-in-progress preview with sample data. If you've been given an access phrase, enter it below. If you landed here by accident, please check back later.</p>
+  <input type="password" id="gate-input" placeholder="Access phrase" autofocus>
+  <button type="button" id="gate-submit">Continue</button>
+  <div class="gate-error" id="gate-error"></div>
+</div>
+
+<a class="back-link" href="index.html">&larr; Back</a>
+<div class="page-title">ALPR Contract Status</div>
+
+<div class="search-wrap">
+  <input type="text" id="search-box" placeholder="Search city or agency..." autocomplete="off">
+  <div id="search-results"></div>
+</div>
+
+<div id="map"></div>
+
+<div class="legend">
+  <div class="legend-row"><span class="legend-x">✕</span> Canceled</div>
+  <div class="legend-row"><span class="legend-dot" style="background:#ea580c"></span> Paused</div>
+  <div class="legend-row"><span class="legend-dot" style="background:#f59e0b"></span> Reviewing</div>
+  <div class="legend-row"><span class="legend-dot" style="background:#fbbf24"></span> Considering</div>
+  <div class="legend-row"><span class="legend-dot" style="background:#2563eb"></span> Reinstated</div>
+</div>
+
+<div class="info-panel" id="info">
+  <button class="close-btn" type="button" aria-label="Close" id="info-close">&times;</button>
+  <div id="info-body"></div>
+</div>
+
+<div class="reason-legend" id="reason-legend" style="display:none">
+  <div class="reason-legend-title">Why contracts ended</div>
+  <div id="reason-legend-body"></div>
+</div>
+
+<script src="js/contracts.js"></script>
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="https://gc.zgo.at/count.js"></script>
+</body>
+</html>

--- a/docs/contracts.html
+++ b/docs/contracts.html
@@ -177,11 +177,19 @@
   .reason-legend .reason-chip { margin-bottom: 3px; }
 
   .articles { list-style: none; padding: 0; margin: 0; }
-  .articles li { padding: 6px 0; border-bottom: 1px solid #f1f5f9; font-size: 13px; }
+  .articles li { padding: 8px 0; border-bottom: 1px solid #f1f5f9; font-size: 13px; }
   .articles li:last-child { border-bottom: none; }
   .articles .outlet { color: #6b7280; font-size: 12px; }
   .articles a { color: #2563eb; text-decoration: none; }
   .articles a:hover { text-decoration: underline; }
+  .articles .pull-quote {
+    margin: 4px 0 2px; padding: 4px 10px;
+    border-left: 3px solid #cbd5e1; background: #f8fafc;
+    color: #334155; font-style: italic; font-size: 12.5px;
+    line-height: 1.45;
+  }
+  .articles .pull-quote::before { content: "\201C"; margin-right: 1px; }
+  .articles .pull-quote::after { content: "\201D"; margin-left: 1px; }
 
   .legend {
     position: absolute; bottom: 16px; left: 16px; z-index: 1000;

--- a/docs/js/contracts.js
+++ b/docs/js/contracts.js
@@ -1,0 +1,349 @@
+// ALPR Contract Status Map — renders data/contract_map_data.json.
+
+// Soft preview gate. NOT real authentication — the password is in the source
+// and this is shipped as a static page. Purpose: keep random visitors who
+// stumble across the URL from seeing preliminary, not-yet-fact-checked data,
+// and signal to reviewers that the page isn't for public citation yet.
+// Change the password here when you want to rotate access.
+const PREVIEW_PASSWORD = 'preview';
+const UNLOCK_KEY = 'contracts-preview-unlocked';
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function safeUrl(u) {
+  if (typeof u !== 'string') return '';
+  return /^https?:\/\//.test(u) ? u : '';
+}
+
+const STATUS_LABEL = {
+  canceled: 'Canceled',
+  paused: 'Paused',
+  reviewing: 'Reviewing',
+  considering: 'Considering',
+  reinstated: 'Reinstated',
+  signed: 'Signed',
+};
+
+const STATUS_COLOR = {
+  canceled: '#dc2626',
+  paused: '#ea580c',
+  reviewing: '#f59e0b',
+  considering: '#fbbf24',
+  reinstated: '#2563eb',
+  signed: '#6b7280',
+};
+
+function markerIcon(status) {
+  const color = STATUS_COLOR[status] || '#6b7280';
+  if (status === 'canceled') {
+    // Red X
+    const html = `<div style="font-size:22px;font-weight:900;color:${color};
+      text-shadow:0 0 3px #fff,0 0 3px #fff,0 0 3px #fff,0 0 3px #fff;
+      line-height:1;user-select:none;">&#x2715;</div>`;
+    return L.divIcon({ className: 'contract-icon', html, iconSize: [22, 22], iconAnchor: [11, 11] });
+  }
+  // Filled circle for other statuses
+  const html = `<div style="width:16px;height:16px;border-radius:50%;
+    background:${color};border:2px solid #fff;
+    box-shadow:0 0 0 1px rgba(0,0,0,0.3);"></div>`;
+  return L.divIcon({ className: 'contract-icon', html, iconSize: [20, 20], iconAnchor: [10, 10] });
+}
+
+function formatDate(raw) {
+  if (!raw) return 'undated';
+  return raw;
+}
+
+function renderStatusChip(status) {
+  const cls = STATUS_LABEL[status] ? status : 'signed';
+  return `<span class="status-chip ${cls}">${escapeHtml(STATUS_LABEL[status] || status || 'unknown')}</span>`;
+}
+
+function renderFlockSnapshot(payload) {
+  const snap = payload.flock_snapshot;
+  if (!snap) return '';
+  const portal = safeUrl(payload.flock_portal_url);
+  const prior = payload.flock_snapshot_prior;
+  let delta = '';
+  if (prior && typeof snap.camera_count === 'number' && typeof prior.camera_count === 'number') {
+    const diff = snap.camera_count - prior.camera_count;
+    if (diff < 0) {
+      delta = `<span class="delta-down">&#x2193; ${Math.abs(diff)} cameras since ${escapeHtml(prior.as_of || '')}</span>`;
+    } else if (diff > 0) {
+      delta = `<span class="delta-same">&#x2191; ${diff} cameras since ${escapeHtml(prior.as_of || '')}</span>`;
+    } else {
+      delta = `<span class="delta-same">unchanged since ${escapeHtml(prior.as_of || '')}</span>`;
+    }
+  }
+  const stats = [];
+  if (typeof snap.camera_count === 'number') stats.push(`<span class="stat"><b>${snap.camera_count}</b> cameras</span>`);
+  if (typeof snap.vehicles_detected_30d === 'number') stats.push(`<span class="stat"><b>${snap.vehicles_detected_30d.toLocaleString()}</b> vehicles / 30d</span>`);
+  if (typeof snap.hotlist_hits_30d === 'number') stats.push(`<span class="stat"><b>${snap.hotlist_hits_30d.toLocaleString()}</b> hotlist hits / 30d</span>`);
+  const portalLink = portal
+    ? `<a class="portal-link" href="${escapeHtml(portal)}" target="_blank" rel="noopener">Live Flock portal &rarr;</a>`
+    : '';
+  const asOf = snap.as_of ? ` <small style="color:#6b7280">(as of ${escapeHtml(snap.as_of)})</small>` : '';
+  return `
+    <div class="flock-snapshot">
+      <div style="margin-bottom:6px;font-weight:600;">Flock transparency${asOf}</div>
+      ${stats.join(' ')}
+      ${delta ? `<div style="margin-top:6px;font-size:12px">${delta}</div>` : ''}
+      ${portalLink}
+    </div>`;
+}
+
+let REASONS_META = {};
+
+function renderReasonChip(code) {
+  const meta = REASONS_META[code];
+  if (!meta) return '';
+  return `<span class="reason-chip" style="background:${escapeHtml(meta.color)}" title="${escapeHtml(meta.description || '')}">
+    <span class="reason-icon">${escapeHtml(meta.icon || '?')}</span>${escapeHtml(meta.label || code)}
+  </span>`;
+}
+
+function renderEvent(ev, articlesById) {
+  const type = ev.type;
+  const date = formatDate(ev.date);
+  const vendor = ev.vendor ? ` &middot; ${escapeHtml(ev.vendor)}` : '';
+  const notes = ev.notes ? `<div class="event-notes">${escapeHtml(ev.notes)}</div>` : '';
+  const cameras = (typeof ev.cameras_affected === 'number')
+    ? `<div class="event-cameras">${ev.cameras_affected} cameras</div>`
+    : '';
+  const reasons = Array.isArray(ev.reasons) ? ev.reasons : [];
+  const reasonsHtml = reasons.length
+    ? `<div class="event-reasons">${reasons.map(renderReasonChip).join('')}</div>`
+    : '';
+  const articleIds = Array.isArray(ev.article_ids) ? ev.article_ids : [];
+  const links = articleIds
+    .map(id => articlesById[id])
+    .filter(Boolean)
+    .map(a => {
+      const url = safeUrl(a.url);
+      if (!url) return '';
+      return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${escapeHtml(a.outlet || 'source')}</a>`;
+    })
+    .filter(Boolean)
+    .join(' &middot; ');
+  const linksHtml = links ? `<div class="event-articles">${links}</div>` : '';
+  return `
+    <li>
+      <div class="event-dot ${type}"></div>
+      <div class="event-body">
+        <div class="event-head">${escapeHtml(STATUS_LABEL[type] || type)}<span class="event-date">${escapeHtml(date)}</span><span class="event-vendor">${vendor}</span></div>
+        ${notes}
+        ${cameras}
+        ${reasonsHtml}
+        ${linksHtml}
+      </div>
+    </li>`;
+}
+
+function renderReasonLegend(reasonsMeta, events) {
+  // Only show reasons actually used in the dataset
+  const used = new Set();
+  for (const e of events) {
+    for (const r of e.reasons || []) used.add(r);
+  }
+  const legend = document.getElementById('reason-legend');
+  const body = document.getElementById('reason-legend-body');
+  if (!used.size) {
+    legend.style.display = 'none';
+    return;
+  }
+  body.innerHTML = Array.from(used)
+    .filter(code => reasonsMeta[code])
+    .map(renderReasonChip)
+    .join('<br>');
+  legend.style.display = 'block';
+}
+
+function renderArticleList(articles) {
+  if (!articles.length) return '';
+  const items = articles.map(a => {
+    const url = safeUrl(a.url);
+    const title = escapeHtml(a.title || '(untitled)');
+    const outlet = escapeHtml(a.outlet || '');
+    const date = escapeHtml(a.published_date || '');
+    const link = url
+      ? `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${title}</a>`
+      : title;
+    return `<li>${link}<br><span class="outlet">${outlet}${date ? ' &middot; ' + date : ''}</span></li>`;
+  }).join('');
+  return `
+    <div class="section-title">Articles (${articles.length})</div>
+    <ul class="articles">${items}</ul>`;
+}
+
+function renderPanel(payload) {
+  if (!payload) return '';
+  const articlesById = {};
+  for (const a of payload.articles || []) articlesById[a.id] = a;
+
+  const loc = [payload.city, payload.state].filter(Boolean).join(', ');
+  const vendorRows = Object.entries(payload.status_by_vendor || {}).map(([v, info]) => {
+    return `<div class="vendor-row">
+      <span class="vendor-name">${escapeHtml(v)}</span>
+      ${renderStatusChip(info.status)}
+      <span style="color:#6b7280;font-size:12px">${escapeHtml(formatDate(info.last_event_date))}</span>
+    </div>`;
+  }).join('');
+
+  const timeline = (payload.events || []).map(ev => renderEvent(ev, articlesById)).join('');
+  const flock = renderFlockSnapshot(payload);
+  const notes = payload.notes ? `<div style="font-size:13px;margin-top:8px;color:#374151">${escapeHtml(payload.notes)}</div>` : '';
+
+  return `
+    <h2>${escapeHtml(payload.name)}</h2>
+    <div class="locality">${escapeHtml(loc)}</div>
+    ${vendorRows ? `<div class="section-title">Current status by vendor</div>${vendorRows}` : ''}
+    ${flock ? `<div class="section-title">Live data</div>${flock}` : ''}
+    ${timeline ? `<div class="section-title">Timeline (${payload.events.length})</div><ul class="timeline">${timeline}</ul>` : ''}
+    ${renderArticleList(payload.articles || [])}
+    ${notes}
+  `;
+}
+
+function init(data) {
+  REASONS_META = (data.meta && data.meta.reasons) || {};
+
+  const map = L.map('map').setView([39.5, -98.35], 4);
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png', {
+    attribution: '&copy; OpenStreetMap &copy; CARTO',
+    subdomains: 'abcd',
+    maxZoom: 19,
+  }).addTo(map);
+
+  const markersById = {};
+  const markerList = [];
+
+  const markers = Array.isArray(data.markers) ? data.markers : [];
+  for (const m of markers) {
+    if (typeof m.lat !== 'number' || typeof m.lng !== 'number') continue;
+    const marker = L.marker([m.lat, m.lng], { icon: markerIcon(m.status_overall) });
+    marker.on('click', () => selectAgency(m.id));
+    marker.addTo(map);
+    markersById[m.id] = marker;
+    markerList.push(m);
+  }
+
+  if (!markers.length) {
+    const div = document.createElement('div');
+    div.className = 'empty-state';
+    div.textContent = 'No contract-status entries yet. As articles are curated into data/contracts/, agencies will appear here.';
+    document.body.appendChild(div);
+  }
+
+  // Build the reasons legend from all events in the dataset
+  const allEvents = [];
+  for (const a of Object.values(data.agencies || {})) {
+    for (const ev of a.events || []) allEvents.push(ev);
+  }
+  renderReasonLegend(REASONS_META, allEvents);
+
+  const panel = document.getElementById('info');
+  const body = document.getElementById('info-body');
+  document.getElementById('info-close').addEventListener('click', () => {
+    panel.classList.remove('open');
+  });
+
+  function selectAgency(id) {
+    const payload = (data.agencies || {})[id];
+    if (!payload) return;
+    body.innerHTML = renderPanel(payload);
+    panel.classList.add('open');
+    const m = markersById[id];
+    if (m) map.panTo(m.getLatLng());
+  }
+
+  const searchBox = document.getElementById('search-box');
+  const results = document.getElementById('search-results');
+  searchBox.addEventListener('input', () => {
+    const q = searchBox.value.trim().toLowerCase();
+    if (q.length < 2) {
+      results.style.display = 'none';
+      results.innerHTML = '';
+      return;
+    }
+    const matches = markerList.filter(m => {
+      const hay = `${m.name} ${m.full_name || ''} ${m.city || ''} ${m.state || ''}`.toLowerCase();
+      return hay.includes(q);
+    }).slice(0, 20);
+    if (!matches.length) {
+      results.style.display = 'block';
+      results.innerHTML = '<div class="result" style="color:#9ca3af;cursor:default">No matches</div>';
+      return;
+    }
+    results.innerHTML = matches.map(m => {
+      const loc = [m.city, m.state].filter(Boolean).join(', ');
+      return `<div class="result" data-id="${escapeHtml(m.id)}">
+        <strong>${escapeHtml(m.full_name || m.name)}</strong>
+        ${loc ? `<small> &middot; ${escapeHtml(loc)}</small>` : ''}
+      </div>`;
+    }).join('');
+    results.style.display = 'block';
+    results.querySelectorAll('.result[data-id]').forEach(el => {
+      el.addEventListener('click', () => {
+        const id = el.getAttribute('data-id');
+        selectAgency(id);
+        results.style.display = 'none';
+        searchBox.value = '';
+      });
+    });
+  });
+  searchBox.addEventListener('blur', () => {
+    setTimeout(() => { results.style.display = 'none'; }, 200);
+  });
+}
+
+function bootstrap() {
+  fetch('data/contract_map_data.json')
+    .then(r => r.json())
+    .then(init)
+    .catch(err => {
+      console.error('Failed to load contract_map_data.json', err);
+      const div = document.createElement('div');
+      div.className = 'empty-state';
+      div.textContent = 'Failed to load contract data.';
+      document.body.appendChild(div);
+    });
+}
+
+function unlockAndBoot() {
+  sessionStorage.setItem(UNLOCK_KEY, '1');
+  const overlay = document.getElementById('gate-overlay');
+  if (overlay) overlay.style.display = 'none';
+  bootstrap();
+}
+
+function wireGate() {
+  const submit = document.getElementById('gate-submit');
+  const input = document.getElementById('gate-input');
+  const err = document.getElementById('gate-error');
+  const tryUnlock = () => {
+    const val = (input.value || '').trim().toLowerCase();
+    if (val === PREVIEW_PASSWORD) {
+      err.textContent = '';
+      unlockAndBoot();
+    } else {
+      err.textContent = 'Incorrect phrase. Try again.';
+      input.select();
+    }
+  };
+  submit.addEventListener('click', tryUnlock);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') tryUnlock();
+  });
+}
+
+if (sessionStorage.getItem(UNLOCK_KEY) === '1') {
+  const overlay = document.getElementById('gate-overlay');
+  if (overlay) overlay.style.display = 'none';
+  bootstrap();
+} else {
+  wireGate();
+}

--- a/docs/js/contracts.js
+++ b/docs/js/contracts.js
@@ -172,7 +172,10 @@ function renderArticleList(articles) {
     const link = url
       ? `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${title}</a>`
       : title;
-    return `<li>${link}<br><span class="outlet">${outlet}${date ? ' &middot; ' + date : ''}</span></li>`;
+    const quote = a.quote
+      ? `<div class="pull-quote">${escapeHtml(a.quote)}</div>`
+      : '';
+    return `<li>${link}${quote}<div class="outlet">${outlet}${date ? ' &middot; ' + date : ''}</div></li>`;
   }).join('');
   return `
     <div class="section-title">Articles (${articles.length})</div>

--- a/scripts/build_contract_map.py
+++ b/scripts/build_contract_map.py
@@ -68,10 +68,16 @@ KNOWN_VENDORS = {"flock", "vigilant", "axon-fusus", "rekor", "other"}
 # The UI renders each as a colored chip with a short letter-badge icon.
 REASONS = {
     "federal-access": {
-        "label": "Federal / ICE access",
+        "label": "Federal / ICE access (confirmed)",
         "icon": "F",
         "color": "#b91c1c",
-        "description": "Data accessed by federal immigration enforcement (ICE, CBP, DHS) or shared without local authorization.",
+        "description": "Documented incident: ICE, CBP, DHS, or other federal enforcement accessed the jurisdiction's ALPR data, or data was demonstrably shared without local authorization. Reserved for cases with an audit finding, investigative report, or direct disclosure. For preemptive cancellations motivated by the risk of such access, use federal-access-risk.",
+    },
+    "federal-access-risk": {
+        "label": "Federal / ICE access (risk)",
+        "icon": "F",
+        "color": "#f59e0b",
+        "description": "Jurisdiction cited the risk of federal immigration access as a reason for canceling or pausing, but no incident was demonstrated. Typical for preemptive cancellations by sanctuary jurisdictions or cities responding to national reporting.",
     },
     "unauthorized-access": {
         "label": "Unauthorized searches",

--- a/scripts/build_contract_map.py
+++ b/scripts/build_contract_map.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Build the data bundle for the ALPR contract-status map.
+
+Reads hand-curated source files under data/contracts/:
+  - events.json    (flat list of timeline events)
+  - articles.json  (article metadata, referenced by events)
+
+Agency identity, name, and coordinates are resolved from
+assets/agency_registry.json via the event's `agency_id` (registry UUID).
+The registry is the central identity DB — any agency that lacks a registry
+entry must be added there first (see scripts/seed_contract_registry.py for
+a bulk-seeding helper, or scripts/build_agency_registry.py for the general
+workflow).
+
+When the registry entry has a scraped Flock transparency portal under
+assets/transparency.flocksafety.com/<slug>/, the latest snapshot (plus an
+older one for deltas) is attached to the agency payload.
+
+Usage:
+  uv run python scripts/build_contract_map.py
+  uv run python scripts/build_contract_map.py --out path/to/out.json
+"""
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import (  # noqa: E402
+    agency_active_slug,
+    agency_coords,
+    agency_display_name,
+    agency_state,
+    load_registry,
+    portal_jsons,
+    registry_by_id,
+)
+
+SRC_DIR = Path("data/contracts")
+DEFAULT_OUT = Path("docs/data/contract_map_data.json")
+TRANSPARENCY_DIR = Path("assets/transparency.flocksafety.com")
+
+VALID_EVENT_TYPES = {
+    "signed",
+    "considering",
+    "reviewing",
+    "paused",
+    "canceled",
+    "reinstated",
+}
+
+# Severity ordering for the "overall" marker color. Lower index = more severe.
+STATUS_SEVERITY = [
+    "canceled",
+    "paused",
+    "reviewing",
+    "considering",
+    "reinstated",
+    "signed",
+]
+
+KNOWN_VENDORS = {"flock", "vigilant", "axon-fusus", "rekor", "other"}
+
+# Reason codes for why an event happened. Attached to events as `reasons: [...]`.
+# The UI renders each as a colored chip with a short letter-badge icon.
+REASONS = {
+    "federal-access": {
+        "label": "Federal / ICE access",
+        "icon": "F",
+        "color": "#b91c1c",
+        "description": "Data accessed by federal immigration enforcement (ICE, CBP, DHS) or shared without local authorization.",
+    },
+    "unauthorized-access": {
+        "label": "Unauthorized searches",
+        "icon": "U",
+        "color": "#c2410c",
+        "description": "Out-of-state, federal, or third-party agencies ran searches against the jurisdiction's data without approval.",
+    },
+    "vendor-misconduct": {
+        "label": "Vendor misconduct",
+        "icon": "V",
+        "color": "#7f1d1d",
+        "description": "Flock (or vendor) conduct: unauthorized installations, misrepresentation to the city, undisclosed pilots.",
+    },
+    "broad-disclosure": {
+        "label": "Broad disclosure clause",
+        "icon": "D",
+        "color": "#6d28d9",
+        "description": "Contract language permits the vendor to disclose data to any government entity or third party.",
+    },
+    "sanctuary-conflict": {
+        "label": "Sanctuary conflict",
+        "icon": "S",
+        "color": "#b45309",
+        "description": "Data use conflicts with the jurisdiction's sanctuary ordinance or non-cooperation policy.",
+    },
+    "data-breach": {
+        "label": "Data breach / leak",
+        "icon": "B",
+        "color": "#9f1239",
+        "description": "An actual breach or unauthorized exposure of collected data.",
+    },
+    "privacy-general": {
+        "label": "Privacy concerns",
+        "icon": "P",
+        "color": "#475569",
+        "description": "Catchall for general privacy concerns not captured by a more specific code.",
+    },
+}
+
+# Continental US + Alaska + Hawaii + territories rough bounding box.
+US_BBOX = {"lat_min": 17.0, "lat_max": 72.0, "lng_min": -180.0, "lng_max": -64.0}
+
+MIN_SNAPSHOT_DELTA_DAYS = 14
+
+
+def load_source(name, src_dir=None):
+    p = (src_dir or SRC_DIR) / name
+    with open(p) as f:
+        return json.load(f)
+
+
+def parse_event_date(raw):
+    """Return (sortable_tuple, display_string, is_full_date)."""
+    if raw is None or raw == "":
+        return (9999, 99, 99), "undated", False
+    parts = raw.split("-")
+    try:
+        if len(parts) == 3:
+            y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+            dt.date(y, m, d)
+            return (y, m, d), raw, True
+        if len(parts) == 2:
+            y, m = int(parts[0]), int(parts[1])
+            if not (1 <= m <= 12):
+                raise ValueError(f"bad month: {m}")
+            return (y, m, 99), raw, False
+        if len(parts) == 1:
+            y = int(parts[0])
+            return (y, 99, 99), raw, False
+    except ValueError as e:
+        raise ValueError(f"invalid date {raw!r}: {e}")
+    raise ValueError(f"invalid date format {raw!r}")
+
+
+def validate(events, articles, reg_by_id):
+    errors = []
+    warnings = []
+
+    article_ids = set()
+    for art in articles:
+        aid = art.get("id")
+        if not aid:
+            errors.append(f"article missing id: {art}")
+            continue
+        if aid in article_ids:
+            errors.append(f"duplicate article id: {aid}")
+        article_ids.add(aid)
+        for f in ("url", "title", "outlet", "published_date"):
+            if not art.get(f):
+                errors.append(f"article {aid}: missing required field {f!r}")
+
+    for ev in events:
+        agid = ev.get("agency_id")
+        if not agid:
+            errors.append(f"event missing agency_id: {ev}")
+            continue
+        reg = reg_by_id.get(agid)
+        if not reg:
+            errors.append(
+                f"event references unknown agency_id {agid!r} — add to registry "
+                f"via scripts/seed_contract_registry.py or "
+                f"scripts/build_agency_registry.py"
+            )
+            continue
+        lat, lng = agency_coords(reg)
+        if lat is None or lng is None:
+            errors.append(f"event for {agid}: registry entry lacks lat/lng")
+        else:
+            if not (US_BBOX["lat_min"] <= lat <= US_BBOX["lat_max"]):
+                errors.append(f"agency {agid}: lat {lat} outside US bbox")
+            if not (US_BBOX["lng_min"] <= lng <= US_BBOX["lng_max"]):
+                errors.append(f"agency {agid}: lng {lng} outside US bbox")
+        t = ev.get("type")
+        if t not in VALID_EVENT_TYPES:
+            errors.append(f"event for {agid}: invalid type {t!r}")
+        v = ev.get("vendor")
+        if v and v not in KNOWN_VENDORS:
+            warnings.append(f"event for {agid}: unknown vendor {v!r}")
+        try:
+            parse_event_date(ev.get("date"))
+        except ValueError as e:
+            errors.append(f"event for {agid}: {e}")
+        for art_id in ev.get("article_ids") or []:
+            if art_id not in article_ids:
+                errors.append(
+                    f"event for {agid}: unknown article_id {art_id!r}"
+                )
+        for r in ev.get("reasons") or []:
+            if r not in REASONS:
+                errors.append(f"event for {agid}: unknown reason {r!r}")
+
+    return errors, warnings
+
+
+def snapshot_from_portal_json(path):
+    with open(path) as f:
+        d = json.load(f)
+    return {
+        "as_of": d.get("archived_date"),
+        "camera_count": d.get("camera_count"),
+        "vehicles_detected_30d": d.get("vehicles_detected_30d"),
+        "hotlist_hits_30d": d.get("hotlist_hits_30d"),
+        "searches_30d": d.get("searches_30d"),
+        "data_retention_days": d.get("data_retention_days"),
+    }
+
+
+def load_flock_snapshots(reg_entry):
+    """If the registry entry has a crawled Flock portal, return
+    (latest_snapshot, prior_snapshot_or_none, slug). Else (None, None, None)."""
+    slug = reg_entry.get("flock_active_slug")
+    if not slug:
+        return None, None, None
+    portal_dir = TRANSPARENCY_DIR / slug
+    if not portal_dir.is_dir():
+        return None, None, None
+    jsons = portal_jsons(portal_dir)
+    if not jsons:
+        return None, None, None
+    latest = snapshot_from_portal_json(jsons[-1])
+    prior = None
+    if len(jsons) >= 2:
+        latest_date = latest.get("as_of")
+        try:
+            latest_d = dt.date.fromisoformat(latest_date) if latest_date else None
+        except ValueError:
+            latest_d = None
+        if latest_d:
+            for candidate in jsons[:-1]:
+                try:
+                    cand_d = dt.date.fromisoformat(candidate.stem)
+                except ValueError:
+                    continue
+                if (latest_d - cand_d).days >= MIN_SNAPSHOT_DELTA_DAYS:
+                    prior = snapshot_from_portal_json(candidate)
+                    break
+    return latest, prior, slug
+
+
+def derive_status(agency_events):
+    """Per vendor, status = latest event type. Returns (per_vendor, overall)."""
+    by_vendor = {}
+    for ev in agency_events:
+        v = ev.get("vendor") or "other"
+        by_vendor.setdefault(v, []).append(ev)
+    per_vendor = {}
+    for v, evs in by_vendor.items():
+        evs_sorted = sorted(evs, key=lambda e: parse_event_date(e.get("date"))[0])
+        latest = evs_sorted[-1]
+        per_vendor[v] = {
+            "status": latest["type"],
+            "last_event_date": latest.get("date"),
+        }
+    overall = None
+    for s in STATUS_SEVERITY:
+        if any(p["status"] == s for p in per_vendor.values()):
+            overall = s
+            break
+    return per_vendor, overall
+
+
+def build(events_src, articles_src, reg_by_id):
+    articles_by_id = {a["id"]: a for a in articles_src}
+
+    events_by_agency = {}
+    for ev in events_src:
+        events_by_agency.setdefault(ev["agency_id"], []).append(ev)
+
+    markers = []
+    agencies_out = {}
+    for aid, agency_events in events_by_agency.items():
+        reg = reg_by_id[aid]  # validated above
+        name = agency_display_name(reg)
+        state = agency_state(reg)
+        lat, lng = agency_coords(reg)
+        geo = reg.get("geo") or {}
+        city = geo.get("name") if geo.get("kind") == "place" else None
+
+        # Vendors = union of vendors from all this agency's events
+        vendors = sorted({ev.get("vendor") for ev in agency_events if ev.get("vendor")})
+
+        per_vendor, overall = derive_status(agency_events)
+        sorted_events = sorted(
+            agency_events,
+            key=lambda e: parse_event_date(e.get("date"))[0],
+            reverse=True,
+        )
+
+        # Dedup articles in event-order (newest event first)
+        article_ids_seen = []
+        seen = set()
+        for ev in sorted_events:
+            for art_id in ev.get("article_ids") or []:
+                if art_id in seen:
+                    continue
+                seen.add(art_id)
+                article_ids_seen.append(art_id)
+        agency_articles = [articles_by_id[a_id] for a_id in article_ids_seen if a_id in articles_by_id]
+
+        # Flock snapshot enrichment (if registry has a crawled portal)
+        snapshot, snapshot_prior, flock_slug = load_flock_snapshots(reg)
+        flock_portal_url = (
+            f"https://transparency.flocksafety.com/{flock_slug}"
+            if flock_slug else None
+        )
+
+        payload = {
+            "id": aid,
+            "name": name,
+            "city": city,
+            "state": state,
+            "lat": lat,
+            "lng": lng,
+            "vendors": vendors,
+            "events": sorted_events,
+            "articles": agency_articles,
+            "status_by_vendor": per_vendor,
+            "status_overall": overall,
+        }
+        if snapshot:
+            payload["flock_portal_url"] = flock_portal_url
+            payload["flock_active_slug"] = flock_slug
+            payload["flock_snapshot"] = snapshot
+            if snapshot_prior:
+                payload["flock_snapshot_prior"] = snapshot_prior
+        agencies_out[aid] = payload
+
+        marker = {
+            "id": aid,
+            "lat": lat,
+            "lng": lng,
+            "name": name,
+            "full_name": name,
+            "city": city,
+            "state": state,
+            "vendors": vendors,
+            "status_overall": overall,
+            "status_by_vendor": per_vendor,
+            "event_count": len(agency_events),
+            "article_count": len(agency_articles),
+            "camera_count": (snapshot or {}).get("camera_count"),
+        }
+        markers.append(marker)
+
+    return {
+        "markers": markers,
+        "agencies": agencies_out,
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "meta": {
+            "status_severity": STATUS_SEVERITY,
+            "known_vendors": sorted(KNOWN_VENDORS),
+            "reasons": REASONS,
+        },
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=str(DEFAULT_OUT), type=Path)
+    ap.add_argument(
+        "--src",
+        default=str(SRC_DIR),
+        type=Path,
+        help="Source dir with events.json/articles.json",
+    )
+    args = ap.parse_args()
+
+    src_dir = args.src
+    events = load_source("events.json", src_dir)
+    articles = load_source("articles.json", src_dir)
+
+    load_registry()
+    reg_by_id = registry_by_id()
+
+    errors, warnings = validate(events, articles, reg_by_id)
+    for w in warnings:
+        print(f"WARN: {w}", file=sys.stderr)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    bundle = build(events, articles, reg_by_id)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(bundle, f, indent=2)
+    print(
+        f"wrote {args.out}: {len(bundle['markers'])} agencies, "
+        f"{sum(len(a['events']) for a in bundle['agencies'].values())} events, "
+        f"{len({a['id'] for g in bundle['agencies'].values() for a in g['articles']})} articles"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -47,11 +47,15 @@ def main():
     # Load agency registry indexed by agency_id
     reg_by_id = registry_by_id()
 
-    # Also build slug-based lookups for JS output
+    # Also build slug-based lookups for JS output. Skip entries without a
+    # slug — the JS keys all its lookups by slug, so null-slug agencies
+    # can't participate in the sharing map.
     registry_by_slug = {}
     id_to_slug = {}  # agency_id -> slug (for translating graph edges to JS)
     for e in load_registry():
-        slug = e["slug"]
+        slug = e.get("slug")
+        if not slug:
+            continue
         registry_by_slug[slug] = e
         id_to_slug[e["agency_id"]] = slug
 
@@ -132,7 +136,12 @@ def main():
         aid = e["agency_id"]
         if aid in seen_ids:
             continue
-        slug = e["slug"]
+        slug = e.get("slug")
+        if not slug:
+            # Registry entries without a verified Flock slug don't belong
+            # on the sharing map — they have no crawlable portal and can't
+            # be interacted with via the JS (which keys by slug).
+            continue
         lat, lng = agency_coords(e)
         if lat is None or lng is None:
             continue

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -563,8 +563,11 @@ def percentile_of(value, sorted_values):
 def main():
     registry = load_registry()
     reg_by_id = registry_by_id()
-    id_to_slug = {e["agency_id"]: e["slug"] for e in registry}
-    slug_to_id = {e["slug"]: e["agency_id"] for e in registry}
+    # Filter out entries with null slug — those agencies have no crawlable
+    # Flock portal and can't produce per-agency reports (reports are keyed
+    # by slug for the report.html?agency=<slug> URL pattern).
+    id_to_slug = {e["agency_id"]: e["slug"] for e in registry if e.get("slug")}
+    slug_to_id = {e["slug"]: e["agency_id"] for e in registry if e.get("slug")}
     # Also handle legacy flock_slugs → primary slug
     for e in registry:
         for fs in e.get("flock_slugs", []):
@@ -971,7 +974,11 @@ def main():
     reports = {}
     for e in registry:
         aid = e["agency_id"]
-        slug = e["slug"]
+        slug = e.get("slug")
+        if not slug:
+            # Per-agency reports are keyed by slug (URL: report.html?agency=<slug>).
+            # Agencies without a verified Flock slug can't produce a report.
+            continue
         reg = e
         gdata = graph_agencies.get(aid, {})
         crawled = bool(gdata.get("crawled"))

--- a/scripts/build_scoreboard.py
+++ b/scripts/build_scoreboard.py
@@ -57,7 +57,9 @@ def load_crawled_stats(slug):
 def main():
     registry = load_registry()
     reg_by_id = registry_by_id()
-    id_to_slug = {e["agency_id"]: e["slug"] for e in registry}
+    # Filter out null-slug entries (agencies without a verified Flock portal).
+    # Scoreboard links use slugs to form report.html?agency=<slug> URLs.
+    id_to_slug = {e["agency_id"]: e["slug"] for e in registry if e.get("slug")}
 
     with open(GRAPH_PATH) as f:
         graph = json.load(f)

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -49,8 +49,12 @@ def registry_by_id():
 
 
 def registry_by_slug():
-    """Return slug -> registry entry lookup. Backward compat."""
-    return {e["slug"]: e for e in load_registry()}
+    """Return slug -> registry entry lookup. Backward compat.
+
+    Entries without a slug (non-Flock agencies or not-yet-verified slugs)
+    are excluded — use registry_by_id() instead for those.
+    """
+    return {e["slug"]: e for e in load_registry() if e.get("slug")}
 
 
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")

--- a/scripts/publish_docs.sh
+++ b/scripts/publish_docs.sh
@@ -9,6 +9,7 @@ uv run python scripts/build_sharing_graph.py
 uv run python scripts/build_map.py
 uv run python scripts/build_scoreboard.py
 uv run python scripts/build_audit_log.py
+uv run python scripts/build_contract_map.py
 
 # Copy findings
 cp outputs/SMPD_ALPR_Findings.pdf docs/SMPD_ALPR_Findings.pdf
@@ -18,5 +19,6 @@ echo "Done. docs/ ready for GitHub Pages."
 echo "  docs/index.html"
 echo "  docs/sharing_map.html"
 echo "  docs/scoreboard.html"
+echo "  docs/contracts.html"
 echo "  docs/SMPD_ALPR_Findings.pdf"
 echo "  docs/SMPD_ALPR_Findings.md"

--- a/scripts/seed_contract_registry.py
+++ b/scripts/seed_contract_registry.py
@@ -40,54 +40,67 @@ REGISTRY_PATH = Path("assets/agency_registry.json")
 #                   Leave None for agencies that never used Flock or have
 #                   no crawlable portal.
 
+# SEED_KEY is a stable internal identifier used for UUID minting and for
+# idempotent dedup when slug is null. Never change a seed_key after an entry
+# is written to the registry — agency_ids depend on it.
+#
+# flock_slug is only set when the Flock transparency portal has been verified
+# to exist (user manual confirmation or Playwright probe). Setting it here
+# also populates flock_slugs/flock_names in the registry entry.
+#
+# Agencies we suspect had Flock but whose real slug we haven't verified get
+# flock_slug=None. A future slug-guesser tool can upgrade these in place.
 SEEDS = [
-    # CA — most already in registry from the SMPD sharing crawl, but we
-    # include them here so slug → agency_id mapping is explicit and
-    # any missing ones get auto-added.
-    {"slug": "santa-cruz-ca-pd",     "display_name": "Santa Cruz Police Department",      "state": "CA", "role": "police",  "type": "city",   "flock_slug": "santa-cruz-ca-pd"},
-    {"slug": "mountain-view-ca-pd",  "display_name": "Mountain View Police Department",   "state": "CA", "role": "police",  "type": "city",   "flock_slug": "mountain-view-ca-pd"},
-    {"slug": "south-pasadena-ca-pd", "display_name": "South Pasadena Police Department",  "state": "CA", "role": "police",  "type": "city",   "flock_slug": "south-pasadena-ca-pd"},
-    {"slug": "berkeley-ca-pd",       "display_name": "Berkeley Police Department",        "state": "CA", "role": "police",  "type": "city",   "flock_slug": "berkeley-ca-pd"},
-    {"slug": "alameda-county-ca-so", "display_name": "Alameda County Sheriff's Office",   "state": "CA", "role": "sheriff", "type": "county", "flock_slug": "alameda-county-ca-so"},
+    # CA — already in registry from the SMPD sharing crawl (seeder skips them).
+    {"seed_key": "santa-cruz-ca-pd",     "slug": "santa-cruz-ca-pd",     "display_name": "Santa Cruz Police Department",      "state": "CA", "role": "police",  "type": "city",   "flock_slug": "santa-cruz-ca-pd"},
+    {"seed_key": "south-pasadena-ca-pd", "slug": "south-pasadena-ca-pd", "display_name": "South Pasadena Police Department",  "state": "CA", "role": "police",  "type": "city",   "flock_slug": "south-pasadena-ca-pd"},
+    {"seed_key": "berkeley-ca-pd",       "slug": "berkeley-ca-pd",       "display_name": "Berkeley Police Department",        "state": "CA", "role": "police",  "type": "city",   "flock_slug": "berkeley-ca-pd"},
+    {"seed_key": "alameda-county-ca-so", "slug": "alameda-county-ca-so", "display_name": "Alameda County Sheriff's Office",   "state": "CA", "role": "sheriff", "type": "county", "flock_slug": "alameda-county-ca-so"},
+    {"seed_key": "springfield-or-pd",    "slug": "springfield-or-pd",    "display_name": "Springfield Police Department",     "state": "OR", "role": "police",  "type": "city",   "flock_slug": "springfield-or-pd"},
+    {"seed_key": "richmond-va-pd",       "slug": "richmond-va-pd",       "display_name": "Richmond Police Department",        "state": "VA", "role": "police",  "type": "city",   "flock_slug": "richmond-va-pd"},
 
-    # Non-CA / non-Flock-crawled — registry entry with flock_slug=None
-    {"slug": "oak-park-il-pd",       "display_name": "Oak Park Police Department",        "state": "IL", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "evanston-il-pd",       "display_name": "Evanston Police Department",        "state": "IL", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "austin-tx-pd",         "display_name": "Austin Police Department",          "state": "TX", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "denver-co-pd",         "display_name": "Denver Police Department",          "state": "CO", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "charlottesville-va-pd","display_name": "Charlottesville Police Department", "state": "VA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "staunton-va-pd",       "display_name": "Staunton Police Department",        "state": "VA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "flagstaff-az-pd",      "display_name": "Flagstaff Police Department",       "state": "AZ", "role": "police",  "type": "city",       "flock_slug": "flagstaff-az-pd-inactive"},
-    {"slug": "cambridge-ma-pd",      "display_name": "Cambridge Police Department",       "state": "MA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "eugene-or-pd",         "display_name": "Eugene Police Department",          "state": "OR", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "springfield-or-pd",    "display_name": "Springfield Police Department",     "state": "OR", "role": "police",  "type": "city",       "flock_slug": "springfield-or-pd"},
-    {"slug": "ithaca-ny-pd",         "display_name": "Ithaca Police Department",          "state": "NY", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "tompkins-county-ny-so","display_name": "Tompkins County Sheriff's Office",  "state": "NY", "role": "sheriff", "type": "county",     "flock_slug": None},
-    {"slug": "hillsborough-nc-pd",   "display_name": "Hillsborough Police Department",    "state": "NC", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "coralville-ia-pd",     "display_name": "Coralville Police Department",      "state": "IA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "lynnwood-wa-pd",       "display_name": "Lynnwood Police Department",        "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "olympia-wa-pd",        "display_name": "Olympia Police Department",         "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "redmond-wa-pd",        "display_name": "Redmond Police Department",         "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "oshkosh-wi-pd",        "display_name": "Oshkosh Police Department",         "state": "WI", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "windsor-ct-pd",        "display_name": "Windsor Police Department",         "state": "CT", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "columbus-oh-pd",       "display_name": "Columbus Police Department",        "state": "OH", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "el-paso-tx-pd",        "display_name": "El Paso Police Department",         "state": "TX", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "bloomington-in-pd",    "display_name": "Bloomington Police Department",     "state": "IN", "role": "police",  "type": "city",       "flock_slug": None},
-    {"slug": "richmond-va-pd",       "display_name": "Richmond Police Department",        "state": "VA", "role": "police",  "type": "city",       "flock_slug": "richmond-va-pd"},
+    # Verified portals (user manual + Playwright).
+    {"seed_key": "mountain-view-ca-pd",   "slug": "mountain-view-ca-pd",   "display_name": "Mountain View Police Department",   "state": "CA", "role": "police",  "type": "city",   "flock_slug": "mountain-view-ca-pd"},
+    {"seed_key": "austin-tx-pd",          "slug": "austin-tx-pd",          "display_name": "Austin Police Department",          "state": "TX", "role": "police",  "type": "city",   "flock_slug": "austin-tx-pd"},
+    {"seed_key": "denver-co-pd",          "slug": "denver-co-pd",          "display_name": "Denver Police Department",          "state": "CO", "role": "police",  "type": "city",   "flock_slug": "denver-co-pd"},
+    {"seed_key": "charlottesville-va-pd", "slug": "charlottesville-va-pd", "display_name": "Charlottesville Police Department", "state": "VA", "role": "police",  "type": "city",   "flock_slug": "charlottesville-va-pd"},
+    {"seed_key": "staunton-va-pd",        "slug": "staunton-va-pd",        "display_name": "Staunton Police Department",        "state": "VA", "role": "police",  "type": "city",   "flock_slug": "staunton-va-pd"},
+    {"seed_key": "flagstaff-az-pd",       "slug": "flagstaff-az-pd",       "display_name": "Flagstaff Police Department",       "state": "AZ", "role": "police",  "type": "city",   "flock_slug": "flagstaff-az-pd"},
+    {"seed_key": "eugene-or-pd",          "slug": "eugene-or-pd",          "display_name": "Eugene Police Department",          "state": "OR", "role": "police",  "type": "city",   "flock_slug": "eugene-or-pd"},
+    {"seed_key": "tompkins-county-ny-so", "slug": "tompkins-county-ny-so", "display_name": "Tompkins County Sheriff's Office",  "state": "NY", "role": "sheriff", "type": "county", "flock_slug": "tompkins-county-ny-so"},
+    {"seed_key": "hillsborough-nc-pd",    "slug": "hillsborough-nc-pd",    "display_name": "Hillsborough Police Department",    "state": "NC", "role": "police",  "type": "city",   "flock_slug": "hillsborough-nc-pd"},
+    {"seed_key": "lynnwood-wa-pd",        "slug": "lynnwood-wa-pd",        "display_name": "Lynnwood Police Department",        "state": "WA", "role": "police",  "type": "city",   "flock_slug": "lynnwood-wa-pd"},
+    {"seed_key": "oshkosh-wi-pd",         "slug": "oshkosh-wi-pd",         "display_name": "Oshkosh Police Department",         "state": "WI", "role": "police",  "type": "city",   "flock_slug": "oshkosh-wi-pd"},
+    {"seed_key": "windsor-ct-pd",         "slug": "windsor-ct-pd",         "display_name": "Windsor Police Department",         "state": "CT", "role": "police",  "type": "city",   "flock_slug": "windsor-ct-pd"},
+
+    # Unverified: real slug unknown. Registry entry exists but carries no
+    # flock_* data until the slug-guesser tool verifies.
+    {"seed_key": "oak-park-il-pd",        "slug": None, "display_name": "Oak Park Police Department",        "state": "IL", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "evanston-il-pd",        "slug": None, "display_name": "Evanston Police Department",        "state": "IL", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "cambridge-ma-pd",       "slug": None, "display_name": "Cambridge Police Department",       "state": "MA", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "ithaca-ny-pd",          "slug": None, "display_name": "Ithaca Police Department",          "state": "NY", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "coralville-ia-pd",      "slug": None, "display_name": "Coralville Police Department",      "state": "IA", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "olympia-wa-pd",         "slug": None, "display_name": "Olympia Police Department",         "state": "WA", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "redmond-wa-pd",         "slug": None, "display_name": "Redmond Police Department",         "state": "WA", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "columbus-oh-pd",        "slug": None, "display_name": "Columbus Police Department",        "state": "OH", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "el-paso-tx-pd",         "slug": None, "display_name": "El Paso Police Department",         "state": "TX", "role": "police",  "type": "city",   "flock_slug": None},
+    {"seed_key": "bloomington-in-pd",     "slug": None, "display_name": "Bloomington Police Department",     "state": "IN", "role": "police",  "type": "city",   "flock_slug": None},
 ]
 
 
-def mint_agency_id(slug):
-    # Same namespace as build_agency_registry.py so slugs → UUIDs stay stable.
-    return str(uuid.uuid5(uuid.NAMESPACE_DNS, "flock-registry:" + slug))
+def mint_agency_id(seed_key):
+    # Deterministic UUID keyed on seed_key. Same namespace prefix as
+    # build_agency_registry.py (flock-registry:) so seeds whose seed_key
+    # matches an existing slug in the registry produce the same UUID as
+    # the original auto-populated entry — enabling deduplication.
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, "flock-registry:" + seed_key))
 
 
 def build_entry(seed):
-    slug = seed["slug"]
     flock_slug = seed.get("flock_slug")
     entry = {
-        "agency_id": mint_agency_id(slug),
-        "slug": slug,
+        "agency_id": mint_agency_id(seed["seed_key"]),
+        "slug": seed["slug"],  # may be None for unverified agencies
         "flock_active_slug": flock_slug,
         "flock_slugs": [flock_slug] if flock_slug else [],
         "flock_names": [seed["display_name"]] if flock_slug else [],
@@ -110,13 +123,17 @@ def main():
     args = ap.parse_args()
 
     registry = json.loads(REGISTRY_PATH.read_text())
-    by_slug = {e.get("slug"): e for e in registry}
+    # Dedup by agency_id (deterministic from seed_key). Works whether or
+    # not the slug is populated, which matters for entries whose real
+    # Flock slug has not yet been verified.
+    by_id = {e.get("agency_id"): e for e in registry}
 
     added = []
     existed = []
     for seed in SEEDS:
-        if seed["slug"] in by_slug:
-            existed.append(seed["slug"])
+        aid = mint_agency_id(seed["seed_key"])
+        if aid in by_id:
+            existed.append(seed["seed_key"])
             continue
         entry = build_entry(seed)
         # Geocode to replace the "state-only" stub with precise coords
@@ -131,7 +148,8 @@ def main():
     print(f"new to be added:     {len(added)}")
     for e in added:
         g = e.get("geo") or {}
-        print(f"  add   {e['slug']:30s}  agency_id={e['agency_id']}  "
+        ident = e.get("slug") or e.get("display_name")
+        print(f"  add   {ident:40s}  agency_id={e['agency_id']}  "
               f"geo={g.get('kind')} lat={g.get('lat')} lng={g.get('lng')}")
 
     if args.dry_run:

--- a/scripts/seed_contract_registry.py
+++ b/scripts/seed_contract_registry.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Idempotently add the seed agencies used by the contract-status map to
+assets/agency_registry.json. Agencies that already exist in the registry
+(by slug) are left untouched; new entries are appended and geocoded.
+
+Non-Flock agencies get `flock_slugs: []` and `flock_active_slug: null` —
+the registry is the central identity DB regardless of ALPR vendor.
+
+Usage:
+  uv run python scripts/seed_contract_registry.py
+  uv run python scripts/seed_contract_registry.py --dry-run
+"""
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from geocode_agencies import geocode_entry  # noqa: E402
+
+REGISTRY_PATH = Path("assets/agency_registry.json")
+
+# Each seed entry below becomes a registry row. Slugs are stable and
+# deterministic — re-running produces the same UUIDs. For agencies already
+# tracked in the registry (CA Flock portal crawls), this script is a no-op
+# because the slug already exists.
+#
+# Fields:
+#   slug          — hand-chosen stable slug (idempotency key)
+#   display_name  — how the agency should be rendered
+#   state         — 2-letter state code
+#   role          — "police" | "sheriff" | "da" | ...
+#   type          — "city" | "county" | "state" | "federal" | "university"
+#   website       — optional official website URL
+#   flock_slug    — set ONLY if the agency has a known Flock transparency
+#                   portal (so the contract map can pull live snapshots).
+#                   Leave None for agencies that never used Flock or have
+#                   no crawlable portal.
+
+SEEDS = [
+    # CA — most already in registry from the SMPD sharing crawl, but we
+    # include them here so slug → agency_id mapping is explicit and
+    # any missing ones get auto-added.
+    {"slug": "santa-cruz-ca-pd",     "display_name": "Santa Cruz Police Department",      "state": "CA", "role": "police",  "type": "city",   "flock_slug": "santa-cruz-ca-pd"},
+    {"slug": "mountain-view-ca-pd",  "display_name": "Mountain View Police Department",   "state": "CA", "role": "police",  "type": "city",   "flock_slug": "mountain-view-ca-pd"},
+    {"slug": "south-pasadena-ca-pd", "display_name": "South Pasadena Police Department",  "state": "CA", "role": "police",  "type": "city",   "flock_slug": "south-pasadena-ca-pd"},
+    {"slug": "berkeley-ca-pd",       "display_name": "Berkeley Police Department",        "state": "CA", "role": "police",  "type": "city",   "flock_slug": "berkeley-ca-pd"},
+    {"slug": "alameda-county-ca-so", "display_name": "Alameda County Sheriff's Office",   "state": "CA", "role": "sheriff", "type": "county", "flock_slug": "alameda-county-ca-so"},
+
+    # Non-CA / non-Flock-crawled — registry entry with flock_slug=None
+    {"slug": "oak-park-il-pd",       "display_name": "Oak Park Police Department",        "state": "IL", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "evanston-il-pd",       "display_name": "Evanston Police Department",        "state": "IL", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "austin-tx-pd",         "display_name": "Austin Police Department",          "state": "TX", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "denver-co-pd",         "display_name": "Denver Police Department",          "state": "CO", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "charlottesville-va-pd","display_name": "Charlottesville Police Department", "state": "VA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "staunton-va-pd",       "display_name": "Staunton Police Department",        "state": "VA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "flagstaff-az-pd",      "display_name": "Flagstaff Police Department",       "state": "AZ", "role": "police",  "type": "city",       "flock_slug": "flagstaff-az-pd-inactive"},
+    {"slug": "cambridge-ma-pd",      "display_name": "Cambridge Police Department",       "state": "MA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "eugene-or-pd",         "display_name": "Eugene Police Department",          "state": "OR", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "springfield-or-pd",    "display_name": "Springfield Police Department",     "state": "OR", "role": "police",  "type": "city",       "flock_slug": "springfield-or-pd"},
+    {"slug": "ithaca-ny-pd",         "display_name": "Ithaca Police Department",          "state": "NY", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "tompkins-county-ny-so","display_name": "Tompkins County Sheriff's Office",  "state": "NY", "role": "sheriff", "type": "county",     "flock_slug": None},
+    {"slug": "hillsborough-nc-pd",   "display_name": "Hillsborough Police Department",    "state": "NC", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "coralville-ia-pd",     "display_name": "Coralville Police Department",      "state": "IA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "lynnwood-wa-pd",       "display_name": "Lynnwood Police Department",        "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "olympia-wa-pd",        "display_name": "Olympia Police Department",         "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "redmond-wa-pd",        "display_name": "Redmond Police Department",         "state": "WA", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "oshkosh-wi-pd",        "display_name": "Oshkosh Police Department",         "state": "WI", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "windsor-ct-pd",        "display_name": "Windsor Police Department",         "state": "CT", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "columbus-oh-pd",       "display_name": "Columbus Police Department",        "state": "OH", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "el-paso-tx-pd",        "display_name": "El Paso Police Department",         "state": "TX", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "bloomington-in-pd",    "display_name": "Bloomington Police Department",     "state": "IN", "role": "police",  "type": "city",       "flock_slug": None},
+    {"slug": "richmond-va-pd",       "display_name": "Richmond Police Department",        "state": "VA", "role": "police",  "type": "city",       "flock_slug": "richmond-va-pd"},
+]
+
+
+def mint_agency_id(slug):
+    # Same namespace as build_agency_registry.py so slugs → UUIDs stay stable.
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, "flock-registry:" + slug))
+
+
+def build_entry(seed):
+    slug = seed["slug"]
+    flock_slug = seed.get("flock_slug")
+    entry = {
+        "agency_id": mint_agency_id(slug),
+        "slug": slug,
+        "flock_active_slug": flock_slug,
+        "flock_slugs": [flock_slug] if flock_slug else [],
+        "flock_names": [seed["display_name"]] if flock_slug else [],
+        "display_name": seed["display_name"],
+        "agency_role": seed["role"],
+        "agency_type": seed["type"],
+        "website": seed.get("website"),
+        "notes": None,
+        "tags": ["public"],
+        "flags": [],
+        "geo": {"kind": "state-only", "state": seed["state"]},
+    }
+    return entry
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Report what would change, don't write")
+    args = ap.parse_args()
+
+    registry = json.loads(REGISTRY_PATH.read_text())
+    by_slug = {e.get("slug"): e for e in registry}
+
+    added = []
+    existed = []
+    for seed in SEEDS:
+        if seed["slug"] in by_slug:
+            existed.append(seed["slug"])
+            continue
+        entry = build_entry(seed)
+        # Geocode to replace the "state-only" stub with precise coords
+        geo = geocode_entry(entry)
+        if geo:
+            entry["geo"] = geo
+        added.append(entry)
+
+    print(f"existed in registry: {len(existed)}")
+    for s in existed:
+        print(f"  skip  {s}")
+    print(f"new to be added:     {len(added)}")
+    for e in added:
+        g = e.get("geo") or {}
+        print(f"  add   {e['slug']:30s}  agency_id={e['agency_id']}  "
+              f"geo={g.get('kind')} lat={g.get('lat')} lng={g.get('lng')}")
+
+    if args.dry_run:
+        print("\n(dry run — no changes written)")
+        return
+
+    if not added:
+        print("nothing to write")
+        return
+
+    registry.extend(added)
+    REGISTRY_PATH.write_text(json.dumps(registry, indent=2) + "\n")
+    print(f"\nwrote {REGISTRY_PATH}: {len(added)} new entries, "
+          f"{len(registry)} total")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contract_data.py
+++ b/tests/test_contract_data.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Validate data/contracts/ source files: id uniqueness, cross-references
+against both articles.json and assets/agency_registry.json, event types,
+vendor enum, reason enum, date parseability, and US-bbox coords.
+
+Run with: uv run pytest tests/test_contract_data.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from build_contract_map import (  # noqa: E402
+    KNOWN_VENDORS,
+    REASONS,
+    US_BBOX,
+    VALID_EVENT_TYPES,
+    parse_event_date,
+    validate,
+)
+from lib import agency_coords, load_registry, registry_by_id  # noqa: E402
+
+SRC = ROOT / "data" / "contracts"
+
+
+@pytest.fixture(scope="module")
+def data():
+    return {
+        "events": json.loads((SRC / "events.json").read_text()),
+        "articles": json.loads((SRC / "articles.json").read_text()),
+    }
+
+
+@pytest.fixture(scope="module")
+def reg_by_id():
+    load_registry.__globals__["_registry_cache"] = None  # force reload
+    load_registry()
+    return registry_by_id()
+
+
+def test_sources_exist():
+    assert (SRC / "events.json").is_file()
+    assert (SRC / "articles.json").is_file()
+
+
+def test_sources_parse_as_lists(data):
+    assert isinstance(data["events"], list)
+    assert isinstance(data["articles"], list)
+
+
+def test_no_validation_errors(data, reg_by_id):
+    errors, _ = validate(data["events"], data["articles"], reg_by_id)
+    assert errors == [], "validation errors: " + "\n".join(errors)
+
+
+def test_article_ids_unique(data):
+    ids = [a["id"] for a in data["articles"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_event_types_valid(data):
+    for ev in data["events"]:
+        assert ev.get("type") in VALID_EVENT_TYPES, ev
+
+
+def test_event_agency_refs_resolve_to_registry(data, reg_by_id):
+    for ev in data["events"]:
+        assert ev["agency_id"] in reg_by_id, (
+            f"event references agency_id {ev['agency_id']!r} not in registry"
+        )
+
+
+def test_event_article_refs_valid(data):
+    article_ids = {a["id"] for a in data["articles"]}
+    for ev in data["events"]:
+        for aid in ev.get("article_ids") or []:
+            assert aid in article_ids, (ev, aid)
+
+
+def test_referenced_agencies_have_coords(data, reg_by_id):
+    for ev in data["events"]:
+        reg = reg_by_id[ev["agency_id"]]
+        lat, lng = agency_coords(reg)
+        assert lat is not None and lng is not None, (
+            f"registry entry for {ev['agency_id']} lacks coords"
+        )
+        assert US_BBOX["lat_min"] <= lat <= US_BBOX["lat_max"]
+        assert US_BBOX["lng_min"] <= lng <= US_BBOX["lng_max"]
+
+
+def test_dates_parseable(data):
+    for ev in data["events"]:
+        parse_event_date(ev.get("date"))
+
+
+def test_event_vendors(data):
+    for ev in data["events"]:
+        v = ev.get("vendor")
+        if v is None:
+            continue
+        assert isinstance(v, str)
+
+
+def test_event_reasons_valid(data):
+    for ev in data["events"]:
+        for r in ev.get("reasons") or []:
+            assert r in REASONS, f"unknown reason {r!r} in event {ev}"
+
+
+def test_parse_date_formats():
+    assert parse_event_date("2025-06-15")[2] is True
+    assert parse_event_date("2025-06")[2] is False
+    assert parse_event_date("2025")[2] is False
+    assert parse_event_date(None)[1] == "undated"
+    with pytest.raises(ValueError):
+        parse_event_date("not-a-date")
+    with pytest.raises(ValueError):
+        parse_event_date("2025-13-01")
+
+
+def test_known_vendors_includes_flock():
+    assert "flock" in KNOWN_VENDORS
+
+
+def test_reasons_metadata_shape():
+    for code, meta in REASONS.items():
+        assert "label" in meta
+        assert "icon" in meta
+        assert "color" in meta

--- a/tests/test_contract_map_smoke.py
+++ b/tests/test_contract_map_smoke.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Smoke test for the contracts map: verifies required UI elements exist in
+docs/contracts.html, build_contract_map.py runs against a fixture backed by
+the real registry, and the generated bundle has the expected top-level shape.
+
+No browser involved — grepping the HTML for required selectors is enough to
+catch regressions at this stage.
+
+Run with: uv run pytest tests/test_contract_map_smoke.py
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HTML_PATH = ROOT / "docs" / "contracts.html"
+JS_PATH = ROOT / "docs" / "js" / "contracts.js"
+BUILD_SCRIPT = ROOT / "scripts" / "build_contract_map.py"
+
+# Required UI elements — keep in sync with docs/contracts.html / contracts.js.
+# If you add a new top-level UI overlay, add its selector here.
+_UI_ELEMENTS = [
+    'id="map"',
+    'id="info"',
+    'id="info-close"',
+    'id="search-box"',
+    'id="search-results"',
+    'id="reason-legend"',
+    'id="gate-overlay"',
+    'id="draft-banner"',
+    'class="legend"',
+    'class="back-link"',
+    'class="page-title"',
+    'src="js/contracts.js"',
+    "data/contract_map_data.json",
+]
+
+
+def test_html_exists():
+    assert HTML_PATH.is_file(), f"missing {HTML_PATH}"
+
+
+def test_js_exists():
+    assert JS_PATH.is_file(), f"missing {JS_PATH}"
+
+
+def test_html_has_required_ui_elements():
+    html = HTML_PATH.read_text()
+    joint = html + "\n" + JS_PATH.read_text()
+    missing = [sel for sel in _UI_ELEMENTS if sel not in joint]
+    assert not missing, f"missing UI elements: {missing}"
+
+
+def test_html_has_leaflet_include():
+    html = HTML_PATH.read_text()
+    assert "leaflet@1.9.4" in html
+    assert "integrity=" in html  # SRI on CDN assets
+
+
+def test_html_has_strict_csp():
+    html = HTML_PATH.read_text()
+    assert "Content-Security-Policy" in html
+    assert "default-src 'self'" in html
+
+
+def _pick_seeded_agency_id():
+    """Return a registry agency_id known to have coords — used to validate
+    the build against a working fixture without inventing a fake UUID."""
+    reg = json.loads((ROOT / "assets" / "agency_registry.json").read_text())
+    for e in reg:
+        if e.get("slug") == "santa-cruz-ca-pd":
+            return e["agency_id"]
+    # Fallback: any entry with a valid place geo
+    for e in reg:
+        geo = e.get("geo") or {}
+        if geo.get("lat") and geo.get("lng"):
+            return e["agency_id"]
+    raise RuntimeError("no suitable registry entry for fixture")
+
+
+def test_build_runs_against_fixture(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    agency_id = _pick_seeded_agency_id()
+    articles = [{
+        "id": "fixture-news-2025-01-01-cancel",
+        "url": "https://example.com/story",
+        "title": "Fixture City cancels ALPR contract",
+        "outlet": "Fixture Tribune",
+        "author": None,
+        "published_date": "2025-01-01",
+        "summary": None,
+        "tags": [],
+    }]
+    events = [{
+        "agency_id": agency_id,
+        "type": "canceled",
+        "date": "2025-01-01",
+        "vendor": "flock",
+        "cameras_affected": 12,
+        "article_ids": ["fixture-news-2025-01-01-cancel"],
+        "reasons": ["federal-access", "privacy-general"],
+        "notes": "Canceled by council vote.",
+    }]
+    (src / "events.json").write_text(json.dumps(events))
+    (src / "articles.json").write_text(json.dumps(articles))
+
+    out = tmp_path / "bundle.json"
+    result = subprocess.run(
+        [sys.executable, str(BUILD_SCRIPT), "--src", str(src), "--out", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    bundle = json.loads(out.read_text())
+
+    assert set(bundle.keys()) >= {"markers", "agencies", "generated_at", "meta"}
+    assert len(bundle["markers"]) == 1
+    m = bundle["markers"][0]
+    assert m["id"] == agency_id
+    assert m["status_overall"] == "canceled"
+    assert m["event_count"] == 1
+    assert m["article_count"] == 1
+
+    payload = bundle["agencies"][agency_id]
+    assert payload["status_overall"] == "canceled"
+    assert payload["status_by_vendor"]["flock"]["status"] == "canceled"
+    assert payload["events"][0]["cameras_affected"] == 12
+    assert payload["events"][0]["reasons"] == ["federal-access", "privacy-general"]
+    assert payload["articles"][0]["id"] == "fixture-news-2025-01-01-cancel"
+
+    # Meta carries reasons metadata for the UI to render chips
+    assert "reasons" in bundle["meta"]
+    assert "federal-access" in bundle["meta"]["reasons"]
+
+
+def test_build_fails_on_unknown_agency_id(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "articles.json").write_text("[]")
+    (src / "events.json").write_text(json.dumps([{
+        "agency_id": "00000000-0000-0000-0000-000000000000",
+        "type": "canceled", "date": None, "vendor": "flock",
+        "article_ids": [], "reasons": [], "notes": "",
+    }]))
+    out = tmp_path / "bundle.json"
+    result = subprocess.run(
+        [sys.executable, str(BUILD_SCRIPT), "--src", str(src), "--out", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "not in registry" in result.stderr or "unknown agency_id" in result.stderr
+
+
+def test_build_fails_on_dangling_article_ref(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    agency_id = _pick_seeded_agency_id()
+    (src / "articles.json").write_text("[]")
+    (src / "events.json").write_text(json.dumps([{
+        "agency_id": agency_id,
+        "type": "canceled", "date": None, "vendor": "flock",
+        "article_ids": ["ghost-article"], "reasons": [], "notes": "",
+    }]))
+    out = tmp_path / "bundle.json"
+    result = subprocess.run(
+        [sys.executable, str(BUILD_SCRIPT), "--src", str(src), "--out", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "ghost-article" in result.stderr

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -104,7 +104,9 @@ class TestRegistry:
         p = Path("assets/agency_registry.json")
         assert p.exists()
         self.registry = json.loads(p.read_text())
-        self.by_slug = {e["slug"]: e for e in self.registry}
+        # Only slug-keyed tests need this lookup; non-slugged entries
+        # (non-Flock agencies from the contract map) are unreachable here.
+        self.by_slug = {e["slug"]: e for e in self.registry if e.get("slug")}
 
     def test_has_entries(self):
         assert len(self.registry) > 300

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -139,16 +139,25 @@ class TestRegistry:
                 assert False, f"{e['slug']} has invalid UUID: {e['agency_id']}"
 
     def test_has_flock_slugs(self):
+        # Every entry carries the keys, but the arrays are only required to
+        # be non-empty for agencies with an actively-crawled Flock portal.
+        # Non-Flock agencies (used by the contract-map feature) have
+        # flock_active_slug=None and empty slug/name lists.
         for e in self.registry:
             assert "flock_slugs" in e, f"{e['agency_id']} missing flock_slugs"
-            assert len(e["flock_slugs"]) >= 1
+            assert isinstance(e["flock_slugs"], list)
             assert "flock_active_slug" in e
-            assert e["flock_active_slug"] in e["flock_slugs"]
+            if e["flock_active_slug"]:
+                assert e["flock_active_slug"] in e["flock_slugs"], (
+                    f"{e['agency_id']}: flock_active_slug not in flock_slugs"
+                )
 
     def test_has_flock_names(self):
+        # Same relaxation as test_has_flock_slugs: non-Flock registry entries
+        # have an empty flock_names list.
         for e in self.registry:
             assert "flock_names" in e, f"{e['agency_id']} missing flock_names"
-            assert len(e["flock_names"]) >= 1
+            assert isinstance(e["flock_names"], list)
 
     def test_no_crawled_fields_in_registry(self):
         """crawled/crawled_date are derived at runtime, not stored."""

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -122,7 +122,11 @@ class TestRegistry:
         assert "private" in uop.get("tags", [])
 
     def test_no_duplicate_slugs(self):
-        slugs = [e["slug"] for e in self.registry]
+        # slug may be null for registry entries that represent an agency
+        # we track without a verified Flock portal (non-Flock vendor, or
+        # a slug-guesser hasn't confirmed the real slug yet). Only check
+        # uniqueness among entries that actually carry a slug.
+        slugs = [e["slug"] for e in self.registry if e.get("slug")]
         assert len(slugs) == len(set(slugs)), "Duplicate slugs found"
 
     def test_no_duplicate_agency_ids(self):


### PR DESCRIPTION
## Summary

New page at [docs/contracts.html](docs/contracts.html) showing US police agencies that have canceled, paused, or are reviewing their Flock (or other vendor) ALPR contracts. Click a marker → side panel with a chronological timeline, linked news coverage, reason chips, and (when available) a live Flock transparency snapshot with camera-count delta.

- **28 seed cases** curated from web research: 18 canceled, 4 paused, 5 reviewing, 1 signed (Richmond VA as a contrast point).
- **Vendor-agnostic** by design — the contribution model is intended to extend to Vigilant / Axon Fusus / Rekor / etc.
- **Registry is the central identity DB.** Events reference `agency_id` (registry UUID); no separate agency table. 22 new agencies were seeded into the registry via the auto-geocoder (gazetteer hit rate: 22/22).
- **Reason iconography:** seven codes (`federal-access`, `unauthorized-access`, `vendor-misconduct`, `broad-disclosure`, `sanctuary-conflict`, `data-breach`, `privacy-general`) render as colored chips with letter-badge icons. A legend appears in the bottom-right listing only the codes used in the dataset.
- **Flock snapshot cross-link:** when the registry entry has crawled portal data, the side panel surfaces live camera count + 30-day vehicle/hotlist/search stats + a delta against an older snapshot. Currently lights up for South Pasadena (27 cams), Berkeley (52), Alameda County SO (93).

## Preview posture — read before merging

This ships with **guard rails** because the data is preliminary:

- 🔒 **Soft gate:** page shows a password prompt on first load. Password is `preview` (plaintext in [docs/js/contracts.js:9](docs/js/contracts.js#L9) — rotate by editing that constant). Unlock is per-session (`sessionStorage`). **Not real authentication** — it's for keeping random GoatCounter referrers off an unvetted page, not for keeping secrets.
- 🟨 **Persistent DRAFT banner** across the top reads \"PREVIEW — sample data, not for citation. Data is being actively curated and may be inaccurate or incomplete.\"
- 🔗 **Unlinked from the landing page.** `docs/index.html` does not advertise this URL. Only people given the direct link + password will find it.

Thin-sourcing caveats to address before making this public:
- Redmond WA (paused) sourced only from a Washington Retail Association aggregator, not a primary outlet.
- Windsor CT (paused) sourced only from the CarScoops compilation piece.

Rest have first-party city releases or named-outlet coverage.

## Future direction

Long-term contribution model (not in this PR — saved as a memory for the follow-up): **one submission file per news story** at `data/contracts/submissions/<date>-<slug>.yml`, self-contained with article + events. Build reconciles against the registry, auto-creates missing agencies. Flat \`events.json\` / \`articles.json\` become build artifacts. Eventually a web form generates the submission file so contributors never hand-edit JSON. Meant to scale to the ~75 articles user is about to import and beyond.

## Files of note

- [scripts/build_contract_map.py](scripts/build_contract_map.py) — validates events + articles, resolves registry entries, attaches Flock snapshots, writes [docs/data/contract_map_data.json](docs/data/contract_map_data.json) (gitignored).
- [scripts/seed_contract_registry.py](scripts/seed_contract_registry.py) — idempotent bulk-adder for the 28 seed agencies; reusable as the pattern for future bulk adds.
- [data/contracts/README.md](data/contracts/README.md) — schema + contribution workflow.
- [data/contracts/events.json](data/contracts/events.json), [data/contracts/articles.json](data/contracts/articles.json) — curated source files.
- [docs/contracts.html](docs/contracts.html) + [docs/js/contracts.js](docs/js/contracts.js) — page shell + Leaflet renderer (committed, not template-generated).
- [tests/test_contract_data.py](tests/test_contract_data.py) — 15 data-integrity checks.
- [tests/test_contract_map_smoke.py](tests/test_contract_map_smoke.py) — 7 structural/build checks including a fixture end-to-end run.

## Test plan

- [x] \`uv run pytest tests/test_contract_data.py tests/test_contract_map_smoke.py\` — 22/22 pass
- [x] \`uv run python scripts/build_contract_map.py\` — builds cleanly (28 agencies, 28 events, 38 articles)
- [x] \`uv run python scripts/seed_contract_registry.py --dry-run\` — no-op on re-run (idempotency)
- [x] Page served from \`python -m http.server\`: gate → unlock → map renders → click marker → side panel with timeline + reason chips + Flock snapshot (where applicable). No CSP violations.
- [ ] **Needs human review**: click-through a handful of markers to sanity-check notes / reason mappings before removing the gate
- [ ] **Needs human review**: verify thin-sourced Redmond WA and Windsor CT entries, or drop them