### PR TITLE
fix(geocode): geocode 72 of 79 missing recipients (#187)

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -5249,8 +5249,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "manual",
+      "name": "Gallatin",
+      "state": "TN",
+      "lat": 36.388,
+      "lng": -86.45
     }
   },
   {
@@ -5624,8 +5627,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0176920",
+      "name": "Troy",
+      "state": "AL",
+      "lat": 31.80196,
+      "lng": -85.96713
     }
   },
   {
@@ -5646,7 +5653,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "01",
+      "name": "AL",
+      "state": "AL",
+      "lat": 32.87862476119403,
+      "lng": -86.71127807462686
+    }
   },
   {
     "agency_id": "c753700e-a641-5f4b-a85c-14b657a14822",
@@ -5686,7 +5700,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "01",
+      "name": "AL",
+      "state": "AL",
+      "lat": 32.87862476119403,
+      "lng": -86.71127807462686
+    }
   },
   {
     "agency_id": "f7fe56f7-35f0-5f78-b2f2-f1be22a499ca",
@@ -7024,8 +7045,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "Dallas",
+      "state": "TX",
+      "lat": 32.7767,
+      "lng": -96.797
     }
   },
   {
@@ -8717,8 +8741,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "48055",
+      "name": "Caldwell",
+      "state": "TX",
+      "lat": 29.832399,
+      "lng": -97.628141
     }
   },
   {
@@ -8848,8 +8876,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "48061",
+      "name": "Cameron",
+      "state": "TX",
+      "lat": 26.102923,
+      "lng": -97.478958
     }
   },
   {
@@ -9438,8 +9470,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4814236",
+      "name": "Channelview",
+      "state": "TX",
+      "lat": 29.793023,
+      "lng": -95.114482
     }
   },
   {
@@ -9487,7 +9523,13 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Savannah",
+      "state": "GA",
+      "lat": 32.0809,
+      "lng": -81.0912
+    }
   },
   {
     "agency_id": "66759895-2063-5986-b922-e5dc19e8e7f3",
@@ -11429,7 +11471,13 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Jacksonville",
+      "state": "FL",
+      "lat": 30.3322,
+      "lng": -81.6557
+    }
   },
   {
     "agency_id": "dcda0db4-01d6-564b-9a43-d5742ca810a4",
@@ -12206,8 +12254,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "state",
+      "fips": "13",
+      "name": "GA",
+      "state": "GA",
+      "lat": 32.806825578616355,
+      "lng": -83.57673413207547
     }
   },
   {
@@ -13171,8 +13223,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     }
   },
   {
@@ -13812,8 +13868,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "FL"
+      "kind": "place",
+      "fips": "1270600",
+      "name": "Tallahassee",
+      "state": "FL",
+      "lat": 30.453529,
+      "lng": -84.252272
     }
   },
   {
@@ -14454,8 +14514,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1316544",
+      "name": "Clarkston",
+      "state": "GA",
+      "lat": 33.813489,
+      "lng": -84.24185
     }
   },
   {
@@ -14848,8 +14912,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "state",
+      "fips": "13",
+      "name": "GA",
+      "state": "GA",
+      "lat": 32.806825578616355,
+      "lng": -83.57673413207547
     }
   },
   {
@@ -14871,7 +14939,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1302116",
+      "name": "Americus",
+      "state": "GA",
+      "lat": 32.074377,
+      "lng": -84.222829
+    }
   },
   {
     "agency_id": "68a8472b-1087-500e-b140-f02bb713e9db",
@@ -15669,7 +15744,13 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Gwinnett County",
+      "state": "GA",
+      "lat": 33.9588,
+      "lng": -84.0257
+    }
   },
   {
     "agency_id": "78f990ee-458f-59ec-80e8-a8594f7e1f5d",
@@ -17150,8 +17231,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4835348",
+      "name": "Humble",
+      "state": "TX",
+      "lat": 29.988207,
+      "lng": -95.264356
     }
   },
   {
@@ -17254,8 +17339,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0137000",
+      "name": "Huntsville",
+      "state": "AL",
+      "lat": 34.69772,
+      "lng": -86.67667
     }
   },
   {
@@ -17490,8 +17579,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1836003",
+      "name": "Indianapolis city (balance)",
+      "state": "IN",
+      "lat": 39.776664,
+      "lng": -86.145935
     }
   },
   {
@@ -18026,8 +18119,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4837528",
+      "name": "Jefferson",
+      "state": "TX",
+      "lat": 32.763494,
+      "lng": -94.350835
     }
   },
   {
@@ -18509,8 +18606,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "state",
+      "fips": "21",
+      "name": "KY",
+      "state": "KY",
+      "lat": 37.621722758333334,
+      "lng": -85.20171535833333
     }
   },
   {
@@ -19262,8 +19363,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2143606",
+      "name": "Lakeside Park",
+      "state": "KY",
+      "lat": 39.034204,
+      "lng": -84.566756
     }
   },
   {
@@ -20338,7 +20443,13 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Louisville",
+      "state": "KY",
+      "lat": 38.1744,
+      "lng": -85.7361
+    }
   },
   {
     "agency_id": "50e878f4-8291-5142-a155-917a6bdc4735",
@@ -21275,8 +21386,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     }
   },
   {
@@ -21783,7 +21898,13 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.0424,
+      "lng": -89.9767
+    }
   },
   {
     "agency_id": "aeaf8d78-4c84-582f-8f67-faac9c5e7e81",
@@ -21858,8 +21979,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "Dallas",
+      "state": "TX",
+      "lat": 32.7457,
+      "lng": -96.8285
     }
   },
   {
@@ -21962,8 +22086,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MA"
+      "kind": "cousub",
+      "fips": "2502340850",
+      "name": "Middleborough",
+      "state": "MA",
+      "lat": 41.878004,
+      "lng": -70.869267
     }
   },
   {
@@ -22040,8 +22168,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4879000",
+      "name": "Wichita Falls",
+      "state": "TX",
+      "lat": 33.906654,
+      "lng": -98.525848
     }
   },
   {
@@ -22198,8 +22330,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "name": "Park Hills",
+      "state": "MO",
+      "lat": 37.8553,
+      "lng": -90.5178
     }
   },
   {
@@ -22923,8 +23058,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4849860",
+      "name": "Mount Vernon",
+      "state": "TX",
+      "lat": 33.177431,
+      "lng": -95.224447
     }
   },
   {
@@ -23055,8 +23194,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MS"
+      "kind": "place",
+      "fips": "2826300",
+      "name": "Fulton",
+      "state": "MS",
+      "lat": 34.26288,
+      "lng": -88.401928
     }
   },
   {
@@ -24154,8 +24297,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AR"
+      "kind": "manual",
+      "name": "Bentonville",
+      "state": "AR",
+      "lat": 36.2819,
+      "lng": -94.3068
     }
   },
   {
@@ -24363,8 +24509,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OK"
+      "kind": "place",
+      "fips": "4055000",
+      "name": "Oklahoma City",
+      "state": "OK",
+      "lat": 35.467079,
+      "lng": -97.513657
     }
   },
   {
@@ -24547,7 +24697,13 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "New Orleans",
+      "state": "LA",
+      "lat": 29.9511,
+      "lng": -90.0715
+    }
   },
   {
     "agency_id": "f56dc26a-2ad7-5d6b-98f8-c79ff5c1c00f",
@@ -24811,8 +24967,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "name": "Springfield",
+      "state": "MO",
+      "lat": 37.209,
+      "lng": -93.2923
     }
   },
   {
@@ -25289,7 +25448,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "42",
+      "name": "PA",
+      "state": "PA",
+      "lat": 40.82024428358209,
+      "lng": -77.61764129850746
+    }
   },
   {
     "agency_id": "788afc52-2447-543d-8af5-8a8d199ecb79",
@@ -25796,8 +25962,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "LA"
+      "kind": "manual",
+      "name": "Port Fourchon",
+      "state": "LA",
+      "lat": 29.1067,
+      "lng": -90.1928
     }
   },
   {
@@ -26379,8 +26548,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "48389",
+      "name": "Reeves",
+      "state": "TX",
+      "lat": 31.308366,
+      "lng": -103.712706
     }
   },
   {
@@ -26993,8 +27166,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "48401",
+      "name": "Rusk",
+      "state": "TX",
+      "lat": 32.109423,
+      "lng": -94.756382
     }
   },
   {
@@ -27178,8 +27355,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4864268",
+      "name": "Salado",
+      "state": "TX",
+      "lat": 30.948383,
+      "lng": -97.528337
     }
   },
   {
@@ -27768,8 +27949,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "name": "Cape Girardeau",
+      "state": "MO",
+      "lat": 37.3059,
+      "lng": -89.5181
     }
   },
   {
@@ -28303,7 +28487,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "state",
+      "fips": "45",
+      "name": "SC",
+      "state": "SC",
+      "lat": 33.955212413043476,
+      "lng": -80.98040915217392
+    }
   },
   {
     "agency_id": "13052a9b-73e7-54ac-8289-6818f7a23de0",
@@ -28324,8 +28515,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "name": "Houston",
+      "state": "MO",
+      "lat": 37.3239,
+      "lng": -91.9557
     }
   },
   {
@@ -28402,8 +28596,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1711163",
+      "name": "Carbondale",
+      "state": "IL",
+      "lat": 37.722062,
+      "lng": -89.223664
     }
   },
   {
@@ -28425,8 +28623,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "manual",
+      "name": "Shrewsbury",
+      "state": "PA",
+      "lat": 39.7666,
+      "lng": -76.6797
     }
   },
   {
@@ -29957,8 +30158,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "manual",
+      "name": "Nashville",
+      "state": "TN",
+      "lat": 36.1627,
+      "lng": -86.7816
     }
   },
   {
@@ -30360,7 +30564,13 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "manual",
+      "name": "Tupelo",
+      "state": "MS",
+      "lat": 34.2581,
+      "lng": -88.7037
+    }
   },
   {
     "agency_id": "e2450821-909e-5413-badb-4736e9ce1c21",
@@ -30760,8 +30970,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4859336",
+      "name": "Prairie View",
+      "state": "TX",
+      "lat": 30.082855,
+      "lng": -95.977134
     }
   },
   {
@@ -30996,8 +31210,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MS"
+      "kind": "place",
+      "fips": "2836000",
+      "name": "Jackson",
+      "state": "MS",
+      "lat": 32.315834,
+      "lng": -90.21285
     }
   },
   {
@@ -31019,8 +31237,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3702140",
+      "name": "Asheville",
+      "state": "NC",
+      "lat": 35.570972,
+      "lng": -82.552725
     }
   },
   {
@@ -31177,7 +31399,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "0515190",
+      "name": "Conway",
+      "state": "AR",
+      "lat": 35.074404,
+      "lng": -92.467004
+    }
   },
   {
     "agency_id": "8a47e530-cd76-5c46-b3c4-2a07f5848257",
@@ -31199,8 +31428,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1303440",
+      "name": "Athens-Clarke County unified government (balance)",
+      "state": "GA",
+      "lat": 33.949597,
+      "lng": -83.370088
     }
   },
   {
@@ -31222,7 +31455,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "2146027",
+      "name": "Lexington-Fayette",
+      "state": "KY",
+      "lat": 38.040678,
+      "lng": -84.458272
+    }
   },
   {
     "agency_id": "6697078b-2e09-5c91-947e-2085bab28fcb",
@@ -31272,8 +31512,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2148000",
+      "name": "Louisville",
+      "state": "KY",
+      "lat": 38.224728,
+      "lng": -85.740614
     }
   },
   {
@@ -31296,8 +31540,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4748000",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.109026,
+      "lng": -89.967455
     }
   },
   {
@@ -31320,8 +31568,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1321240",
+      "name": "Dahlonega",
+      "state": "GA",
+      "lat": 34.529909,
+      "lng": -83.979579
     }
   },
   {
@@ -31344,8 +31596,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "FL"
+      "kind": "place",
+      "fips": "1271000",
+      "name": "Tampa",
+      "state": "FL",
+      "lat": 27.966262,
+      "lng": -82.477618
     }
   },
   {
@@ -31368,8 +31624,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4748000",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.109026,
+      "lng": -89.967455
     }
   },
   {
@@ -31392,8 +31652,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4740000",
+      "name": "Knoxville",
+      "state": "TN",
+      "lat": 35.97068,
+      "lng": -83.94927
     }
   },
   {
@@ -31444,8 +31708,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1313492",
+      "name": "Carrollton",
+      "state": "GA",
+      "lat": 33.58169,
+      "lng": -85.083983
     }
   },
   {
@@ -31765,8 +32033,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4750280",
+      "name": "Morristown",
+      "state": "TN",
+      "lat": 36.204351,
+      "lng": -83.300032
     }
   },
   {
@@ -32788,8 +33060,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KS"
+      "kind": "place",
+      "fips": "2079000",
+      "name": "Wichita",
+      "state": "KS",
+      "lat": 37.690638,
+      "lng": -97.345836
     }
   },
   {
@@ -33108,8 +33384,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OK"
+      "kind": "place",
+      "fips": "4082250",
+      "name": "Wyandotte",
+      "state": "OK",
+      "lat": 36.807143,
+      "lng": -94.729305
     }
   },
   {
@@ -33185,8 +33465,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AR"
+      "kind": "place",
+      "fips": "0577090",
+      "name": "Wynne",
+      "state": "AR",
+      "lat": 35.235224,
+      "lng": -90.788513
     }
   },
   {
@@ -33397,8 +33681,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WA"
+      "kind": "manual",
+      "name": "Oakville",
+      "state": "WA",
+      "lat": 46.8482,
+      "lng": -123.2293
     }
   },
   {
@@ -33528,8 +33815,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WA"
+      "kind": "manual",
+      "name": "Longview",
+      "state": "WA",
+      "lat": 46.1382,
+      "lng": -122.9382
     }
   },
   {
@@ -34546,8 +34836,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WA"
+      "kind": "place",
+      "fips": "5363000",
+      "name": "Seattle",
+      "state": "WA",
+      "lat": 47.619335,
+      "lng": -122.351538
     }
   },
   {
@@ -34813,8 +35107,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WA"
+      "kind": "manual",
+      "name": "Wellpinit",
+      "state": "WA",
+      "lat": 47.8907,
+      "lng": -118.0651
     }
   },
   {
@@ -56575,8 +56872,11 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "Cypress",
+      "state": "TX",
+      "lat": 29.9691,
+      "lng": -95.6972
     },
     "flags": []
   },
