### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -8,6 +8,30 @@
         "desert-hot-springs-ca-po": "http_404"
       }
     },
+    "650ab346-a013-56f6-a970-1bf8a61acb18": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:21:41.426150+00:00",
+      "tried": {
+        "riverside-county-ca-district-attorney-ca-da": "http_404"
+      }
+    },
+    "69489e25-1027-5396-86a7-c68d5111eecd": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:21:35.753684+00:00",
+      "tried": {
+        "calexico-ca-po": "http_404"
+      }
+    },
+    "6fc47404-6f79-5f5d-ace0-18db02bc2391": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T03:21:29.309962+00:00",
+      "tried": {
+        "anderson-ca-po": "http_404"
+      }
+    },
     "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
       "exhausted": false,
       "found": null,
@@ -25,6 +49,6 @@
       }
     }
   },
-  "updated": "2026-04-24T03:06:57.382795+00:00",
+  "updated": "2026-04-24T03:21:41.461867+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.