### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -284,6 +284,14 @@
         "yreka-ca-po": "http_404"
       }
     },
+    "3f7eb8d2-ed50-5eac-9b8c-ac66584c00aa": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T08:09:07.557538+00:00",
+      "tried": {
+        "ukiah-ca-po": "http_404"
+      }
+    },
     "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
       "exhausted": false,
       "found": null,
@@ -599,6 +607,14 @@
       "last_probed": "2026-04-26T21:23:07.425470+00:00",
       "tried": {
         "los-gatos-ca-pd": "http_200"
+      }
+    },
+    "7b4d182e-412e-59e3-9967-75d4f4f1bedf": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T08:09:11.803774+00:00",
+      "tried": {
+        "lasd-ca-san-dimas-station-ca-pd": "http_404"
       }
     },
     "7d2b8047-a15b-524a-bc77-627e8eeab00a": {
@@ -984,6 +1000,14 @@
         "sand-city-ca-police-department": "http_404"
       }
     },
+    "dde5fe3d-8dc6-5d4d-af6a-a28a62387cf6": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T08:09:18.339872+00:00",
+      "tried": {
+        "ukiah-ca-fd": "http_404"
+      }
+    },
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
       "exhausted": false,
       "found": null,
@@ -1142,6 +1166,6 @@
       }
     }
   },
-  "updated": "2026-04-29T01:26:36.178395+00:00",
+  "updated": "2026-05-04T08:09:18.380269+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -97,8 +97,9 @@
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T22:21:42.380544+00:00",
+      "last_probed": "2026-05-04T15:33:26.790589+00:00",
       "tried": {
+        "hemet-ca": "http_404",
         "hemet-ca-po": "http_404",
         "hemet-ca-police": "http_404",
         "hemet-ca-police-department": "http_404",
@@ -932,6 +933,14 @@
         "east-bay-parks-ca-police-department": "http_404"
       }
     },
+    "c11a14ff-0bc7-5a6d-9876-c5932d05c38e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T15:33:20.291190+00:00",
+      "tried": {
+        "butler-township-oh-po": "http_404"
+      }
+    },
     "c246371a-5810-5428-b861-52b526e54678": {
       "exhausted": false,
       "found": null,
@@ -1072,9 +1081,10 @@
     "e9d63958-c540-592f-aeb5-6fc9953296ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T15:27:27.301633+00:00",
+      "last_probed": "2026-05-04T15:33:30.576985+00:00",
       "tried": {
-        "hermosa-beach-ca-pd": "http_404"
+        "hermosa-beach-ca-pd": "http_404",
+        "hermosa-beach-ca-po": "http_404"
       }
     },
     "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
@@ -1193,6 +1203,6 @@
       }
     }
   },
-  "updated": "2026-05-04T13:13:22.134463+00:00",
+  "updated": "2026-05-04T15:33:30.607560+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -268,6 +268,14 @@
         "albion-mi-dps-mi-pd": "http_404"
       }
     },
+    "34b09634-c949-542c-90ce-e790b877570d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T13:13:22.098149+00:00",
+      "tried": {
+        "daly-city-ca-po": "http_404"
+      }
+    },
     "3684a873-d18a-57d8-a30b-c1fe3b4c93a3": {
       "exhausted": false,
       "found": null,
@@ -282,6 +290,14 @@
       "last_probed": "2026-04-28T21:44:48.896557+00:00",
       "tried": {
         "yreka-ca-po": "http_404"
+      }
+    },
+    "38082941-85be-5f33-9a53-20afd458675a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T13:13:12.767552+00:00",
+      "tried": {
+        "hawthorne-ca-po": "http_404"
       }
     },
     "3f7eb8d2-ed50-5eac-9b8c-ac66584c00aa": {
@@ -1108,9 +1124,10 @@
     "ef0c3682-0153-527c-a973-0bb7b07056be": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T22:21:33.039988+00:00",
+      "last_probed": "2026-05-04T13:13:18.430685+00:00",
       "tried": {
-        "bishop-ca-po": "http_404"
+        "bishop-ca-po": "http_404",
+        "bishop-ca-police-department": "http_404"
       }
     },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
@@ -1176,6 +1193,6 @@
       }
     }
   },
-  "updated": "2026-05-04T10:50:27.271126+00:00",
+  "updated": "2026-05-04T13:13:22.134463+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -371,11 +371,12 @@
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T23:25:15.602614+00:00",
+      "last_probed": "2026-05-04T10:50:27.234385+00:00",
       "tried": {
         "indio-ca-po": "http_404",
         "indio-ca-police": "http_404",
-        "indio-ca-police-department": "http_404"
+        "indio-ca-police-department": "http_404",
+        "indio-ca-ps": "http_404"
       }
     },
     "5077b862-25fa-52a7-9ead-bb712a54b7af": {
@@ -451,9 +452,10 @@
     "62f9d91a-99cb-5428-8312-38718e2196ed": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T12:32:28.434900+00:00",
+      "last_probed": "2026-05-04T10:50:22.284149+00:00",
       "tried": {
-        "pomona-ca-po": "http_404"
+        "pomona-ca-po": "http_404",
+        "pomona-ca-police-department": "http_404"
       }
     },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
@@ -657,6 +659,14 @@
       "last_probed": "2026-04-25T19:34:17.104825+00:00",
       "tried": {
         "san-jose-evergreen-community-college-campus-ca-pd": "http_404"
+      }
+    },
+    "84006518-b4f2-528e-9094-f7a94132223f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T10:50:18.662720+00:00",
+      "tried": {
+        "woodlake-ca-po": "http_404"
       }
     },
     "844ec58f-3abf-5a88-a280-2ba0f235264a": {
@@ -1166,6 +1176,6 @@
       }
     }
   },
-  "updated": "2026-05-04T08:09:18.380269+00:00",
+  "updated": "2026-05-04T10:50:27.271126+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.