### PR TITLE
fix(deploy): run build_contract_map.py on Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,13 +47,14 @@ jobs:
           packages: tesseract-ocr
           version: 1.0
 
-      - name: Build sharing graph, map, scoreboard, report data, and findings PDF
+      - name: Build sharing graph, map, scoreboard, report data, contracts map, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_scoreboard.py &
           uv run python scripts/build_report_data.py &
+          uv run python scripts/build_contract_map.py &
           uv run python scripts/md_to_pdf.py docs/SMPD_ALPR_Findings.md "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" &
           wait
 


### PR DESCRIPTION
## Summary

The merged contracts-map feature (#142) ships a data file (\`docs/data/contract_map_data.json\`) that's gitignored as a build artifact. The deploy workflow never ran \`build_contract_map.py\`, so the file didn't exist on the live Pages site — page rendered \"Failed to load contract data.\"

Fix: add \`build_contract_map.py\` to the parallel build block in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).

## Test plan

- [x] After merge, Pages deploy runs \`build_contract_map.py\`
- [ ] https://none-below.github.io/sm-alpr/contracts.html loads map markers with password \`preview\`