### PR TITLE
fix(ci): exclude assets/articles/ from the PII scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,17 @@ jobs:
           # A dash-prefixed filename would still be misinterpreted; fix
           # would require teaching pii_scan.py positional args, out of
           # scope here.)
+          # Exclude assets/articles/**/*.pdf — those are public news
+          # articles fetched from third-party publishers. Editorial
+          # contact emails (jason@404media.co, events@eff.org, etc.)
+          # are intentionally public on the original sites; surfacing
+          # them in the scanner is a false positive against this
+          # corpus's threat model. The PII scanner is for catching
+          # accidentally-captured constituent PII in PRA responses,
+          # not republished journalism.
           mapfile -d '' -t PDF_FILES < <(
             git diff --name-only -z origin/main...HEAD \
+              | { grep -zviE '^assets/articles/' || true; } \
               | { grep -ziE '\.pdf$' || true; }
           )
           if [ "${#PDF_FILES[@]}" -eq 0 ]; then


### PR DESCRIPTION
PR #211 (the rolling \`article-registry-bot\` PR) is failing CI on its PII scan, flagging:

- \`jason@404media.co\` (404 Media reporter's tip line, in their Flock article)
- \`events@eff.org\` (EFF events contact, in their op-ed)

Both are intentionally-public editorial contacts on the original publishers' sites. Republishing the PDF doesn't increase any individual's PII exposure beyond what the original publisher chose. The PII scanner exists to catch constituent PII accidentally captured in PRA responses and police records — wrong threat model for republished journalism.

## Fix

Filter \`assets/articles/**/*.pdf\` out of the changed-PDFs list the scanner sees. All other paths (\`docs/\`, \`assets/transparency.flocksafety.com/\` attachments, etc.) still get scanned as before.

## Sequencing

After this lands, the bot branch needs a separate rescue (it's also behind main on PR #207's queue migration). I'll cherry-pick the in-flight curated articles onto fresh main as a follow-up so the work isn't lost.