### PR TITLE
fix: alameda parser + crawl queue starvation

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -198,6 +198,29 @@ def latest_capture_date(slug, data_dir):
         return None
 
 
+def split_batch_across_levels(batch, num_levels):
+    """Allocate a per-level slot budget for a depth-iterating crawl.
+
+    Returns a list of length `num_levels`. Lower levels (closer to seed)
+    get the remainder when the split is uneven — they're the highest-
+    signal candidates so they get the extra slot. With `batch=None` /
+    `batch=0`, every level gets unlimited budget (float('inf')).
+
+    Examples:
+      batch=3, num_levels=2 → [2, 1]
+      batch=3, num_levels=3 → [1, 1, 1]
+      batch=2, num_levels=3 → [1, 1, 0]   (level 2 starves, by design)
+    """
+    if not batch:
+        return [float("inf")] * num_levels
+    per_level_floor = batch // num_levels
+    remainder = batch % num_levels
+    return [
+        per_level_floor + (1 if lvl < remainder else 0)
+        for lvl in range(num_levels)
+    ]
+
+
 def latest_capture_attempt_date(slug, data_dir):
     """Return the latest *attempted* capture date — date of the latest .txt
     even if parsing failed afterwards. Used only for crawl-queue ordering
@@ -1065,11 +1088,23 @@ def cmd_crawl(args):
             visited.update(
                 s for s in hashes if not is_stale(s, data_dir, args.max_age)
             )
-        batch_remaining = args.batch if args.batch else float("inf")
-
         if args.all_agencies or args.depth:
             max_depth = args.depth if args.depth else 1
-            for level in range(max_depth + 1):
+            # Split --batch across levels so peers reachable only at deeper
+            # levels actually get a turn. Without this, level 0 (the seed's
+            # direct outbound) consumes the whole batch every run and tier-0
+            # candidates that only surface at level 1+ starve (e.g. alameda-
+            # ca-pd, which is in 70 peers' outbound but not san-mateo's).
+            # Lower levels (closer to seed = higher signal) get the remainder
+            # when the split is uneven; e.g. batch=3 at 2 levels → 2 + 1.
+            # Unused budget rolls forward into the next level via `available`,
+            # so we still spend up to the global rate limit when possible.
+            num_levels = max_depth + 1
+            level_budgets = split_batch_across_levels(args.batch, num_levels)
+            available = 0
+
+            for level in range(num_levels):
+                available += level_budgets[level]
                 # For already-visited slugs, load sharing lists from stored JSONs
                 # so we can discover their downstream agencies without re-fetching
                 discovered_from_existing = []
@@ -1128,14 +1163,14 @@ def cmd_crawl(args):
                     return (0, date.min)
                 new_slugs.sort(key=_order)
                 if args.batch:
-                    # Pick a random sample from the top 3*batch oldest
+                    # Pick a random sample from the top 3*budget oldest
                     # candidates instead of strictly the top N. Preserves
                     # "oldest first" intent but spreads attention so a
                     # single failing slug at position #1 doesn't waste
                     # the same crawl slot on every run — over a few
                     # cycles the failing slug just becomes one of many
                     # candidates for the slot.
-                    n = int(batch_remaining)
+                    n = int(available)
                     pool = new_slugs[:n * 3]
                     new_slugs = random.sample(pool, min(n, len(pool)))
 
@@ -1156,12 +1191,8 @@ def cmd_crawl(args):
                     )
                     all_results.extend(results)
                     visited.update(s for s, _ in results)
-                    batch_remaining -= len(new_slugs)
+                    available -= len(new_slugs)
                     discovered.extend(newly_discovered)
-
-                    if batch_remaining <= 0:
-                        print(f"\n  batch limit reached, stopping.\n")
-                        break
 
                 slugs = dedupe(discovered)
         else:

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -355,6 +355,9 @@ _DYNAMIC_HEADINGS = [
         re.IGNORECASE,
     ), None),
     (re.compile(r".+Transparency Portal$", re.IGNORECASE), None),
+    # Empty-state placeholder for sharing fields, e.g.
+    # "None: Alameda does not share with outside agencies".
+    (re.compile(r"^None:\s", re.IGNORECASE), None),
 ]
 
 _MAX_HEADING_LEN = 120

--- a/tests/test_crawl_queue.py
+++ b/tests/test_crawl_queue.py
@@ -1,0 +1,46 @@
+"""Pin the per-level batch-allocation behavior in flock_transparency.cmd_crawl.
+
+Crawl runs at depth 1 with a hard rate-limit cap (batch=3 at the
+hourly cadence). Without per-level allocation, level 0 (the seed's
+direct outbound) consumes the whole batch every run and slugs that
+only surface at level 1+ starve — alameda-ca-pd hadn't been re-
+crawled for 16 days because it's not in san-mateo-ca-pd's outbound,
+only reachable via 70 peers at level 1.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from flock_transparency import split_batch_across_levels
+
+
+def test_even_split_across_three_levels():
+    """3 levels, batch=3 → 1 slot per level. The user's stated cadence."""
+    assert split_batch_across_levels(3, 3) == [1, 1, 1]
+
+
+def test_remainder_goes_to_lower_levels():
+    """Lower levels (closer to seed) carry higher-signal candidates,
+    so when the split is uneven they get the remainder. batch=3, 2
+    levels → [2, 1] (not [1, 2])."""
+    assert split_batch_across_levels(3, 2) == [2, 1]
+    assert split_batch_across_levels(7, 3) == [3, 2, 2]
+
+
+def test_single_level_gets_full_batch():
+    """Without depth iteration, behavior collapses to the full batch."""
+    assert split_batch_across_levels(3, 1) == [3]
+
+
+def test_starvation_when_batch_smaller_than_levels():
+    """If batch < num_levels, deeper levels get 0 — still better than the
+    pre-fix behavior where deeper levels always got 0."""
+    assert split_batch_across_levels(2, 3) == [1, 1, 0]
+    assert split_batch_across_levels(1, 3) == [1, 0, 0]
+
+
+def test_unbatched_runs_get_unlimited_per_level():
+    """Manual `crawl` invocations without --batch shouldn't be capped."""
+    assert split_batch_across_levels(None, 2) == [float("inf"), float("inf")]
+    assert split_batch_across_levels(0, 3) == [float("inf")] * 3

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -384,6 +384,26 @@ def test_following_link_blurb_classifies_as_policy_info():
     assert field == "alpr_policy"
 
 
