### PR TITLE
fix(parser): classify '...the following link' blurbs as policy_info

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -335,16 +335,18 @@ _HEADING_MAP = {
 _DYNAMIC_HEADINGS = [
     (re.compile(r"^Last Updated:", re.IGNORECASE), "last_updated"),
     (re.compile(r"^(Link to |To view ).+", re.IGNORECASE), "policy_info"),
-    # Sentence-style link blurbs, e.g. "Auburn PD's Policies and
-    # Procedures can be found at the following link:" — same role as
-    # the "Policy Documents" / "Policy Link" exact headings.
-    (re.compile(r"^.+\bthe following link\b.*$", re.IGNORECASE), "policy_info"),
     (re.compile(r"^(Full ALPR|Full LPR|Full ALPRY).+", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+ (ALPR|LPR) Policy.*$", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+Police Department Policy Manual.*$", re.IGNORECASE), "alpr_policy"),
     # Success-story subheadings — agencies post titled excerpts under
     # "Success Stories" (e.g. "Yuba County SO - Facebook Post - …").
     (re.compile(r"^.+ - Facebook Post - .+$", re.IGNORECASE), "success_stories"),
+    # Sentence-style link blurbs, e.g. "Auburn PD's Policies and
+    # Procedures can be found at the following link:" — same role as
+    # the "Policy Documents" / "Policy Link" exact headings. Placed
+    # last (before the structural-noise None patterns) so more specific
+    # patterns above (e.g. alpr_policy) win when a heading matches both.
+    (re.compile(r"^.+\bthe following link\b.*$", re.IGNORECASE), "policy_info"),
     # Page chrome / structural noise — explicit None so these don't trip
     # the bold-heading fail-loud check downstream.
     (re.compile(

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -335,6 +335,10 @@ _HEADING_MAP = {
 _DYNAMIC_HEADINGS = [
     (re.compile(r"^Last Updated:", re.IGNORECASE), "last_updated"),
     (re.compile(r"^(Link to |To view ).+", re.IGNORECASE), "policy_info"),
+    # Sentence-style link blurbs, e.g. "Auburn PD's Policies and
+    # Procedures can be found at the following link:" — same role as
+    # the "Policy Documents" / "Policy Link" exact headings.
+    (re.compile(r"^.+\bthe following link\b.*$", re.IGNORECASE), "policy_info"),
     (re.compile(r"^(Full ALPR|Full LPR|Full ALPRY).+", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+ (ALPR|LPR) Policy.*$", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+Police Department Policy Manual.*$", re.IGNORECASE), "alpr_policy"),

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -354,6 +354,24 @@ def test_prefix_matching_prefers_longest_match():
     assert _match_heading("Sharing Restrictions") == "sharing_restrictions"
 
 
+def test_following_link_blurb_classifies_as_policy_info():
+    """Some agencies (auburn-ca-pd) use a sentence-style heading like
+    "Auburn PD's Policies and Procedures can be found at the following
+    link:" instead of an exact heading like "Policy Documents". The
+    dynamic pattern should route it to policy_info just like the
+    "Link to..." / "To view..." prefixes do."""
+    from flock_transparency import _match_heading_kind
+    field, kind = _match_heading_kind(
+        "Auburn PD's Policies and Procedures can be found at the following link:"
+    )
+    assert (field, kind) == ("policy_info", "dynamic")
+    # Without the trailing colon, same routing.
+    field, kind = _match_heading_kind(
+        "Auburn PD's Policies and Procedures can be found at the following link"
+    )
+    assert (field, kind) == ("policy_info", "dynamic")
+
+
 def test_month_year_bold_heading_does_not_raise():
     """Success-stories sections often have month-year subheadings
     ("April 2026"). Those are styled bold but aren't field headings —

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -370,6 +370,18 @@ def test_following_link_blurb_classifies_as_policy_info():
         "Auburn PD's Policies and Procedures can be found at the following link"
     )
     assert (field, kind) == ("policy_info", "dynamic")
+    # The "the following link" pattern is a fallthrough — if a heading
+    # also matches a more specific earlier rule (exact/prefix from
+    # _HEADING_MAP, or one of the alpr_policy dynamic patterns), the
+    # earlier rule must win and route to its specific field.
+    field, _kind = _match_heading_kind(
+        "Full ALPR Policy can be found at the following link:"
+    )
+    assert field == "alpr_policy"
+    field, _kind = _match_heading_kind(
+        "Anytown Police Department Policy Manual can be found at the following link:"
+    )
+    assert field == "alpr_policy"
 
 
 def test_month_year_bold_heading_does_not_raise():


### PR DESCRIPTION
## Summary

- Adds a dynamic heading pattern that routes any heading ending with `the following link` to the existing `policy_info` field.
- Unblocks the hourly `refresh-flock-data` crawler, which was failing on `auburn-ca-pd` with `bold headings not in _HEADING_MAP: ["Auburn PD's Policies and Procedures can be found at the following link:"]`.
- New `auburn-ca-pd`-style heading is the same role as the existing `"Policy Documents"` / `"Policy Link"` exact headings and the `^(Link to |To view ).+` dynamic prefix — Flock agencies just phrase the same link-to-PDF pointer as a sentence.

## Test plan

- [x] `pytest tests/test_flock_transparency_headings.py` — 22 passed (1 new)
- [ ] Next refresh-flock-data run after merge succeeds for auburn-ca-pd