### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -225,6 +225,14 @@
         "san-luis-obispo-ca-po": "http_404"
       }
     },
+    "33355e4c-36f3-5437-8c38-46dca8c24adc": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T22:35:21.154196+00:00",
+      "tried": {
+        "el-monte-ca-po": "http_404"
+      }
+    },
     "33845531-5686-56e0-a3ff-371fae83d26b": {
       "exhausted": false,
       "found": null,
@@ -621,9 +629,10 @@
     "9eb7354b-b6ff-590b-b3bb-f097e0b30033": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T19:35:40.659057+00:00",
+      "last_probed": "2026-04-27T22:35:29.281901+00:00",
       "tried": {
-        "tustin-ca-po": "http_404"
+        "tustin-ca-po": "http_404",
+        "tustin-ca-police-department": "http_404"
       }
     },
     "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f": {
@@ -682,6 +691,14 @@
       "last_probed": "2026-04-27T07:57:23.125527+00:00",
       "tried": {
         "riverside-county-ca-sd": "http_200"
+      }
+    },
+    "aecd81f3-fb7f-579a-895a-44d90a82a427": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T22:35:25.052734+00:00",
+      "tried": {
+        "lancaster-ca-po": "http_404"
       }
     },
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
@@ -946,6 +963,6 @@
       }
     }
   },
-  "updated": "2026-04-27T17:11:49.346340+00:00",
+  "updated": "2026-04-27T22:35:29.318802+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -144,9 +144,10 @@
     "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T08:45:29.435161+00:00",
+      "last_probed": "2026-04-28T23:40:05.440451+00:00",
       "tried": {
         "suisun-city-ca-po": "http_404",
+        "suisun-city-ca-police": "http_404",
         "suisun-city-ca-police-department": "http_404"
       }
     },
@@ -484,11 +485,12 @@
     "6be9f842-1658-5490-8be4-14b77cc1e96d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T01:16:35.177588+00:00",
+      "last_probed": "2026-04-28T23:40:15.292085+00:00",
       "tried": {
         "santa-clara-ca": "http_404",
         "santa-clara-ca-da": "http_404",
-        "santa-clara-ca-district-attorney": "http_404"
+        "santa-clara-ca-district-attorney": "http_404",
+        "santa-clara-district-attorney-ca": "http_404"
       }
     },
     "6c6b2202-9b87-5c04-b232-040a4f6e1468": {
@@ -539,6 +541,14 @@
       "last_probed": "2026-04-26T15:29:46.877101+00:00",
       "tried": {
         "orange-county-da-office-ca-da": "http_404"
+      }
+    },
+    "76cb73e9-49c4-5198-bf3e-a1c921e65231": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T23:40:10.844713+00:00",
+      "tried": {
+        "riverside-ca-pd": "http_404"
       }
     },
     "76ffd436-962c-5842-92bc-1fb2c82f20dd": {
@@ -1115,6 +1125,6 @@
       }
     }
   },
-  "updated": "2026-04-28T22:41:43.638408+00:00",
+  "updated": "2026-04-28T23:40:15.328132+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -329,9 +329,10 @@
     "589597b2-0d45-5add-ac97-bf6a042fceae": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T07:12:34.053064+00:00",
+      "last_probed": "2026-04-28T10:50:14.374778+00:00",
       "tried": {
         "cal-state-san-bernadino-ca-po": "http_404",
+        "cal-state-san-bernadino-ca-police": "http_404",
         "cal-state-san-bernadino-ca-police-department": "http_404"
       }
     },
@@ -750,6 +751,14 @@
         "ventura-county-district-attorneys-office-ca-district-attorney": "http_404"
       }
     },
+    "b5a06458-86ec-5e2f-a673-172fdf4ac1af": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T10:50:02.595941+00:00",
+      "tried": {
+        "dnu-pd": "http_404"
+      }
+    },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
       "exhausted": false,
       "found": null,
@@ -817,6 +826,14 @@
         "gustine-ca-pd": "http_404",
         "gustine-ca-po": "http_404",
         "gustine-ca-police-department": "http_404"
+      }
+    },
+    "d30c1555-ff35-55be-8226-4d5f62612e97": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T10:50:08.856168+00:00",
+      "tried": {
+        "avenal-ca-po": "http_404"
       }
     },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
