### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -26504,9 +26504,10 @@
   {
     "agency_id": "79d1a399-1db1-5b50-aaa9-b4bbc64d8dd2",
     "slug": "town-of-los-gatos-ca",
-    "flock_active_slug": "town-of-los-gatos-ca",
+    "flock_active_slug": "los-gatos-ca-pd",
     "flock_slugs": [
-      "town-of-los-gatos-ca"
+      "town-of-los-gatos-ca",
+      "los-gatos-ca-pd"
     ],
     "flock_names": [
       "Town of Los Gatos CA"

--- a/assets/transparency.flocksafety.com/.failed_slugs.json
+++ b/assets/transparency.flocksafety.com/.failed_slugs.json
@@ -595,10 +595,6 @@
     "date": "2026-04-10",
     "reason": "http_404"
   },
-  "town-of-los-gatos-ca": {
-    "date": "2026-04-22",
-    "reason": "http_404"
-  },
   "town-of-woodside-ca": {
     "date": "2026-04-10",
     "reason": "http_404"

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -40,6 +40,14 @@
         "yuba-county-pd": "http_404"
       }
     },
+    "64da8ade-ab72-5519-8f11-b65be44e0387": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T17:39:17.165536+00:00",
+      "tried": {
+        "el-dorado-county-ca-sd": "http_404"
+      }
+    },
     "650ab346-a013-56f6-a970-1bf8a61acb18": {
       "exhausted": false,
       "found": null,
@@ -72,6 +80,14 @@
         "anderson-ca-po": "http_404"
       }
     },
+    "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T17:39:10.433779+00:00",
+      "tried": {
+        "rialto-ca-pd": "http_404"
+      }
+    },
     "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
       "exhausted": false,
       "found": null,
@@ -94,6 +110,14 @@
       "last_probed": "2026-04-24T08:53:49.367842+00:00",
       "tried": {
         "vernon-ca-po": "http_404"
+      }
+    },
+    "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T17:39:23.476207+00:00",
+      "tried": {
+        "san-joaquin-delta-college-ca-pd": "http_404"
       }
     },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
@@ -193,6 +217,6 @@
       }
     }
   },
-  "updated": "2026-04-24T15:53:08.768112+00:00",
+  "updated": "2026-04-24T17:39:23.513348+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -18,6 +18,14 @@
         "redondo-beach-ca-police-department": "http_404"
       }
     },
+    "03c310c0-6e05-5ad2-872a-d4e8b804358f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T20:22:33.780812+00:00",
+      "tried": {
+        "selma-ca-po": "http_404"
+      }
+    },
     "069764d3-6b36-5e35-ba95-2e4b38441b0e": {
       "exhausted": false,
       "found": null,
@@ -57,6 +65,14 @@
       "tried": {
         "hemet-ca-po": "http_404",
         "hemet-ca-police-department": "http_404"
+      }
+    },
+    "16449917-ee53-5406-ade9-4b7361ec7ba2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T20:22:28.863571+00:00",
+      "tried": {
+        "elk-grove-ca-po": "http_404"
       }
     },
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
@@ -129,6 +145,14 @@
       "last_probed": "2026-04-24T20:31:11.421470+00:00",
       "tried": {
         "san-luis-obispo-ca-po": "http_404"
+      }
+    },
+    "4219823b-c553-51fd-9a9b-5618cb5f82b5": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T20:22:24.167944+00:00",
+      "tried": {
+        "la-habra-ca-po": "http_404"
       }
     },
     "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
@@ -585,6 +609,6 @@
       }
     }
   },
-  "updated": "2026-04-25T19:34:17.139735+00:00",
+  "updated": "2026-04-25T20:22:33.815287+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -268,6 +268,14 @@
         "bear-valley-springs-ca-po": "http_404"
       }
     },
+    "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T16:24:13.173974+00:00",
+      "tried": {
+        "colton-ca-po": "http_404"
+      }
+    },
     "81e727b4-f1d6-5aea-8cd4-db0cf88a7306": {
       "exhausted": false,
       "found": null,
@@ -431,6 +439,14 @@
         "wheatland-ca-police-department": "http_404"
       }
     },
+    "dbfeb93f-10ea-5aaf-8862-a6b186764b79": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T16:24:18.584073+00:00",
+      "tried": {
+        "la-mesa-ca-po": "http_404"
+      }
+    },
     "dddefaf4-84f7-5857-8011-45b6eda02991": {
       "exhausted": false,
       "found": null,
@@ -506,6 +522,14 @@
         "soledad-ca-po": "http_404"
       }
     },
+    "f17f02e4-77c4-50ca-a858-8e388e2b8e85": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T16:24:08.991448+00:00",
+      "tried": {
+        "san-pasqual-ca-po": "http_404"
+      }
+    },
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
       "exhausted": false,
       "found": null,
@@ -524,6 +548,6 @@
       }
     }
   },
-  "updated": "2026-04-25T15:27:35.640079+00:00",
+  "updated": "2026-04-25T16:24:18.623768+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -269,6 +269,14 @@
         "monterey-county-district-attorneys-office-ca-district-attorney": "http_404"
       }
     },
+    "62f9d91a-99cb-5428-8312-38718e2196ed": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T12:32:28.434900+00:00",
+      "tried": {
+        "pomona-ca-po": "http_404"
+      }
+    },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
       "exhausted": false,
       "found": null,
@@ -522,11 +530,12 @@
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T22:18:54.280116+00:00",
+      "last_probed": "2026-04-26T12:32:38.873317+00:00",
       "tried": {
         "san-joaquin-delta-college-ca-pd": "http_404",
         "san-joaquin-delta-college-ca-police": "http_404",
-        "san-joaquin-delta-college-ca-ps": "http_404"
+        "san-joaquin-delta-college-ca-ps": "http_404",
+        "san-joaquin-delta-college-ca-public-safety": "http_404"
       }
     },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
@@ -698,6 +707,14 @@
         "san-pasqual-ca-police-department": "http_404"
       }
     },
+    "f4073ba9-2a85-50ab-82d6-1800ff5491c6": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T12:32:34.365857+00:00",
+      "tried": {
+        "burlingame-ca-po": "http_404"
+      }
+    },
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
       "exhausted": false,
       "found": null,
@@ -716,6 +733,6 @@
       }
     }
   },
-  "updated": "2026-04-26T11:27:46.693136+00:00",
+  "updated": "2026-04-26T12:32:38.909026+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -360,6 +360,14 @@
         "tulare-ca-po": "http_404"
       }
     },
+    "9079f9e0-e3c2-5611-8f09-a0276b7911f8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T21:22:49.273231+00:00",
+      "tried": {
+        "california-state-university-long-beach-campus-ca-pd": "http_404"
+      }
+    },
     "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
       "exhausted": false,
       "found": null,
@@ -390,6 +398,14 @@
       "last_probed": "2026-04-24T22:27:41.795446+00:00",
       "tried": {
         "west-valley-mission-college-dist-campus-ca-pd": "http_404"
+      }
+    },
+    "a17a8e7d-6ebb-50e2-ad83-14ecd689e810": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T21:22:44.413027+00:00",
+      "tried": {
+        "los-angeles-ca-po": "http_404"
       }
     },
     "a24c4de9-ca70-5829-838e-12907c88c3a9": {
@@ -428,9 +444,10 @@
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T17:39:23.476207+00:00",
+      "last_probed": "2026-04-25T21:22:53.709225+00:00",
       "tried": {
-        "san-joaquin-delta-college-ca-pd": "http_404"
+        "san-joaquin-delta-college-ca-pd": "http_404",
+        "san-joaquin-delta-college-ca-ps": "http_404"
       }
     },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
@@ -609,6 +626,6 @@
       }
     }
   },
-  "updated": "2026-04-25T20:22:33.815287+00:00",
+  "updated": "2026-04-25T21:22:53.743605+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -166,6 +166,14 @@
         "la-habra-ca-po": "http_404"
       }
     },
