### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -42860,9 +42860,10 @@
   {
     "agency_id": "ae8c6210-8473-5a62-96af-7ea959cb19ff",
     "slug": "riverside-county-ca-so",
-    "flock_active_slug": "riverside-county-ca-so",
+    "flock_active_slug": "riverside-county-ca-sd",
     "flock_slugs": [
-      "riverside-county-ca-so"
+      "riverside-county-ca-so",
+      "riverside-county-ca-sd"
     ],
     "flock_names": [
       "Riverside County CA SO"

--- a/assets/transparency.flocksafety.com/.failed_slugs.json
+++ b/assets/transparency.flocksafety.com/.failed_slugs.json
@@ -587,10 +587,6 @@
     "date": "2026-04-09",
     "reason": "http_404"
   },
-  "riverside-county-ca-so": {
-    "date": "2026-04-24",
-    "reason": "http_404"
-  },
   "rocklin-ca-pd": {
     "date": "2026-04-09",
     "reason": "http_404"

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -176,6 +176,14 @@
         "huntington-beach-ca-po": "http_404"
       }
     },
+    "2c981ce6-8d54-565f-bb99-ac885eee8769": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T04:55:27.263052+00:00",
+      "tried": {
+        "orange-county-ca-so": "http_404"
+      }
+    },
     "2e1e1b36-7a6b-5c97-8143-65347503186c": {
       "exhausted": false,
       "found": null,
@@ -638,6 +646,14 @@
         "san-joaquin-delta-college-ca-public-safety": "http_404"
       }
     },
+    "b1eec57c-0fcc-5546-bfb6-7005adc695d3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T04:55:32.527170+00:00",
+      "tried": {
+        "turlock-ca-po": "http_404"
+      }
+    },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
       "exhausted": false,
       "found": null,
@@ -855,9 +871,10 @@
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T18:30:17.628155+00:00",
+      "last_probed": "2026-04-27T04:55:38.763630+00:00",
       "tried": {
         "chino-ca-po": "http_404",
+        "chino-ca-police": "http_404",
         "chino-ca-police-department": "http_404"
       }
     },
@@ -871,6 +888,6 @@
       }
     }
   },
-  "updated": "2026-04-27T01:16:35.216882+00:00",
+  "updated": "2026-04-27T04:55:38.802844+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -209,6 +209,14 @@
         "san-luis-obispo-ca-po": "http_404"
       }
     },
+    "33845531-5686-56e0-a3ff-371fae83d26b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T07:57:12.706254+00:00",
+      "tried": {
+        "albion-mi-dps-mi-pd": "http_404"
+      }
+    },
     "4219823b-c553-51fd-9a9b-5618cb5f82b5": {
       "exhausted": false,
       "found": null,
@@ -635,6 +643,14 @@
         "cerritos-college-ca-ps": "http_404"
       }
     },
+    "ae8c6210-8473-5a62-96af-7ea959cb19ff": {
+      "exhausted": false,
+      "found": "riverside-county-ca-sd",
+      "last_probed": "2026-04-27T07:57:23.125527+00:00",
+      "tried": {
+        "riverside-county-ca-sd": "http_200"
+      }
+    },
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
       "exhausted": false,
       "found": null,
@@ -652,6 +668,14 @@
       "last_probed": "2026-04-27T04:55:32.527170+00:00",
       "tried": {
         "turlock-ca-po": "http_404"
+      }
+    },
+    "b592938c-c2c4-597c-b6cd-2bbb3b52447b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T07:57:06.379587+00:00",
+      "tried": {
+        "ventura-county-district-attorneys-office-ca-da": "http_404"
       }
     },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
@@ -888,6 +912,6 @@
       }
     }
   },
-  "updated": "2026-04-27T04:55:38.802844+00:00",
+  "updated": "2026-04-27T07:57:23.168572+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.