+def test_none_prefixed_empty_state_does_not_raise():
+    """Flock renders an empty-state for non-sharing agencies as a bold
+    heading like "None: Alameda does not share with outside agencies".
+    The dynamic noise pattern should swallow it instead of failing the
+    unrecognized-bold-heading check (alameda-ca-pd, 2026-05-05)."""
+    from flock_transparency import _match_heading_kind
+    field, kind = _match_heading_kind(
+        "None: Alameda does not share with outside agencies"
+    )
+    assert (field, kind) == (None, "dynamic")
+    text = "What's Detected\n\nLicense Plates\n\n"
+    parse_portal_text(
+        text, "test-agency", "2026-05-05",
+        bold_headings={
+            "What's Detected",
+            "None: Alameda does not share with outside agencies",
+        },
+    )
+
+
 def test_month_year_bold_heading_does_not_raise():
     """Success-stories sections often have month-year subheadings
     ("April 2026"). Those are styled bold but aren't field headings —


### PR DESCRIPTION
Two fixes that together explain why alameda-ca-pd hadn't been re-scraped since 4/19 and broke today's run.

## 1. Parser: ignore \`None: ...\` empty-state bold heading
Flock styles \`None: Alameda does not share with outside agencies\` as a bold heading on portals where the agency doesn't share. Added \`^None:\\s\` to \`_DYNAMIC_HEADINGS\` so the unrecognized-bold guard skips it. Pinned with [test_none_prefixed_empty_state_does_not_raise](tests/test_flock_transparency_headings.py).

## 2. Crawl: split \`--batch\` across depth levels
The deeper bug. \`alameda-ca-pd\` isn't in \`san-mateo-ca-pd\`'s outbound (SM lists *Alameda County CA SO* — a different agency). It's reachable at level 1 via 70 other peers. But \`--batch 3\` consumed all 3 slots at level 0 every run, so level 1 never got a turn. Alameda was crawled exactly once (4/19) because that hour all of SM's direct outbound was fresh, so level 0 yielded nothing and the loop fell through.

Fix: allocate per-level budgets via \`split_batch_across_levels\`. With \`batch=3\` and 2 levels, the split is \`[2, 1]\` — level 1 gets at least one pick per run. Unused budget rolls into the next level so we still hit the rate-limit ceiling when possible. New unit tests in [tests/test_crawl_queue.py](tests/test_crawl_queue.py).

## Test plan
- [x] \`uv run pytest tests/test_flock_transparency_headings.py tests/test_crawl_queue.py\`
- [ ] After merge: confirm next refresh run picks up level-1 candidates (e.g. via the \`[depth 1]\` log marker)