+    "42ac4d61-32cd-5fa4-aa11-b6713123a5c7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T07:12:40.336062+00:00",
+      "tried": {
+        "irvine-ca-po": "http_404"
+      }
+    },
     "458b707c-5b99-5ec3-95c8-f7c9ae95ee0d": {
       "exhausted": false,
       "found": null,
@@ -203,9 +211,10 @@
     "589597b2-0d45-5add-ac97-bf6a042fceae": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T07:55:30.950190+00:00",
+      "last_probed": "2026-04-26T07:12:34.053064+00:00",
       "tried": {
-        "cal-state-san-bernadino-ca-po": "http_404"
+        "cal-state-san-bernadino-ca-po": "http_404",
+        "cal-state-san-bernadino-ca-police-department": "http_404"
       }
     },
     "59158344-4894-55be-bc8a-de15bcb986f0": {
@@ -541,10 +550,11 @@
     "d0843cde-d450-5617-b977-103218524b39": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T21:34:50.443571+00:00",
+      "last_probed": "2026-04-26T07:12:28.633759+00:00",
       "tried": {
         "gustine-ca-pd": "http_404",
-        "gustine-ca-po": "http_404"
+        "gustine-ca-po": "http_404",
+        "gustine-ca-police-department": "http_404"
       }
     },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
@@ -673,6 +683,6 @@
       }
     }
   },
-  "updated": "2026-04-26T04:47:39.151234+00:00",
+  "updated": "2026-04-26T07:12:40.369762+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -36,9 +36,10 @@
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T04:22:56.741374+00:00",
+      "last_probed": "2026-04-25T09:38:03.255108+00:00",
       "tried": {
-        "hemet-ca-po": "http_404"
+        "hemet-ca-po": "http_404",
+        "hemet-ca-police-department": "http_404"
       }
     },
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
@@ -63,6 +64,14 @@
       "last_probed": "2026-04-25T04:22:52.141856+00:00",
       "tried": {
         "national-city-ca-po": "http_404"
+      }
+    },
+    "270aae46-f0d1-558e-bb3f-249d03b0510f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T09:37:57.089524+00:00",
+      "tried": {
+        "concord-ca-po": "http_404"
       }
     },
     "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
@@ -208,6 +217,14 @@
       "last_probed": "2026-04-25T06:11:43.428630+00:00",
       "tried": {
         "bear-valley-springs-ca-po": "http_404"
+      }
+    },
+    "81e727b4-f1d6-5aea-8cd4-db0cf88a7306": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T09:38:08.585040+00:00",
+      "tried": {
+        "solano-county-ca-da": "http_404"
       }
     },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
@@ -401,6 +418,6 @@
       }
     }
   },
-  "updated": "2026-04-25T07:55:36.262065+00:00",
+  "updated": "2026-04-25T09:38:08.624003+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -140,6 +140,14 @@
         "cal-state-fullerton-ca-po": "http_404"
       }
     },
+    "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T19:34:08.678184+00:00",
+      "tried": {
+        "atwater-ca-po": "http_404"
+      }
+    },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
@@ -288,6 +296,14 @@
         "solano-county-ca-da": "http_404"
       }
     },
+    "8269106d-e127-5d07-97fe-d7963b813025": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T19:34:17.104825+00:00",
+      "tried": {
+        "san-jose-evergreen-community-college-campus-ca-pd": "http_404"
+      }
+    },
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
       "exhausted": false,
       "found": null,
@@ -310,6 +326,14 @@
       "last_probed": "2026-04-25T11:26:42.852152+00:00",
       "tried": {
         "rio-hondo-college-ca-pd": "http_404"
+      }
+    },
+    "8fb27794-b88c-5373-b6a1-da64ae2f059c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T19:34:12.964976+00:00",
+      "tried": {
+        "tulare-ca-po": "http_404"
       }
     },
     "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
@@ -561,6 +585,6 @@
       }
     }
   },
-  "updated": "2026-04-25T18:28:38.709855+00:00",
+  "updated": "2026-04-25T19:34:17.139735+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -16,6 +16,14 @@
         "redondo-beach-ca-po": "http_404"
       }
     },
+    "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T15:52:58.160820+00:00",
+      "tried": {
+        "indio-ca-po": "http_404"
+      }
+    },
     "59158344-4894-55be-bc8a-de15bcb986f0": {
       "exhausted": false,
       "found": null,
@@ -72,6 +80,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "a2c03da5-7700-5042-8d22-ab98c8a1c7f2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T15:53:04.316734+00:00",
+      "tried": {
+        "orange-county-fire-authority-ca-fd": "http_404"
+      }
+    },
     "a5b59684-abcc-5a43-949d-3aec089d30a4": {
       "exhausted": false,
       "found": null,
@@ -118,6 +134,14 @@
       "last_probed": "2026-04-24T05:58:32.630231+00:00",
       "tried": {
         "alhambra-ca-po": "http_404"
+      }
+    },
+    "d0843cde-d450-5617-b977-103218524b39": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T15:53:08.734332+00:00",
+      "tried": {
+        "gustine-ca-pd": "http_404"
       }
     },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
@@ -169,6 +193,6 @@
       }
     }
   },
-  "updated": "2026-04-24T14:24:46.077585+00:00",
+  "updated": "2026-04-24T15:53:08.768112+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -17,6 +17,14 @@
         "redondo-beach-ca-police-department": "http_404"
       }
     },
+    "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T21:34:41.257501+00:00",
+      "tried": {
+        "covina-ca-po": "http_404"
+      }
+    },
     "332407d3-a475-546c-88c0-b2046bb47ca7": {
       "exhausted": false,
       "found": null,
@@ -103,6 +111,14 @@
       "last_probed": "2026-04-24T19:40:24.420157+00:00",
       "tried": {
         "sacramento-ca-district-attorney": "http_404"
+      }
+    },
+    "6be9f842-1658-5490-8be4-14b77cc1e96d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T21:34:45.183851+00:00",
+      "tried": {
+        "santa-clara-ca-da": "http_404"
       }
     },
     "6db175fe-bff6-58bc-a911-d688f797fda9": {
@@ -213,9 +229,10 @@
     "d0843cde-d450-5617-b977-103218524b39": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T15:53:08.734332+00:00",
+      "last_probed": "2026-04-24T21:34:50.443571+00:00",
       "tried": {
-        "gustine-ca-pd": "http_404"
+        "gustine-ca-pd": "http_404",
+        "gustine-ca-po": "http_404"
       }
     },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
@@ -275,6 +292,6 @@
       }
     }
   },
-  "updated": "2026-04-24T20:31:23.476901+00:00",
+  "updated": "2026-04-24T21:34:50.561388+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -92,6 +92,14 @@
         "elk-grove-ca-po": "http_404"
       }
     },
+    "19f7b6cc-d156-57a7-9f61-a0e846b224f2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T11:27:36.986863+00:00",
+      "tried": {
+        "whittier-ca-po": "http_404"
+      }
+    },
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
       "exhausted": false,
       "found": null,
@@ -280,9 +288,10 @@
     "69489e25-1027-5396-86a7-c68d5111eecd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T11:26:38.010811+00:00",
+      "last_probed": "2026-04-26T11:27:46.660202+00:00",
       "tried": {
         "calexico-ca-po": "http_404",
+        "calexico-ca-police": "http_404",
         "calexico-ca-police-department": "http_404"
       }
     },
@@ -496,9 +505,10 @@
     "a5b59684-abcc-5a43-949d-3aec089d30a4": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T08:53:49.367842+00:00",
+      "last_probed": "2026-04-26T11:27:42.371043+00:00",
       "tried": {
-        "vernon-ca-po": "http_404"
+        "vernon-ca-po": "http_404",
+        "vernon-ca-police-department": "http_404"
       }
     },
     "a76f1a12-ea0c-5138-9c77-57a4e6b510ca": {
@@ -706,6 +716,6 @@
       }
     }
   },
-  "updated": "2026-04-26T10:31:42.915726+00:00",
+  "updated": "2026-04-26T11:27:46.693136+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -164,9 +164,10 @@
     "2e9edae6-7b5a-5b86-bd0e-c3e06b3d96d0": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T15:27:30.942928+00:00",
+      "last_probed": "2026-04-26T13:54:55.145930+00:00",
       "tried": {
-        "san-fernando-ca-po": "http_404"
+        "san-fernando-ca-po": "http_404",
+        "san-fernando-ca-police-department": "http_404"
       }
     },
     "332407d3-a475-546c-88c0-b2046bb47ca7": {
@@ -377,6 +378,14 @@
       "last_probed": "2026-04-25T06:11:43.428630+00:00",
       "tried": {
         "bear-valley-springs-ca-po": "http_404"
+      }
+    },
+    "7932e34a-0d6d-524b-9e26-543d66b8b93c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T13:54:51.429140+00:00",
+      "tried": {
+        "lathrop-ca-po": "http_404"
       }
     },
     "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c": {
@@ -701,9 +710,10 @@
     "f17f02e4-77c4-50ca-a858-8e388e2b8e85": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T08:45:34.737885+00:00",
+      "last_probed": "2026-04-26T13:54:47.815430+00:00",
       "tried": {
         "san-pasqual-ca-po": "http_404",
+        "san-pasqual-ca-police": "http_404",
         "san-pasqual-ca-police-department": "http_404"
       }
     },