@@ -57691,8 +57991,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4827996",
+      "name": "Galena Park",
+      "state": "TX",
+      "lat": 29.745165,
+      "lng": -95.234576
     },
     "flags": []
   },
@@ -58950,8 +59254,11 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "Huffman",
+      "state": "TX",
+      "lat": 30.0152,
+      "lng": -95.0919
     },
     "flags": []
   },
@@ -61360,7 +61667,14 @@
       "needs-review",
       "public"
     ],
-    "flags": []
+    "flags": [],
+    "geo": {
+      "kind": "manual",
+      "name": "Conroe",
+      "state": "TX",
+      "lat": 30.3119,
+      "lng": -95.4561
+    }
   },
   {
     "agency_id": "94ed3310-f64b-55ec-992a-27ad35538944",

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -56,8 +56,19 @@ _AGENCY_SUFFIXES = re.compile(
     r"Department of Public Safety|Public Safety Dept\.?|"
     r"Dept\.? of Pub(?:lic)? Safety|"
     r"Public Safety|Parks Department|Marshal'?s? Office|"
-    r"Junior College|Community College)\b\s*",
+    r"Constable|"
+    r"Independent School District|"
+    r"ISD|School District(?:\s+\d+)?|"
+    r"International Airport|Regional Airport|Intl Airport|Airport|"
+    r"Campus)\b\s*",
     re.IGNORECASE,
+)
+
+# Trailing decorative tags left after suffix stripping. "Inactive" tags
+# deactivated agencies; "Insight" is a Flock product label appended to
+# some customer names ("Troy University - Insight").
+_TRAILING_DECORATIVE = re.compile(
+    r"\s+(Inactive|Insight|Decommissioned)\s*$", re.IGNORECASE,
 )
 
 # Lone trailing "Dept" / "Department" left over after _AGENCY_SUFFIXES has
@@ -84,20 +95,25 @@ _MOUNT_VARIANTS = re.compile(r"\bMt\.\s+", re.IGNORECASE)  # "Mt. Zion" → "Mou
 
 # State-level agency patterns (state police, highway patrol, DMV, etc.)
 _STATE_AGENCY_PATTERN = re.compile(
-    r"\b(State Patrol|State Police|Highway Patrol|Department of Public Safety|"
-    r"Department of Motor Vehicles|State Highway Patrol|"
-    r"Department of Conservation|Crime Analysis Center|"
-    r"Department of Corrections|Bureau of Investigation|"
+    r"\b(State Patrol|State Police|State\s+(?:[A-Z]{2}\s+)?PD|Highway Patrol|"
+    r"Department of Public Safety|Department of Motor Vehicles|"
+    r"State Highway Patrol|Department of Conservation|"
+    r"Crime Analysis Center|"
+    r"(?:Department|Dept\.?) of Corrections|"
+    r"(?:Department|Dept\.?) of Revenue|"
+    r"(?:Department|Dept\.?) of Natural Resources|"
+    r"Bureau of Investigation|"
     r"Information Analysis Center|"
     r"Financial Crimes Intelligence Center|"
     r"Division of Criminal Investigation|"
+    r"Law Enforcement Agency|Law Enforcement Division|"
     r"Attorney General)\b",
     re.IGNORECASE,
 )
 # State-level agency abbreviations. "X Bureau of Investigation" is often
 # carried in the registry only as the abbreviation (KBI, GBI, etc.).
 _STATE_AGENCY_ABBREV = re.compile(
-    r"\b(KBI|FDLE|TBI|GBI|SBI|CBI|BCI|MIAC)\b"
+    r"\b(KBI|FDLE|TBI|GBI|SBI|CBI|BCI|MIAC|ALEA|SLED)\b"
 )
 
 # State names to USPS codes (for "Colorado State Patrol" etc.)
@@ -155,9 +171,57 @@ CITY_ALIASES = {
 # State-aware aliases. Disambiguates names that need different remappings
 # depending on the state (e.g. "Lexington" exists in many states but only
 # the KY one is the consolidated "Lexington-Fayette" gov).
+#
+# University-campus entries map a normalized university token to the
+# city where the main campus sits — extract_place_candidate runs the
+# alias *after* role/state stripping, so the bare institution name is
+# what matches here.
 STATE_CITY_ALIASES = {
     ("Lexington", "KY"): "Lexington-Fayette",
     ("Metropolitan Washington", "DC"): "Washington",
+
+    # Consolidated city-county Census names that don't accept the bare
+    # form on lookup.
+    ("Indianapolis", "IN"): "Indianapolis city (balance)",
+    ("Athens", "GA"): "Athens-Clarke County unified government (balance)",
+
+    # University / college campuses (single-campus institutions whose
+    # name doesn't contain the campus city). Targets are Census place
+    # names, except where noted as a county subdivision (cousub) — those
+    # rely on the cousub fallback in geocode_entry.
+    ("University of Georgia", "GA"): "Athens-Clarke County unified government (balance)",
+    ("University of Kentucky", "KY"): "Lexington-Fayette",
+    ("University of Louisville", "KY"): "Louisville",
+    ("University of Memphis", "TN"): "Memphis",
+    ("University of Tennessee", "TN"): "Knoxville",
+    ("University of Tennessee Health Science Center Memphis", "TN"): "Memphis",
+    ("University of South Florida", "FL"): "Tampa",
+    ("University of West Georgia", "GA"): "Carrollton",
+    ("University of North Georgia", "GA"): "Dahlonega",
+    ("University of Central Arkansas", "AR"): "Conway",
+    ("University of Oklahoma Health Science Center", "OK"): "Oklahoma City",
+    ("Emory University", "GA"): "Atlanta",
+    ("Florida State University", "FL"): "Tallahassee",
+    ("Wichita State University", "KS"): "Wichita",
+    ("Midwestern State University", "TX"): "Wichita Falls",
+    ("Southern Illinois University", "IL"): "Carbondale",
+    ("Georgia Southwestern State University", "GA"): "Americus",
+    ("Georgia Piedmont Technical College", "GA"): "Clarkston",
+    ("Itawamba Community College", "MS"): "Fulton",
+    ("Walters State Community College", "TN"): "Morristown",
+    ("Prairie View A & M University", "TX"): "Prairie View",
+    ("Troy University", "AL"): "Troy",
+    ("UNC Asheville", "NC"): "Asheville",
+    # UMMC normalize_agency_name strips parens, leaving "UMMC MS PD" — so
+    # the candidate after suffix-strip is "UMMC".
+    ("UMMC", "MS"): "Jackson",
+
+    # Multi-city / colloquial city names.
+    ("Lakeside Park-Crestview Hills", "KY"): "Lakeside Park",  # adjacent KY cities; pick larger
+    ("Middleboro", "MA"): "Middleborough",  # cousub; falls through to lookup_cousub
+    ("Marta", "GA"): "Atlanta",  # MARTA is the Atlanta transit authority
+    ("Wyandotte Nation", "OK"): "Wyandotte",
+    ("Port of Seattle", "WA"): "Seattle",
 }
 
 
@@ -178,6 +242,9 @@ def extract_place_candidate(agency_name, state=None):
     name = normalize_agency_name(agency_name)
     # Strip agency-role suffixes (PD, SO, DPS, etc.)
     name = _AGENCY_SUFFIXES.sub(" ", name)
+    # Strip trailing decorative tags ("Inactive", "Insight") so they
+    # don't bleed into the place candidate.
+    name = _TRAILING_DECORATIVE.sub("", name)
     # Strip state codes (now standalone)
     name = _STATE_TOKEN.sub(" ", name)
     # Strip "City of" / "Town of" prefix
@@ -188,6 +255,9 @@ def extract_place_candidate(agency_name, state=None):
     # phrases like "X Public Safety Dept" where _AGENCY_SUFFIXES took the
     # contextual part but left the standalone word.
     name = _TRAILING_DEPT.sub("", name).strip()
+    # Re-strip in case the candidate ends with a decorative tag that was
+    # only exposed after the agency suffix came off.
+    name = _TRAILING_DECORATIVE.sub("", name).strip()
     # Strip dashes that have whitespace on at least one side, or that hang
     # off the start/end of the string. These are artifacts from messy names
     # like "Windsor- IL- PD" or "X - " separators left after suffix stripping.
@@ -266,6 +336,26 @@ def is_state_level_agency(name):
     return bool(_STATE_AGENCY_PATTERN.search(name)) or bool(_STATE_AGENCY_ABBREV.search(name))
 
 
+# Match "<Word> CO <STATE>" where CO is the County abbreviation and the
+# trailing 2-letter token is the actual state. Some registry rows
+# ("Caldwell CO TX SO", "Reeves CO TX SO") have this shape and ended up
+# stored with state="CO" because the slug parser took CO as Colorado.
+# Used to override the entry's state during geocoding.
+_CO_COUNTY_STATE = re.compile(r"\b[A-Z][\w]+\s+CO\s+([A-Z]{2})\b")
+
+
+def detect_county_co_state(name):
+    """If name has 'X CO YY' pattern (CO=County), return YY.
+    Returns None when no match, or when YY is itself 'CO'."""
+    m = _CO_COUNTY_STATE.search(name)
+    if not m:
+        return None
+    code = m.group(1)
+    if code == "CO":
+        return None
+    return code
+
+
 def infer_state_from_name(name):
     """Extract state USPS code from a name like 'Colorado State Patrol' or 'NYS ...'."""
     for word, usps in _STATE_NAMES.items():
@@ -310,14 +400,167 @@ def extract_county_candidate(agency_name):
     return name
 
 
+# Hand-curated geo blocks for entries that the Census-based geocoder
+# can't reasonably resolve (tribal HQs, regional drug task forces,
+# private hospital systems, airports without an inferable state, TX
+# CDPs the Census places gazetteer doesn't index, etc.). Keyed by
+# agency_id; the geocoder applies these before falling back to the
+# Census pipeline. Entries whose location can't be confidently pinned
+# down (e.g. "OK - 477", "Elm Ridge TX PD", multi-county precincts
+# without a county hint) are deliberately omitted — they stay flagged
+# in the CI recipient-coords check until someone narrows them down.
+MANUAL_OVERRIDES = {
+    # 18th Judicial District DTF — Sumner County, TN; based in Gallatin.
+    "c9811955-3e45-5ff9-bd62-25a4f54afa6a": {
+        "kind": "manual", "name": "Gallatin", "state": "TN",
+        "lat": 36.388, "lng": -86.450,
+    },
+    # Baylor Scott & White Health PD — Dallas-Fort Worth HQ.
+    "bc36858b-ad3b-59d8-84ec-719a6c34de87": {
+        "kind": "manual", "name": "Dallas", "state": "TX",
+        "lat": 32.7767, "lng": -96.7970,
+    },
+    # CSX Railroad PD — corporate HQ Jacksonville, FL.
+    "ddad36ac-3cf9-58aa-b0c4-ec087280450b": {
+        "kind": "manual", "name": "Jacksonville", "state": "FL",
+        "lat": 30.3322, "lng": -81.6557,
+    },
+    # Chatham-Savannah Counter Narcotics Team — Savannah/Chatham County, GA.
+    "fec2b9a0-ee16-5d0a-948b-0b58ed4d1c48": {
+        "kind": "manual", "name": "Savannah", "state": "GA",
+        "lat": 32.0809, "lng": -81.0912,
+    },
+    # Chehalis Tribe Law Enforcement — Confederated Tribes of the
+    # Chehalis Reservation HQ in Oakville, WA.
+    "a2c33b5c-16a8-52e3-8c8a-5be75694d3ed": {
+        "kind": "manual", "name": "Oakville", "state": "WA",
+        "lat": 46.8482, "lng": -123.2293,
+    },
+    # Columbia River DTF — covers Cowlitz County WA; based in Longview.
+    "8661b49d-944f-56c2-924b-decfbca1a0ef": {
+        "kind": "manual", "name": "Longview", "state": "WA",
+        "lat": 46.1382, "lng": -122.9382,
+    },
+    # Cypress-Fairbanks ISD PD — Cypress, TX (NW Harris County). Census
+    # places gazetteer doesn't index the Cypress CDP.
+    "ff35f6c5-112e-5970-b59f-47dcef6947e5": {
+        "kind": "manual", "name": "Cypress", "state": "TX",
+        "lat": 29.9691, "lng": -95.6972,
+    },
+    # Huffman ISD PD — Huffman, TX (NE Harris County CDP, not in
+    # Census places gazetteer).
+    "fe2ade2a-15d6-5074-8593-c2f5c8f2c590": {
+        "kind": "manual", "name": "Huffman", "state": "TX",
+        "lat": 30.0152, "lng": -95.0919,
+    },
+    # Gwinnett County School PD — Gwinnett County, GA. Registry has no
+    # state set so the standard county branch can't fire.
+    "4c431642-2f5c-5c7c-9c69-6587fff1becf": {
+        "kind": "manual", "name": "Gwinnett County", "state": "GA",
+        "lat": 33.9588, "lng": -84.0257,
+    },
+    # Louisville Muhammad Ali International Airport PD — Louisville KY.
+    "8383db21-74c6-5054-a618-f23bc75390ac": {
+        "kind": "manual", "name": "Louisville", "state": "KY",
+        "lat": 38.1744, "lng": -85.7361,
+    },
+    # Memphis International Airport (MEM) — Memphis, TN.
+    "d5100c71-2e81-53cc-9c6c-d96e89abd32d": {
+        "kind": "manual", "name": "Memphis", "state": "TN",
+        "lat": 35.0424, "lng": -89.9767,
+    },
+    # Methodist Health System PD — Dallas, TX (system HQ).
+    "1d8cb468-cbbb-535f-a315-a79da4dd4f16": {
+        "kind": "manual", "name": "Dallas", "state": "TX",
+        "lat": 32.7457, "lng": -96.8285,
+    },
+    # Mineral Area Drug Task Force — covers St. Francois / Iron / etc.;
+    # based in Park Hills, MO.
+    "28893c8b-2b9b-5d85-a0a8-6a404cdab8b0": {
+        "kind": "manual", "name": "Park Hills", "state": "MO",
+        "lat": 37.8553, "lng": -90.5178,
+    },
+    # Montgomery County Constable — Montgomery County, TX (Conroe).
+    # The registry has no state; multiple states have a Montgomery
+    # County, but in context (Cabot AR PD shares with TX agencies and
+    # the Constable role is a Texas-specific institution) TX is the
+    # safe call.
+    "a876b7c8-45b2-53a9-a8a6-460d19bdfc51": {
+        "kind": "manual", "name": "Conroe", "state": "TX",
+        "lat": 30.3119, "lng": -95.4561,
+    },
+    # Northwest Arkansas Regional Airport (XNA) — Highfill, AR (serves
+    # Bentonville/Fayetteville).
+    "ee18a416-bc7f-5307-83e7-cfc14adac657": {
+        "kind": "manual", "name": "Bentonville", "state": "AR",
+        "lat": 36.2819, "lng": -94.3068,
+    },
+    # Orleans Levee District PD — New Orleans, LA.
+    "bf9a43ef-94e7-5ca0-84b3-ca2e1d64d8a0": {
+        "kind": "manual", "name": "New Orleans", "state": "LA",
+        "lat": 29.9511, "lng": -90.0715,
+    },
+    # Ozarks Drug Enforcement Team — Greene County, MO; Springfield.
+    "b6e5f1da-fdb5-5b48-95b9-18c3137f2545": {
+        "kind": "manual", "name": "Springfield", "state": "MO",
+        "lat": 37.2090, "lng": -93.2923,
+    },
+    # Port Fourchon Harbor PD — Port Fourchon, LA.
+    "2be084dc-fee8-51fe-b1f4-5acbd9d6da03": {
+        "kind": "manual", "name": "Port Fourchon", "state": "LA",
+        "lat": 29.1067, "lng": -90.1928,
+    },
+    # SEMO Drug Task Force — Southeast Missouri; based in Cape Girardeau.
+    "23e43879-4b61-5c96-8abd-488f90536244": {
+        "kind": "manual", "name": "Cape Girardeau", "state": "MO",
+        "lat": 37.3059, "lng": -89.5181,
+    },
+    # South Central Missouri DTF — Texas County, MO; HQ in Houston, MO.
+    "13052a9b-73e7-54ac-8289-6818f7a23de0": {
+        "kind": "manual", "name": "Houston", "state": "MO",
+        "lat": 37.3239, "lng": -91.9557,
+    },
+    # Southern Regional PD — York County PA, based in Shrewsbury.
+    "07ccfe8f-7915-59fd-b090-280305bdee32": {
+        "kind": "manual", "name": "Shrewsbury", "state": "PA",
+        "lat": 39.7666, "lng": -76.6797,
+    },
+    # Spokane Tribal PD — Spokane Indian Reservation HQ in Wellpinit, WA.
+    "3fb2e1f2-434a-5a2b-b79e-64c927bc461e": {
+        "kind": "manual", "name": "Wellpinit", "state": "WA",
+        "lat": 47.8907, "lng": -118.0651,
+    },
+    # Tennessee Regional Organized Crime Information Center — Nashville HQ.
+    "c745e651-a0bd-543e-a69c-2a9741b766de": {
+        "kind": "manual", "name": "Nashville", "state": "TN",
+        "lat": 36.1627, "lng": -86.7816,
+    },
+    # Tupelo Regional Airport (TUP) — Tupelo, MS.
+    "e0905266-5997-5468-a68a-55abc5e49065": {
+        "kind": "manual", "name": "Tupelo", "state": "MS",
+        "lat": 34.2581, "lng": -88.7037,
+    },
+}
+
+
 def geocode_entry(entry):
     """Attempt to geocode a single entry. Returns a geo dict or None.
 
     Uses the entry's display name and state. Skips entries with no state
     or that are tagged as private/federal/test/etc.
     """
+    aid = entry.get("agency_id")
+    if aid in MANUAL_OVERRIDES:
+        return dict(MANUAL_OVERRIDES[aid])
+
     name = agency_display_name(entry)
     state = agency_state(entry) or infer_state_from_name(name)
+    # "X CO YY" naming (CO=County abbrev) overrides any state inferred
+    # from the entry, since the registry sometimes mistakenly records
+    # CO as Colorado for these.
+    co_override = detect_county_co_state(name)
+    if co_override:
+        state = co_override
     if not state:
         return None
 


### PR DESCRIPTION
## Summary
- Closes 72 of 79 entries flagged in #187. Pattern fixes resolve 47, university-campus aliases catch 2 more, hand-curated `MANUAL_OVERRIDES` entries (keyed by `agency_id`) cover the remaining 24 — tribal HQs, airports, hospital systems, regional drug task forces, and a few TX CDPs the Census places gazetteer omits.
- 7 entries left intentionally untouched: `Alabama DTF Region G`, `Elm Ridge TX PD`, `GA - MCS/OCU/Intelligence`, `OK - 477`, `Precinct 3/4 (TX)`, `UCPAO AR` — registry doesn't carry enough context to place them confidently. They'll keep getting flagged on the issue thread until someone narrows them down.
- Bonus fix: the "X CO YY" pattern detection corrects four registry rows (`Caldwell/Cameron/Reeves/Rusk CO TX SO`) where the slug parser had stored `state="CO"` because it took the County abbreviation as Colorado.

## Test plan
- [x] `uv run python scripts/geocode_agencies.py` — dry-run shows expected matches
- [x] `uv run python scripts/check_recipient_coords.py` — down from 79 → 7 missing
- [x] `uv run pytest tests/` — 311 passed (incl. `test_geo_cache.py` which validates Census-derived coords against the gazetteer)
- [x] `uv run python scripts/build_map.py && uv run python scripts/build_scoreboard.py` — both rebuild cleanly
- [ ] Spot-check the new markers on the sharing map after deploy