### PR TITLE
Geocode 70 ungeocoded sharing recipients (closes #151)

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -5164,7 +5164,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "01",
+      "name": "AL",
+      "state": "AL",
+      "lat": 32.87862476119403,
+      "lng": -86.71127807462686
+    }
   },
   {
     "agency_id": "cb017071-39e4-5042-968e-07216ad78bfc",
@@ -5643,7 +5650,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "17",
+      "name": "IL",
+      "state": "IL",
+      "lat": 39.84225869607843,
+      "lng": -89.1744509509804
+    }
   },
   {
     "agency_id": "8909ba11-05c9-5abd-870e-5dc7244d36f8",
@@ -8291,8 +8305,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "place",
+      "fips": "2713456",
+      "name": "Cottage Grove",
+      "state": "MN",
+      "lat": 44.813326,
+      "lng": -92.914315
     }
   },
   {
@@ -8854,8 +8872,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1719499",
+      "name": "De Pue",
+      "state": "IL",
+      "lat": 41.329565,
+      "lng": -89.303736
     }
   },
   {
@@ -9765,8 +9787,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "county",
+      "fips": "17197",
+      "name": "Will",
+      "state": "IL",
+      "lat": 41.448474,
+      "lng": -87.978456
     }
   },
   {
@@ -9788,8 +9814,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "manual",
+      "state": "IL",
+      "lat": 41.7508,
+      "lng": -88.3089
     }
   },
   {
@@ -10189,8 +10217,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "county",
+      "fips": "29073",
+      "name": "Gasconade",
+      "state": "MO",
+      "lat": 38.441183,
+      "lng": -91.50578
     }
   },
   {
@@ -10617,8 +10649,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "manual",
+      "state": "MI",
+      "lat": 41.7676,
+      "lng": -86.7913
     }
   },
   {
@@ -10776,8 +10810,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "manual",
+      "state": "MI",
+      "lat": 42.9636,
+      "lng": -85.8884
     }
   },
   {
@@ -10962,8 +10998,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "county",
+      "fips": "17063",
+      "name": "Grundy",
+      "state": "IL",
+      "lat": 41.29241,
+      "lng": -88.401054
     }
   },
   {
@@ -11012,8 +11052,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "manual",
+      "state": "MI",
+      "lat": 42.595,
+      "lng": -85.5167
     }
   },
   {
@@ -11171,8 +11213,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "manual",
+      "state": "IL",
+      "lat": 42.1126,
+      "lng": -88.0381
     }
   },
   {
@@ -11599,8 +11643,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1735411",
+      "name": "Hoffman Estates",
+      "state": "IL",
+      "lat": 42.065217,
+      "lng": -88.152996
     }
   },
   {
@@ -11891,7 +11939,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "17",
+      "name": "IL",
+      "state": "IL",
+      "lat": 39.84225869607843,
+      "lng": -89.1744509509804
+    }
   },
   {
     "agency_id": "6c14bcb5-4490-5d6d-93fd-c80cbc3517ee",
@@ -12046,7 +12101,12 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "IN",
+      "lat": 39.7684,
+      "lng": -86.1581
+    }
   },
   {
     "agency_id": "01e1c9a1-edc3-5c32-9d00-21aa1c14b296",
@@ -12120,7 +12180,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "19",
+      "name": "IA",
+      "state": "IA",
+      "lat": 42.02990211111111,
+      "lng": -93.46609284848485
+    }
   },
   {
     "agency_id": "0c8a1c92-24bd-52fb-9892-5225730c62d0",
@@ -12303,8 +12370,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IA"
+      "kind": "county",
+      "fips": "19099",
+      "name": "Jasper",
+      "state": "IA",
+      "lat": 41.685551,
+      "lng": -93.054147
     }
   },
   {
@@ -12462,8 +12533,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1738570",
+      "name": "Joliet",
+      "state": "IL",
+      "lat": 41.517701,
+      "lng": -88.148846
     }
   },
   {
@@ -12727,7 +12802,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "20",
+      "name": "KS",
+      "state": "KS",
+      "lat": 38.485365533333336,
+      "lng": -98.08532483809525
+    }
   },
   {
     "agency_id": "48b1c67e-d8ea-5e18-96fd-6fab506a4ac9",
@@ -12801,7 +12883,12 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "IL",
+      "lat": 41.8784,
+      "lng": -88.3092
+    }
   },
   {
     "agency_id": "97944767-063d-512c-9002-ac050873a225",
@@ -12984,8 +13071,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KS"
+      "kind": "manual",
+      "state": "KS",
+      "lat": 39.0571,
+      "lng": -94.6092
     }
   },
   {
@@ -13274,8 +13363,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "county",
+      "fips": "17097",
+      "name": "Lake",
+      "state": "IL",
+      "lat": 42.185968,
+      "lng": -87.805939
     }
   },
   {
@@ -13540,8 +13633,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "manual",
+      "state": "MN",
+      "lat": 45.2786,
+      "lng": -92.9852
     }
   },
   {
@@ -13617,8 +13712,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "county",
+      "fips": "17099",
+      "name": "LaSalle",
+      "state": "IL",
+      "lat": 41.343341,
+      "lng": -88.885931
     }
   },
   {
@@ -13829,8 +13928,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2146027",
+      "name": "Lexington-Fayette",
+      "state": "KY",
+      "lat": 38.040678,
+      "lng": -84.458272
     }
   },
   {
@@ -14419,8 +14522,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IA"
+      "kind": "manual",
+      "state": "IA",
+      "lat": 43.0247,
+      "lng": -91.1818
     }
   },
   {
@@ -14982,8 +15087,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "manual",
+      "state": "WI",
+      "lat": 44.8869,
+      "lng": -88.6332
     }
   },
   {
@@ -15059,8 +15166,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "manual",
+      "state": "IL",
+      "lat": 41.8779,
+      "lng": -87.6411
     }
   },
   {
@@ -15082,8 +15191,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "manual",
+      "state": "IL",
+      "lat": 38.7011,
+      "lng": -90.1487
     }
   },
   {
@@ -15129,8 +15240,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "DC"
+      "kind": "place",
+      "fips": "1150000",
+      "name": "Washington",
+      "state": "DC",
+      "lat": 38.904247,
+      "lng": -77.016517
     }
   },
   {
@@ -15179,8 +15294,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "place",
+      "fips": "2653760",
+      "name": "Middleville",
+      "state": "MI",
+      "lat": 42.715319,
+      "lng": -85.468617
     }
   },
   {
@@ -15223,8 +15342,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "state": "MO",
+      "lat": 38.5767,
+      "lng": -92.1735
     }
   },
   {
@@ -15299,7 +15420,12 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "KS",
+      "lat": 38.9613,
+      "lng": -94.7611
+    }
   },
   {
     "agency_id": "ca02cebe-ea6d-55d5-8a9f-b54efeb6e816",
@@ -15481,7 +15607,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "29",
+      "name": "MO",
+      "state": "MO",
+      "lat": 38.45001594782608,
+      "lng": -92.4807440173913
+    }
   },
   {
     "agency_id": "a91b1817-a8b3-5f5d-b919-97ebd40ed049",
@@ -15555,7 +15688,12 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "MO",
+      "lat": 37.2089,
+      "lng": -93.2923
+    }
   },
   {
     "agency_id": "4c41fb01-ce59-5e0c-b7cd-27a0d430a135",
@@ -15738,8 +15876,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "county",
+      "fips": "29141",
+      "name": "Morgan",
+      "state": "MO",
+      "lat": 38.420806,
+      "lng": -92.874835
     }
   },
   {
@@ -16004,8 +16146,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "manual",
+      "state": "WI",
+      "lat": 44.5919,
+      "lng": -88.0648
     }
   },
   {
@@ -16027,8 +16171,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1751206",
+      "name": "Mount Zion",
+      "state": "IL",
+      "lat": 39.784016,
+      "lng": -88.885011
     }
   },
   {
@@ -16265,7 +16413,12 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "VA",
+      "lat": 38.8043,
+      "lng": -77.0518
+    }
   },
   {
     "agency_id": "16d11768-19bb-5329-beea-53bba5831199",
@@ -16286,8 +16439,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NE"
+      "kind": "county",
+      "fips": "31037",
+      "name": "Colfax",
+      "state": "NE",
+      "lat": 41.57496,
+      "lng": -97.088945
     }
   },
   {
@@ -16390,8 +16547,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "place",
+      "fips": "2745430",
+      "name": "New Brighton",
+      "state": "MN",
+      "lat": 45.067226,
+      "lng": -93.205779
     }
   },
   {
@@ -16548,8 +16709,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "manual",
+      "state": "IN",
+      "lat": 41.6105,
+      "lng": -87.0581
     }
   },
   {
@@ -16571,8 +16734,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "manual",
+      "state": "IL",
+      "lat": 39.8403,
+      "lng": -88.9548
     }
   },
   {
@@ -16702,8 +16867,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "state": "MO",
+      "lat": 38.7728,
+      "lng": -90.3239
     }
   },
   {
@@ -16779,8 +16946,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "state": "MO",
+      "lat": 39.7853,
+      "lng": -93.078
     }
   },
   {
@@ -16802,8 +16971,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "state": "MO",
+      "lat": 39.7853,
+      "lng": -93.078
     }
   },
   {
@@ -17635,8 +17806,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "manual",
+      "state": "MN",
+      "lat": 47.4737,
+      "lng": -94.8803
     }
   },
   {
@@ -18171,8 +18344,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "manual",
+      "state": "MI",
+      "lat": 41.9842,
+      "lng": -86.1083
     }
   },
   {
@@ -18573,8 +18748,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "county",
+      "fips": "55101",
+      "name": "Racine",
+      "state": "WI",
+      "lat": 42.780392,
+      "lng": -87.771599
     }
   },
   {
@@ -18968,8 +19147,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "manual",
+      "state": "WI",
+      "lat": 44.8113,
+      "lng": -91.4985
     }
   },
   {
@@ -19963,8 +20144,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SD"
+      "kind": "place",
+      "fips": "4659020",
+      "name": "Sioux Falls",
+      "state": "SD",
+      "lat": 43.540696,
+      "lng": -96.731962
     }
   },
   {
@@ -19986,8 +20171,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SD"
+      "kind": "place",
+      "fips": "4659260",
+      "name": "Sisseton",
+      "state": "SD",
+      "lat": 45.662499,
+      "lng": -97.045293
     }
   },
   {
@@ -20063,8 +20252,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "manual",
+      "state": "IN",
+      "lat": 41.7088,
+      "lng": -86.3166
     }
   },
   {
@@ -20113,8 +20304,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SD"
+      "kind": "state",
+      "fips": "46",
+      "name": "SD",
+      "state": "SD",
+      "lat": 44.270824363636365,
+      "lng": -99.3081913030303
     }
   },
   {
@@ -20163,8 +20358,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "manual",
+      "state": "MN",
+      "lat": 44.9036,
+      "lng": -93.5703
     }
   },
   {
@@ -20186,8 +20383,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "place",
+      "fips": "2761492",
+      "name": "South St. Paul",
+      "state": "MN",
+      "lat": 44.888027,
+      "lng": -93.040497
     }
   },
   {
@@ -20371,8 +20572,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "manual",
+      "state": "WI",
+      "lat": 45.9092,
+      "lng": -92.3667
     }
   },
   {
@@ -21041,7 +21244,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "48",
+      "name": "TX",
+      "state": "TX",
+      "lat": 31.658176677165354,
+      "lng": -98.65226565748031
+    }
   },
   {
     "agency_id": "0eadee12-f285-5750-a555-20e83e01cd3d",
@@ -21438,7 +21648,12 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "state": "MO",
+      "lat": 38.7672,
+      "lng": -93.7372
+    }
   },
   {
     "agency_id": "bf524189-2ba8-53a6-a3d3-9336e0c5d876",
@@ -21460,8 +21675,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1777005",
+      "name": "Urbana",
+      "state": "IL",
+      "lat": 40.110126,
+      "lng": -88.197323
     }
   },
   {
@@ -21484,8 +21703,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1714000",
+      "name": "Chicago",
+      "state": "IL",
+      "lat": 41.837045,
+      "lng": -87.684939
     }
   },
   {
@@ -21507,7 +21730,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1772000",
+      "name": "Springfield",
+      "state": "IL",
+      "lat": 39.791063,
+      "lng": -89.644572
+    }
   },
   {
     "agency_id": "f8511920-caf4-5fed-ae0c-9d91e3678cb5",
@@ -21529,8 +21759,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "manual",
+      "state": "MN",
+      "lat": 44.974,
+      "lng": -93.2277
     }
   },
   {
@@ -21553,8 +21785,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "place",
+      "fips": "5531000",
+      "name": "Green Bay",
+      "state": "WI",
+      "lat": 44.521542,
+      "lng": -87.986568
     }
   },
   {
@@ -21577,8 +21813,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "place",
+      "fips": "5548000",
+      "name": "Madison",
+      "state": "WI",
+      "lat": 43.087815,
+      "lng": -89.429856
     }
   },
   {
@@ -22518,8 +22758,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "manual",
+      "state": "MN",
+      "lat": 45.0083,
+      "lng": -93.7044
     }
   },
   {
@@ -22568,8 +22810,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "place",
+      "fips": "2769700",
+      "name": "West St. Paul",
+      "state": "MN",
+      "lat": 44.902414,
+      "lng": -93.085327
     }
   },
   {
@@ -22781,8 +23027,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "county",
+      "fips": "18183",
+      "name": "Whitley",
+      "state": "IN",
+      "lat": 41.136426,
+      "lng": -85.501892
     }
   },
   {
@@ -22936,8 +23186,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1782322",
+      "name": "Windsor",
+      "state": "IL",
+      "lat": 39.4389,
+      "lng": -88.595389
     }
   },
   {
@@ -25820,7 +26074,15 @@
     "tags": [
       "public"
     ],
-    "flags": []
+    "flags": [],
+    "geo": {
+      "kind": "state",
+      "fips": "08",
+      "name": "CO",
+      "state": "CO",
+      "lat": 38.9288305625,
+      "lng": -105.4910921875
+    }
   },
   {
     "agency_id": "1dfc1565-66fb-5bcb-aca3-73a8080a4883",
@@ -26134,8 +26396,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "NM"
+      "kind": "county",
+      "fips": "35009",
+      "name": "Curry",
+      "state": "NM",
+      "lat": 34.572984,
+      "lng": -103.346055
     },
     "flags": []
   },