@@ -733,6 +743,6 @@
       }
     }
   },
-  "updated": "2026-04-26T12:32:38.909026+00:00",
+  "updated": "2026-04-26T13:54:55.181059+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -82,6 +82,14 @@
         "greenfield-ca-po": "http_404"
       }
     },
+    "2e1e1b36-7a6b-5c97-8143-65347503186c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T10:30:35.054595+00:00",
+      "tried": {
+        "oxnard-ca-po": "http_404"
+      }
+    },
     "332407d3-a475-546c-88c0-b2046bb47ca7": {
       "exhausted": false,
       "found": null,
@@ -350,6 +358,14 @@
         "wheatland-ca-police-department": "http_404"
       }
     },
+    "dddefaf4-84f7-5857-8011-45b6eda02991": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T10:30:46.105414+00:00",
+      "tried": {
+        "sand-city-ca-po": "http_404"
+      }
+    },
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
       "exhausted": false,
       "found": null,
@@ -416,8 +432,16 @@
       "tried": {
         "chino-ca-po": "http_404"
       }
+    },
+    "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T10:30:40.415017+00:00",
+      "tried": {
+        "sonoma-county-ca-sd": "http_404"
+      }
     }
   },
-  "updated": "2026-04-25T09:38:08.624003+00:00",
+  "updated": "2026-04-25T10:30:46.141115+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -175,9 +175,10 @@
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T15:52:58.160820+00:00",
+      "last_probed": "2026-04-25T22:18:59.050830+00:00",
       "tried": {
-        "indio-ca-po": "http_404"
+        "indio-ca-po": "http_404",
+        "indio-ca-police-department": "http_404"
       }
     },
     "589597b2-0d45-5add-ac97-bf6a042fceae": {
@@ -285,6 +286,14 @@
       "last_probed": "2026-04-24T03:21:29.309962+00:00",
       "tried": {
         "anderson-ca-po": "http_404"
+      }
+    },
+    "727915ef-bda7-5399-8e79-0369d7bb7782": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T22:18:48.873053+00:00",
+      "tried": {
+        "la-verne-ca-po": "http_404"
       }
     },
     "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
@@ -444,9 +453,10 @@
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T21:22:53.709225+00:00",
+      "last_probed": "2026-04-25T22:18:54.280116+00:00",
       "tried": {
         "san-joaquin-delta-college-ca-pd": "http_404",
+        "san-joaquin-delta-college-ca-police": "http_404",
         "san-joaquin-delta-college-ca-ps": "http_404"
       }
     },
@@ -626,6 +636,6 @@
       }
     }
   },
-  "updated": "2026-04-25T21:22:53.743605+00:00",
+  "updated": "2026-04-25T22:18:59.082419+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "winters-ca-po": "http_404"
       }
     },
+    "06f1b20d-a403-5088-9d3a-d8df6edcb126": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T13:52:49.813473+00:00",
+      "tried": {
+        "san-luis-obispo-county-ca-so": "http_404"
+      }
+    },
     "11949eb7-26df-5b98-a23d-ac249879ec01": {
       "exhausted": false,
       "found": null,
@@ -276,6 +284,14 @@
         "rio-hondo-college-ca-pd": "http_404"
       }
     },
+    "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T13:52:54.508166+00:00",
+      "tried": {
+        "central-marin-ca-po": "http_404"
+      }
+    },
     "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
       "exhausted": false,
       "found": null,
@@ -339,6 +355,14 @@
       "last_probed": "2026-04-24T10:55:13.729041+00:00",
       "tried": {
         "san-diego-harbor-ca-po": "http_404"
+      }
+    },
+    "b79270e4-262d-5069-ba04-0e4aa6298b3d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T13:52:45.922826+00:00",
+      "tried": {
+        "garden-grove-ca-po": "http_404"
       }
     },
     "ba6dffec-c362-5bc4-b042-eef688d730a2": {
@@ -476,6 +500,6 @@
       }
     }
   },
-  "updated": "2026-04-25T12:30:08.470856+00:00",
+  "updated": "2026-04-25T13:52:54.547987+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -45,8 +45,9 @@
     "06f1b20d-a403-5088-9d3a-d8df6edcb126": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T13:52:49.813473+00:00",
+      "last_probed": "2026-04-26T15:29:52.926715+00:00",
       "tried": {
+        "san-luis-obispo-county-ca-sd": "http_404",
         "san-luis-obispo-county-ca-so": "http_404"
       }
     },
@@ -264,8 +265,9 @@
     "5d80780f-d47b-5f56-acf4-a457bbb421ac": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T18:28:38.674453+00:00",
+      "last_probed": "2026-04-26T15:29:40.664025+00:00",
       "tried": {
+        "monterey-county-district-attorneys-office-ca": "http_404",
         "monterey-county-district-attorneys-office-ca-da": "http_404",
         "monterey-county-district-attorneys-office-ca-district-attorney": "http_404"
       }
@@ -361,6 +363,14 @@
       "last_probed": "2026-04-25T23:23:49.936037+00:00",
       "tried": {
         "trinity-county-ca-so": "http_404"
+      }
+    },
+    "74719b7b-43cb-57ec-a0bc-26515454b5dc": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T15:29:46.877101+00:00",
+      "tried": {
+        "orange-county-da-office-ca-da": "http_404"
       }
     },
     "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
@@ -743,6 +753,6 @@
       }
     }
   },
-  "updated": "2026-04-26T13:54:55.181059+00:00",
+  "updated": "2026-04-26T15:29:52.961379+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -71,11 +71,12 @@
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T04:47:30.814912+00:00",
+      "last_probed": "2026-04-26T22:21:42.380544+00:00",
       "tried": {
         "hemet-ca-po": "http_404",
         "hemet-ca-police": "http_404",
-        "hemet-ca-police-department": "http_404"
+        "hemet-ca-police-department": "http_404",
+        "hemet-ca-ps": "http_404"
       }
     },
     "1360ff78-db4c-529a-b889-81746642325e": {
@@ -723,9 +724,10 @@
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T09:40:01.216843+00:00",
+      "last_probed": "2026-04-26T22:21:38.452759+00:00",
       "tried": {
         "brentwood-ca-po": "http_404",
+        "brentwood-ca-police": "http_404",
         "brentwood-ca-police-department": "http_404"
       }
     },
@@ -788,6 +790,14 @@
         "ca-wasco-ca-pd": "http_404"
       }
     },
+    "ef0c3682-0153-527c-a973-0bb7b07056be": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T22:21:33.039988+00:00",
+      "tried": {
+        "bishop-ca-po": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -841,6 +851,6 @@
       }
     }
   },
-  "updated": "2026-04-26T21:23:18.221035+00:00",
+  "updated": "2026-04-26T22:21:42.416618+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -26,6 +26,14 @@
         "selma-ca-po": "http_404"
       }
     },
+    "0649c75b-a49d-5ec7-a240-18692dea2047": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T10:31:38.077122+00:00",
+      "tried": {
+        "marin-county-ca-district-attorney": "http_404"
+      }
+    },
     "069764d3-6b36-5e35-ba95-2e4b38441b0e": {
       "exhausted": false,
       "found": null,
@@ -87,9 +95,10 @@
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T21:34:41.257501+00:00",
+      "last_probed": "2026-04-26T10:31:42.881510+00:00",
       "tried": {
-        "covina-ca-po": "http_404"
+        "covina-ca-po": "http_404",
+        "covina-ca-police-department": "http_404"
       }
     },
     "2279723d-b2cf-59d8-8732-4fdefd822546": {
@@ -129,9 +138,10 @@
     "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T01:14:49.052199+00:00",
+      "last_probed": "2026-04-26T10:31:33.074227+00:00",
       "tried": {
         "greenfield-ca-po": "http_404",
+        "greenfield-ca-police": "http_404",
         "greenfield-ca-police-department": "http_404"
       }
     },
@@ -696,6 +706,6 @@
       }
     }
   },
-  "updated": "2026-04-26T09:40:13.091094+00:00",
+  "updated": "2026-04-26T10:31:42.915726+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -8,6 +8,14 @@
         "desert-hot-springs-ca-po": "http_404"
       }
     },
