### PR TITLE
geocode: place Moreno Valley and Winchester Trails

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -5087,7 +5087,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "0649270",
+      "name": "Moreno Valley",
+      "state": "CA",
+      "lat": 33.923253,
+      "lng": -117.205685
+    }
   },
   {
     "agency_id": "7ef569b7-a705-54be-bfa6-7e115991bd53",
@@ -5135,8 +5142,10 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "manual",
+      "state": "CA",
+      "lat": 33.71463,
+      "lng": -117.077398
     }
   },
   {


### PR DESCRIPTION
## Summary
- Today's Riverside County SD scrape introduced three new sharing recipients. UC Riverside auto-geocoded, but two needed manual help.
- **City of Moreno Valley** → Census place `0649270`. The auto-geocoder missed because the agency name has no state token and the entry had no state field, so `geocode_entry` bailed at the `if not state` check.
- **Winchester Trails (CA)** → manual coords at the Winchester CDP centroid (Riverside County). It's an HOA inside Winchester; Census has no matching place.

## Test plan
- [x] \`uv run python scripts/check_recipient_coords.py\` — clean
- [x] \`uv run pytest tests/test_geo_cache.py\` — 9 passed