### PR TITLE
fix(pii-scan): skip assets/articles/ scrapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,17 +106,8 @@ jobs:
           # A dash-prefixed filename would still be misinterpreted; fix
           # would require teaching pii_scan.py positional args, out of
           # scope here.)
-          # Exclude assets/articles/**/*.pdf — those are public news
-          # articles fetched from third-party publishers. Editorial
-          # contact emails (jason@404media.co, events@eff.org, etc.)
-          # are intentionally public on the original sites; surfacing
-          # them in the scanner is a false positive against this
-          # corpus's threat model. The PII scanner is for catching
-          # accidentally-captured constituent PII in PRA responses,
-          # not republished journalism.
           mapfile -d '' -t PDF_FILES < <(
             git diff --name-only -z origin/main...HEAD \
-              | { grep -zviE '^assets/articles/' || true; } \
               | { grep -ziE '\.pdf$' || true; }
           )
           if [ "${#PDF_FILES[@]}" -eq 0 ]; then

--- a/scripts/pii_scan.py
+++ b/scripts/pii_scan.py
@@ -27,6 +27,13 @@ import io
 
 # ── Allowlists ──
 
+# Path prefixes excluded from scanning. Article PDFs under assets/articles/ are
+# scraped public journalism — author bylines and outlet contact addresses are
+# intentional, not leaked PII, and would otherwise flood the scanner.
+EXCLUDED_PATH_PREFIXES = (
+    "assets/articles/",
+)
+
 ALLOWED_EMAIL_DOMAINS = {
     "cityofsanmateo.org",
     "flocksafety.com",
@@ -146,6 +153,11 @@ def get_staged_pdfs():
             if f.lower().endswith(".pdf")]
 
 
+def is_excluded(path):
+    posix = Path(path).as_posix()
+    return any(prefix in posix for prefix in EXCLUDED_PATH_PREFIXES)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Scan PDF assets for PII")
     parser.add_argument("--dir", default="assets/san-mateo-public-records",
@@ -168,6 +180,8 @@ def main():
             print(f"Error: {scan_dir} not found", file=sys.stderr)
             sys.exit(1)
         pdfs = sorted(scan_dir.rglob("*.pdf")) + sorted(scan_dir.rglob("*.PDF"))
+
+    pdfs = [p for p in pdfs if not is_excluded(p)]
 
     all_findings = []
     for pdf in pdfs:


### PR DESCRIPTION
## Summary
- PII scanner now skips `assets/articles/` PDFs. Scraped news articles intentionally include author bylines (e.g. `jason@404media.co`) and outlet contact addresses (`events@eff.org`); treating those as PII findings blocks unrelated PRs ([#211 CI run](https://github.com/none-below/sm-alpr/actions/runs/25363783373/job/74369357376?pr=211)).
- Exclusion is applied centrally in `scripts/pii_scan.py` so all invocation modes (`--files`, `--staged`, `--dir`) inherit it. PRA materials under `assets/san-mateo-public-records/` and transparency-portal pulls remain in scope.

## Test plan
- [x] Run scanner against the two article PDFs that failed in #211 — exits 0.
- [x] Run scanner with one article path + one PRA PDF — confirms filter is selective (1 of 2 scanned).
- [ ] Re-run CI on #211 after merge to confirm the validate job goes green.