@@ -1010,6 +1027,6 @@
       }
     }
   },
-  "updated": "2026-04-28T07:56:50.384467+00:00",
+  "updated": "2026-04-28T10:50:14.411274+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -201,6 +201,14 @@
         "huntington-beach-ca-po": "http_404"
       }
     },
+    "296ca8d3-956b-5f18-8743-2bd6c53e41f9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T20:06:33.274829+00:00",
+      "tried": {
+        "placer-county-ca-da-office-ca-da": "http_404"
+      }
+    },
     "2c981ce6-8d54-565f-bb99-ac885eee8769": {
       "exhausted": false,
       "found": null,
@@ -311,9 +319,10 @@
     "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T19:34:08.678184+00:00",
+      "last_probed": "2026-04-28T20:06:43.492060+00:00",
       "tried": {
-        "atwater-ca-po": "http_404"
+        "atwater-ca-po": "http_404",
+        "atwater-ca-police-department": "http_404"
       }
     },
     "4cc1fd23-7711-52b8-be07-9d6e1ad7b364": {
@@ -669,9 +678,10 @@
     "9a02b7a4-b078-5f90-9323-a684dcda6674": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T16:02:11.323415+00:00",
+      "last_probed": "2026-04-28T20:06:37.313021+00:00",
       "tried": {
-        "santa-rosa-band-of-cahuilla-indians-ca-pd": "http_404"
+        "santa-rosa-band-of-cahuilla-indians-ca-pd": "http_404",
+        "santa-rosa-band-of-cahuilla-indians-ca-po": "http_404"
       }
     },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
@@ -1078,6 +1088,6 @@
       }
     }
   },
-  "updated": "2026-04-28T18:10:44.051538+00:00",
+  "updated": "2026-04-28T20:06:43.531668+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -53,6 +53,14 @@
         "san-luis-obispo-county-ca-so": "http_404"
       }
     },
+    "08bd5589-6ad6-5be4-bea5-60bd90bf6883": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T13:19:30.469917+00:00",
+      "tried": {
+        "stallion-springs-ca-po": "http_403"
+      }
+    },
     "098c0089-e37c-50d0-bafc-0387298e7108": {
       "exhausted": false,
       "found": null,
@@ -245,9 +253,10 @@
     "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T07:56:40.656670+00:00",
+      "last_probed": "2026-04-28T13:19:34.824302+00:00",
       "tried": {
-        "chabot-college-campus-safety-security-ca-pd": "http_404"
+        "chabot-college-campus-safety-security-ca-pd": "http_404",
+        "chabot-college-campus-safety-security-ca-ps": "http_404"
       }
     },
     "4219823b-c553-51fd-9a9b-5618cb5f82b5": {
@@ -836,6 +845,14 @@
         "avenal-ca-po": "http_404"
       }
     },
+    "d542f966-5b6d-5af2-9487-b56dcceff9bc": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T13:19:39.618391+00:00",
+      "tried": {
+        "acworth-ga-po": "http_404"
+      }
+    },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
       "exhausted": false,
       "found": null,
@@ -1027,6 +1044,6 @@
       }
     }
   },
-  "updated": "2026-04-28T10:50:14.411274+00:00",
+  "updated": "2026-04-28T13:19:39.760552+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -573,6 +573,14 @@
         "san-jose-evergreen-community-college-campus-ca-pd": "http_404"
       }
     },
+    "844ec58f-3abf-5a88-a280-2ba0f235264a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T16:02:17.452877+00:00",
+      "tried": {
+        "salinas-ca-po": "http_404"
+      }
+    },
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
       "exhausted": false,
       "found": null,
@@ -636,9 +644,18 @@
     "98a2b052-2421-5f90-a95c-88c85615e128": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T09:40:07.163061+00:00",
+      "last_probed": "2026-04-28T16:02:06.050727+00:00",
       "tried": {
+        "california-department-of-ca-corrections": "http_403",
         "california-department-of-ca-doc": "http_404"
+      }
+    },
+    "9a02b7a4-b078-5f90-9323-a684dcda6674": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T16:02:11.323415+00:00",
+      "tried": {
+        "santa-rosa-band-of-cahuilla-indians-ca-pd": "http_404"
       }
     },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