+    "59158344-4894-55be-bc8a-de15bcb986f0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T08:53:55.092109+00:00",
+      "tried": {
+        "laguna-beach-ca-po": "http_404"
+      }
+    },
     "650ab346-a013-56f6-a970-1bf8a61acb18": {
       "exhausted": false,
       "found": null,
@@ -40,6 +48,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "a5b59684-abcc-5a43-949d-3aec089d30a4": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T08:53:49.367842+00:00",
+      "tried": {
+        "vernon-ca-po": "http_404"
+      }
+    },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
       "exhausted": false,
       "found": null,
@@ -64,6 +80,14 @@
         "madera-county-ca-so": "http_404"
       }
     },
+    "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T08:53:44.745211+00:00",
+      "tried": {
+        "los-alamitos-ca-pd": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -73,6 +97,6 @@
       }
     }
   },
-  "updated": "2026-04-24T05:58:32.667617+00:00",
+  "updated": "2026-04-24T08:53:55.132358+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -104,18 +104,20 @@
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T10:31:42.881510+00:00",
+      "last_probed": "2026-04-26T20:23:35.768508+00:00",
       "tried": {
         "covina-ca-po": "http_404",
+        "covina-ca-police": "http_404",
         "covina-ca-police-department": "http_404"
       }
     },
     "2279723d-b2cf-59d8-8732-4fdefd822546": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T01:14:42.792887+00:00",
+      "last_probed": "2026-04-26T20:23:29.666815+00:00",
       "tried": {
         "tehama-county-ca-sd": "http_404",
+        "tehama-county-ca-sheriffs-department": "http_404",
         "tehama-county-ca-sheriffs-office": "http_404"
       }
     },
@@ -421,6 +423,14 @@
       "last_probed": "2026-04-25T06:11:43.428630+00:00",
       "tried": {
         "bear-valley-springs-ca-po": "http_404"
+      }
+    },
+    "7929aea5-907c-554a-be3f-2e9053c94df8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T20:23:24.797779+00:00",
+      "tried": {
+        "kerman-ca-po": "http_404"
       }
     },
     "7932e34a-0d6d-524b-9e26-543d66b8b93c": {
@@ -821,6 +831,6 @@
       }
     }
   },
-  "updated": "2026-04-26T19:35:40.695411+00:00",
+  "updated": "2026-04-26T20:23:35.806523+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -40,6 +40,30 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "cc269287-49ca-5831-af72-f6dacf356bd1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T05:58:32.630231+00:00",
+      "tried": {
+        "alhambra-ca-po": "http_404"
+      }
+    },
+    "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T05:58:27.011483+00:00",
+      "tried": {
+        "wheatland-ca-po": "http_404"
+      }
+    },
+    "e7331865-34fd-5831-8028-c63398d95e55": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T05:58:21.564519+00:00",
+      "tried": {
+        "madera-county-ca-so": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -49,6 +73,6 @@
       }
     }
   },
-  "updated": "2026-04-24T03:21:41.461867+00:00",
+  "updated": "2026-04-24T05:58:32.667617+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -66,6 +66,14 @@
         "covina-ca-po": "http_404"
       }
     },
+    "2279723d-b2cf-59d8-8732-4fdefd822546": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T15:27:35.603473+00:00",
+      "tried": {
+        "tehama-county-ca-sd": "http_404"
+      }
+    },
     "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c": {
       "exhausted": false,
       "found": null,
@@ -104,6 +112,14 @@
       "last_probed": "2026-04-25T10:30:35.054595+00:00",
       "tried": {
         "oxnard-ca-po": "http_404"
+      }
+    },
+    "2e9edae6-7b5a-5b86-bd0e-c3e06b3d96d0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T15:27:30.942928+00:00",
+      "tried": {
+        "san-fernando-ca-po": "http_404"
       }
     },
     "332407d3-a475-546c-88c0-b2046bb47ca7": {
@@ -456,6 +472,14 @@
         "madera-county-ca-so": "http_404"
       }
     },
+    "e9d63958-c540-592f-aeb5-6fc9953296ef": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T15:27:27.301633+00:00",
+      "tried": {
+        "hermosa-beach-ca-pd": "http_404"
+      }
+    },
     "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
       "exhausted": false,
       "found": null,
@@ -500,6 +524,6 @@
       }
     }
   },
-  "updated": "2026-04-25T13:52:54.547987+00:00",
+  "updated": "2026-04-25T15:27:35.640079+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -61,9 +61,10 @@
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T09:38:03.255108+00:00",
+      "last_probed": "2026-04-26T04:47:30.814912+00:00",
       "tried": {
         "hemet-ca-po": "http_404",
+        "hemet-ca-police": "http_404",
         "hemet-ca-police-department": "http_404"
       }
     },
@@ -276,8 +277,9 @@
     "6a2741a1-b6d5-5537-9963-9f2fb2b2447e": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T19:40:24.420157+00:00",
+      "last_probed": "2026-04-26T04:47:35.036083+00:00",
       "tried": {
+        "sacramento-ca": "http_404",
         "sacramento-ca-district-attorney": "http_404"
       }
     },
@@ -554,6 +556,14 @@
         "wheatland-ca-police-department": "http_404"
       }
     },
+    "d9342287-962b-509a-9861-e44e0172394e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T04:47:39.114516+00:00",
+      "tried": {
+        "sutter-county-ca-sd": "http_404"
+      }
+    },
     "dbfeb93f-10ea-5aaf-8862-a6b186764b79": {
       "exhausted": false,
       "found": null,
@@ -663,6 +673,6 @@
       }
     }
   },
-  "updated": "2026-04-26T01:14:53.327963+00:00",
+  "updated": "2026-04-26T04:47:39.151234+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -223,9 +223,10 @@
     "4d51cf25-3dd8-5b26-ae54-6c0b50511be2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T16:25:41.751870+00:00",
+      "last_probed": "2026-04-26T17:26:20.408145+00:00",
       "tried": {
-        "lakeport-ca-po": "http_404"
+        "lakeport-ca-po": "http_404",
+        "lakeport-ca-police-department": "http_404"
       }
     },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
@@ -260,6 +261,14 @@
       "last_probed": "2026-04-24T18:32:01.439811+00:00",
       "tried": {
         "pleasant-hill-ca-po": "http_404"
+      }
+    },
+    "5aad1905-8ff9-5a45-931a-7298f983153a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T17:26:31.161009+00:00",
+      "tried": {
+        "newark-ca-po": "http_404"
       }
     },
     "5b3abf70-5581-5412-8165-b9b12db5a69b": {
@@ -725,6 +734,14 @@
         "university-of-california-berkeley-ca-pd": "http_404"
       }
     },
+    "ec0349b0-2d81-546b-acf9-ded505a551a7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T17:26:25.161720+00:00",
+      "tried": {
+        "ca-wasco-ca-pd": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -777,6 +794,6 @@
       }
     }
   },
-  "updated": "2026-04-26T16:25:41.781849+00:00",
+  "updated": "2026-04-26T17:26:31.199830+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -82,9 +82,10 @@
     "1360ff78-db4c-529a-b889-81746642325e": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T23:23:45.896536+00:00",
+      "last_probed": "2026-04-26T23:25:11.776062+00:00",
       "tried": {
-        "kern-county-ca-sd": "http_404"
+        "kern-county-ca-sd": "http_404",
+        "kern-county-ca-sheriffs-office": "http_404"
       }
     },
     "16449917-ee53-5406-ade9-4b7361ec7ba2": {
@@ -252,9 +253,10 @@
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T22:18:59.050830+00:00",
+      "last_probed": "2026-04-26T23:25:15.602614+00:00",
       "tried": {
         "indio-ca-po": "http_404",
+        "indio-ca-police": "http_404",
         "indio-ca-police-department": "http_404"
       }
     },
@@ -790,6 +792,14 @@
         "ca-wasco-ca-pd": "http_404"
       }
     },
+    "eef11480-824c-5b76-9049-541470c862b1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T23:25:06.673286+00:00",
+      "tried": {
+        "cal-ca-fd": "http_404"
+      }
+    },
     "ef0c3682-0153-527c-a973-0bb7b07056be": {
       "exhausted": false,
       "found": null,
@@ -851,6 +861,6 @@
       }
     }
   },
-  "updated": "2026-04-26T22:21:42.416618+00:00",
+  "updated": "2026-04-26T23:25:15.639930+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -16,6 +16,14 @@
         "redondo-beach-ca-po": "http_404"
       }
     },
