### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -78,6 +78,14 @@
         "del-norte-county-ca-sd": "http_404"
       }
     },
+    "0c16750f-dc42-5f60-9071-6ebb60654027": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T07:34:25.509685+00:00",
+      "tried": {
+        "san-francisco-district-attorney-ca-da": "http_404"
+      }
+    },
     "11949eb7-26df-5b98-a23d-ac249879ec01": {
       "exhausted": false,
       "found": null,
@@ -935,9 +943,10 @@
     "bae9861d-a7ef-567d-b31b-a627075decf9": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-04T20:52:34.525762+00:00",
+      "last_probed": "2026-05-05T07:34:29.745917+00:00",
       "tried": {
-        "sacramento-ca-po": "http_404"
+        "sacramento-ca-po": "http_404",
+        "sacramento-ca-police-department": "http_404"
       }
     },
     "c246371a-5810-5428-b861-52b526e54678": {
@@ -986,9 +995,10 @@
     "d30c1555-ff35-55be-8226-4d5f62612e97": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-04T16:32:35.433931+00:00",
+      "last_probed": "2026-05-05T07:34:34.053903+00:00",
       "tried": {
         "avenal-ca-po": "http_404",
+        "avenal-ca-police": "http_404",
         "avenal-ca-police-department": "http_404"
       }
     },
@@ -1202,6 +1212,6 @@
       }
     }
   },
-  "updated": "2026-05-05T04:49:40.800241+00:00",
+  "updated": "2026-05-05T07:34:34.090658+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.