### PR TITLE
fix(check-injection): threshold numeric values in hidden-CSS detector

### DIFF
--- a/scripts/check_injection.py
+++ b/scripts/check_injection.py
@@ -122,6 +122,29 @@ HIDDEN_CSS = re.compile(
     re.IGNORECASE,
 )
 
+# Numeric-value patterns used by `_has_hiding_declaration` to apply
+# magnitude thresholds. The bare HIDDEN_CSS regex over-matches because
+# `opacity\s*:\s*0` greedily accepts the `0` in `opacity: 0.92` (a
+# perfectly visible hover transition), and `font-size\s*:\s*0` accepts
+# `font-size: 0.5em`. Both fire as false-positive HIGH findings on Ghost
+# CMS templates and similar. Capturing the value lets us threshold:
+# truly invisible values (≤ 0.05 opacity, < 0.1px/pt/em font-size) are
+# real injection signals; partial transparency or readable text is not.
+_OPACITY_VALUE = re.compile(r"opacity\s*:\s*([\d.]+)", re.IGNORECASE)
+_FONT_SIZE_VALUE = re.compile(
+    r"font-size\s*:\s*([\d.]+)\s*(?:px|pt|em|rem|%)?", re.IGNORECASE,
+)
+_HIDING_KEYWORDS = re.compile(
+    r"display\s*:\s*none|visibility\s*:\s*hidden",
+    re.IGNORECASE,
+)
+_WHITE_VALUE = re.compile(
+    r"(?:white|#fff(?:fff)?|rgb\(\s*255\s*,\s*255\s*,\s*255)",
+    re.IGNORECASE,
+)
+_COLOR_DECL = re.compile(r"(?<!-)color\s*:\s*(\S[^;]*)", re.IGNORECASE)
+_BG_DECL = re.compile(r"background(?:-color)?\s*:\s*(\S[^;]*)", re.IGNORECASE)
+
 # Vendor pseudo-elements that target browser UI chrome (scrollbars,
 # resizers, file-upload buttons, etc.). A hiding rule scoped only to
 # these cannot hide document text content, so it isn't a prompt-
@@ -331,6 +354,41 @@ def emit_decoded(findings, severity, category, decoded, start, end):
     ))
 
 
+def _has_hiding_declaration(rule_body: str) -> bool:
+    """Return True if a CSS declaration block contains a hiding effect.
+
+    Distinct from a bare HIDDEN_CSS regex match because:
+      - numeric values are thresholded: `opacity: 0.92` and
+        `font-size: 0.5em` are visible and do not count, while
+        `opacity: 0.0001` and `font-size: 0.00001em` do (real injection
+        technique — text rendered for an LLM but invisible to humans);
+      - `color: white` only counts when paired with a white background
+        in the same rule. White text on a dark CTA or button is
+        ubiquitous web styling, not a hiding signal.
+    """
+    if _HIDING_KEYWORDS.search(rule_body):
+        return True
+    for m in _OPACITY_VALUE.finditer(rule_body):
+        try:
+            if float(m.group(1)) <= 0.05:
+                return True
+        except ValueError:
+            continue
+    for m in _FONT_SIZE_VALUE.finditer(rule_body):
+        try:
+            if float(m.group(1)) < 0.1:
+                return True
+        except ValueError:
+            continue
+    color_m = _COLOR_DECL.search(rule_body)
+    bg_m = _BG_DECL.search(rule_body)
+    if (color_m and bg_m
+            and _WHITE_VALUE.match(color_m.group(1).strip())
+            and _WHITE_VALUE.match(bg_m.group(1).strip())):
+        return True
+    return False
+
+
 def _stylesheet_hides_content(body: str) -> bool:
     """Return True if a <style> body contains a hiding rule whose
     selector could hide document text content (not just UI chrome).
@@ -343,11 +401,11 @@ def _stylesheet_hides_content(body: str) -> bool:
     """
     cleaned = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
     for rule in cleaned.split("}"):
-        if not HIDDEN_CSS.search(rule):
-            continue
         if "{" not in rule:
             continue
-        selector_part = rule.split("{", 1)[0]
+        selector_part, decl_part = rule.split("{", 1)
+        if not _has_hiding_declaration(decl_part):
+            continue
         selectors = [s.strip() for s in selector_part.split(",") if s.strip()]
         if not selectors:
             return True

--- a/tests/test_check_injection.py
+++ b/tests/test_check_injection.py
@@ -513,6 +513,20 @@ class TestStylesheetHidesContent:
             '<style> .gone { color: white; background: white; } </style>'
         )
 
