### PR TITLE
ci(refresh-flock-data): make parser-issue step non-fatal

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Surface parser failures as an issue
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- The hourly Flock-refresh workflow has been failing on most runs (only 1 success overnight). Root cause: the `Surface parser failures as an issue` step calls `gh issue create --label parser`, the `parser` label was missing from the repo, gh aborted with `could not add label: 'parser' not found`, and because that step is in the main job before parse/build/commit, the whole run failed and discarded the partial-but-valid crawl.
- The `parser` label has been created in the repo manually (yellow #FBCA04, "Flock portal parser tripped on a new format variant"), so future runs can file/append the rolling parser-issue normally.
- This PR additionally hardens the workflow so a tracking-issue glitch never throws away a good crawl: `continue-on-error: true` on the surface-parser step. PARSE_ERROR is still logged to stdout, so the signal isn't lost.

## Test plan

- [ ] Next scheduled run completes (`gh run list --workflow refresh-flock-data.yml`)
- [ ] If a portal trips PARSE_ERROR, the rolling `parser`-labeled issue is created/commented and the run still proceeds to commit