@@ -1044,6 +1061,6 @@
       }
     }
   },
-  "updated": "2026-04-28T13:19:39.760552+00:00",
+  "updated": "2026-04-28T16:02:17.491026+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -538,8 +538,9 @@
     "81e727b4-f1d6-5aea-8cd4-db0cf88a7306": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T23:38:43.118836+00:00",
+      "last_probed": "2026-04-28T01:23:27.772655+00:00",
       "tried": {
+        "solano-county-ca": "http_404",
         "solano-county-ca-da": "http_404",
         "solano-county-ca-district-attorney": "http_404"
       }
@@ -601,6 +602,14 @@
       "tried": {
         "los-angeles-port-ca-pd": "http_404",
         "los-angeles-port-ca-po": "http_404"
+      }
+    },
+    "981e7edd-d5e6-549a-9c63-9f5e6e6238a9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T01:23:37.934926+00:00",
+      "tried": {
+        "inglewood-ca-po": "http_404"
       }
     },
     "98a2b052-2421-5f90-a95c-88c85615e128": {
@@ -936,6 +945,14 @@
         "san-pasqual-ca-police-department": "http_404"
       }
     },
+    "f296ea7d-37b7-583c-aef6-5058b2df232d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T01:23:32.310618+00:00",
+      "tried": {
+        "fremont-ca-po": "http_404"
+      }
+    },
     "f4073ba9-2a85-50ab-82d6-1800ff5491c6": {
       "exhausted": false,
       "found": null,
@@ -973,6 +990,6 @@
       }
     }
   },
-  "updated": "2026-04-27T23:38:47.785238+00:00",
+  "updated": "2026-04-28T01:23:37.965735+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -538,9 +538,10 @@
     "81e727b4-f1d6-5aea-8cd4-db0cf88a7306": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T09:38:08.585040+00:00",
+      "last_probed": "2026-04-27T23:38:43.118836+00:00",
       "tried": {
-        "solano-county-ca-da": "http_404"
+        "solano-county-ca-da": "http_404",
+        "solano-county-ca-district-attorney": "http_404"
       }
     },
     "8269106d-e127-5d07-97fe-d7963b813025": {
@@ -879,9 +880,10 @@
     "eaef691d-609c-566f-ad67-3a187a241852": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T23:27:14.232978+00:00",
+      "last_probed": "2026-04-27T23:38:47.747105+00:00",
       "tried": {
-        "university-of-california-berkeley-ca-pd": "http_404"
+        "university-of-california-berkeley-ca-pd": "http_404",
+        "university-of-california-berkeley-ca-ps": "http_404"
       }
     },
     "ec0349b0-2d81-546b-acf9-ded505a551a7": {
@@ -890,6 +892,14 @@
       "last_probed": "2026-04-26T17:26:25.161720+00:00",
       "tried": {
         "ca-wasco-ca-pd": "http_404"
+      }
+    },
+    "ee39b0f7-1dd6-5526-88ce-57e3dd7d8488": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-27T23:38:36.644377+00:00",
+      "tried": {
+        "placentia-ca-po": "http_404"
       }
     },
     "eef11480-824c-5b76-9049-541470c862b1": {
@@ -963,6 +973,6 @@
       }
     }
   },
-  "updated": "2026-04-27T22:35:29.318802+00:00",
+  "updated": "2026-04-27T23:38:47.785238+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -381,9 +381,10 @@
     "59158344-4894-55be-bc8a-de15bcb986f0": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T08:53:55.092109+00:00",
