### PR TITLE
feat(slug_probe): standalone crawler for unknown Flock portal slugs

### DIFF
--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -1,0 +1,115 @@
+name: Probe Unknown Flock Slugs
+
+# Looks for working Flock transparency portal slugs for agencies whose
+# current slug 404s. Runs on its own rate budget (default 3 probes per run)
+# separate from refresh-flock-data so neither starves the other.
+
+on:
+  schedule:
+    - cron: '47 * * * *'   # hourly at :47 (offset from refresh-flock-data at :17)
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Max HTTP probes this run'
+        default: '3'
+      agency:
+        description: 'Force probe a single agency_id (skips failed_slugs filter)'
+        default: ''
+      delay:
+        description: 'Seconds between probes (jittered)'
+        default: '90'
+
+concurrency:
+  group: slug-probe
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          # PAT (if configured) attributes the resulting PR to a human so
+          # CI doesn't require approval-for-bots on every run.
+          token: ${{ secrets.REFRESH_PAT || github.token }}
+
+      - name: Set up probe branch
+        run: |
+          git fetch origin slug-probe || true
+          if git rev-parse --verify origin/slug-probe >/dev/null 2>&1; then
+            git checkout slug-probe
+            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+          else
+            git checkout -b slug-probe
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+
+      - name: Install Chromium for Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: uv run playwright install chromium
+
+      - name: Probe candidate slugs
+        id: probe
+        run: |
+          ARGS="--limit ${{ inputs.limit || '3' }} --delay ${{ inputs.delay || '90' }}"
+          if [ -n "${{ inputs.agency }}" ]; then
+            ARGS="$ARGS --agency ${{ inputs.agency }}"
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/slug_probe.py $ARGS
+
+      - name: Commit and push
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add \
+            assets/agency_registry.json \
+            assets/transparency.flocksafety.com/.slug_probe_state.json \
+            assets/transparency.flocksafety.com/.failed_slugs.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          # Detect hit vs. pure state bookkeeping for commit message
+          if git diff --cached --quiet assets/agency_registry.json; then
+            git commit -m "chore: slug probe state update (no hits)"
+          else
+            git commit -m "chore: slug probe found new Flock portal slug(s)"
+          fi
+          git push --force-with-lease origin slug-probe
+
+      - name: Create or update PR
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --head slug-probe --state open --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "chore: slug probe finds" \
+              --body "Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried." \
+              --head slug-probe \
+              --base main
+          fi

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -49,12 +49,14 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from lib import resolve_agency, name_to_slug, portal_jsons, portal_txts
+from lib import (
+    BASE_URL, FAILED_FILE, USER_AGENT,
+    dedupe, load_json, save_json,
+    name_to_slug, portal_jsons, portal_txts, resolve_agency,
+)
 
-BASE_URL = "https://transparency.flocksafety.com"
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
 HASH_FILE = ".content_hashes.json"
-FAILED_FILE = ".failed_slugs.json"
 VIEWPORT = {"width": 1440, "height": 900}
 WAIT_MS = 5000
 STALE_DAYS = 14
@@ -149,23 +151,8 @@ def slug_variations(slug):
     return dedupe(variations)
 
 
-def load_json(path):
-    if path.exists():
-        return json.loads(path.read_text())
-    return {}
-
-
-def save_json(path, data):
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
-
-
 def content_hash(text):
     return hashlib.sha256(text.encode()).hexdigest()
-
-
-def dedupe(slugs):
-    seen = set()
-    return [s for s in slugs if not (s in seen or seen.add(s))]
 
 
 def is_stale(slug, data_dir, max_age_days=STALE_DAYS):
@@ -795,11 +782,7 @@ def cmd_crawl(args):
             browser = p.chromium.launch(headless=True, args=launch_args)
         context = browser.new_context(
             viewport=VIEWPORT,
-            user_agent=(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/131.0.0.0 Safari/537.36"
-            ),
+            user_agent=USER_AGENT,
         )
         page = context.new_page()
 

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -12,6 +12,31 @@ from pathlib import Path
 
 REGISTRY_PATH = Path("assets/agency_registry.json")
 