@@ -28079,8 +28345,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48201",
+      "name": "Harris",
+      "state": "TX",
+      "lat": 29.857273,
+      "lng": -95.393037
     },
     "flags": []
   },
@@ -28103,8 +28373,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48201",
+      "name": "Harris",
+      "state": "TX",
+      "lat": 29.857273,
+      "lng": -95.393037
     },
     "flags": []
   },
@@ -28127,8 +28401,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48201",
+      "name": "Harris",
+      "state": "TX",
+      "lat": 29.857273,
+      "lng": -95.393037
     },
     "flags": []
   },
@@ -36613,7 +36891,13 @@
     "tags": [
       "needs-review"
     ],
-    "flags": []
+    "flags": [],
+    "geo": {
+      "kind": "manual",
+      "state": "MI",
+      "lat": 42.2911,
+      "lng": -84.4194
+    }
   },
   {
     "agency_id": "c649eb74-6ffa-5be7-96b5-a08458128a6d",

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -50,12 +50,21 @@ REGISTRY_PATH = Path("assets/agency_registry.json")
 _AGENCY_SUFFIXES = re.compile(
     r"\s*\b(PD|SO|SD|DA|FD|DPS|Police Department|Police Services|"
     r"Division of Police|Sheriff'?s? Office|"
-    r"Sheriff'?s? Department|Prosecutor'?s? Office|"
+    r"Sheriff'?s? Department|Sheriff|"
+    r"Prosecutor'?s? Office|Prosecutor|"
     r"District Attorney|Fire Department|"
-    r"Department of Public Safety|"
-    r"Public Safety|Parks Department|Marshal'?s? Office)\b\s*",
+    r"Department of Public Safety|Public Safety Dept\.?|"
+    r"Dept\.? of Pub(?:lic)? Safety|"
+    r"Public Safety|Parks Department|Marshal'?s? Office|"
+    r"Junior College|Community College)\b\s*",
     re.IGNORECASE,
 )
+
+# Lone trailing "Dept" / "Department" left over after _AGENCY_SUFFIXES has
+# already stripped the contextual phrase (e.g. "Cottage Grove Public Safety
+# Dept" → "Cottage Grove Dept" → "Cottage Grove"). End-of-string only, to
+# avoid stripping mid-name uses.
+_TRAILING_DEPT = re.compile(r"\s+(Dept\.?|Department)\s*$", re.IGNORECASE)
 
 _STATE_TOKEN = re.compile(r"\s*\b[A-Z]{2}\b\s*")  # Strip " CA " etc.
 _PARENS = re.compile(r"\s*\[[^\]]*\]\s*|\s*\([^)]*\)\s*")  # Strip "(CA)" and "[Inactive]"
@@ -64,17 +73,31 @@ _CITY_OF = re.compile(r"^(City|Town|Village|Borough)\s+of\s+", re.IGNORECASE)
 # Main's version uses a simple ASCII hyphen; accepts an en-dash too
 # for robustness.
 _STATE_PREFIX = re.compile(r"^[A-Z]{2}\s*[-\u2013]\s*", re.IGNORECASE)
-_DASH_SUFFIX = re.compile(r"\s*-\s*(original|[A-Z]{2})$", re.IGNORECASE)  # "Oxford PD - OH", "Harrah OK PD - original"
-_ABBREV_CO = re.compile(r"\bCo\.", re.IGNORECASE)  # "Schuyler Co. IL SO"
+# "Oxford PD - OH", "Harrah OK PD - original", "LaSalle Co. IL SO - New"
+_DASH_SUFFIX = re.compile(r"\s*-\s*(original|new|old|[A-Z]{2})$", re.IGNORECASE)
+_ABBREV_CO = re.compile(r"\bCo\b\.?", re.IGNORECASE)  # "Schuyler Co. IL SO" / "Gasconade Co MO SO"
 _ABBREV_INTL = re.compile(r"\bIntl\b", re.IGNORECASE)  # "Nashville Intl Airport"
-_SAINT_VARIANTS = re.compile(r"^Saint\s+", re.IGNORECASE)  # "Saint Johns AZ" -> "St. Johns AZ"
+# "Saint" → "St." anywhere in the name (Census uses "St."; Flock data
+# sometimes spells it out, e.g. "South Saint Paul MN PD").
+_SAINT_VARIANTS = re.compile(r"\bSaint\s+", re.IGNORECASE)
+_MOUNT_VARIANTS = re.compile(r"\bMt\.\s+", re.IGNORECASE)  # "Mt. Zion" → "Mount Zion"
 
 # State-level agency patterns (state police, highway patrol, DMV, etc.)
 _STATE_AGENCY_PATTERN = re.compile(
     r"\b(State Patrol|State Police|Highway Patrol|Department of Public Safety|"
     r"Department of Motor Vehicles|State Highway Patrol|"
-    r"Department of Conservation|Crime Analysis Center)\b",
+    r"Department of Conservation|Crime Analysis Center|"
+    r"Department of Corrections|Bureau of Investigation|"
+    r"Information Analysis Center|"
+    r"Financial Crimes Intelligence Center|"
+    r"Division of Criminal Investigation|"
+    r"Attorney General)\b",
     re.IGNORECASE,
+)
+# State-level agency abbreviations. "X Bureau of Investigation" is often
+# carried in the registry only as the abbreviation (KBI, GBI, etc.).
+_STATE_AGENCY_ABBREV = re.compile(
+    r"\b(KBI|FDLE|TBI|GBI|SBI|CBI|BCI|MIAC)\b"
 )
 
 # State names to USPS codes (for "Colorado State Patrol" etc.)
@@ -105,12 +128,13 @@ def normalize_agency_name(name):
     name = _STATE_PREFIX.sub("", name)
     # Strip "- OH" or "- original" suffix
     name = _DASH_SUFFIX.sub(" ", name)
-    # "Co." -> "County"
+    # "Co." or "Co" -> "County"
     name = _ABBREV_CO.sub("County", name)
     # "Intl" -> "International" (will be stripped by other patterns)
     name = _ABBREV_INTL.sub("International", name)
-    # "Saint" -> "St." for gazetteer matching
+    # "Saint" -> "St." anywhere; "Mt." -> "Mount" (Census uses these forms)
     name = _SAINT_VARIANTS.sub("St. ", name)
+    name = _MOUNT_VARIANTS.sub("Mount ", name)
     # Strip "Metro" suffix (Louisville Metro, Cumberland Metro) — usually denotes
     # a consolidated gov or metro area but the bare name is what we want
     name = re.sub(r"\s+Metro\b", "", name, flags=re.IGNORECASE)
@@ -125,10 +149,19 @@ def normalize_agency_name(name):
 CITY_ALIASES = {
     "Carmel": "Carmel-by-the-Sea",  # Census has the hyphenated form
     "Angels Camp": "Angels",         # Census place is "Angels city"
+    "Depue": "De Pue",               # Census place is "De Pue village"
+}
+
+# State-aware aliases. Disambiguates names that need different remappings
+# depending on the state (e.g. "Lexington" exists in many states but only
+# the KY one is the consolidated "Lexington-Fayette" gov).
+STATE_CITY_ALIASES = {
+    ("Lexington", "KY"): "Lexington-Fayette",
+    ("Metropolitan Washington", "DC"): "Washington",
 }
 
 
-def extract_place_candidate(agency_name):
+def extract_place_candidate(agency_name, state=None):
     """Derive a candidate place name from an agency name.
 
     Examples:
@@ -140,6 +173,7 @@ def extract_place_candidate(agency_name):
       "KS - Meade County SO" -> "Meade County"
       "CA - Wasco PD" -> "Wasco"
       "Carmel CA PD" -> "Carmel-by-the-Sea" (via CITY_ALIASES)
+      "Lexington KY PD" -> "Lexington-Fayette" (via STATE_CITY_ALIASES, when state=KY)
     """
     name = normalize_agency_name(agency_name)
     # Strip agency-role suffixes (PD, SO, DPS, etc.)
@@ -150,16 +184,86 @@ def extract_place_candidate(agency_name):
     name = _CITY_OF.sub("", name)
     # Collapse whitespace
     name = re.sub(r"\s+", " ", name).strip()
+    # Strip a lone trailing "Dept" / "Department" left over from compound
+    # phrases like "X Public Safety Dept" where _AGENCY_SUFFIXES took the
+    # contextual part but left the standalone word.
+    name = _TRAILING_DEPT.sub("", name).strip()
+    # Strip dashes that have whitespace on at least one side, or that hang
+    # off the start/end of the string. These are artifacts from messy names
+    # like "Windsor- IL- PD" or "X - " separators left after suffix stripping.
+    # Internal hyphens like "Carmel-by-the-Sea" have no adjacent whitespace
+    # and are preserved.
+    name = re.sub(r"\s+-\s*|\s*-\s+|^-+\s*|\s*-+$", " ", name)
+    name = re.sub(r"\s+", " ", name).strip()
     # Apply targeted alias mapping last, so the cleaned candidate is
     # what we alias against (not the raw agency name).
-    if name in CITY_ALIASES:
+    if state and (name, state) in STATE_CITY_ALIASES:
+        name = STATE_CITY_ALIASES[(name, state)]
+    elif name in CITY_ALIASES:
         name = CITY_ALIASES[name]
     return name
 
 
+# Match a single capital-word immediately before County/Parish/etc.
+# Multi-word counties (St. Louis, Salt Lake) usually appear adjacent to
+# a county-suffix agency name and are handled by the primary path.
+_COUNTY_WINDOW = re.compile(
+    r"\b([A-Z][\w.'\-]+)\s+(County|Parish|Borough|Census Area)\b",
+)
+
+
+def extract_county_window(agency_name):
+    """Find an "X County" / "X Parish" substring anywhere in the name.
+
+    Useful for special-purpose county-level agencies where the county
+    name is buried in the middle of the agency name:
+
+      "Forest Preserve District Will County PD (IL)" -> "Will County"
+      "Lake County Forest Preserves IL PD"           -> "Lake County"
+      "Grundy County IL 911"                          -> "Grundy County"
+      "Whitley County IN Prosector"                   -> "Whitley County"
+      "Racine County WI Communications Center"        -> "Racine County"
+    """
+    norm = normalize_agency_name(agency_name)
+    norm = _STATE_TOKEN.sub(" ", norm)
+    m = _COUNTY_WINDOW.search(norm)
+    if not m:
+        return None
+    return f"{m.group(1).strip()} {m.group(2)}"
+
+
+def extract_university_campus(agency_name):
+    """Extract a campus city from a multi-campus university name.
+
+    Splits on " - " / " at " / "- " and returns the rightmost segment
+    after the "University of …" stem. Returns None for single-campus
+    universities, where no separator is present.
+
+      "University of Wisconsin - Madison WI PD"        -> "Madison"
+      "University of Illinois - Chicago IL PD"          -> "Chicago"
+      "University of Illinois at Urbana-Champaign IL PD"-> "Urbana-Champaign"
+      "University of Illinois- Springfield"             -> "Springfield"
+      "University of Minnesota MN PD (Twin Cities)"     -> None  (no separator)
+      "Grand Valley State University MI"                -> None  (not "University of …")
+    """
+    name = normalize_agency_name(agency_name)
+    name = _AGENCY_SUFFIXES.sub(" ", name)
+    name = _STATE_TOKEN.sub(" ", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    if not re.match(r"^University of\b", name, re.IGNORECASE):
+        return None
+    for sep_re in (r"\s+at\s+", r"\s*[-–]\s*"):
+        parts = re.split(sep_re, name, maxsplit=1, flags=re.IGNORECASE)
+        if len(parts) == 2:
+            campus = parts[1].strip()
+            if campus and not re.match(r"^University\b", campus, re.IGNORECASE):
+                return campus
+    return None
+
+
 def is_state_level_agency(name):
     """Does this name describe a state-level agency (state patrol, etc.)?"""
-    return bool(_STATE_AGENCY_PATTERN.search(name))
+    return bool(_STATE_AGENCY_PATTERN.search(name)) or bool(_STATE_AGENCY_ABBREV.search(name))
 
 
 def infer_state_from_name(name):
@@ -220,9 +324,11 @@ def geocode_entry(entry):
     # Skip entries that shouldn't be geocoded
     if has_tag(entry, "federal"):
         return None
-    if entry.get("agency_type") in ("federal", "test", "decommissioned", "private",
-                                     "community"):
+    if entry.get("agency_type") in ("federal", "test", "decommissioned", "private"):
         return None
+    # type=community covers HOAs but also some misclassified incorporated
+    # places (e.g. "MI - Village of Middleville" tagged community/hoa).
+    # Allow them to try place lookup; if no match, return None below.
 
     # State-level agencies (state patrol, highway patrol, etc.)
     # → point to state centroid
@@ -282,7 +388,7 @@ def geocode_entry(entry):
     # County-level agencies (sheriff, DA, etc.) — always try county first
     # Strip role-suffix from name; the remainder is the county name
     if kind == "county" or role in ("sheriff", "da"):
-        county_candidate = extract_place_candidate(name)  # strips role/state
+        county_candidate = extract_place_candidate(name, state)  # strips role/state
         if county_candidate:
             county = lookup_county(county_candidate, state)
             if county:
@@ -307,12 +413,74 @@ def geocode_entry(entry):
                     "lat": county["lat"],
                     "lng": county["lng"],
                 }
-        # Don't fall through — county-semantic agency in a same-named place
-        # is almost always wrong (e.g. "Sacramento DA" = county DA, not city)
+        # Window extraction: pull "X County" out of the middle of the name.
+        # Handles special-purpose county agencies like "Forest Preserve
+        # District Will County PD" or "Grundy County 911".
+        windowed = extract_county_window(name)
+        if windowed:
+            county = lookup_county(windowed, state)
+            if county:
+                return {
+                    "kind": "county",
+                    "fips": county["fips"],
+                    "name": county["bare_name"],
+                    "state": state,
+                    "lat": county["lat"],
+                    "lng": county["lng"],
+                }
+        # Mistyped city PDs: a few entries are tagged type=county/role=sheriff
+        # but the agency name explicitly says " PD" (e.g. "Sioux Falls SD PD").
+        # In those cases fall through to a place lookup. Restricted to names
+        # containing " PD" to avoid breaking e.g. "Sacramento DA" cases where
+        # the city/county name collision would mis-map a county DA to a city.
+        if kind == "county" and role == "sheriff" and re.search(r"\bPD\b", name):
+            place_candidate = extract_place_candidate(name, state)
+            if place_candidate:
+                place = lookup_place(place_candidate, state)
+                if place:
+                    return {
+                        "kind": "place",
+                        "fips": place["fips"],
+                        "name": place["name"],
+                        "state": state,
+                        "lat": place["lat"],
+                        "lng": place["lng"],
+                    }
         return None
 
+    # University with named campus — extract the campus city before
+    # falling through to the generic place candidate (which would just
+    # see "University of Wisconsin - Madison" and miss).
+    if kind == "university":
+        campus = extract_university_campus(name)
+        if campus:
+            place = lookup_place(campus, state)
+            if place:
+                return {
+                    "kind": "place",
+                    "fips": place["fips"],
+                    "name": place["name"],
+                    "state": state,
+                    "lat": place["lat"],
+                    "lng": place["lng"],
+                }
+            # Two-city campuses ("Urbana-Champaign", "Tri-Cities") often
+            # appear as a hyphenated pair. Try the first half.
+            if "-" in campus:
+                first = campus.split("-", 1)[0].strip()
+                place = lookup_place(first, state)
+                if place:
+                    return {
+                        "kind": "place",
+                        "fips": place["fips"],
+                        "name": place["name"],
+                        "state": state,
+                        "lat": place["lat"],
+                        "lng": place["lng"],
+                    }
+
     # Try as a place (city/town)
-    candidate = extract_place_candidate(name)
+    candidate = extract_place_candidate(name, state)
     if candidate:
         place = lookup_place(candidate, state)
         if place:
@@ -350,6 +518,22 @@ def geocode_entry(entry):
                 "state": state,
                 "lat": county["lat"],
                 "lng": county["lng"],
+            }
+
+    # State agencies (Department of Corrections, Information Analysis Center,
+    # etc.) with no specific city — point at the state centroid as a final
+    # fallback. The named-pattern check at the top handles most of these,
+    # but type=state catches the rest by classification rather than name.
+    if kind == "state":
+        s = lookup_state(state)
+        if s:
+            return {
+                "kind": "state",
+                "fips": s["state_fips"],
+                "name": state,
+                "state": state,
+                "lat": s["lat"],
+                "lng": s["lng"],
             }
 
     return None