+    def test_white_text_on_dark_does_not_flag(self):
+        # Ghost CMS member CTA (`<style id="gh-members-styles">`) and
+        # countless other site templates style white text on a dark
+        # button or CTA. White text alone is not a hiding signal — only
+        # white text + white background is.
+        for html in (
+            '<style> .gh-post-upgrade-cta h2 { color: #ffffff; font-size: 28px; } </style>',
+            '<style> .btn { color: white; background: #15171a; } </style>',
+            '<style> .header { color: rgb(255,255,255); background-color: #000; } </style>',
+        ):
+            assert not self._has_hidden_css(html), (
+                f"white-on-dark should not flag: {html}"
+            )
+
     def test_flock_portal_pattern_does_not_flag(self):
         # Verbatim from the Flock UI rollout that started 2026-04-29.
         html = (
@@ -522,6 +536,47 @@ class TestStylesheetHidesContent:
             '<div>content</div></div>'
         )
         assert not self._has_hidden_css(html)
+
+    def test_hover_opacity_does_not_flag(self):
+        # Ghost CMS CTA hover style — `opacity: 0.92` is clearly visible,
+        # not a hiding declaration. Caught a false positive that flagged
+        # every 404media article with a HIGH finding before the fix.
+        html = (
+            '<style> a.gh-btn:hover { opacity: 0.92; } </style>'
+        )
+        assert not self._has_hidden_css(html)
+
+    def test_partial_opacity_does_not_flag(self):
+        for value in ("0.5", "0.25", "0.1", "0.06"):
+            html = f'<style> .fade {{ opacity: {value}; }} </style>'
+            assert not self._has_hidden_css(html), (
+                f"opacity: {value} should not flag (visible)"
+            )
+
+    def test_microdose_opacity_flags(self):
+        # Real injection technique — text technically rendered but
+        # functionally invisible to a human reader.
+        for value in ("0", "0.0", "0.001", "0.0001", "0.05"):
+            html = f'<style> .sneaky {{ opacity: {value}; }} </style>'
+            assert self._has_hidden_css(html), (
+                f"opacity: {value} should flag (effectively hidden)"
+            )
+
+    def test_readable_font_size_does_not_flag(self):
+        for value in ("0.5em", "0.5rem", "0.5", "1px", "12px", "0.9em"):
+            html = f'<style> .readable {{ font-size: {value}; }} </style>'
+            assert not self._has_hidden_css(html), (
+                f"font-size: {value} should not flag (readable)"
+            )
+
+    def test_microdose_font_size_flags(self):
+        # Sub-1px / sub-0.1em is unreadable by humans but the text is
+        # still in the DOM for an LLM to ingest.
+        for value in ("0", "0px", "0em", "0.00001em", "0.001px"):
+            html = f'<style> .micro {{ font-size: {value}; }} </style>'
+            assert self._has_hidden_css(html), (
+                f"font-size: {value} should flag (effectively zero)"
+            )
 
 
 class TestInvisibleSplicingEvasion:


### PR DESCRIPTION
## Summary

Fixes false-positive HIGH findings (`hidden-css-rule-with-content`) on Ghost-CMS-themed pages — the trigger that flagged both 404media articles in [run 25363627045](https://github.com/none-below/sm-alpr/actions/runs/25363627045/job/74368838984) as REVIEW REQUIRED.

Two over-matches in `HIDDEN_CSS`:

- `opacity\s*:\s*0` matched the leading `0` of `opacity: 0.92` — Ghost's `.gh-btn:hover` transition, perfectly visible.
- `color: white` flagged any white text regardless of background, but white-on-dark headings and buttons are everywhere.

## Fix

New `_has_hiding_declaration` helper used inside `_stylesheet_hides_content`:

- Captures opacity / font-size values and applies thresholds: ≤ 0.05 opacity, < 0.1-unit font-size. Still catches `opacity: 0.0001` and `font-size: 0.00001em` — real prompt-injection techniques where text is rendered for an LLM but invisible to humans.
- Only flags `color: white` when paired with a white `background` / `background-color` in the same rule.

After the fix, both 404media articles drop from REVIEW REQUIRED (37 pts) to WARNINGS (30 pts, all from `data-srcset` lazy-load — separate, lower-priority noise).

## Test plan

- [x] All 93 tests in `tests/test_check_injection.py` pass (added 7 regression tests: hover opacity, partial opacity, microdose opacity, readable font-size, microdose font-size, white-on-dark CTA, Ghost-style template)
- [x] Verified verdicts on the actual 404media files: REVIEW REQUIRED → WARNINGS
- [x] Existing tests still pass (Flock scrollbar carve-out, white-on-white still flags, universal-selector `opacity: 0`, etc.)