### PR TITLE
feat(article-registry): async Wayback SPN with IA auth + secrets docs

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -78,6 +78,12 @@ jobs:
 
       - name: Crawl queued URLs
         if: ${{ inputs.phase2_only != 'true' }}
+        # IA_ACCESS_KEY + IA_SECRET_KEY enable async Wayback Machine SPN
+        # saves with server-side dedup. Without them the crawler falls
+        # back to slower anonymous availability+sync-save behavior.
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
           uv run python scripts/article_crawl.py \
             --limit ${{ inputs.crawl_limit || '3' }} \

--- a/README.md
+++ b/README.md
@@ -135,3 +135,65 @@ uv run playwright install chromium
 ```
 
 Tesseract is required for OCR: `brew install tesseract`
+
+## Secrets (for the article-registry pipeline)
+
+The hourly `Crawl & Curate Articles` workflow runs the article pipeline
+in CI and reads two optional credentials from repo secrets. Both have
+graceful no-op fallbacks — the workflow won't fail if either is unset,
+it just runs in a degraded mode for that integration.
+
+### `ANTHROPIC_API_KEY` — Phase 2 semantic enrichment
+
+Without it the workflow runs Phase 1 (mechanical curation, free) only;
+articles land in the registry as `curation_status: "mechanical"` with
+no summary/quotes/genre fields.
+
+Recommended setup:
+
+1. Sign in at <https://console.anthropic.com>
+2. Create a dedicated workspace (sidebar workspace dropdown → "Create
+   workspace"), e.g. `sm-alpr`. This isolates spend from any other
+   work in your org and bounds blast-radius if the key leaks.
+3. Set a monthly spend cap on the new workspace under **Manage →
+   Limits** (or org Billing for the default workspace). Recommended:
+   $50/month — comfortably above the ~$0.05/article enrichment cost,
+   well below typical credit balances.
+4. Generate the key under **Manage → API keys** (in the new
+   workspace, not Default). Key is shown once; copy it.
+5. Plant in repo secrets:
+
+   ```sh
+   gh secret set ANTHROPIC_API_KEY -R none-below/sm-alpr
+   ```
+
+Defaults to Claude Opus 4.7. Override with `SM_ALPR_CURATE_MODEL` env
+var (set in the workflow or locally) for `claude-sonnet-4-6` or
+`claude-haiku-4-5` if you want cheaper enrichment.
+
+### `IA_ACCESS_KEY` + `IA_SECRET_KEY` — Wayback async SPN
+
+Without them the crawler falls back to the slower anonymous Wayback
+flow (Availability API check + sync save with up to 90s blocking
+wait). With them it uses the authenticated async Save Page Now API:
+submit returns a job_id in ~1s, status polled at the tail of the run,
+and `if_not_archived_within=86400` does server-side dedup so we don't
+re-trigger saves of URLs archived in the last 24 hours.
+
+Setup:
+
+1. Get keys at <https://archive.org/account/s3.php> (logged in to your
+   Internet Archive account). Returns an access key + secret pair.
+   Secret is shown once; copy both.
+2. Plant both in repo secrets:
+
+   ```sh
+   gh secret set IA_ACCESS_KEY -R none-below/sm-alpr
+   gh secret set IA_SECRET_KEY -R none-below/sm-alpr
+   ```
+
+Saves submitted with auth show up under your IA account — useful for
+attribution/integrity ("zero-below saved this on date X" beats
+"anonymous"). The keys carry no payment authority, only rate limits
+and identity; if leaked the worst case is rate-limited Wayback abuse,
+not money.

--- a/scripts/article_crawl.py
+++ b/scripts/article_crawl.py
@@ -33,6 +33,7 @@ import functools
 import hashlib
 import html
 import json
+import os
 import random
 import re
 import subprocess
@@ -264,6 +265,162 @@ def run_scanner(paths: list[Path]) -> dict:
 # ───────────────────────── archival ─────────────────────────
 
 
+def _ia_keys() -> tuple[str, str] | None:
+    """Return (access, secret) IA SPN credentials, or None if unset.
+
+    With keys we use the async Save Page Now API: submit returns a
+    job_id in ~1s, status polled at end of run. Without keys we fall
+    back to the slower anonymous Availability + sync save path.
+    """
+    a = os.environ.get("IA_ACCESS_KEY")
+    s = os.environ.get("IA_SECRET_KEY")
+    return (a, s) if a and s else None
+
+
+def wayback_submit(url: str) -> dict:
+    """Submit a Save Page Now job. Authenticated path is async; anonymous
+    falls back to wayback_lookup_or_save (sync, blocking).
+
+    The authenticated path uses ``if_not_archived_within=86400`` so
+    re-runs of the same URL within 24h get the existing snapshot back
+    server-side rather than triggering a redundant save — eliminates
+    the Availability-API indexing-lag false negative.
+
+    Returns: wayback_url + wayback_timestamp (set if existing snapshot),
+    wayback_source ("submitted" | "existing" | "submit-failed"),
+    wayback_job_id (set if a poll is needed), wayback_error.
+    """
+    keys = _ia_keys()
+    if not keys:
+        return wayback_lookup_or_save(url)
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+        "Authorization": f"LOW {keys[0]}:{keys[1]}",
+        "Spn-Async": "1",
+    }
+    data = {
+        "url": url,
+        "if_not_archived_within": "86400",
+    }
+    out = {
+        "wayback_url": None,
+        "wayback_timestamp": None,
+        "wayback_source": None,
+        "wayback_job_id": None,
+        "wayback_error": None,
+    }
+    try:
+        resp = requests.post(
+            "https://web.archive.org/save",
+            headers=headers, data=data, timeout=15,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+    except (requests.RequestException, ValueError) as e:
+        out["wayback_source"] = "submit-failed"
+        out["wayback_error"] = f"{type(e).__name__}: {e}"
+        return out
+
+    if body.get("job_id"):
+        out["wayback_job_id"] = body["job_id"]
+        out["wayback_source"] = "submitted"
+    elif body.get("url"):
+        # if_not_archived_within served back an existing snapshot.
+        out["wayback_url"] = body["url"]
+        out["wayback_source"] = "existing"
+        m = re.search(r"/web/(\d{14})/", body["url"])
+        if m:
+            out["wayback_timestamp"] = m.group(1)
+    else:
+        out["wayback_source"] = "submit-failed"
+        out["wayback_error"] = f"unexpected SPN response: {str(body)[:300]}"
+    return out
+
+
+def wayback_poll(job_id: str, *, deadline: float,
+                 poll_interval: float = 3.0) -> dict:
+    """Poll SPN status until done or `deadline` (monotonic time.time())
+    elapses. Returns wayback_url/timestamp/source/error suitable for
+    merging into a record. On timeout, source="pending" — the job is
+    still running server-side and a follow-up workflow can finalize it.
+    """
+    keys = _ia_keys()
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    if keys:
+        headers["Authorization"] = f"LOW {keys[0]}:{keys[1]}"
+
+    out = {
+        "wayback_url": None,
+        "wayback_timestamp": None,
+        "wayback_source": None,
+        "wayback_error": None,
+    }
+    while time.time() < deadline:
+        try:
+            resp = requests.get(
+                f"https://web.archive.org/save/status/{job_id}",
+                headers=headers, timeout=10,
+            )
+            data = resp.json()
+        except (requests.RequestException, ValueError) as e:
+            out["wayback_source"] = "poll-failed"
+            out["wayback_error"] = f"{type(e).__name__}: {e}"
+            return out
+
+        status = data.get("status")
+        if status == "success":
+            ts = data.get("timestamp")
+            orig = data.get("original_url") or ""
+            if ts and orig:
+                out["wayback_url"] = f"https://web.archive.org/web/{ts}/{orig}"
+                out["wayback_timestamp"] = ts
+            out["wayback_source"] = "saved"
+            return out
+        if status == "error":
+            out["wayback_source"] = "save-failed"
+            out["wayback_error"] = data.get("message") or "unknown SPN error"
+            return out
+        # status == "pending" — keep polling
+        time.sleep(poll_interval)
+
+    out["wayback_source"] = "pending"
+    out["wayback_error"] = "poll deadline elapsed; job may still complete"
+    return out
+
+
+def wayback_poll_pending(pending: list[tuple[dict, Path]], *,
+                         total_timeout: int = 90) -> None:
+    """Finalize all submitted-but-pending wayback jobs.
+
+    Single shared deadline across all jobs — Wayback runs them all in
+    parallel server-side, so sequential polling on one shared budget is
+    equivalent in wall-clock time to parallel polling. Updates each
+    record in place and rewrites its meta sidecar.
+    """
+    if not pending:
+        return
+    print(f"wayback: polling {len(pending)} pending save(s) "
+          f"(deadline {total_timeout}s)...")
+    deadline = time.time() + total_timeout
+    for record, meta_path in pending:
+        job_id = record.get("wayback_job_id")
+        if not job_id:
+            continue
+        result = wayback_poll(job_id, deadline=deadline)
+        record["wayback_url"] = result.get("wayback_url")
+        record["wayback_timestamp"] = result.get("wayback_timestamp")
+        record["wayback_source"] = result.get("wayback_source")
+        if result.get("wayback_error"):
+            record["wayback_error"] = result["wayback_error"]
+        else:
+            record.pop("wayback_error", None)
+        save_json(meta_path, record)
+        wb = record.get("wayback_url") or record.get("wayback_source")
+        print(f"  {record['url']}: {wb}")
+
+
 def wayback_lookup_or_save(url: str) -> dict:
     """Get a Wayback Machine snapshot URL for `url`, saving only if needed.
 
@@ -471,16 +628,21 @@ def crawl_once(entry: dict, *, dry_run: bool,
         "scanner_score": scanner.get("total_score", 0),
     })
 
-    # Wayback snapshot — query first, save only if missing. The final_url
-    # (post-redirects) is what we want to archive, since that's the
-    # canonical address of the content we actually fetched.
+    # Wayback snapshot — final_url (post-redirects) is what we want to
+    # archive, since that's the canonical address of the content we
+    # actually fetched. With IA credentials this submits an async SPN
+    # job and returns a job_id in ~1s; status polling happens after all
+    # crawls complete. Without credentials it falls back to the slower
+    # sync availability+save path.
     if skip_wayback:
         record["wayback_source"] = "skipped"
     else:
-        wayback = wayback_lookup_or_save(final_url)
+        wayback = wayback_submit(final_url)
         record["wayback_url"] = wayback.get("wayback_url")
         record["wayback_timestamp"] = wayback.get("wayback_timestamp")
         record["wayback_source"] = wayback.get("wayback_source")
+        if wayback.get("wayback_job_id"):
+            record["wayback_job_id"] = wayback["wayback_job_id"]
         if wayback.get("wayback_error"):
             record["wayback_error"] = wayback["wayback_error"]
 
@@ -592,6 +754,18 @@ def main() -> int:
             f["error"] = rec.get("error")
             if f["attempts"] >= MAX_RETRIES_PER_URL:
                 remove_from_queue(url)
+
+    # Wayback async: submit happens inline in crawl_once and returns
+    # immediately; poll all pending jobs here at the tail of the run.
+    # All jobs are running concurrently server-side so a single shared
+    # 90s deadline polls them efficiently.
+    if not args.dry_run and not args.skip_wayback:
+        pending = []
+        for rec in results:
+            if rec.get("wayback_job_id") and not rec.get("wayback_url"):
+                meta_path = ROOT / rec["paths"]["meta"]
+                pending.append((rec, meta_path))
+        wayback_poll_pending(pending, total_timeout=90)
 
     if not args.dry_run:
         state["last_run"] = now_iso()


### PR DESCRIPTION
The cron's biggest spender was Wayback Save Page Now — fresh saves of never-archived URLs take 30-90s each, and we were blocking serially. With IA credentials we can use the async SPN API: submit returns a job_id in ~1s, status polled at the tail of the run, all jobs running concurrently server-side.

Net effect on a 3-article cron tick: ~5 min of save-blocking → ~30 seconds.

## Behavior

- **\`IA_ACCESS_KEY\` + \`IA_SECRET_KEY\` set** → async SPN with \`if_not_archived_within=86400\`. Server-side dedup eliminates the Availability-API indexing-lag false negative we hit yesterday (re-running on a URL we just saved no longer triggers a redundant save).
- **Either unset** → falls back to the existing \`wayback_lookup_or_save\` (Availability + sync-save) path. No regression for users who haven't set up IA keys.

The polling phase shares a single 90s deadline across all jobs, equivalent to parallel polling in wall-clock time without ThreadPoolExecutor complexity. Jobs that don't finish by the deadline keep \`wayback_source: \"pending\"\` + \`wayback_job_id\` in the meta sidecar so a follow-up tool can finalize them.

## README

Adds a \"Secrets\" section documenting both \`ANTHROPIC_API_KEY\` and \`IA_ACCESS_KEY\`/\`IA_SECRET_KEY\`:
- Where to get each
- Recommended workspace + spend-cap hygiene for Anthropic
- \`gh secret set\` commands
- Graceful no-op fallbacks for both

## Test plan

- [x] Syntax check + dry-run pass
- [x] Anonymous fallback path verified locally (\`_ia_keys()\` returns None)
- [ ] After merge + secrets land in repo: next cron tick should show \`wayback_source: \"saved\"\` with timestamps in the seconds (not minutes) range, and total run time should drop from ~8min → ~3min for a 3-article tick