### PR TITLE
feat(article-registry): RSS discoverer for autonomous URL seeding

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -28,7 +28,9 @@ on:
         default: 'false'
 
 concurrency:
-  group: article-registry
+  # Shared with discover-articles.yml — both push to article-registry-bot
+  # so they need to serialize to avoid force-with-lease conflicts.
+  group: article-pipeline
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/discover-articles.yml
+++ b/.github/workflows/discover-articles.yml
@@ -1,0 +1,99 @@
+name: Discover Articles via RSS
+
+# Polls RSS feeds declared in assets/sources.json (entries with a
+# `feed_url` field), filters items by ALPR/Flock keywords, and appends
+# matching URLs to the article queue. The dedup in article_queue_add.py
+# means re-running over the same feed is a no-op.
+#
+# Shares the article-registry-bot branch with the hourly crawl
+# workflow — both push to the same branch under one PR. They share a
+# concurrency group so they don't race.
+
+on:
+  schedule:
+    - cron: '37 5 * * *'   # daily at 05:37 UTC (off-peak, between cron ticks)
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Single source domain to process (default all)'
+        default: ''
+      dry_run:
+        description: 'Print would-queue without writing'
+        default: 'false'
+
+concurrency:
+  group: article-pipeline
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.REFRESH_PAT || github.token }}
+
+      - name: Set up long-lived branch
+        run: |
+          git fetch origin article-registry-bot || true
+          if git rev-parse --verify origin/article-registry-bot >/dev/null 2>&1; then
+            git checkout article-registry-bot
+            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+          else
+            git checkout -b article-registry-bot
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Discover via RSS
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.source }}" ]; then
+            ARGS="$ARGS --source ${{ inputs.source }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/discover_articles.py $ARGS
+
+      - name: Commit and push
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add assets/articles/queue.jsonl assets/articles/queue_priority.jsonl 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No new URLs discovered"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          git commit -m "chore: rss-discovered article URLs"
+          git push --force-with-lease origin article-registry-bot
+
+      - name: Create or update PR
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --head article-registry-bot --state open \
+                       --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "chore: article registry updates" \
+              --body "Automated rolling article crawl + curation + RSS discovery." \
+              --head article-registry-bot \
+              --base main
+          fi

--- a/README.md
+++ b/README.md
@@ -197,3 +197,25 @@ attribution/integrity ("zero-below saved this on date X" beats
 "anonymous"). The keys carry no payment authority, only rate limits
 and identity; if leaked the worst case is rate-limited Wayback abuse,
 not money.
+
+## Adding sources to the discoverer
+
+`scripts/discover_articles.py` polls RSS feeds declared in
+`assets/sources.json` (any source with a `feed_url` field) and
+auto-appends ALPR/Flock-related items to the queue. Runs daily via
+`.github/workflows/discover-articles.yml`. To add a new feed:
+
+1. Confirm the publisher's domain is in `sources.json` with a tier
+   and stance. Add it if not.
+2. Add `"feed_url": "https://..."` to that entry.
+3. Optionally test locally:
+   ```sh
+   uv run python scripts/discover_articles.py --source <domain> --dry-run
+   ```
+4. Commit. Next daily tick will start polling it.
+
+The keyword filter (in `discover_articles.py` → `KEYWORDS`) is
+hardcoded. Adjust it there if you want to broaden/narrow the topic
+scope. The discoverer is state-free: re-running over the same feed
+produces no new queue entries because `article_queue_add.py` dedupes
+URLs.

--- a/assets/sources.json
+++ b/assets/sources.json
@@ -6,6 +6,7 @@
     "name": "human-readable publisher name",
     "stance": "neutral | critical | supportive | industry | unknown — posture toward law-enforcement surveillance",
     "last_reviewed": "YYYY-MM-DD when tier/stance was last confirmed by a human",
