### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -288,6 +288,22 @@
         "yreka-ca-po": "http_404"
       }
     },
+    "39054b43-7c24-5b8f-a4ca-266e742af0d4": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T04:49:34.151178+00:00",
+      "tried": {
+        "blue-lake-rancheria-tribal-po": "http_404"
+      }
+    },
+    "3dbed6a1-dadc-5951-b32d-32d3f816d17d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T04:49:29.257655+00:00",
+      "tried": {
+        "chaffey-college-ca-pd": "http_404"
+      }
+    },
     "3fc7d46a-3f58-5638-a86a-182bbaf116b4": {
       "exhausted": false,
       "found": null,
@@ -703,9 +719,10 @@
     "8fb27794-b88c-5373-b6a1-da64ae2f059c": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T19:34:12.964976+00:00",
+      "last_probed": "2026-05-05T04:49:40.764290+00:00",
       "tried": {
-        "tulare-ca-po": "http_404"
+        "tulare-ca-po": "http_404",
+        "tulare-ca-police-department": "http_404"
       }
     },
     "9079f9e0-e3c2-5611-8f09-a0276b7911f8": {
@@ -1185,6 +1202,6 @@
       }
     }
   },
-  "updated": "2026-05-05T01:21:17.736162+00:00",
+  "updated": "2026-05-05T04:49:40.800241+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.