+      "last_probed": "2026-04-28T22:41:37.181711+00:00",
       "tried": {
-        "laguna-beach-ca-po": "http_404"
+        "laguna-beach-ca-po": "http_404",
+        "laguna-beach-ca-police-department": "http_404"
       }
     },
     "59b1f730-2412-5790-92fd-a707e3ac23cd": {
@@ -488,6 +489,14 @@
         "santa-clara-ca": "http_404",
         "santa-clara-ca-da": "http_404",
         "santa-clara-ca-district-attorney": "http_404"
+      }
+    },
+    "6c6b2202-9b87-5c04-b232-040a4f6e1468": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T22:41:32.304622+00:00",
+      "tried": {
+        "santa-maria-ca-po": "http_404"
       }
     },
     "6db175fe-bff6-58bc-a911-d688f797fda9": {
@@ -1021,9 +1030,10 @@
     "ee39b0f7-1dd6-5526-88ce-57e3dd7d8488": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T23:38:36.644377+00:00",
+      "last_probed": "2026-04-28T22:41:43.605730+00:00",
       "tried": {
-        "placentia-ca-po": "http_404"
+        "placentia-ca-po": "http_404",
+        "placentia-ca-police-department": "http_404"
       }
     },
     "eef11480-824c-5b76-9049-541470c862b1": {
@@ -1105,6 +1115,6 @@
       }
     }
   },
-  "updated": "2026-04-28T21:44:53.589538+00:00",
+  "updated": "2026-04-28T22:41:43.638408+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -266,6 +266,14 @@
         "san-benito-county-ca-so": "http_404"
       }
     },
+    "36d68f61-6c39-53ec-815e-c0853fca118d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T21:44:48.896557+00:00",
+      "tried": {
+        "yreka-ca-po": "http_404"
+      }
+    },
     "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
       "exhausted": false,
       "found": null,
@@ -501,9 +509,10 @@
     "727915ef-bda7-5399-8e79-0369d7bb7782": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T09:40:13.050864+00:00",
+      "last_probed": "2026-04-28T21:44:53.551321+00:00",
       "tried": {
         "la-verne-ca-po": "http_404",
+        "la-verne-ca-police": "http_404",
         "la-verne-ca-police-department": "http_404"
       }
     },
@@ -673,6 +682,14 @@
       "tried": {
         "california-department-of-ca-corrections": "http_403",
         "california-department-of-ca-doc": "http_404"
+      }
+    },
+    "99e640ed-c175-5ce6-90c8-5ea55dfa2ed3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T21:44:44.856748+00:00",
+      "tried": {
+        "solano-county-special-investigations-bureau-ca-pd": "http_404"
       }
     },
     "9a02b7a4-b078-5f90-9323-a684dcda6674": {
@@ -1088,6 +1105,6 @@
       }
     }
   },
-  "updated": "2026-04-28T20:06:43.531668+00:00",
+  "updated": "2026-04-28T21:44:53.589538+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -12,9 +12,10 @@
     "02126911-e73c-519e-b23b-8bc1cfb0d92d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T20:31:23.442769+00:00",
+      "last_probed": "2026-04-28T07:56:50.357619+00:00",
       "tried": {
         "redondo-beach-ca-po": "http_404",
+        "redondo-beach-ca-police": "http_404",
         "redondo-beach-ca-police-department": "http_404"
       }
     },
@@ -241,6 +242,14 @@
         "albion-mi-dps-mi-pd": "http_404"
       }
     },
+    "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T07:56:40.656670+00:00",
+      "tried": {
+        "chabot-college-campus-safety-security-ca-pd": "http_404"
+      }
+    },
     "4219823b-c553-51fd-9a9b-5618cb5f82b5": {
       "exhausted": false,
       "found": null,
@@ -337,9 +346,10 @@
     "59b1f730-2412-5790-92fd-a707e3ac23cd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-24T18:32:01.439811+00:00",
+      "last_probed": "2026-04-28T07:56:45.495922+00:00",
       "tried": {
-        "pleasant-hill-ca-po": "http_404"
+        "pleasant-hill-ca-po": "http_404",
+        "pleasant-hill-ca-police-department": "http_404"
       }
     },
     "59e2385f-2649-5b82-9bf7-aee2e73b0af1": {
@@ -1000,6 +1010,6 @@
       }
     }
   },
-  "updated": "2026-04-28T05:03:31.938351+00:00",
+  "updated": "2026-04-28T07:56:50.384467+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -250,6 +250,14 @@
         "albion-mi-dps-mi-pd": "http_404"
       }
     },
+    "3684a873-d18a-57d8-a30b-c1fe3b4c93a3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T18:10:44.009116+00:00",
+      "tried": {
+        "san-benito-county-ca-so": "http_404"
+      }
+    },
     "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
       "exhausted": false,
       "found": null,
