### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -224,8 +224,9 @@
     "2c981ce6-8d54-565f-bb99-ac885eee8769": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T04:55:27.263052+00:00",
+      "last_probed": "2026-05-04T23:38:28.785278+00:00",
       "tried": {
+        "orange-county-ca-sd": "http_404",
         "orange-county-ca-so": "http_404"
       }
     },
@@ -323,10 +324,11 @@
     "46022a7f-7efe-5f30-9695-ef9a6c9f2093": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T17:26:14.957962+00:00",
+      "last_probed": "2026-05-04T23:38:18.044868+00:00",
       "tried": {
         "cal-state-fullerton-ca-pd": "http_404",
-        "cal-state-fullerton-ca-po": "http_404"
+        "cal-state-fullerton-ca-po": "http_404",
+        "cal-state-fullerton-pd-ca": "http_404"
       }
     },
     "47a01976-2030-52f3-9c3f-3347ce75fcf7": {
@@ -615,9 +617,10 @@
     "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T16:24:13.173974+00:00",
+      "last_probed": "2026-05-04T23:38:22.219801+00:00",
       "tried": {
-        "colton-ca-po": "http_404"
+        "colton-ca-po": "http_404",
+        "colton-ca-police-department": "http_404"
       }
     },
     "7f21a88e-2c0f-53d5-b5e3-22920a3f9872": {
@@ -1172,6 +1175,6 @@
       }
     }
   },
-  "updated": "2026-05-04T20:52:34.563957+00:00",
+  "updated": "2026-05-04T23:38:28.818835+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.