### PR TITLE
chore(article-registry): stop auto-resetting bot branch on rebase conflict

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -53,7 +53,18 @@ jobs:
           git fetch origin article-registry-bot || true
           if git rev-parse --verify origin/article-registry-bot >/dev/null 2>&1; then
             git checkout article-registry-bot
-            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+            # NOTE: previously this fell back to `git reset --hard origin/main`
+            # on rebase failure. That destroyed accumulated bot work
+            # (curated articles, scanner state) when a queue.jsonl conflict
+            # surfaced — we recovered once via cherry-pick from local
+            # reflog but it was a real save. Now: abort the rebase, leave
+            # the bot branch untouched, and fail this run loudly. A human
+            # resolves and force-pushes.
+            git rebase origin/main || {
+              git rebase --abort
+              echo "::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually. NOT auto-resetting (would destroy unmerged work)."
+              exit 1
+            }
           else
             git checkout -b article-registry-bot
           fi

--- a/.github/workflows/discover-articles.yml
+++ b/.github/workflows/discover-articles.yml
@@ -43,7 +43,13 @@ jobs:
           git fetch origin article-registry-bot || true
           if git rev-parse --verify origin/article-registry-bot >/dev/null 2>&1; then
             git checkout article-registry-bot
-            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+            # See article-registry.yml for context — never auto-reset to
+            # main on rebase failure (it destroys accumulated bot work).
+            git rebase origin/main || {
+              git rebase --abort
+              echo "::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually. NOT auto-resetting (would destroy unmerged work)."
+              exit 1
+            }
           else
             git checkout -b article-registry-bot
           fi


### PR DESCRIPTION
The fallback in both bot workflows that ate PR #185's curated work earlier today.

## The bug

Both \`article-registry.yml\` and \`discover-articles.yml\` had this on the long-lived \`article-registry-bot\` branch setup:

\`\`\`bash
git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
\`\`\`

When a \`queue.jsonl\` rebase conflict surfaced (main had PR #192's seed additions, bot had its own removed-processed-URLs state), the rebase failed → \`reset --hard origin/main\` → every commit on the bot branch (3 enriched articles + HTML/txt/PDF/meta sidecars + OCR sidecars) was discarded.

We recovered via cherry-pick from local reflog (rescue is at \`7641214 → 929ff06\`, now part of merged #185), but a fresh clone would have missed the recovery window entirely.

## The fix

On rebase conflict: abort, leave the bot branch untouched, log a \`::error::\` annotation, exit 1.

\`\`\`bash
git rebase origin/main || {
  git rebase --abort
  echo \"::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually. NOT auto-resetting (would destroy unmerged work).\"
  exit 1
}
\`\`\`

The run fails loud. A human investigates. Next cron tick will try again once main has settled (or the human force-pushes a manual resolution).

## Followup that prevents conflicts at the source

PR coming next: migrate \`queue.jsonl\` to \`assets/articles/queue/<urlhash>.json\` per-URL files. Different URLs become different files — concurrent add+remove on different URLs commute trivially, and there's no shared mutable file to merge in the first place. That eliminates the entire conflict class that exercised this fallback.

## Test plan

- [ ] Workflow YAML lints OK (no syntax errors)
- [ ] Next cron tick proceeds normally if no conflict
- [ ] If a synthetic conflict is introduced (e.g., manual edit to bot branch), workflow fails loudly with the annotation rather than silently destroying state