+    "feed_url": "(optional) RSS/Atom feed URL — scripts/discover_articles.py polls this and auto-queues items matching ALPR keywords",
     "notes": "free-form"
   },
   "_handler_policy": {
@@ -28,13 +29,13 @@
     {"domain": "kqed.org",               "tier": 1, "name": "KQED",                        "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
     {"domain": "npr.org",                "tier": 1, "name": "NPR",                         "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
 
-    {"domain": "eff.org",                "tier": 2, "name": "Electronic Frontier Foundation", "stance": "critical", "last_reviewed": "2026-04-27", "notes": "Privacy/surveillance advocacy."},
+    {"domain": "eff.org",                "tier": 2, "name": "Electronic Frontier Foundation", "stance": "critical", "last_reviewed": "2026-04-27", "feed_url": "https://www.eff.org/rss/updates.xml", "notes": "Privacy/surveillance advocacy."},
     {"domain": "aclu.org",               "tier": 2, "name": "ACLU (national)",             "stance": "critical",   "last_reviewed": "2026-04-27", "notes": ""},
     {"domain": "aclunc.org",             "tier": 2, "name": "ACLU of Northern California",  "stance": "critical",   "last_reviewed": "2026-04-27", "notes": ""},
     {"domain": "epic.org",               "tier": 2, "name": "Electronic Privacy Information Center", "stance": "critical", "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "themarkup.org",          "tier": 2, "name": "The Markup",                  "stance": "critical",   "last_reviewed": "2026-04-27", "notes": "Accountability journalism, tech/algorithm beat."},
-    {"domain": "404media.co",            "tier": 2, "name": "404 Media",                   "stance": "critical",   "last_reviewed": "2026-04-27", "notes": "Tech/surveillance reporting; covers prompt-injection beats — scanner-flagged content may be a quoted attack, not a real one."},
-    {"domain": "propublica.org",         "tier": 2, "name": "ProPublica",                  "stance": "critical",   "last_reviewed": "2026-04-27", "notes": ""},
+    {"domain": "themarkup.org",          "tier": 2, "name": "The Markup",                  "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://themarkup.org/feeds/rss.xml", "notes": "Accountability journalism, tech/algorithm beat."},
+    {"domain": "404media.co",            "tier": 2, "name": "404 Media",                   "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://www.404media.co/rss/", "notes": "Tech/surveillance reporting; covers prompt-injection beats — scanner-flagged content may be a quoted attack, not a real one."},
+    {"domain": "propublica.org",         "tier": 2, "name": "ProPublica",                  "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://www.propublica.org/feeds/propublica/main", "notes": ""},
     {"domain": "wired.com",              "tier": 2, "name": "Wired",                       "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
     {"domain": "arstechnica.com",        "tier": 2, "name": "Ars Technica",                "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
     {"domain": "brennancenter.org",      "tier": 2, "name": "Brennan Center for Justice",  "stance": "critical",   "last_reviewed": "2026-04-27", "notes": ""},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "SMPD ALPR investigation — findings report and tooling"
 requires-python = ">=3.14"
 dependencies = [
     "anthropic>=0.97.0",
+    "feedparser>=6.0.12",
     "pillow>=12.1.1",
     "playwright>=1.52.0",
     "pymupdf>=1.27.2.2",

--- a/scripts/discover_articles.py
+++ b/scripts/discover_articles.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Discover ALPR/Flock articles via RSS and append to the queue.
+
+Iterates assets/sources.json for entries with a ``feed_url``, fetches
+each feed, filters items by ALPR/Flock-related keywords in title or
+summary, and passes matching URLs through scripts/article_queue_add.py
+(which validates the domain against the allowlist and dedupes against
+existing queue + registry entries).
+
+State-free: relies on article_queue_add's URL-level dedup. Re-running
+over the same feed produces zero new queue entries — every URL we'd
+add was already added on the previous run, so dedup short-circuits it.
+
+Usage:
+  uv run python scripts/discover_articles.py                # all feeds
+  uv run python scripts/discover_articles.py --source eff.org
+  uv run python scripts/discover_articles.py --dry-run
+  uv run python scripts/discover_articles.py --keywords kw1,kw2
+"""
+
+import argparse
+import functools
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import feedparser
+import requests
+
+print = functools.partial(print, flush=True)
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCES_PATH = ROOT / "assets" / "sources.json"
+QUEUE_ADD = ROOT / "scripts" / "article_queue_add.py"
+
+USER_AGENT = (
+    "Mozilla/5.0 (compatible; sm-alpr-research/1.0; "
+    "+https://github.com/none-below/sm-alpr)"
+)
+
+# Substrings we look for (case-insensitive) in feed-item title or
+# summary. Keep "flock" out of the bare list — it's too generic
+# (covers flocks of birds, demographic flocking, etc.). Require a
+# disambiguating second word.
+KEYWORDS = [
+    "alpr",
+    "license plate reader",
+    "license-plate reader",
+    "license plate recognition",
+    "license-plate recognition",
+    "license plate camera",
+    "license-plate camera",
+    "automated license plate",
+    "flock safety",
+    "flock camera",
+    "flock contract",
+    "flock alpr",
+    "flock surveillance",
+    "vigilant solutions",
+    "axon alpr",
+]
+
+
+def matches_keywords(text: str, kws: list[str]) -> str | None:
+    """Return the first matching keyword (lowercased), or None."""
+    if not text:
+        return None
+    low = text.lower()
+    for kw in kws:
+        if kw in low:
+            return kw
+    return None
+
+
+def fetch_feed(url: str) -> tuple[list, str | None]:
+    """Fetch + parse a feed. Returns (entries, error_or_None)."""
+    try:
+        resp = requests.get(url,
+                            headers={"User-Agent": USER_AGENT},
+                            timeout=30)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        return [], f"{type(e).__name__}: {e}"
+    parsed = feedparser.parse(resp.content)
+    # feedparser sets bozo=1 for any quirk including non-fatal ones
+    # (e.g. unknown XML namespaces). Only treat it as an error when
+    # we got zero entries — otherwise the parse is usable.
+    if parsed.bozo and not parsed.entries:
+        return [], f"bozo parse: {parsed.bozo_exception}"
+    return parsed.entries, None
+
+
+def queue_add_batch(urls: list[str], *, discovered_by: str,
+                    dry_run: bool) -> tuple[int, str]:
+    """Run article_queue_add.py with the given URLs. Returns (rc, output)."""
+    if dry_run or not urls:
+        for u in urls:
+            print(f"  [dry-run] would queue: {u}")
+        return 0, ""
+    cmd = [sys.executable, str(QUEUE_ADD),
+           "--discovered-by", discovered_by, *urls]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.stdout.strip():
+        print(f"  {result.stdout.strip()}")
+    if result.stderr.strip():
+        # queue_add prints REJECT lines and friendly errors to stderr;
+        # echo them so the workflow log captures them.
+        print(result.stderr.strip(), file=sys.stderr)
+    return result.returncode, result.stdout
+
+
+def process_source(source: dict, *, kws: list[str],
+                   dry_run: bool) -> dict:
+    """Process one source's feed. Returns stats dict."""
+    domain = source["domain"]
+    feed_url = source.get("feed_url")
+    stats = {
+        "domain": domain, "items": 0, "matched": 0,
+        "appended": 0, "duplicate": 0, "error": None,
+    }
+    if not feed_url:
+        stats["error"] = "no feed_url"
+        return stats
+
+    print(f"\n=== {domain}  feed: {feed_url}")
+    entries, err = fetch_feed(feed_url)
+    if err:
+        stats["error"] = err
+        print(f"  ERROR: {err}")
+        return stats
+
+    stats["items"] = len(entries)
+    matches: list[tuple[str, str]] = []
+    for entry in entries:
+        url = entry.get("link")
+        if not url:
+            continue
+        title = entry.get("title") or ""
+        summary = entry.get("summary") or ""
+        kw = matches_keywords(f"{title}\n{summary}", kws)
+        if kw:
+            matches.append((url, kw))
+    stats["matched"] = len(matches)
+    if not matches:
+        print(f"  {len(entries)} items, 0 matched")
+        return stats
+
+    print(f"  {len(entries)} items, {len(matches)} matched:")
+    for url, kw in matches:
+        print(f"    [{kw}]  {url}")
+
+    discovered_by = f"rss:{domain}"
+    _, qa_out = queue_add_batch(
+        [u for u, _ in matches],
+        discovered_by=discovered_by,
+        dry_run=dry_run,
+    )
+    # article_queue_add prints "appended=N duplicate=M rejected=K -> ..."
+    # We parse that line for stats; failures or malformed output just
+    # leave the counters at 0.
+    for line in qa_out.splitlines():
+        line = line.strip()
+        if line.startswith("appended="):
+            for token in line.split():
+                k, _, v = token.partition("=")
+                if v.isdigit() and k in stats:
+                    stats[k] = int(v)
+            break
+    return stats
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--source", default=None,
+                   help="process only this source domain (default: all)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="show would-queue without writing")
+    p.add_argument("--keywords", default=None,
+                   help="comma-separated keyword list "
+                        "(default: built-in ALPR/Flock set)")
+    args = p.parse_args()
+
+    kws = ([k.strip().lower() for k in args.keywords.split(",") if k.strip()]
+           if args.keywords else KEYWORDS)
+
+    sources = json.loads(SOURCES_PATH.read_text()).get("sources", [])
+    if args.source:
+        match = args.source.lower()
+        sources = [s for s in sources if s["domain"].lower() == match]
+        if not sources:
+            print(f"no source named {args.source!r}", file=sys.stderr)
+            return 1
+
+    all_stats = []
+    for source in sources:
+        if not source.get("feed_url"):
+            continue
+        stats = process_source(source, kws=kws, dry_run=args.dry_run)
+        all_stats.append(stats)
+
+    print("\n=== summary ===")
+    print(f"feeds processed:    {len(all_stats)}")
+    total_items = sum(s["items"] for s in all_stats)
+    total_matched = sum(s["matched"] for s in all_stats)
+    total_appended = sum(s["appended"] for s in all_stats)
+    total_duplicate = sum(s["duplicate"] for s in all_stats)
+    print(f"feed items scanned: {total_items}")
+    print(f"keyword matched:    {total_matched}")
+    print(f"newly queued:       {total_appended}")
+    print(f"already queued:     {total_duplicate}")
+    errs = [s for s in all_stats if s["error"]]
+    if errs:
+        print(f"feeds with errors:  {len(errs)}")
+        for s in errs:
+            print(f"  {s['domain']}: {s['error']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,18 @@ wheels = [
 ]
 
 [[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -455,11 +467,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
 name = "sm-alpr"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "feedparser" },
     { name = "pillow" },
     { name = "playwright" },
     { name = "pymupdf" },
@@ -476,6 +495,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.97.0" },
+    { name = "feedparser", specifier = ">=6.0.12" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "playwright", specifier = ">=1.52.0" },
     { name = "pymupdf", specifier = ">=1.27.2.2" },


### PR DESCRIPTION
Eliminates the manual \"ask Claude to find more articles\" step in the maintenance loop. The hourly crawler still drains the queue; now a daily discoverer keeps the queue fed from trusted RSS feeds.

## How it works

- **\`scripts/discover_articles.py\`** iterates \`assets/sources.json\` for entries with a \`feed_url\` field, fetches each feed, filters items by ALPR/Flock keywords in title/summary, and pipes matching URLs through \`article_queue_add.py\`. Existing URL-level dedup means re-running over the same feed is a no-op — script is state-free.
- **\`.github/workflows/discover-articles.yml\`** runs daily at 05:37 UTC (off-peak between hourly crawl ticks).
- **Shared concurrency group** (\`article-pipeline\`) with the crawl workflow so both can push to \`article-registry-bot\` branch without racing on force-with-lease.
- **Same long-lived PR** — discoveries land alongside crawl/curation updates, not in a separate stream.

## Initial feeds (4 confident, more can be added)

| Source | Feed URL |
|---|---|
| eff.org | https://www.eff.org/rss/updates.xml |
| themarkup.org | https://themarkup.org/feeds/rss.xml |
| 404media.co | https://www.404media.co/rss/ |
| propublica.org | https://www.propublica.org/feeds/propublica/main |

## Local smoke test (against these 4 feeds)

- 105 feed items scanned
- **5 matches found**, all real ALPR pieces:
  - EFF (4): \"open records laws reveal ALPRs sprawling surveillance\" (April 2026), \"updated guide to tech at the US-Mexico border\", \"selling mass surveillance EFFector 387\", \"print blocking won't work\" (cross-references ALPR work)
  - The Markup (1): \"He saw an abandoned trailer, then he uncovered a surveillance network on California's border\" (March 2026 investigation)
- Re-run shows 0 newly queued + 5 already queued — dedup works.

## README

Adds an \"Adding sources to the discoverer\" section: 2-line steps to onboard a new feed (declare \`feed_url\`, commit). Keyword filter is in \`KEYWORDS\` constant in the script — adjust there if you want to broaden/narrow scope.

## Out of scope (follow-ups)

- ACLU / EPIC / KQED feeds — they exist but I haven't verified URLs/format. Easy to add later via 1-line edit.
- NPR per-topic feeds — would need a more topic-specific feed than their main one to avoid swamping the keyword filter.
- Per-feed last-checked state — current design is state-free; if feed-fetch becomes expensive we can add it. Not needed now.

## Test plan

- [x] Local smoke test on 4 feeds — works
- [x] Dedup verified on second run
- [ ] First scheduled run after merge produces a small PR with 5 newly-discovered URLs (already verified locally; CI behavior should match)