### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -150,6 +150,14 @@
         "national-city-ca-police-department": "http_404"
       }
     },
+    "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T17:11:49.306876+00:00",
+      "tried": {
+        "california-department-of-insurance-fraud-ca-pd": "http_404"
+      }
+    },
     "26ed4286-4037-515f-a9f8-f411f8303bc0": {
       "exhausted": false,
       "found": null,
@@ -272,6 +280,14 @@
       "last_probed": "2026-04-25T19:34:08.678184+00:00",
       "tried": {
         "atwater-ca-po": "http_404"
+      }
+    },
+    "4cc1fd23-7711-52b8-be07-9d6e1ad7b364": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T17:11:39.226975+00:00",
+      "tried": {
+        "tulare-county-ca-sd": "http_404"
       }
     },
     "4d51cf25-3dd8-5b26-ae54-6c0b50511be2": {
@@ -530,9 +546,10 @@
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T12:29:58.721709+00:00",
+      "last_probed": "2026-04-27T17:11:45.140175+00:00",
       "tried": {
-        "imperial-county-ca-sd": "http_404"
+        "imperial-county-ca-sd": "http_404",
+        "imperial-county-ca-sheriffs-office": "http_404"
       }
     },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
@@ -929,6 +946,6 @@
       }
     }
   },
-  "updated": "2026-04-27T15:27:40.233138+00:00",
+  "updated": "2026-04-27T17:11:49.346340+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -150,6 +150,14 @@
         "national-city-ca-police-department": "http_404"
       }
     },
+    "26ed4286-4037-515f-a9f8-f411f8303bc0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T15:27:33.822158+00:00",
+      "tried": {
+        "roseville-ca-po": "http_404"
+      }
+    },
     "270aae46-f0d1-558e-bb3f-249d03b0510f": {
       "exhausted": false,
       "found": null,
@@ -308,6 +316,14 @@
       "last_probed": "2026-04-24T18:32:01.439811+00:00",
       "tried": {
         "pleasant-hill-ca-po": "http_404"
+      }
+    },
+    "59e2385f-2649-5b82-9bf7-aee2e73b0af1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T15:27:27.286459+00:00",
+      "tried": {
+        "milpitas-ca-po": "http_404"
       }
     },
     "5aad1905-8ff9-5a45-931a-7298f983153a": {
@@ -887,9 +903,10 @@
     "f4a21139-b8d6-5bed-959f-5a847ba09031": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T16:25:35.516655+00:00",
+      "last_probed": "2026-04-27T15:27:40.200232+00:00",
       "tried": {
-        "arcadia-ca-po": "http_404"
+        "arcadia-ca-po": "http_404",
+        "arcadia-ca-police-department": "http_404"
       }
     },
     "fae06461-0698-548b-ad4e-a8e2b5d8539a": {
@@ -912,6 +929,6 @@
       }
     }
   },
-  "updated": "2026-04-27T07:57:23.168572+00:00",
+  "updated": "2026-04-27T15:27:40.233138+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.