+    "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T19:40:19.996639+00:00",
+      "tried": {
+        "cal-state-fullerton-ca-pd": "http_404"
+      }
+    },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
@@ -78,6 +86,14 @@
       "last_probed": "2026-04-24T03:21:35.753684+00:00",
       "tried": {
         "calexico-ca-po": "http_404"
+      }
+    },
+    "6a2741a1-b6d5-5537-9963-9f2fb2b2447e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T19:40:24.420157+00:00",
+      "tried": {
+        "sacramento-ca-district-attorney": "http_404"
       }
     },
     "6db175fe-bff6-58bc-a911-d688f797fda9": {
@@ -208,6 +224,14 @@
         "foothill-deanza-ca-po": "http_404"
       }
     },
+    "e35b094f-0435-50b5-a03c-e644ad6144be": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T19:40:29.930745+00:00",
+      "tried": {
+        "sanger-ca-po": "http_404"
+      }
+    },
     "e7331865-34fd-5831-8028-c63398d95e55": {
       "exhausted": false,
       "found": null,
@@ -241,6 +265,6 @@
       }
     }
   },
-  "updated": "2026-04-24T18:32:07.475128+00:00",
+  "updated": "2026-04-24T19:40:29.963701+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "winters-ca-po": "http_404"
       }
     },
+    "13422e46-1750-5a1f-865c-a7219949a2ef": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T04:22:56.741374+00:00",
+      "tried": {
+        "hemet-ca-po": "http_404"
+      }
+    },
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
       "exhausted": false,
       "found": null,
@@ -39,6 +47,14 @@
       "last_probed": "2026-04-24T23:27:22.238097+00:00",
       "tried": {
         "suisun-city-ca-po": "http_404"
+      }
+    },
+    "23febb79-0d19-5c75-b964-46a43c1cd423": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T04:22:52.141856+00:00",
+      "tried": {
+        "national-city-ca-po": "http_404"
       }
     },
     "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
@@ -319,10 +335,11 @@
     "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T01:07:03.843502+00:00",
+      "last_probed": "2026-04-25T04:22:45.971339+00:00",
       "tried": {
         "los-alamitos-ca-pd": "http_404",
-        "los-alamitos-ca-po": "http_403"
+        "los-alamitos-ca-po": "http_403",
+        "los-alamitos-ca-police-department": "http_404"
       }
     },
     "eaef691d-609c-566f-ad67-3a187a241852": {
@@ -350,6 +367,6 @@
       }
     }
   },
-  "updated": "2026-04-25T01:07:15.841204+00:00",
+  "updated": "2026-04-25T04:22:56.777696+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -321,9 +321,10 @@
     "727915ef-bda7-5399-8e79-0369d7bb7782": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T22:18:48.873053+00:00",
+      "last_probed": "2026-04-26T09:40:13.050864+00:00",
       "tried": {
-        "la-verne-ca-po": "http_404"
+        "la-verne-ca-po": "http_404",
+        "la-verne-ca-police-department": "http_404"
       }
     },
     "72812ca1-c7b8-5c94-8327-508726647ad8": {
@@ -423,6 +424,14 @@
       "tried": {
         "los-angeles-port-ca-pd": "http_404",
         "los-angeles-port-ca-po": "http_404"
+      }
+    },
+    "98a2b052-2421-5f90-a95c-88c85615e128": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T09:40:07.163061+00:00",
+      "tried": {
+        "california-department-of-ca-doc": "http_404"
       }
     },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
@@ -595,9 +604,10 @@
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T23:27:18.644443+00:00",
+      "last_probed": "2026-04-26T09:40:01.216843+00:00",
       "tried": {
-        "brentwood-ca-po": "http_404"
+        "brentwood-ca-po": "http_404",
+        "brentwood-ca-police-department": "http_404"
       }
     },
     "dead7dd4-476d-528d-92bd-89a198d5f518": {
@@ -686,6 +696,6 @@
       }
     }
   },
-  "updated": "2026-04-26T08:45:38.361787+00:00",
+  "updated": "2026-04-26T09:40:13.091094+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "covina-ca-po": "http_404"
       }
     },
+    "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T23:27:22.238097+00:00",
+      "tried": {
+        "suisun-city-ca-po": "http_404"
+      }
+    },
     "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
       "exhausted": false,
       "found": null,
@@ -259,6 +267,14 @@
         "wheatland-ca-po": "http_404"
       }
     },
+    "de913a80-ceee-5eef-a74c-0093e8dcc033": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T23:27:18.644443+00:00",
+      "tried": {
+        "brentwood-ca-po": "http_404"
+      }
+    },
     "dead7dd4-476d-528d-92bd-89a198d5f518": {
       "exhausted": false,
       "found": null,
@@ -292,6 +308,14 @@
         "los-alamitos-ca-pd": "http_404"
       }
     },
+    "eaef691d-609c-566f-ad67-3a187a241852": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T23:27:14.232978+00:00",
+      "tried": {
+        "university-of-california-berkeley-ca-pd": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -309,6 +333,6 @@
       }
     }
   },
-  "updated": "2026-04-24T22:27:52.117520+00:00",
+  "updated": "2026-04-24T23:27:22.277437+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -133,9 +133,10 @@
     "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T19:40:19.996639+00:00",
+      "last_probed": "2026-04-25T17:26:14.957962+00:00",
       "tried": {
-        "cal-state-fullerton-ca-pd": "http_404"
+        "cal-state-fullerton-ca-pd": "http_404",
+        "cal-state-fullerton-ca-po": "http_404"
       }
     },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
@@ -230,9 +231,10 @@
     "6be9f842-1658-5490-8be4-14b77cc1e96d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T21:34:45.183851+00:00",
+      "last_probed": "2026-04-25T17:26:21.667431+00:00",
       "tried": {
-        "santa-clara-ca-da": "http_404"
+        "santa-clara-ca-da": "http_404",
+        "santa-clara-ca-district-attorney": "http_404"
       }
     },
     "6db175fe-bff6-58bc-a911-d688f797fda9": {
@@ -306,6 +308,14 @@
       "last_probed": "2026-04-25T11:26:42.852152+00:00",
       "tried": {
         "rio-hondo-college-ca-pd": "http_404"
+      }
+    },
+    "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T17:26:09.214319+00:00",
+      "tried": {
+        "los-angeles-port-ca-pd": "http_404"
       }
     },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
@@ -548,6 +558,6 @@
       }
     }
   },
-  "updated": "2026-04-25T16:24:18.623768+00:00",
+  "updated": "2026-04-25T17:26:21.704867+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -24,6 +24,14 @@
         "laguna-beach-ca-po": "http_404"
       }
     },
+    "5b3abf70-5581-5412-8165-b9b12db5a69b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T14:24:39.512234+00:00",
+      "tried": {
+        "yuba-county-pd": "http_404"
+      }
+    },
     "650ab346-a013-56f6-a970-1bf8a61acb18": {
       "exhausted": false,
       "found": null,
@@ -80,12 +88,28 @@
         "san-diego-harbor-ca-po": "http_404"
       }
     },
+    "ba6dffec-c362-5bc4-b042-eef688d730a2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T14:24:46.051972+00:00",
+      "tried": {
+        "east-bay-parks-ca-po": "http_404"
+      }
+    },
     "c246371a-5810-5428-b861-52b526e54678": {
       "exhausted": false,
       "found": null,
       "last_probed": "2026-04-24T12:46:28.731601+00:00",
       "tried": {
         "university-of-the-pacific-ca-pd": "http_404"
+      }
+    },
+    "ca169c85-b556-58a0-a0bc-988c09bc6d01": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T14:24:34.913401+00:00",
+      "tried": {
+        "blythe-ca-po": "http_404"
       }
     },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
@@ -145,6 +169,6 @@
       }
     }
   },
-  "updated": "2026-04-24T12:46:32.992514+00:00",
+  "updated": "2026-04-24T14:24:46.077585+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -154,6 +154,14 @@
         "greenfield-ca-police-department": "http_404"
       }
     },
+    "27d3370c-1004-57a6-b76f-c2efedaefc53": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T19:35:29.076772+00:00",
+      "tried": {
+        "huntington-beach-ca-po": "http_404"
+      }
+    },
     "2e1e1b36-7a6b-5c97-8143-65347503186c": {
       "exhausted": false,
       "found": null,
@@ -529,6 +537,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "9eb7354b-b6ff-590b-b3bb-f097e0b30033": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T19:35:40.659057+00:00",
+      "tried": {
+        "tustin-ca-po": "http_404"
+      }
+    },
     "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f": {
       "exhausted": false,
       "found": null,
@@ -626,9 +642,10 @@
     "ca169c85-b556-58a0-a0bc-988c09bc6d01": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T14:24:34.913401+00:00",
+      "last_probed": "2026-04-26T19:35:33.913295+00:00",
       "tried": {
-        "blythe-ca-po": "http_404"
+        "blythe-ca-po": "http_404",
+        "blythe-ca-police-department": "http_404"
       }
     },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
