### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -447,9 +447,10 @@
     "59e2385f-2649-5b82-9bf7-aee2e73b0af1": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T15:27:27.286459+00:00",
+      "last_probed": "2026-05-05T11:06:44.400129+00:00",
       "tried": {
-        "milpitas-ca-po": "http_404"
+        "milpitas-ca-po": "http_404",
+        "milpitas-ca-police-department": "http_404"
       }
     },
     "5aad1905-8ff9-5a45-931a-7298f983153a": {
@@ -882,9 +883,10 @@
     "aecd81f3-fb7f-579a-895a-44d90a82a427": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T22:35:25.052734+00:00",
+      "last_probed": "2026-05-05T11:06:50.510707+00:00",
       "tried": {
-        "lancaster-ca-po": "http_404"
+        "lancaster-ca-po": "http_404",
+        "lancaster-ca-police-department": "http_404"
       }
     },
     "afc27a65-11a4-5c6e-9c22-3d94e875a399": {
@@ -1049,9 +1051,10 @@
     "dddefaf4-84f7-5857-8011-45b6eda02991": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T18:10:38.738287+00:00",
+      "last_probed": "2026-05-05T11:06:55.660119+00:00",
       "tried": {
         "sand-city-ca-po": "http_404",
+        "sand-city-ca-police": "http_404",
         "sand-city-ca-police-department": "http_404"
       }
     },
@@ -1222,6 +1225,6 @@
       }
     }
   },
-  "updated": "2026-05-05T09:32:45.539118+00:00",
+  "updated": "2026-05-05T11:06:55.696416+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -299,8 +299,9 @@
     "39054b43-7c24-5b8f-a4ca-266e742af0d4": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-05T04:49:34.151178+00:00",
+      "last_probed": "2026-05-05T09:32:45.500709+00:00",
       "tried": {
+        "blue-lake-rancheria-tribal": "http_404",
         "blue-lake-rancheria-tribal-po": "http_404"
       }
     },
@@ -499,6 +500,14 @@
       "last_probed": "2026-04-24T03:21:41.426150+00:00",
       "tried": {
         "riverside-county-ca-district-attorney-ca-da": "http_404"
+      }
+    },
+    "65131837-e542-51b5-9c61-28181333089f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T09:32:34.627030+00:00",
+      "tried": {
+        "lake-county-ca-da": "http_404"
       }
     },
     "69489e25-1027-5396-86a7-c68d5111eecd": {
@@ -1170,9 +1179,10 @@
     "f296ea7d-37b7-583c-aef6-5058b2df232d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T01:23:32.310618+00:00",
+      "last_probed": "2026-05-05T09:32:38.863330+00:00",
       "tried": {
-        "fremont-ca-po": "http_404"
+        "fremont-ca-po": "http_404",
+        "fremont-ca-police-department": "http_404"
       }
     },
     "f4073ba9-2a85-50ab-82d6-1800ff5491c6": {
@@ -1212,6 +1222,6 @@
       }
     }
   },
-  "updated": "2026-05-05T07:34:34.090658+00:00",
+  "updated": "2026-05-05T09:32:45.539118+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -695,9 +695,10 @@
     "844ec58f-3abf-5a88-a280-2ba0f235264a": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T16:02:17.452877+00:00",
+      "last_probed": "2026-05-05T12:58:32.587157+00:00",
       "tried": {
-        "salinas-ca-po": "http_404"
+        "salinas-ca-po": "http_404",
+        "salinas-ca-police-department": "http_404"
       }
     },
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
@@ -716,6 +717,14 @@
       "last_probed": "2026-05-04T19:07:44.306438+00:00",
       "tried": {
         "branson-mo-po": "http_404"
+      }
+    },
+    "8a88be54-e69a-5e38-88f2-02bc79b89ebe": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T12:58:39.126437+00:00",
+      "tried": {
+        "california-city-ca-pd": "http_404"
       }
     },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
@@ -861,6 +870,14 @@
       "tried": {
         "vernon-ca-po": "http_404",
         "vernon-ca-police-department": "http_404"
+      }
+    },
+    "a752d5bb-a9d8-575f-a5fd-b9c605074330": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T12:58:27.509295+00:00",
+      "tried": {
+        "aurora-oh-po": "http_404"
       }
     },
     "a76f1a12-ea0c-5138-9c77-57a4e6b510ca": {
@@ -1225,6 +1242,6 @@
       }
     }
   },
-  "updated": "2026-05-05T11:06:55.696416+00:00",
+  "updated": "2026-05-05T12:58:39.161178+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.