### PR TITLE
chore(article-registry): drop crawl_delay default 90s -> 5s

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -18,8 +18,8 @@ on:
         description: 'Max URLs to fetch this run'
         default: '3'
       crawl_delay:
-        description: 'Seconds between fetches (jittered ±25%)'
-        default: '90'
+        description: 'Seconds between fetches (jittered ±25%). Hourly cron is the real rate limit; this just avoids bursting.'
+        default: '5'
       phase2_limit:
         description: 'Max articles to enrich via Anthropic API this run'
         default: '5'

--- a/scripts/article_crawl.py
+++ b/scripts/article_crawl.py
@@ -345,8 +345,10 @@ def main() -> int:
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--limit", type=int, default=3,
                    help="max URLs to process this run (default: 3)")
-    p.add_argument("--delay", type=int, default=90,
-                   help="base seconds between fetches; ±25%% jitter (default: 90)")
+    p.add_argument("--delay", type=int, default=5,
+                   help="base seconds between fetches; ±25%% jitter (default: 5). "
+                        "The hourly cron schedule is the real rate limit; this "
+                        "delay is just so back-to-back fetches don't burst.")
     p.add_argument("--dry-run", action="store_true",
                    help="list candidates, no HTTP")
     p.add_argument("--url", action="append", default=[],


### PR DESCRIPTION
Cron is the rate limit; within-run delay was wasting runner time.

At 90s × 3 articles, ~3 min of every hourly run was sleeping = ~72 min/day across 24 runs. 5s ±25% jitter still avoids same-domain bursts but no longer dominates run cost.