### PR DESCRIPTION
## Summary

Closes #151. Adds coordinates for the 70 recipients of Anoka County MN SO data that were flagged by `check_recipient_coords.py`. 42 are auto-resolved by an improved geocoder; 33 are hand-pinned manual entries.

## Geocoder improvements (`scripts/geocode_agencies.py`)

- Mid-name `Saint` → `St.`; `Mt.` → `Mount`
- Optional period on `Co` abbreviation (`Gasconade Co MO SO` etc.)
- State-aware aliases (`Lexington` KY → `Lexington-Fayette`; `Metropolitan Washington` DC → `Washington`)
- `extract_county_window` finds `X County` buried in the middle of agency names — handles `Forest Preserve District Will County PD`, `Grundy County 911`, `Whitley County Prosector`, `Racine County Communications Center`, etc.
- `extract_university_campus` splits multi-campus names like `University of Wisconsin - Madison`, `University of Illinois at Urbana-Champaign` into the campus city
- Extended state-level pattern: `Department of Corrections`, `Bureau of Investigation`, `Attorney General`, `Information Analysis Center`, `Financial Crimes Intelligence Center`, `Division of Criminal Investigation`; plus abbreviations (`KBI`, `MIAC`, `GBI`, `FDLE`, etc.)
- Default-route `agency_type=state` to state centroid
- Allow `agency_type=community` to fall through to place lookup (handles `Hoffman Estates IL`, `Village of Middleville MI` — both real places mistagged as community/HOA)
- Narrow place fallthrough for `type=county/role=sheriff` entries when the name explicitly says ` PD` (handles `Sioux Falls SD PD`, `Sisseton SD PD` — mistyped in the registry; rule restricted to `PD` to avoid breaking `Sacramento DA` style cases)
- Dangling-hyphen cleanup (`Windsor- IL- PD` → `Windsor`)
- Trailing `Dept`/`Department` cleanup after `Public Safety` is stripped (`Cottage Grove Public Safety Dept` → `Cottage Grove`)
- Bare `Sheriff`/`Prosecutor` and `Junior College`/`Community College` added to suffix list

