### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -214,9 +214,10 @@
     "296ca8d3-956b-5f18-8743-2bd6c53e41f9": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T20:06:33.274829+00:00",
+      "last_probed": "2026-05-04T16:32:26.621992+00:00",
       "tried": {
-        "placer-county-ca-da-office-ca-da": "http_404"
+        "placer-county-ca-da-office-ca-da": "http_404",
+        "placer-county-ca-da-office-ca-district-attorney": "http_404"
       }
     },
     "2c981ce6-8d54-565f-bb99-ac885eee8769": {
@@ -723,9 +724,10 @@
     "99e640ed-c175-5ce6-90c8-5ea55dfa2ed3": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T21:44:44.856748+00:00",
+      "last_probed": "2026-05-04T16:32:31.253114+00:00",
       "tried": {
-        "solano-county-special-investigations-bureau-ca-pd": "http_404"
+        "solano-county-special-investigations-bureau-ca-pd": "http_404",
+        "solano-county-special-investigations-bureau-ca-po": "http_404"
       }
     },
     "9a02b7a4-b078-5f90-9323-a684dcda6674": {
@@ -936,9 +938,10 @@
     "d30c1555-ff35-55be-8226-4d5f62612e97": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T10:50:08.856168+00:00",
+      "last_probed": "2026-05-04T16:32:35.433931+00:00",
       "tried": {
-        "avenal-ca-po": "http_404"
+        "avenal-ca-po": "http_404",
+        "avenal-ca-police-department": "http_404"
       }
     },
     "d542f966-5b6d-5af2-9487-b56dcceff9bc": {
@@ -1142,6 +1145,6 @@
       }
     }
   },
-  "updated": "2026-04-29T01:26:36.178395+00:00",
+  "updated": "2026-05-04T16:32:35.473230+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.