### PR TITLE
fix(ci): use REFRESH_PAT so in-CI sidecar push retriggers validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          # PAT (when available) so the sidecar commit pushed below
+          # triggers a follow-up CI run. A push authenticated with the
+          # default GITHUB_TOKEN does not fire downstream workflows, which
+          # leaves the required `validate` check absent on the new HEAD
+          # and wedges the PR in BLOCKED state even with auto-merge on.
+          # The follow-up run is a no-op for sidecars (already committed,
+          # so have-new-sidecars=false short-circuits the publish step).
+          token: ${{ secrets.REFRESH_PAT || github.token }}
 
       - name: Download publish artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- The CI `publish` job pushes a sidecar commit back to the PR branch when validate produces new sidecars. That push uses the default `GITHUB_TOKEN`, which deliberately suppresses the downstream `pull_request` event (anti-loop), so the required `validate` check never re-runs on the new HEAD and the PR wedges in `BLOCKED` even with auto-merge enabled. #199 hit this earlier today — close+reopen unstuck it manually.
- Fix: swap the **publish job's** checkout token to `secrets.REFRESH_PAT || github.token`. The sidecar push fires a fresh `pull_request` event and `validate` satisfies on the final SHA. The follow-up run is a no-op for sidecars — `have-new-sidecars=false` short-circuits the publish step, so no loop.
- Validate stays `contents: read` on the default token (its read-only-from-PR-branch posture is intentional and unchanged). Only the publish job, which legitimately needs to write, gets the PAT.

## Tradeoff
- PRs that produce sidecars now run CI twice (initial push + sidecar push). The second run skips the actual sidecar commit and just re-posts the screenshot preview comment, which is already deduped by `<!-- page-preview -->`. Article-registry PRs are the only frequent producer.
- Fork PRs (rare here) silently fall back to `github.token` and would still wedge if they include OCR-eligible files, but the existing publish-job `if:` already gates fork PRs out, so this isn't worse than today.

## Test plan
- [ ] Merge and watch the next article-registry-bot PR carrying new sidecars through to auto-merge without intervention.
- [ ] Confirm only one screenshot preview comment lands on the PR after the dust settles.