+# Flock portal constants — shared by flock_transparency.py and slug_probe.py
+BASE_URL = "https://transparency.flocksafety.com"
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+FAILED_FILE = ".failed_slugs.json"
+
+
+def load_json(path):
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}
+
+
+def save_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def dedupe(items):
+    seen = set()
+    return [x for x in items if not (x in seen or seen.add(x))]
+
 # Portal captures are named exactly YYYY-MM-DD.{txt,json} — nothing else.
 # OCR sidecars (YYYY-MM-DD.pdf.HASH.txt) and any .pdf.HASH.json artifacts
 # left over from past parser bugs must not be treated as captures.

--- a/scripts/slug_probe.py
+++ b/scripts/slug_probe.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""
+Slug probe crawler — find the Flock transparency portal slug for agencies
+where our guess 404'd.
+
+Standalone from the main flock_transparency crawler so it can run on its own
+schedule without eating that crawler's rate budget. Hits at most --limit
+candidates per run (default 3) against the Flock portal and records what it
+tried in a state file so the next run doesn't repeat itself.
+
+When a candidate returns a live portal, the registry entry is updated so the
+primary crawler picks it up on its next pass:
+  - the found slug is appended to flock_slugs (if not already there)
+  - flock_active_slug is repointed at the found slug
+  - the old failing slug is removed from .failed_slugs.json so the main
+    crawler will try again
+
+Usage:
+  uv run python scripts/slug_probe.py              # probe 3 candidates
+  uv run python scripts/slug_probe.py --limit 10   # probe more
+  uv run python scripts/slug_probe.py --dry-run    # list candidates, no HTTP
+  uv run python scripts/slug_probe.py --agency <agency_id>   # force one agency
+
+State:
+  assets/transparency.flocksafety.com/.slug_probe_state.json
+"""
+
+import functools
+print = functools.partial(print, flush=True)
+
+import argparse
+import json
+import random
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import (
+    BASE_URL, FAILED_FILE, REGISTRY_PATH, USER_AGENT,
+    dedupe, load_json, load_registry, save_json,
+)
+
+DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
+STATE_FILE = ".slug_probe_state.json"
+
+# Per-role suffix variants. Order matters — most common first so we probe
+# the likely winners before exotic forms. State-specific spellings (SMCSO,
+# ACSO) are handled per-agency via tags, not here.
+ROLE_SUFFIXES = {
+    "police":        ["pd", "po", "police-department", "police", "ps"],
+    "sheriff":       ["so", "sd", "sheriffs-office", "sheriffs-department", "sheriff"],
+    "da":            ["da", "district-attorney"],
+    "fire":          ["fd", "fire", "fire-department"],
+    "campus_safety": ["pd", "ps", "police", "public-safety", "campus-safety"],
+    "parks":         ["parks", "parks-pd"],
+    "highway_patrol":["chp", "highway-patrol"],
+    "corrections":   ["doc", "corrections"],
+    "intelligence":  [],
+    "other":         ["pd", "po"],
+}
+
+# Place-type prefixes that sometimes appear in slugs. "Town of X" and
+# "City of X" are common for smaller municipalities in the Flock portal.
+PLACE_PREFIXES = ["", "city-of-", "town-of-", "village-of-"]
+
+
+# ═══════════════════════════════════════════════════════════
+# Candidate generation
+# ═══════════════════════════════════════════════════════════
+
+_PUNCT_RE = re.compile(r"[^a-z0-9\s-]")
+_WHITESPACE_RE = re.compile(r"\s+")
+_MULTI_DASH_RE = re.compile(r"-+")
+
+
+def normalize_name(name):
+    """Lowercase, drop parenthesized groups, strip punctuation, hyphen-join."""
+    s = name.strip().lower()
+    # Drop parenthesized qualifiers like (CA), (SMCSO), (ACSO)
+    s = re.sub(r"\([^)]*\)", " ", s)
+    # Possessives: sheriff's -> sheriffs
+    s = re.sub(r"['’]s\b", "s", s)
+    s = _PUNCT_RE.sub(" ", s)
+    s = _WHITESPACE_RE.sub("-", s.strip())
+    s = _MULTI_DASH_RE.sub("-", s).strip("-")
+    return s
+
+
+_STRIP_HEAD = ["city-of-", "town-of-", "village-of-", "the-"]
+_STRIP_TAIL_ROLES = {
+    "pd", "po", "ps", "police", "police-department", "department",
+    "so", "sd", "sheriff", "sheriffs-office", "sheriffs-department",
+    "da", "fd", "fire", "chp", "doc", "corrections",
+}
+
+
+def extract_hints(name, state=None, agency_role=None):
+    """Pull structured hints out of a display name.
+
+    Returns a dict with:
+      base:      the bare place / agency name (e.g. "woodside", "mendocino-county")
+      state:     two-letter lowercase state code or None
+      role:      "police"|"sheriff"|... or None
+      prefixes:  list of place prefixes observed ("town-of-", "city-of-") that
+                 should be tried in addition to no-prefix
+    """
+    n = normalize_name(name)
+    tokens = n.split("-")
+
+    # Strip leading place prefix
+    prefixes = []
+    changed = True
+    while changed and tokens:
+        changed = False
+        for p in _STRIP_HEAD:
+            p_tokens = p.strip("-").split("-")
+            if len(tokens) > len(p_tokens) and tokens[:len(p_tokens)] == p_tokens:
+                prefixes.append(p)
+                tokens = tokens[len(p_tokens):]
+                changed = True
+                break
+
+    # Strip trailing role tokens and state codes, alternating — a display
+    # like "Shafter PD CA" has role BEFORE state, so we need multiple passes
+    # to peel off both. Keep going until nothing strips.
+    from build_agency_registry import ALL_STATES
+    role_from_name = None
+    state_from_name = None
+    changed = True
+    while changed and tokens:
+        changed = False
+        # Try to strip trailing role (two-word forms before one-word forms)
+        last1 = tokens[-1]
+        last2 = "-".join(tokens[-2:]) if len(tokens) >= 2 else None
+        if last2 in _STRIP_TAIL_ROLES:
+            role_from_name = _map_role_token(last2) or role_from_name
+            tokens = tokens[:-2]
+            changed = True
+            continue
+        if last1 in _STRIP_TAIL_ROLES:
+            role_from_name = _map_role_token(last1) or role_from_name
+            tokens = tokens[:-1]
+            changed = True
+            continue
+        # Try to strip trailing state code
+        if tokens and len(tokens[-1]) == 2 and tokens[-1].upper() in ALL_STATES:
+            state_from_name = tokens[-1]
+            tokens = tokens[:-1]
+            changed = True
+
+    base = "-".join(tokens)
+
+    return {
+        "base": base,
+        "state": (state or state_from_name or "").lower() or None,
+        "role": agency_role or role_from_name,
+        "prefixes": prefixes or [""],
+    }
+
+
+def _map_role_token(token):
+    """Map a trailing slug token to a canonical agency_role."""
+    t = token.lower()
+    if t in ("pd", "po", "ps", "police", "police-department", "department"):
+        return "police"
+    if t in ("so", "sd", "sheriff", "sheriffs-office", "sheriffs-department"):
+        return "sheriff"
+    if t == "da":
+        return "da"
+    if t in ("fd", "fire", "fire-department"):
+        return "fire"
+    if t == "chp":
+        return "highway_patrol"
+    if t in ("doc", "corrections"):
+        return "corrections"
+    return None
+
+
+def generate_candidates(entry):
+    """Generate candidate slugs for a registry entry, most-likely first.
+
+    Uses display name + state + agency_role as structured hints, combined
+    combinatorially with known Flock URL conventions.
+    """
+    # Prefer display_name, then latest flock_name
+    name = entry.get("display_name") or (entry.get("flock_names") or [None])[-1] or entry.get("slug", "")
+    state = (entry.get("geo") or {}).get("state") or entry.get("state")
+    role = entry.get("agency_role")
+
+    hints = extract_hints(name, state=state, agency_role=role)
+    base = hints["base"]
+    state_l = hints["state"]
+    role_canon = hints["role"]
+    observed_prefixes = hints["prefixes"]
+
+    if not base:
+        return []
+
+    suffixes = ROLE_SUFFIXES.get(role_canon, ROLE_SUFFIXES["other"])
+
+    bases = [base]
+    # Dehyphenated variant for compound names (e.g. foothill-deanza -> foothilldeanza)
+    if "-" in base:
+        bases.append(base.replace("-", ""))
+
+    # Place prefixes — always include bare ("") plus any observed; for county/SO
+    # entries the city-of/town-of prefix doesn't help, so only add observed ones.
+    prefixes_to_try = dedupe([""] + observed_prefixes)
+
+    candidates = []
+
+    for pfx in prefixes_to_try:
+        for b in bases:
+            pfx_base = pfx + b
+
+            # {prefix}{base}-{state}-{suffix}  — default convention
+            if state_l:
+                for suf in suffixes:
+                    candidates.append(f"{pfx_base}-{state_l}-{suf}")
+                # No role suffix (e.g. "city-of-lemoore-ca")
+                candidates.append(f"{pfx_base}-{state_l}")
+
+            # {prefix}{base}-{suffix}-{state}  — swapped order (e.g. -el-cajon-pd-ca)
+            if state_l:
+                for suf in suffixes:
+                    candidates.append(f"{pfx_base}-{suf}-{state_l}")
+
+            # {prefix}{base}-{suffix}  — no state code at all
+            for suf in suffixes:
+                candidates.append(f"{pfx_base}-{suf}")
+
+            # {prefix}{base}-{suffix}{state}  — collapsed (e.g. mendocino-county-soca)
+            if state_l:
+                for suf in suffixes:
+                    if len(suf) == 2:  # only collapse short codes
+                        candidates.append(f"{pfx_base}-{suf}{state_l}")
+
+            # {prefix}{base}  — bare, no role or state (rare but happens)
+            candidates.append(pfx_base)
+
+    # Leading-dash variants (e.g. -el-cajon-pd-ca). Flock stores some agencies
+    # this way; probably a portal-import artifact.
+    candidates = candidates + ["-" + c for c in candidates if not c.startswith("-")]
+
+    return dedupe(candidates)
+
+
+# ═══════════════════════════════════════════════════════════
+# Probe: HTTP GET, check for portal markers
+# ═══════════════════════════════════════════════════════════
+
+# Markers that distinguish a real portal page from a 200-OK SPA shell /
+# marketing page. Any one of these in the rendered body is strong evidence.
+PORTAL_MARKERS = [
+    "Provided by Flock Safety",
+    "Transparency Portal",
+    "What's Detected",
+    "Hotlist Policy",
+    "Acceptable Use Policy",
+    "Policies",
+    "Usage",
+]
+
+WAIT_MS = 5000  # matches flock_transparency.py — let SPA hydrate
+
+
+def probe(page, slug, timeout_ms=30000):
+    """Probe a candidate slug via playwright.
+
+    Flock blocks non-browser clients at the edge (403 on curl/urllib), so we
+    need a real Chromium. Returns ("hit"|"miss"|"rate_limited"|"error", detail).
+    """
+    url = f"{BASE_URL}/{slug}"
+    try:
+        response = page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
+    except Exception as e:
+        return "error", f"navigation:{e}"
+
+    if response is None:
+        return "error", "no_response"
+    if response.status == 429:
+        return "rate_limited", "http_429"
+    if response.status == 404:
+        return "miss", "http_404"
+    if response.status >= 400:
+        return "miss", f"http_{response.status}"
+
+    page.wait_for_timeout(WAIT_MS)
+    body = page.inner_text("body")
+
+    if any(marker in body for marker in PORTAL_MARKERS):
+        return "hit", f"http_{response.status}"
+
+    return "miss", f"http_{response.status}_no_marker"
+
+
+# ═══════════════════════════════════════════════════════════
+# State management
+# ═══════════════════════════════════════════════════════════
+
+
+def load_state(data_dir):
+    path = data_dir / STATE_FILE
+    if path.exists():
+        return json.loads(path.read_text())
+    return {"version": 1, "updated": None, "agencies": {}}
+
+
+def save_state(data_dir, state):
+    state["updated"] = datetime.now(timezone.utc).isoformat()
+    save_json(data_dir / STATE_FILE, state)
+
+
+def agency_state(state, agency_id):
+    return state["agencies"].setdefault(agency_id, {
+        "tried": {},
+        "found": None,
+        "last_probed": None,
+        "exhausted": False,
+    })
+
+
+# ═══════════════════════════════════════════════════════════
+# Target selection
+# ═══════════════════════════════════════════════════════════
+
+
+def select_targets(registry, failed_slugs, state, only_agency=None):
+    """Return registry entries whose active slug is failing and not yet found."""
+    targets = []
+    for e in registry:
+        aid = e["agency_id"]
+        if only_agency and aid != only_agency:
+            continue
+        if state.get("agencies", {}).get(aid, {}).get("found"):
+            continue
+        if state.get("agencies", {}).get(aid, {}).get("exhausted"):
+            continue
+        active = e.get("flock_active_slug")
+        if not active:
+            continue
+        if active in failed_slugs:
+            targets.append(e)
+    return targets
+
+
+# ═══════════════════════════════════════════════════════════
+# Registry promotion
+# ═══════════════════════════════════════════════════════════
+
+
+def promote_slug(registry, agency_id, found_slug):
+    """Update the registry in-place: add found_slug and make it active."""
+    for e in registry:
+        if e["agency_id"] == agency_id:
+            slugs = e.setdefault("flock_slugs", [])
+            if found_slug not in slugs:
+                slugs.append(found_slug)
+            e["flock_active_slug"] = found_slug
+            return True
+    return False
+
+
+def clear_failed(failed_slugs, slug):
+    failed_slugs.pop(slug, None)
+
+
+# ═══════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Probe Flock portal for missing agency slugs")
+    parser.add_argument("--limit", type=int, default=3,
+                        help="Max number of HTTP probes per run (default: 3)")
+    parser.add_argument("--delay", type=int, default=90,
+                        help="Seconds between probes, jittered (default: 90)")
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List candidates for targets, make no HTTP calls")
+    parser.add_argument("--agency", default=None,
+                        help="Probe one specific agency_id only")
+    parser.add_argument("--reset-exhausted", action="store_true",
+                        help="Clear 'exhausted' flags so probes resume for agencies that ran out of candidates")
+    args = parser.parse_args()
+
+    registry = load_registry()
+    data_dir = args.data_dir
+    failed_slugs = load_json(data_dir / FAILED_FILE)
+    state = load_state(data_dir)
+
+    if args.reset_exhausted:
+        for aid, st in state.get("agencies", {}).items():
+            st["exhausted"] = False
+        save_state(data_dir, state)
+        print(f"Cleared 'exhausted' flags for {len(state.get('agencies', {}))} agencies")
+
+    targets = select_targets(registry, failed_slugs, state, only_agency=args.agency)
+    print(f"Found {len(targets)} target agencies (slug in failed_slugs, not yet resolved)")
+
+    if args.agency and not targets:
+        print(f"  (no target for agency_id={args.agency})")
+        return
+
+    probes_done = 0
+    hits = []
+
+    # Round-robin across agencies so one agency's long candidate list doesn't
+    # starve the others. Build per-agency candidate queues up front.
+    queues = []
+    for e in targets:
+        aid = e["agency_id"]
+        tried = state["agencies"].get(aid, {}).get("tried", {})
+        # Skip candidates already in the failed_slugs.json — we know those 404.
+        # The primary crawler populated that file; no point re-probing.
+        candidates = [
+            c for c in generate_candidates(e)
+            if c not in tried and c not in failed_slugs
+        ]
+        if not candidates:
+            agency_state(state, aid)["exhausted"] = True
+            continue
+        queues.append((e, candidates))
+
+    # Shuffle queue order so we don't always probe the same few agencies first.
+    random.shuffle(queues)
+
+    if args.dry_run:
+        for entry, candidates in queues[:10]:
+            name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
+            print(f"\n{name}  [{entry['agency_id']}]")
+            print(f"  current active: {entry.get('flock_active_slug')}")
+            print(f"  candidates ({len(candidates)}):")
+            for c in candidates[:20]:
+                print(f"    {c}")
+            if len(candidates) > 20:
+                print(f"    ... and {len(candidates) - 20} more")
+        return
+
+    from playwright.sync_api import sync_playwright
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--headless=new"])
+        context = browser.new_context(
+            viewport={"width": 1440, "height": 900},
+            user_agent=USER_AGENT,
+        )
+        page = context.new_page()
+
+        # Round-robin: pull one candidate from each queue in turn until limit hit
+        q_idx = 0
+        while probes_done < args.limit and queues:
+            entry, candidates = queues[q_idx % len(queues)]
+            if not candidates:
+                queues.pop(q_idx % len(queues))
+                if not queues:
+                    break
+                continue
+            candidate = candidates.pop(0)
+            aid = entry["agency_id"]
+            name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
+
+            print(f"\n[{probes_done + 1}/{args.limit}] {name}  ->  {candidate}")
+            result, detail = probe(page, candidate)
+            st = agency_state(state, aid)
+            st["tried"][candidate] = detail
+            st["last_probed"] = datetime.now(timezone.utc).isoformat()
+            probes_done += 1
+
+            if result == "hit":
+                print(f"    HIT ({detail}) — promoting to registry")
+                st["found"] = candidate
+                old_slug = entry.get("flock_active_slug")
+                promote_slug(registry, aid, candidate)
+                if old_slug:
+                    clear_failed(failed_slugs, old_slug)
+                clear_failed(failed_slugs, candidate)
+                hits.append((name, candidate))
+                queues.pop(q_idx % len(queues))
+            elif result == "miss":
+                print(f"    miss ({detail})")
+                q_idx += 1
+            elif result == "rate_limited":
+                print(f"    RATE LIMITED — stopping this run")
+                # Roll back the consumed candidate — we don't want to mark it
+                # tried without actually knowing the answer.
+                st["tried"].pop(candidate, None)
+                probes_done -= 1
+                break
+            else:  # error
+                print(f"    error ({detail}) — leaving as tried to avoid retry loops")
+                q_idx += 1
+
+            # Save after every probe so a crash mid-run doesn't lose progress
+            save_state(data_dir, state)
+            save_json(data_dir / FAILED_FILE, failed_slugs)
+            if hits:
+                REGISTRY_PATH.write_text(json.dumps(registry, indent=2) + "\n")
+
+            if probes_done < args.limit and queues:
+                sleep_for = args.delay * random.uniform(0.7, 1.3)
+                print(f"    sleeping {sleep_for:.0f}s...")
+                time.sleep(sleep_for)
+
+        browser.close()
+
+    # Final save
+    save_state(data_dir, state)
+    save_json(data_dir / FAILED_FILE, failed_slugs)
+
+    print(f"\nDone: {probes_done} probe(s), {len(hits)} hit(s)")
+    if hits:
+        print("Hits:")
+        for name, slug in hits:
+            print(f"  {name} -> {slug}")
+        # Expose hits to GitHub Actions via output file, if requested.
+        import os
+        gha_output = os.environ.get("GITHUB_OUTPUT")
+        if gha_output:
+            with open(gha_output, "a") as f:
+                f.write("has_hits=true\n")
+                f.write(f"hit_slugs={' '.join(slug for _, slug in hits)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_slug_probe.py
+++ b/tests/test_slug_probe.py
@@ -1,0 +1,156 @@
+"""Tests for the slug probe candidate generator.
+
+The generator is the load-bearing part: if it doesn't produce the right
+spellings, we can't find the portal. These tests pin the known quirks
+(leading dash, collapsed state suffix, dehyphenation) against real
+registry agencies.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from slug_probe import (
+    extract_hints,
+    generate_candidates,
+    normalize_name,
+)
+
+
+def test_normalize_drops_parens():
+    assert normalize_name("Town of Woodside CA (SMCSO)") == "town-of-woodside-ca"
+    assert normalize_name("El Cajon CA PD") == "el-cajon-ca-pd"
+
+
+def test_normalize_handles_apostrophe():
+    assert normalize_name("Sheriff's Office") == "sheriffs-office"
+
+
+def test_hints_strip_prefix_suffix():
+    h = extract_hints("Town of Woodside CA (SMCSO)")
+    assert h["base"] == "woodside"
+    assert h["state"] == "ca"
+    assert "town-of-" in h["prefixes"]
+
+
+def test_hints_role_from_name():
+    h = extract_hints("El Cajon CA PD")
+    assert h["base"] == "el-cajon"
+    assert h["state"] == "ca"
+    assert h["role"] == "police"
+
+
+def test_hints_sheriff_role():
+    h = extract_hints("Mendocino County CA SO")
+    assert h["base"] == "mendocino-county"
+    assert h["role"] == "sheriff"
+
+
+def test_hints_role_before_state_in_name():
+    # "Shafter PD CA" — role appears BEFORE state, both must strip
+    h = extract_hints("Shafter PD CA")
+    assert h["base"] == "shafter"
+    assert h["state"] == "ca"
+    assert h["role"] == "police"
+
+
+def test_hints_respect_entry_role_over_name():
+    # agency_role on the registry entry is authoritative
+    h = extract_hints("Foo Bar", state="CA", agency_role="sheriff")
+    assert h["role"] == "sheriff"
+
+
+def test_candidates_include_leading_dash_variant():
+    # El Cajon's real Flock slug is "-el-cajon-pd-ca" — the leading dash
+    # and the pd-before-state order are the quirk we most need to catch.
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["El Cajon CA PD"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "police",
+        "slug": "el-cajon-ca-pd",
+    }
+    candidates = generate_candidates(entry)
+    assert "-el-cajon-pd-ca" in candidates, (
+        f"missing leading-dash+swap variant; got sample: {candidates[:10]}"
+    )
+    # Also the swapped-order non-dashed variant
+    assert "el-cajon-pd-ca" in candidates
+
+
+def test_candidates_include_collapsed_state_suffix():
+    # mendocino-county-soca is the collapsed form
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["Mendocino County CA SO"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "sheriff",
+        "slug": "mendocino-county-ca-so",
+    }
+    candidates = generate_candidates(entry)
+    assert "mendocino-county-soca" in candidates, (
+        f"missing collapsed state-suffix variant; got sample: {candidates[:10]}"
+    )
+
+
+def test_candidates_include_dehyphenated_base():
+    # Compound names: foothill-deanza -> foothilldeanza
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["Foothill Deanza CA PD"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "police",
+        "slug": "foothill-deanza-ca-pd",
+    }
+    candidates = generate_candidates(entry)
+    assert "foothilldeanza-ca-pd" in candidates, (
+        f"missing dehyphenated base; got sample: {candidates[:10]}"
+    )
+
+
+def test_candidates_include_town_of_prefix_when_observed():
+    # If the name has "Town of", we should try both with and without
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["Town of Woodside CA (SMCSO)"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "police",
+        "slug": "town-of-woodside-ca",
+    }
+    candidates = generate_candidates(entry)
+    # bare (no prefix)
+    assert "woodside-ca-pd" in candidates
+    # with prefix
+    assert "town-of-woodside-ca" in candidates
+    assert "town-of-woodside-ca-pd" in candidates
+
+
+def test_candidates_dedupe():
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["Alameda CA PD"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "police",
+        "slug": "alameda-ca-pd",
+    }
+    candidates = generate_candidates(entry)
+    assert len(candidates) == len(set(candidates))
+
+
+def test_candidates_priority_default_first():
+    # Default pattern {base}-{state}-pd should be the very first candidate
+    entry = {
+        "agency_id": "x",
+        "flock_names": ["Alhambra CA PD"],
+        "display_name": None,
+        "geo": {"state": "CA"},
+        "agency_role": "police",
+        "slug": "alhambra-ca-pd",
+    }
+    candidates = generate_candidates(entry)
+    assert candidates[0] == "alhambra-ca-pd"