@@ -804,6 +821,6 @@
       }
     }
   },
-  "updated": "2026-04-26T18:30:17.658012+00:00",
+  "updated": "2026-04-26T19:35:40.695411+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -97,6 +97,14 @@
         "indio-ca-po": "http_404"
       }
     },
+    "589597b2-0d45-5add-ac97-bf6a042fceae": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T07:55:30.950190+00:00",
+      "tried": {
+        "cal-state-san-bernadino-ca-po": "http_404"
+      }
+    },
     "59158344-4894-55be-bc8a-de15bcb986f0": {
       "exhausted": false,
       "found": null,
@@ -226,6 +234,14 @@
         "west-valley-mission-college-dist-campus-ca-pd": "http_404"
       }
     },
+    "a24c4de9-ca70-5829-838e-12907c88c3a9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T07:55:24.632386+00:00",
+      "tried": {
+        "cloverdale-ca-po": "http_404"
+      }
+    },
     "a2c03da5-7700-5042-8d22-ab98c8a1c7f2": {
       "exhausted": false,
       "found": null,
@@ -311,9 +327,10 @@
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T05:58:27.011483+00:00",
+      "last_probed": "2026-04-25T07:55:36.225841+00:00",
       "tried": {
-        "wheatland-ca-po": "http_404"
+        "wheatland-ca-po": "http_404",
+        "wheatland-ca-police-department": "http_404"
       }
     },
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
@@ -384,6 +401,6 @@
       }
     }
   },
-  "updated": "2026-04-25T06:11:47.196528+00:00",
+  "updated": "2026-04-25T07:55:36.262065+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -21,9 +21,10 @@
     "03c310c0-6e05-5ad2-872a-d4e8b804358f": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T20:22:33.780812+00:00",
+      "last_probed": "2026-04-26T21:23:18.184984+00:00",
       "tried": {
-        "selma-ca-po": "http_404"
+        "selma-ca-po": "http_404",
+        "selma-ca-police-department": "http_404"
       }
     },
     "0649c75b-a49d-5ec7-a240-18692dea2047": {
@@ -441,6 +442,14 @@
         "lathrop-ca-po": "http_404"
       }
     },
+    "79d1a399-1db1-5b50-aaa9-b4bbc64d8dd2": {
+      "exhausted": false,
+      "found": "los-gatos-ca-pd",
+      "last_probed": "2026-04-26T21:23:07.425470+00:00",
+      "tried": {
+        "los-gatos-ca-pd": "http_200"
+      }
+    },
     "7d2b8047-a15b-524a-bc77-627e8eeab00a": {
       "exhausted": false,
       "found": null,
@@ -635,9 +644,10 @@
     "ba6dffec-c362-5bc4-b042-eef688d730a2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T18:28:27.326321+00:00",
+      "last_probed": "2026-04-26T21:23:11.830314+00:00",
       "tried": {
         "east-bay-parks-ca-po": "http_404",
+        "east-bay-parks-ca-police": "http_404",
         "east-bay-parks-ca-police-department": "http_404"
       }
     },
@@ -831,6 +841,6 @@
       }
     }
   },
-  "updated": "2026-04-26T20:23:35.806523+00:00",
+  "updated": "2026-04-26T21:23:18.221035+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -212,6 +212,14 @@
         "cal-state-fullerton-ca-po": "http_404"
       }
     },
+    "47a01976-2030-52f3-9c3f-3347ce75fcf7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T18:30:06.441152+00:00",
+      "tried": {
+        "westmorland-ca-po": "http_404"
+      }
+    },
     "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c": {
       "exhausted": false,
       "found": null,
@@ -661,9 +669,10 @@
     "dbfeb93f-10ea-5aaf-8862-a6b186764b79": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T16:24:18.584073+00:00",
+      "last_probed": "2026-04-26T18:30:11.273987+00:00",
       "tried": {
-        "la-mesa-ca-po": "http_404"
+        "la-mesa-ca-po": "http_404",
+        "la-mesa-ca-police-department": "http_404"
       }
     },
     "dddefaf4-84f7-5857-8011-45b6eda02991": {
@@ -779,9 +788,10 @@
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T10:55:19.602394+00:00",
+      "last_probed": "2026-04-26T18:30:17.628155+00:00",
       "tried": {
-        "chino-ca-po": "http_404"
+        "chino-ca-po": "http_404",
+        "chino-ca-police-department": "http_404"
       }
     },
     "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2": {
@@ -794,6 +804,6 @@
       }
     }
   },
-  "updated": "2026-04-26T17:26:31.199830+00:00",
+  "updated": "2026-04-26T18:30:17.658012+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -104,9 +104,10 @@
     "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T23:27:22.238097+00:00",
+      "last_probed": "2026-04-26T08:45:29.435161+00:00",
       "tried": {
-        "suisun-city-ca-po": "http_404"
+        "suisun-city-ca-po": "http_404",
+        "suisun-city-ca-police-department": "http_404"
       }
     },
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
@@ -409,9 +410,10 @@
     "9079f9e0-e3c2-5611-8f09-a0276b7911f8": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T21:22:49.273231+00:00",
+      "last_probed": "2026-04-26T08:45:38.324251+00:00",
       "tried": {
-        "california-state-university-long-beach-campus-ca-pd": "http_404"
+        "california-state-university-long-beach-campus-ca-pd": "http_404",
+        "california-state-university-long-beach-campus-ca-ps": "http_404"
       }
     },
     "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
@@ -660,9 +662,10 @@
     "f17f02e4-77c4-50ca-a858-8e388e2b8e85": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T16:24:08.991448+00:00",
+      "last_probed": "2026-04-26T08:45:34.737885+00:00",
       "tried": {
-        "san-pasqual-ca-po": "http_404"
+        "san-pasqual-ca-po": "http_404",
+        "san-pasqual-ca-police-department": "http_404"
       }
     },
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
@@ -683,6 +686,6 @@
       }
     }
   },
-  "updated": "2026-04-26T07:12:40.369762+00:00",
+  "updated": "2026-04-26T08:45:38.361787+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -32,6 +32,14 @@
         "calexico-ca-po": "http_404"
       }
     },
+    "6db175fe-bff6-58bc-a911-d688f797fda9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T10:55:09.756432+00:00",
+      "tried": {
+        "shafter-ca-pd": "http_404"
+      }
+    },
     "6fc47404-6f79-5f5d-ace0-18db02bc2391": {
       "exhausted": false,
       "found": null,
@@ -54,6 +62,14 @@
       "last_probed": "2026-04-24T08:53:49.367842+00:00",
       "tried": {
         "vernon-ca-po": "http_404"
+      }
+    },
+    "b66facad-4ee0-558e-8bfe-32d1894afad1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T10:55:13.729041+00:00",
+      "tried": {
+        "san-diego-harbor-ca-po": "http_404"
       }
     },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
@@ -95,8 +111,16 @@
       "tried": {
         "soledad-ca-po": "http_404"
       }
+    },
+    "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T10:55:19.602394+00:00",
+      "tried": {
+        "chino-ca-po": "http_404"
+      }
     }
   },
-  "updated": "2026-04-24T08:53:55.132358+00:00",
+  "updated": "2026-04-24T10:55:19.639185+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -220,6 +220,14 @@
         "atwater-ca-po": "http_404"
       }
     },
+    "4d51cf25-3dd8-5b26-ae54-6c0b50511be2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T16:25:41.751870+00:00",
+      "tried": {
+        "lakeport-ca-po": "http_404"
+      }
+    },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
@@ -396,6 +404,14 @@
       "last_probed": "2026-04-26T13:54:51.429140+00:00",
       "tried": {
         "lathrop-ca-po": "http_404"
+      }
+    },
+    "7d2b8047-a15b-524a-bc77-627e8eeab00a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T16:25:29.990161+00:00",
+      "tried": {
+        "escalon-ca-po": "http_404"
       }
     },
     "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c": {
@@ -735,6 +751,14 @@
         "burlingame-ca-po": "http_404"
       }
     },
