### PR TITLE
fix(slug-probe CI): use full git history so rebase doesn't reset state

### DIFF
--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -2,7 +2,8 @@ name: Probe Unknown Flock Slugs
 
 # Looks for working Flock transparency portal slugs for agencies whose
 # current slug 404s. Runs on its own rate budget (default 3 probes per run)
-# separate from refresh-flock-data so neither starves the other.
+# separate from refresh-flock-data so neither starves the other. Flock
+# rate-limits aggressively, so keep the per-run limit small.
 
 on:
   schedule:
@@ -34,6 +35,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # Need full history so the rebase below can find a common ancestor
+          # with origin/slug-probe. With the default shallow clone, rebase
+          # replays slug-probe's entire history (back to the initial commit)
+          # onto main and conflicts on every binary file added since then;
+          # the fallback `reset --hard` then wipes accumulated probe state.
+          fetch-depth: 0
           # PAT (if configured) attributes the resulting PR to a human so
           # CI doesn't require approval-for-bots on every run.
           token: ${{ secrets.REFRESH_PAT || github.token }}


### PR DESCRIPTION
## Summary
Add `fetch-depth: 0` to the probe job's checkout so `git rebase origin/main` can find a common ancestor with `origin/slug-probe`. The default shallow clone made rebase replay slug-probe's entire history onto main, conflicting on every binary file added since the branch root; the fallback `reset --hard origin/main` then silently wiped all accumulated `tried` candidates from `.slug_probe_state.json`. Net effect: probes kept re-attempting the same most-likely slugs already confirmed missing.

Fresh evidence in the 08:08 run today: https://github.com/none-below/sm-alpr/actions/runs/25308142518 — `Could not apply 59ca9d4... # Initial move towards claude code/git for sm alpr research.` followed by add/add conflicts on `.githooks/pre-commit`, `.gitignore`, and dozens of binary PDFs.

Default per-run limit stays at 3 — Flock rate-limits aggressively.

## Test plan
- [ ] Merge and observe next scheduled run: rebase step should be a clean no-op (slug-probe is just main + N state-file commits with full history)
- [ ] Confirm `.slug_probe_state.json` accumulates `tried` candidates across consecutive runs instead of being reset to main's snapshot
- [ ] Confirm probe progresses past top-3 candidates per agency over time