### PR DESCRIPTION
## Summary

- 168 agencies in the registry have active Flock portal slugs that 404 — we know the agency exists (from sharing-graph mentions) but our slug guess is wrong. Adds a standalone, scheduled crawler that generates better candidates and probes them on its own rate budget (3/run, hourly), independent of the primary refresh workflow.
- On a hit, the registry entry is updated in place (`flock_slugs` += found, `flock_active_slug` := found) and the old failing slug is cleared from `.failed_slugs.json` so the primary crawler picks up the new slug on its next run.
- Also extracts a handful of truly-shared utilities (`BASE_URL`, `USER_AGENT`, `FAILED_FILE`, `load_json`, `save_json`, `dedupe`) from `flock_transparency.py` into `lib.py` since `slug_probe.py` wanted them too.

## Candidate generation

Structured pipeline: normalize display name → extract hints (base, state, role, observed prefixes) → generate combinatorial variations, most-likely first. Covers known quirks:

- Leading dash: `-el-cajon-pd-ca`
- Swapped role/state order: `-pd-ca` vs `-ca-pd`
- Collapsed suffix: `mendocino-county-soca`
- Dehyphenation for compound names: `foothilldeanza-ca-pd`
- `city-of-` / `town-of-` prefixes when present in the name

Pinned with 13 unit tests against real agency names in the registry.

