### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1,0 +1,30 @@
+{
+  "agencies": {
+    "00015f2d-ad5e-5b12-9811-04b7cb13827d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:06:45.204233+00:00",
+      "tried": {
+        "desert-hot-springs-ca-po": "http_404"
+      }
+    },
+    "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:06:57.349255+00:00",
+      "tried": {
+        "monterey-county-ca-sd": "http_404"
+      }
+    },
+    "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:06:51.658668+00:00",
+      "tried": {
+        "soledad-ca-po": "http_404"
+      }
+    }
+  },
+  "updated": "2026-04-24T03:06:57.382795+00:00",
+  "version": 1
+}


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.