+    "f4a21139-b8d6-5bed-959f-5a847ba09031": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-26T16:25:35.516655+00:00",
+      "tried": {
+        "arcadia-ca-po": "http_404"
+      }
+    },
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
       "exhausted": false,
       "found": null,
@@ -753,6 +777,6 @@
       }
     }
   },
-  "updated": "2026-04-26T15:29:52.961379+00:00",
+  "updated": "2026-04-26T16:25:41.781849+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -8,6 +8,14 @@
         "desert-hot-springs-ca-po": "http_404"
       }
     },
+    "02126911-e73c-519e-b23b-8bc1cfb0d92d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T12:46:32.963404+00:00",
+      "tried": {
+        "redondo-beach-ca-po": "http_404"
+      }
+    },
     "59158344-4894-55be-bc8a-de15bcb986f0": {
       "exhausted": false,
       "found": null,
@@ -72,6 +80,14 @@
         "san-diego-harbor-ca-po": "http_404"
       }
     },
+    "c246371a-5810-5428-b861-52b526e54678": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T12:46:28.731601+00:00",
+      "tried": {
+        "university-of-the-pacific-ca-pd": "http_404"
+      }
+    },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
       "exhausted": false,
       "found": null,
@@ -86,6 +102,14 @@
       "last_probed": "2026-04-24T05:58:27.011483+00:00",
       "tried": {
         "wheatland-ca-po": "http_404"
+      }
+    },
+    "dead7dd4-476d-528d-92bd-89a198d5f518": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T12:46:24.361382+00:00",
+      "tried": {
+        "foothill-deanza-ca-po": "http_404"
       }
     },
     "e7331865-34fd-5831-8028-c63398d95e55": {
@@ -121,6 +145,6 @@
       }
     }
   },
-  "updated": "2026-04-24T10:55:19.639185+00:00",
+  "updated": "2026-04-24T12:46:32.992514+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -3,9 +3,10 @@
     "00015f2d-ad5e-5b12-9811-04b7cb13827d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T03:06:45.204233+00:00",
+      "last_probed": "2026-04-25T18:28:32.295555+00:00",
       "tried": {
-        "desert-hot-springs-ca-po": "http_404"
+        "desert-hot-springs-ca-po": "http_404",
+        "desert-hot-springs-ca-police-department": "http_404"
       }
     },
     "02126911-e73c-519e-b23b-8bc1cfb0d92d": {
@@ -182,9 +183,10 @@
     "5d80780f-d47b-5f56-acf4-a457bbb421ac": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T18:32:07.437605+00:00",
+      "last_probed": "2026-04-25T18:28:38.674453+00:00",
       "tried": {
-        "monterey-county-district-attorneys-office-ca-da": "http_404"
+        "monterey-county-district-attorneys-office-ca-da": "http_404",
+        "monterey-county-district-attorneys-office-ca-district-attorney": "http_404"
       }
     },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
@@ -402,9 +404,10 @@
     "ba6dffec-c362-5bc4-b042-eef688d730a2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T14:24:46.051972+00:00",
+      "last_probed": "2026-04-25T18:28:27.326321+00:00",
       "tried": {
-        "east-bay-parks-ca-po": "http_404"
+        "east-bay-parks-ca-po": "http_404",
+        "east-bay-parks-ca-police-department": "http_404"
       }
     },
     "c246371a-5810-5428-b861-52b526e54678": {
@@ -558,6 +561,6 @@
       }
     }
   },
-  "updated": "2026-04-25T17:26:21.704867+00:00",
+  "updated": "2026-04-25T18:28:38.709855+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "winters-ca-po": "http_404"
       }
     },
+    "12c4f64a-7e32-56ec-b95d-b0645a5d1a4b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T06:11:39.291103+00:00",
+      "tried": {
+        "california-state-parks-ca-pd": "http_404"
+      }
+    },
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
@@ -186,6 +194,14 @@
         "rialto-ca-po": "http_404"
       }
     },
+    "7810622c-5cfd-5d8c-922a-9acd7e2ea391": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T06:11:43.428630+00:00",
+      "tried": {
+        "bear-valley-springs-ca-po": "http_404"
+      }
+    },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
       "exhausted": false,
       "found": null,
@@ -213,9 +229,10 @@
     "a2c03da5-7700-5042-8d22-ab98c8a1c7f2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T15:53:04.316734+00:00",
+      "last_probed": "2026-04-25T06:11:47.164721+00:00",
       "tried": {
-        "orange-county-fire-authority-ca-fd": "http_404"
+        "orange-county-fire-authority-ca-fd": "http_404",
+        "orange-county-fire-authority-ca-fire": "http_404"
       }
     },
     "a5b59684-abcc-5a43-949d-3aec089d30a4": {
@@ -367,6 +384,6 @@
       }
     }
   },
-  "updated": "2026-04-25T04:22:56.777696+00:00",
+  "updated": "2026-04-25T06:11:47.196528+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -11,9 +11,18 @@
     "02126911-e73c-519e-b23b-8bc1cfb0d92d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T12:46:32.963404+00:00",
+      "last_probed": "2026-04-24T20:31:23.442769+00:00",
       "tried": {
-        "redondo-beach-ca-po": "http_404"
+        "redondo-beach-ca-po": "http_404",
+        "redondo-beach-ca-police-department": "http_404"
+      }
+    },
+    "332407d3-a475-546c-88c0-b2046bb47ca7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T20:31:11.421470+00:00",
+      "tried": {
+        "san-luis-obispo-ca-po": "http_404"
       }
     },
     "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
@@ -115,9 +124,10 @@
     "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T17:39:10.433779+00:00",
+      "last_probed": "2026-04-24T20:31:17.024133+00:00",
       "tried": {
-        "rialto-ca-pd": "http_404"
+        "rialto-ca-pd": "http_404",
+        "rialto-ca-po": "http_404"
       }
     },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
@@ -265,6 +275,6 @@
       }
     }
   },
-  "updated": "2026-04-24T19:40:29.963701+00:00",
+  "updated": "2026-04-24T20:31:23.476901+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -32,12 +32,28 @@
         "laguna-beach-ca-po": "http_404"
       }
     },
+    "59b1f730-2412-5790-92fd-a707e3ac23cd": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T18:32:01.439811+00:00",
+      "tried": {
+        "pleasant-hill-ca-po": "http_404"
+      }
+    },
     "5b3abf70-5581-5412-8165-b9b12db5a69b": {
       "exhausted": false,
       "found": null,
       "last_probed": "2026-04-24T14:24:39.512234+00:00",
       "tried": {
         "yuba-county-pd": "http_404"
+      }
+    },
+    "5d80780f-d47b-5f56-acf4-a457bbb421ac": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T18:32:07.437605+00:00",
+      "tried": {
+        "monterey-county-district-attorneys-office-ca-da": "http_404"
       }
     },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
@@ -86,6 +102,14 @@
       "last_probed": "2026-04-24T17:39:10.433779+00:00",
       "tried": {
         "rialto-ca-pd": "http_404"
+      }
+    },
+    "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T18:31:56.268359+00:00",
+      "tried": {
+        "california-highway-patrol-ca-chp": "http_404"
       }
     },
     "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
@@ -217,6 +241,6 @@
       }
     }
   },
-  "updated": "2026-04-24T17:39:23.513348+00:00",
+  "updated": "2026-04-24T18:32:07.475128+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -52,6 +52,14 @@
         "san-luis-obispo-county-ca-so": "http_404"
       }
     },
+    "098c0089-e37c-50d0-bafc-0387298e7108": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T01:16:23.753158+00:00",
+      "tried": {
+        "del-norte-county-ca-sd": "http_404"
+      }
+    },
     "11949eb7-26df-5b98-a23d-ac249879ec01": {
       "exhausted": false,
       "found": null,
@@ -136,9 +144,10 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T04:22:52.141856+00:00",
+      "last_probed": "2026-04-27T01:16:29.210234+00:00",
       "tried": {
-        "national-city-ca-po": "http_404"
+        "national-city-ca-po": "http_404",
+        "national-city-ca-police-department": "http_404"
       }
     },
     "270aae46-f0d1-558e-bb3f-249d03b0510f": {
@@ -365,8 +374,9 @@
     "6be9f842-1658-5490-8be4-14b77cc1e96d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T17:26:21.667431+00:00",
+      "last_probed": "2026-04-27T01:16:35.177588+00:00",
       "tried": {
+        "santa-clara-ca": "http_404",
         "santa-clara-ca-da": "http_404",
         "santa-clara-ca-district-attorney": "http_404"
       }
@@ -861,6 +871,6 @@
       }
     }
   },