## Probing

Uses Playwright (same Chromium setup as `flock_transparency.py`) — Flock edge-blocks curl/urllib with 403, so a real browser is required. Round-robin across target agencies so one long candidate queue doesn't starve the rest. State persists in `assets/transparency.flocksafety.com/.slug_probe_state.json`; candidates that already appear in `.failed_slugs.json` are skipped to avoid re-probing what the primary crawler already burned on.

## Workflow

Hourly at `:47` (offset from `refresh-flock-data.yml` at `:17` so they don't collide on rate limits). Default 3 probes per run with 90s jittered delay. Accumulates into a rolling `slug-probe` PR.

## Coordination with #142

No conflict — that PR edits `registry_by_slug()` around line 52 of `lib.py`; this PR adds a constants block near the top. `git merge-tree` confirmed auto-merge is clean regardless of order.

## Test plan

- [x] `uv run pytest tests/test_slug_probe.py` — 13/13 pass
- [x] `uv run python scripts/slug_probe.py --dry-run` — 168 targets, sensible candidate lists
- [x] `uv run python scripts/slug_probe.py --help`
- [x] Import sanity: both `slug_probe` and `flock_transparency` resolve shared `BASE_URL`/`USER_AGENT` to the same object after refactor
- [ ] First live scheduled run — will exercise playwright probe path against real Flock portal (deferred from local to avoid burning the shared rate budget)