## Manual entries (33)

Hand-pinned with `kind: "manual"` for agencies whose location isn't derivable from the Census gazetteer:

- **5 universities**: Grand Valley State, Harper CC, KU Med Center, U Central Missouri, U Minnesota Twin Cities
- **4 tribal PDs**: Gun Lake, Menominee, Pokagon, St. Croix
- **4 multi-state fusion centers**: Indiana HIDTA, Midwest HIDTA, MOCIC, NCMEC
- **6 local task forces**: Mid-Missouri DTF, North-Missouri DTF, Brookfield, Paul Bunyan, RIG WI, Metro East Auto Theft
- **9 joint city/township PDs**: Blackman/Leoni, Grand Beach/Michiana, KenCom, Lakes Area MN, Mar Mac, Mountain Bay, North County Cooperative, South Lake Minnetonka, West Hennepin
- **5 special districts**: Fox Valley Parks, Metra, NICTD, Norfolk Southern, South Bend Airport

A few are best-effort approximations — `RIG WI DTF` (pinned to Eau Claire) and `Lakes Area MN PD` (Forest Lake) are ambiguous names; easy to repin if better intel surfaces.

## Side effects

The improved geocoder also resolves 5 pre-existing ungeocoded entries unrelated to Anoka: `Curry Co NM SO`, `Harris County Const TX Pct 1/4/5`, `Colorado State Parks` (state-only → state).

## Test plan

- [x] `scripts/check_recipient_coords.py` reports "All public-agency recipients have coordinates"
- [x] `pytest tests/` — 206 passed
- [x] `pytest tests/test_map_smoke.py` — 51 passed
- [x] `scripts/build_map.py` runs clean
- [x] Spot-checked auto-geocoded coords (Lexington-Fayette, Sioux Falls, South St. Paul, UW Madison, Mount Zion, De Pue, Washington DC, Whitley County, Will County) for sanity

## Related cleanup not done here

- Sioux Falls / Sisseton / Brookings SD entries are tagged `type=county/role=sheriff` in the registry but their names say `PD` — the new fallthrough rule resolves them, but a registry-side reclassification would be cleaner.
- The `federal` tag is misused on a number of entries (`DuPage Co IL Prosecutor Office`, `Rice Lake WI PD`, etc.). Orthogonal — left untouched.