### PR TITLE
chore(slug_probe): shorten inter-probe delay 90s -> 5s

### DIFF
--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -17,7 +17,7 @@ on:
         default: ''
       delay:
         description: 'Seconds between probes (jittered)'
-        default: '90'
+        default: '5'
 
 concurrency:
   group: slug-probe
@@ -70,7 +70,7 @@ jobs:
       - name: Probe candidate slugs
         id: probe
         run: |
-          ARGS="--limit ${{ inputs.limit || '3' }} --delay ${{ inputs.delay || '90' }}"
+          ARGS="--limit ${{ inputs.limit || '3' }} --delay ${{ inputs.delay || '5' }}"
           if [ -n "${{ inputs.agency }}" ]; then
             ARGS="$ARGS --agency ${{ inputs.agency }}"
           fi

--- a/scripts/slug_probe.py
+++ b/scripts/slug_probe.py
@@ -377,8 +377,8 @@ def main():
     parser = argparse.ArgumentParser(description="Probe Flock portal for missing agency slugs")
     parser.add_argument("--limit", type=int, default=3,
                         help="Max number of HTTP probes per run (default: 3)")
-    parser.add_argument("--delay", type=int, default=90,
-                        help="Seconds between probes, jittered (default: 90)")
+    parser.add_argument("--delay", type=int, default=5,
+                        help="Seconds between probes, jittered (default: 5)")
     parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
     parser.add_argument("--dry-run", action="store_true",
                         help="List candidates for targets, make no HTTP calls")


### PR DESCRIPTION
## Summary

- 90s × 3 probes = ~4.5 minutes of idle runner time per hourly run. Drop to 5s (jittered 0.7-1.3×).
- The 3-probe-per-run limit is what protects against rate limits; the inter-probe sleep was overkill.

## Test plan

- [x] Default in `scripts/slug_probe.py --help` now reads `5`
- [x] Workflow `delay` input default is `'5'`