### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -214,8 +214,9 @@
     "296ca8d3-956b-5f18-8743-2bd6c53e41f9": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-04T16:32:26.621992+00:00",
+      "last_probed": "2026-05-04T19:07:55.208524+00:00",
       "tried": {
+        "placer-county-ca-da-office-ca": "http_404",
         "placer-county-ca-da-office-ca-da": "http_404",
         "placer-county-ca-da-office-ca-district-attorney": "http_404"
       }
@@ -662,6 +663,14 @@
         "imperial-county-ca-sheriffs-office": "http_404"
       }
     },
+    "8850cc76-6d6f-5a25-8e97-8af1c309e550": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T19:07:44.306438+00:00",
+      "tried": {
+        "branson-mo-po": "http_404"
+      }
+    },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
       "exhausted": false,
       "found": null,
@@ -987,6 +996,14 @@
         "sand-city-ca-police-department": "http_404"
       }
     },
+    "dde5fe3d-8dc6-5d4d-af6a-a28a62387cf6": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T19:07:50.111806+00:00",
+      "tried": {
+        "ukiah-ca-fd": "http_404"
+      }
+    },
     "de913a80-ceee-5eef-a74c-0093e8dcc033": {
       "exhausted": false,
       "found": null,
@@ -1145,6 +1162,6 @@
       }
     }
   },
-  "updated": "2026-05-04T16:32:35.473230+00:00",
+  "updated": "2026-05-04T19:07:55.247285+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -273,8 +273,9 @@
     "3684a873-d18a-57d8-a30b-c1fe3b4c93a3": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T18:10:44.009116+00:00",
+      "last_probed": "2026-05-04T20:52:28.683488+00:00",
       "tried": {
+        "san-benito-county-ca-sd": "http_404",
         "san-benito-county-ca-so": "http_404"
       }
     },
@@ -818,8 +819,9 @@
     "a76f1a12-ea0c-5138-9c77-57a4e6b510ca": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T01:07:10.662289+00:00",
+      "last_probed": "2026-05-04T20:52:23.224906+00:00",
       "tried": {
+        "cerritos-college-ca-police": "http_404",
         "cerritos-college-ca-ps": "http_404"
       }
     },
@@ -899,6 +901,14 @@
         "east-bay-parks-ca-po": "http_404",
         "east-bay-parks-ca-police": "http_404",
         "east-bay-parks-ca-police-department": "http_404"
+      }
+    },
+    "bae9861d-a7ef-567d-b31b-a627075decf9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-04T20:52:34.525762+00:00",
+      "tried": {
+        "sacramento-ca-po": "http_404"
       }
     },
     "c246371a-5810-5428-b861-52b526e54678": {
@@ -1162,6 +1172,6 @@
       }
     }
   },
-  "updated": "2026-05-04T19:07:55.247285+00:00",
+  "updated": "2026-05-04T20:52:34.563957+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.