-  "updated": "2026-04-26T23:25:15.639930+00:00",
+  "updated": "2026-04-27T01:16:35.216882+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "winters-ca-po": "http_404"
       }
     },
+    "11949eb7-26df-5b98-a23d-ac249879ec01": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T12:30:08.431856+00:00",
+      "tried": {
+        "upland-ca-po": "http_404"
+      }
+    },
     "12c4f64a-7e32-56ec-b95d-b0645a5d1a4b": {
       "exhausted": false,
       "found": null,
@@ -179,6 +187,14 @@
         "calexico-ca-police-department": "http_404"
       }
     },
+    "6978140c-1211-52e1-8c04-94d5a9791efe": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T12:30:03.068487+00:00",
+      "tried": {
+        "uc-irvine-campus-ca-pd": "http_404"
+      }
+    },
     "6a2741a1-b6d5-5537-9963-9f2fb2b2447e": {
       "exhausted": false,
       "found": null,
@@ -234,6 +250,14 @@
       "last_probed": "2026-04-25T09:38:08.585040+00:00",
       "tried": {
         "solano-county-ca-da": "http_404"
+      }
+    },
+    "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T12:29:58.721709+00:00",
+      "tried": {
+        "imperial-county-ca-sd": "http_404"
       }
     },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
@@ -452,6 +476,6 @@
       }
     }
   },
-  "updated": "2026-04-25T11:26:49.418494+00:00",
+  "updated": "2026-04-25T12:30:08.470856+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -25,6 +25,14 @@
         "covina-ca-po": "http_404"
       }
     },
+    "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T22:27:45.835235+00:00",
+      "tried": {
+        "greenfield-ca-po": "http_404"
+      }
+    },
     "332407d3-a475-546c-88c0-b2046bb47ca7": {
       "exhausted": false,
       "found": null,
@@ -162,6 +170,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-24T22:27:41.795446+00:00",
+      "tried": {
+        "west-valley-mission-college-dist-campus-ca-pd": "http_404"
+      }
+    },
     "a2c03da5-7700-5042-8d22-ab98c8a1c7f2": {
       "exhausted": false,
       "found": null,
@@ -254,9 +270,10 @@
     "e35b094f-0435-50b5-a03c-e644ad6144be": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T19:40:29.930745+00:00",
+      "last_probed": "2026-04-24T22:27:52.080046+00:00",
       "tried": {
-        "sanger-ca-po": "http_404"
+        "sanger-ca-po": "http_404",
+        "sanger-ca-police-department": "http_404"
       }
     },
     "e7331865-34fd-5831-8028-c63398d95e55": {
@@ -292,6 +309,6 @@
       }
     }
   },
-  "updated": "2026-04-24T21:34:50.561388+00:00",
+  "updated": "2026-04-24T22:27:52.117520+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -67,6 +67,14 @@
         "hemet-ca-police-department": "http_404"
       }
     },
+    "1360ff78-db4c-529a-b889-81746642325e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T23:23:45.896536+00:00",
+      "tried": {
+        "kern-county-ca-sd": "http_404"
+      }
+    },
     "16449917-ee53-5406-ade9-4b7361ec7ba2": {
       "exhausted": false,
       "found": null,
@@ -153,6 +161,14 @@
       "last_probed": "2026-04-25T20:22:24.167944+00:00",
       "tried": {
         "la-habra-ca-po": "http_404"
+      }
+    },
+    "458b707c-5b99-5ec3-95c8-f7c9ae95ee0d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T23:23:39.657734+00:00",
+      "tried": {
+        "walnut-creek-ca-po": "http_404"
       }
     },
     "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
@@ -294,6 +310,14 @@
       "last_probed": "2026-04-25T22:18:48.873053+00:00",
       "tried": {
         "la-verne-ca-po": "http_404"
+      }
+    },
+    "72812ca1-c7b8-5c94-8327-508726647ad8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T23:23:49.936037+00:00",
+      "tried": {
+        "trinity-county-ca-so": "http_404"
       }
     },
     "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
@@ -636,6 +660,6 @@
       }
     }
   },
-  "updated": "2026-04-25T22:18:59.082419+00:00",
+  "updated": "2026-04-25T23:23:49.974295+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -17,6 +17,14 @@
         "redondo-beach-ca-police-department": "http_404"
       }
     },
+    "069764d3-6b36-5e35-ba95-2e4b38441b0e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T01:07:15.803855+00:00",
+      "tried": {
+        "winters-ca-po": "http_404"
+      }
+    },
     "1ff2d645-29d6-505b-bca1-271ddb4973ee": {
       "exhausted": false,
       "found": null,
@@ -202,6 +210,14 @@
         "vernon-ca-po": "http_404"
       }
     },
+    "a76f1a12-ea0c-5138-9c77-57a4e6b510ca": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T01:07:10.662289+00:00",
+      "tried": {
+        "cerritos-college-ca-ps": "http_404"
+      }
+    },
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
       "exhausted": false,
       "found": null,
@@ -303,9 +319,10 @@
     "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T08:53:44.745211+00:00",
+      "last_probed": "2026-04-25T01:07:03.843502+00:00",
       "tried": {
-        "los-alamitos-ca-pd": "http_404"
+        "los-alamitos-ca-pd": "http_404",
+        "los-alamitos-ca-po": "http_403"
       }
     },
     "eaef691d-609c-566f-ad67-3a187a241852": {
@@ -333,6 +350,6 @@
       }
     }
   },
-  "updated": "2026-04-24T23:27:22.277437+00:00",
+  "updated": "2026-04-25T01:07:15.841204+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -94,9 +94,10 @@
     "2279723d-b2cf-59d8-8732-4fdefd822546": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T15:27:35.603473+00:00",
+      "last_probed": "2026-04-26T01:14:42.792887+00:00",
       "tried": {
-        "tehama-county-ca-sd": "http_404"
+        "tehama-county-ca-sd": "http_404",
+        "tehama-county-ca-sheriffs-office": "http_404"
       }
     },
     "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c": {
@@ -126,9 +127,10 @@
     "270fd3ce-aefb-503a-82e0-36ea52c1ba28": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T22:27:45.835235+00:00",
+      "last_probed": "2026-04-26T01:14:49.052199+00:00",
       "tried": {
-        "greenfield-ca-po": "http_404"
+        "greenfield-ca-po": "http_404",
+        "greenfield-ca-police-department": "http_404"
       }
     },
     "2e1e1b36-7a6b-5c97-8143-65347503186c": {
@@ -404,9 +406,10 @@
     "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T17:26:09.214319+00:00",
+      "last_probed": "2026-04-26T01:14:53.297503+00:00",
       "tried": {
-        "los-angeles-port-ca-pd": "http_404"
+        "los-angeles-port-ca-pd": "http_404",
+        "los-angeles-port-ca-po": "http_404"
       }
     },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
@@ -660,6 +663,6 @@
       }
     }
   },
-  "updated": "2026-04-25T23:23:49.974295+00:00",
+  "updated": "2026-04-26T01:14:53.327963+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -173,9 +173,10 @@
     "69489e25-1027-5396-86a7-c68d5111eecd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T03:21:35.753684+00:00",
+      "last_probed": "2026-04-25T11:26:38.010811+00:00",
       "tried": {
-        "calexico-ca-po": "http_404"
+        "calexico-ca-po": "http_404",
+        "calexico-ca-police-department": "http_404"
       }
     },
     "6a2741a1-b6d5-5537-9963-9f2fb2b2447e": {
@@ -241,6 +242,14 @@
       "last_probed": "2026-04-24T18:31:56.268359+00:00",
       "tried": {
         "california-highway-patrol-ca-chp": "http_404"
+      }
+    },
+    "8d7fd470-fecf-5788-921d-7f82bc634a71": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-25T11:26:42.852152+00:00",
+      "tried": {
+        "rio-hondo-college-ca-pd": "http_404"
       }
     },
     "9b7b7208-5747-5e9c-bdcb-ed7b430686fd": {
@@ -436,12 +445,13 @@
     "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T10:30:40.415017+00:00",
+      "last_probed": "2026-04-25T11:26:49.382798+00:00",
       "tried": {
-        "sonoma-county-ca-sd": "http_404"
+        "sonoma-county-ca-sd": "http_404",
+        "sonoma-county-ca-sheriffs-office": "http_404"
       }
     }
   },
-  "updated": "2026-04-25T10:30:46.141115+00:00",
+  "updated": "2026-04-25T11:26:49.418494+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.