@@ -333,6 +341,14 @@
         "indio-ca-po": "http_404",
         "indio-ca-police": "http_404",
         "indio-ca-police-department": "http_404"
+      }
+    },
+    "5077b862-25fa-52a7-9ead-bb712a54b7af": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T18:10:33.618962+00:00",
+      "tried": {
+        "cypress-ca-po": "http_404"
       }
     },
     "589597b2-0d45-5add-ac97-bf6a042fceae": {
@@ -899,9 +915,10 @@
     "dddefaf4-84f7-5857-8011-45b6eda02991": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T10:30:46.105414+00:00",
+      "last_probed": "2026-04-28T18:10:38.738287+00:00",
       "tried": {
-        "sand-city-ca-po": "http_404"
+        "sand-city-ca-po": "http_404",
+        "sand-city-ca-police-department": "http_404"
       }
     },
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
@@ -1061,6 +1078,6 @@
       }
     }
   },
-  "updated": "2026-04-28T16:02:17.491026+00:00",
+  "updated": "2026-04-28T18:10:44.051538+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -9,6 +9,14 @@
         "desert-hot-springs-ca-police-department": "http_404"
       }
     },
+    "01f7379e-355c-5c9e-b078-d0b4fd9c69a8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-29T01:26:36.149376+00:00",
+      "tried": {
+        "alpine-county-ca-sd": "http_404"
+      }
+    },
     "02126911-e73c-519e-b23b-8bc1cfb0d92d": {
       "exhausted": false,
       "found": null,
@@ -22,9 +30,10 @@
     "03c310c0-6e05-5ad2-872a-d4e8b804358f": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T21:23:18.184984+00:00",
+      "last_probed": "2026-04-29T01:26:28.120109+00:00",
       "tried": {
         "selma-ca-po": "http_404",
+        "selma-ca-police": "http_404",
         "selma-ca-police-department": "http_404"
       }
     },
@@ -608,6 +617,14 @@
         "colton-ca-po": "http_404"
       }
     },
+    "7f21a88e-2c0f-53d5-b5e3-22920a3f9872": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-29T01:26:32.418127+00:00",
+      "tried": {
+        "amador-county-ca-so": "http_404"
+      }
+    },
     "81e727b4-f1d6-5aea-8cd4-db0cf88a7306": {
       "exhausted": false,
       "found": null,
@@ -1125,6 +1142,6 @@
       }
     }
   },
-  "updated": "2026-04-28T23:40:15.328132+00:00",
+  "updated": "2026-04-29T01:26:36.178395+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -556,9 +556,10 @@
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T17:11:45.140175+00:00",
+      "last_probed": "2026-04-28T05:03:26.688201+00:00",
       "tried": {
         "imperial-county-ca-sd": "http_404",
+        "imperial-county-ca-sheriffs-department": "http_404",
         "imperial-county-ca-sheriffs-office": "http_404"
       }
     },
@@ -733,9 +734,10 @@
     "b592938c-c2c4-597c-b6cd-2bbb3b52447b": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T07:57:06.379587+00:00",
+      "last_probed": "2026-04-28T05:03:21.186462+00:00",
       "tried": {
-        "ventura-county-district-attorneys-office-ca-da": "http_404"
+        "ventura-county-district-attorneys-office-ca-da": "http_404",
+        "ventura-county-district-attorneys-office-ca-district-attorney": "http_404"
       }
     },
     "b66facad-4ee0-558e-8bfe-32d1894afad1": {
@@ -779,6 +781,14 @@
       "tried": {
         "blythe-ca-po": "http_404",
         "blythe-ca-police-department": "http_404"
+      }
+    },
+    "cc1000e2-0754-5577-95b3-76649924222d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-04-28T05:03:31.901238+00:00",
+      "tried": {
+        "csu-long-beach-ca-pd": "http_404"
       }
     },
     "cc269287-49ca-5831-af72-f6dacf356bd1": {
@@ -990,6 +1000,6 @@
       }
     }
   },
-  "updated": "2026-04-28T01:23:37.965735+00:00",
+  "updated": "2026-04-28T05:03:31.938351+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.