### PR TITLE
feat(justifications): per-agency search-justification analysis page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/data/audit/
 docs/data/history/
 docs/data/agency_changelog.json
 docs/data/contract_map_data.json
+docs/data/justifications.json
 docs/js/map.js
 assets/transparency.flocksafety.com/.sharing_graph_full.json
 assets/**/_pending/

--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -1393,6 +1393,16 @@
         'Built from every scrape of this agency&rsquo;s public search audit on file. ' +
         'Flock exposes a rolling ~30-day window; older rows persist here only ' +
         'because they were captured before they aged out.' +
+        '</span>' +
+        '<span class="audit-window-scope">' +
+        '<strong>Scope:</strong> only searches run by ' +
+        escapeHTML(agencyData.display_name) + '&rsquo;s own staff. ' +
+        'Other agencies with shared access also search this data; ' +
+        'those searches appear in those other agencies&rsquo; audits, ' +
+        'not here. The ' +
+        '<a href="report.html?agency=' + encodeURIComponent(agencyData.slug) +
+        '" target="_blank" rel="noopener">per-agency report</a> ' +
+        'sums the search volume across every recipient this agency shares to.' +
         '</span></div>';
     }
     var blurb =

--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -1,0 +1,1536 @@
+/* Renders per-agency search-justification word clouds from the data
+   produced by scripts/build_justifications.py.
+
+   The "cloud" here is the simple flow-layout variant — inline-block
+   words sized by frequency, wrapping into a paragraph. A spiral-packed
+   layout (d3-cloud style) was considered but adds a layout dependency
+   and obscures the count alongside each word. */
+
+(function () {
+  var DATA_URL = 'data/justifications.json';
+  var DEFAULT_SLUG = 'east-palo-alto-ca-pd';
+
+  // Font-size scale for the word cloud, in points. The smallest word
+  // (count == MIN_COUNT, currently 3) renders at MIN_PT; the most
+  // frequent renders at MAX_PT, with a square-root scale in between
+  // so a single dominant token doesn't squash the rest.
+  var MIN_PT = 9;
+  var MAX_PT = 36;
+
+  function fmt(n) { return n == null ? '—' : n.toLocaleString(); }
+  function pct(n) { return n == null ? '—' : n.toFixed(1) + '%'; }
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  function scaleFontSize(count, max) {
+    if (max <= 0) return MIN_PT;
+    var t = Math.sqrt(count / max);
+    return MIN_PT + (MAX_PT - MIN_PT) * t;
+  }
+
+  // A phrase is a "code" if it's a bare or section-suffixed penal /
+  // vehicle code reference (e.g. "10851", "245(a)(2)pc", "23103cvc").
+  // Those render in monospace with a distinct color so the eye can
+  // separate prose justifications from code-shaped ones at a glance.
+  function isCodeToken(s) {
+    return /^[0-9]+(?:\.[0-9]+)?(?:\([^)]*\))*\s?(?:pc|cvc|hsc|wic)?$/.test(s);
+  }
+
+  // 6-color palette in CSS; pick a stable index by hashing the phrase
+  // string so the same phrase keeps its color across reloads while
+  // adjacent (count-sorted) entries land on different colors.
+  function colorClass(s) {
+    var h = 0;
+    for (var i = 0; i < s.length; i++) {
+      h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+    }
+    return 'c' + (Math.abs(h) % 6);
+  }
+
+  // Long-active case-number justifications: a single case number used
+  // as the entire reason across many searches over many days. Renders
+  // as a callout above the cloud when present. The presence of this
+  // pattern is what audit review is meant to surface — case numbers
+  // identify a single incident, so reuse across weeks raises questions
+  // about scope creep, hotlist-style use, or stale flagging.
+  function renderLongActiveCases(items, displayName) {
+    if (!items || !items.length) return '';
+    var html = '<div class="long-active-block">' +
+      '<div class="long-active-head">Long-active case-number justifications</div>' +
+      '<div class="long-active-sub">Single case numbers reused across many searches and days. ' +
+      'A case number identifies one incident, so this pattern is what ALPR audit review ' +
+      'is supposed to surface for proportionality review.</div>' +
+      '<table class="long-active-table"><thead><tr>' +
+      '<th>Case number</th><th class="num">Searches</th>' +
+      '<th>Span</th>' +
+      '<th class="num">Active days</th>' +
+      '<th class="num">Median reach</th>' +
+      '<th>Flags</th>' +
+      '</tr></thead><tbody>';
+    for (var i = 0; i < items.length; i++) {
+      var phrase = items[i][0];
+      var count = items[i][1];
+      var days = items[i][2];
+      var dmin = items[i][3];
+      var dmax = items[i][4];
+      var nc = items[i][5];
+      // Compute span here too — same date arithmetic as the build
+      // does for phrase_details, but the long-active list is a flat
+      // tuple so we recompute. Local-tz parsing not needed since we
+      // only care about whole-day deltas.
+      var span = '';
+      if (dmin && dmax) {
+        var fromMs = Date.parse(dmin + 'T12:00:00Z');
+        var toMs = Date.parse(dmax + 'T12:00:00Z');
+        if (!isNaN(fromMs) && !isNaN(toMs)) {
+          var spanDays = Math.round((toMs - fromMs) / 86400000) + 1;
+          span = '<strong>' + spanFraming(spanDays) + '</strong>' +
+            '<div class="span-dates">' + escapeHTML(dmin) + ' &mdash; ' + escapeHTML(dmax) + '</div>';
+        }
+      }
+      var ncCell = nc == null ? '<span class="muted">—</span>'
+        : nc >= 100
+          ? '<span class="reach-broad" title="Reach beyond direct sharing partners">' + nc.toLocaleString() + '</span>'
+          : nc.toLocaleString();
+      var phraseFlags = '';
+      if (currentDetails && currentDetails[phrase]) {
+        var fset = flagsForDetail(currentDetails[phrase], count, phrase);
+        phraseFlags = renderFlags(fset);
+      }
+      html += '<tr class="bar-row case-row" data-phrase="' + escapeHTML(phrase) + '">' +
+        '<td class="case">' + escapeHTML(phrase) +
+        ' <span class="expand-hint" aria-hidden="true">&#9662;</span></td>' +
+        '<td class="num">' + count.toLocaleString() + '</td>' +
+        '<td>' + span + '</td>' +
+        '<td class="num">' + days + '</td>' +
+        '<td class="num">' + ncCell + '</td>' +
+        '<td>' + phraseFlags + '</td>' +
+        '</tr>';
+    }
+    html += '</tbody></table></div>';
+    return html;
+  }
+
+  // The agency's published "Acceptable Use" / "Prohibited Uses" text,
+  // pulled from the same Flock transparency portal that publishes the
+  // search audit. Surfacing them above the cloud lets the reader judge
+  // whether the cloud's free-text reasons fit the agency's own
+  // declared policy. Both strings are short prose set by the agency.
+  function renderUses(a) {
+    var aup = a.acceptable_use_policy;
+    var pu = a.prohibited_uses;
+    if (!aup && !pu) return '';
+    var portalUrl = 'https://transparency.flocksafety.com/' +
+      encodeURIComponent(a.slug);
+    var html = '<h2>Stated uses ' +
+      '<a class="portal-link" href="' + portalUrl + '"' +
+      ' target="_blank" rel="noopener">' +
+      'View on Flock transparency portal &rarr;</a></h2>' +
+      '<div class="uses-block">';
+    if (aup) {
+      html += '<div class="uses-row uses-acceptable">' +
+        '<div class="uses-label">Acceptable use</div>' +
+        '<div class="uses-text">' + escapeHTML(aup) + '</div>' +
+        '</div>';
+    }
+    if (pu) {
+      html += '<div class="uses-row uses-prohibited">' +
+        '<div class="uses-label">Prohibited uses</div>' +
+        '<div class="uses-text">' + escapeHTML(pu) + '</div>' +
+        '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function renderCloud(items) {
+    if (!items.length) {
+      return '<div class="empty">No tokens to display for this agency.</div>';
+    }
+    var max = items[0][1];
+    var html = '<div class="cloud">';
+    // Shuffle for visual variety — strict sort puts huge words at one
+    // end of the line which reads as a list more than a cloud. Use a
+    // deterministic shuffle so the layout is stable across reloads
+    // (per-agency seed = sum of counts mod something).
+    var order = items.slice();
+    var seed = 0;
+    for (var k = 0; k < items.length; k++) seed = (seed + items[k][1]) | 0;
+    order.sort(function (a, b) {
+      var ha = ((seed * 9301 + a[1] * 49297) >>> 0) % 233280;
+      var hb = ((seed * 9301 + b[1] * 49297 + 1) >>> 0) % 233280;
+      // Tie-break on count so dominant words still tend to anchor;
+      // pure shuffle hides the signal in some agencies.
+      return (b[1] - a[1]) * 0.4 + (ha - hb) * 0.0001;
+    });
+    for (var i = 0; i < order.length; i++) {
+      var tok = order[i][0];
+      var count = order[i][1];
+      var size = scaleFontSize(count, max).toFixed(1);
+      var cls = 'word ' + (isCodeToken(tok) ? 'code' : colorClass(tok));
+      html += '<span class="' + cls + '" style="font-size:' + size + 'pt"' +
+        ' data-phrase="' + escapeHTML(tok) + '"' +
+        ' title="Click for detail &mdash; ' + escapeHTML(tok) + ': ' + count + '">' +
+        escapeHTML(tok) +
+        '<span class="count">' + count + '</span></span>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // Stable display order for filter pills so the row doesn't reflow
+  // depending on which agency you're looking at — concern flags go
+  // first (red), warn next (amber), info last (blue), with each
+  // group sorted by a fixed key order.
+  var FILTER_KIND_ORDER = [
+    'long-lived', 'heavy-use', 'broad-reach', 'stale-case',
+    'multi-officer', 'narrow-reach',
+  ];
+
+  function codeSlug(label) {
+    return String(label).toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  // Functional crime categories — readable journalistic buckets with
+  // an underlying NIBRS Group A correspondence noted in tooltips. Six
+  // top-level groups; an "(uncoded)" pseudo-category catches phrases
+  // with no detected penal/vehicle code.
+  var CODE_CATEGORY = {
+    // Violent (NIBRS 09A, 09B, 11A, 13A, 13B, 120, 100, 200)
+    '187': 'violent', '192': 'violent', '211': 'violent', '215': 'violent',
+    '220': 'violent', '240': 'violent', '242': 'violent', '243': 'violent',
+    '245': 'violent', '246': 'violent', '261': 'violent', '273.5': 'violent',
+    '288': 'violent', '207': 'violent', '417': 'violent', '422': 'violent',
+    '451': 'violent', '452': 'violent', '314': 'violent',
+    // Property (NIBRS 220, 23, 240, 250, 26, 290)
+    '459': 'property', '460': 'property', '466': 'property',
+    '470': 'property', '484': 'property', '487': 'property', '488': 'property',
+    '490.4': 'property', '496': 'property', '496d': 'property',
+    '530.5': 'property', '594': 'property', '10851': 'property',
+    '1030': 'property',
+    // Drug (NIBRS 35A, 35B)
+    '11350': 'drug', '11351': 'drug', '11352': 'drug',
+    '11377': 'drug', '11378': 'drug', '11379': 'drug',
+    // Weapons (NIBRS 520)
+    '25400': 'weapons', '25850': 'weapons', '29800': 'weapons',
+    // Traffic / DUI (NIBRS 90D plus state-specific hit-run)
+    '20001': 'traffic', '20002': 'traffic', '23103': 'traffic',
+    '23152': 'traffic', '23153': 'traffic', '2800': 'traffic',
+    '14601': 'traffic', '23101': 'traffic',
+    // Other / Misc — civil-status, radio codes, juvenile justice
+    '415': 'other', '5150': 'other', '300': 'other', '601': 'other',
+    '602': 'other', '1065': 'other', '10-65': 'other',
+  };
+
+  var CATEGORY_INFO = {
+    'violent':  { label: 'Violent',     order: 0, nibrs: 'NIBRS 09, 11A, 13, 100, 120, 200' },
+    'property': { label: 'Property',    order: 1, nibrs: 'NIBRS 23, 240, 250, 26, 290 (and burglary 220)' },
+    'drug':     { label: 'Drug',        order: 2, nibrs: 'NIBRS 35A, 35B' },
+    'weapons':  { label: 'Weapons',     order: 3, nibrs: 'NIBRS 520' },
+    'traffic':  { label: 'Traffic/DUI', order: 4, nibrs: 'NIBRS 90D plus state-specific hit-and-run' },
+    'case-id':  { label: 'Case IDs',    order: 5, nibrs: 'Custom — phrases shaped like a YY-NNNNN case/report number' },
+    'other':    { label: 'Other',       order: 6, nibrs: 'NIBRS Group B and uncategorized state codes' },
+  };
+
+  function categoriesForCodes(codes, phrase) {
+    var out = [];
+    var seen = {};
+    if (codes && codes.length) {
+      for (var i = 0; i < codes.length; i++) {
+        var cat = CODE_CATEGORY[codes[i][0]];
+        if (cat && !seen[cat]) {
+          seen[cat] = true;
+          out.push(cat);
+        }
+      }
+    }
+    // Case-number-shaped phrases get a synthetic "case-id" category
+    // even when no penal code is detected. A phrase can land in both
+    // a real-code category AND case-id (e.g. "26-13287/PC459") —
+    // that's correct, it deserves both buckets.
+    if (phrase && CASE_NUMBER_RE_JS.test(phrase) && !seen['case-id']) {
+      out.push('case-id');
+    }
+    return out;
+  }
+
+  function renderFilterBar(items) {
+    // Tally flag-kinds and code-labels across all bar items so the
+    // filter UI can offer both dimensions. Code labels collapse
+    // variant phrasings ("pc459" vs "459pc") under one filter — the
+    // user noted these are the same thing.
+    var byKind = {};
+    var byCode = {};
+    var byCat = {};
+    for (var i = 0; i < items.length; i++) {
+      var detail = items[i][3];
+      var phrase = items[i][0];
+      var count = items[i][1];
+      var flags = flagsForDetail(detail, count, phrase);
+      for (var j = 0; j < flags.length; j++) {
+        var f = flags[j];
+        if (!f.kind) continue;
+        if (!byKind[f.kind]) {
+          byKind[f.kind] = { count: 0, tone: f.tone };
+        }
+        byKind[f.kind].count += 1;
+      }
+      var codes = items[i][2] || [];
+      for (var k = 0; k < codes.length; k++) {
+        var label = codes[k][1];
+        var slug = codeSlug(label);
+        if (!byCode[slug]) byCode[slug] = { count: 0, label: label };
+        byCode[slug].count += 1;
+      }
+      var cats = categoriesForCodes(codes, phrase);
+      for (var ck = 0; ck < cats.length; ck++) {
+        var cat = cats[ck];
+        if (!byCat[cat]) byCat[cat] = { count: 0 };
+        byCat[cat].count += 1;
+      }
+    }
+    var kinds = Object.keys(byKind);
+    var codes = Object.keys(byCode);
+    var cats = Object.keys(byCat);
+    if (!kinds.length && !codes.length && !cats.length) return '';
+
+    kinds.sort(function (a, b) {
+      var ai = FILTER_KIND_ORDER.indexOf(a);
+      var bi = FILTER_KIND_ORDER.indexOf(b);
+      if (ai === -1) ai = 99;
+      if (bi === -1) bi = 99;
+      return ai - bi;
+    });
+    codes.sort(function (a, b) { return byCode[b].count - byCode[a].count; });
+    cats.sort(function (a, b) {
+      return (CATEGORY_INFO[a].order || 99) - (CATEGORY_INFO[b].order || 99);
+    });
+
+    var html = '<div class="filter-bar">' +
+      '<span class="filter-bar-label">Filter:</span> ' +
+      '<button class="filter-pill filter-all active" data-filter-type="all">All</button>';
+    for (var ki = 0; ki < kinds.length; ki++) {
+      var kind = kinds[ki];
+      var info = byKind[kind];
+      html += '<button class="filter-pill flag-' + info.tone +
+        '" data-filter-type="flag" data-filter-value="' + kind + '">' +
+        escapeHTML(kind) + ' <span class="filter-count">' +
+        info.count + '</span></button>';
+    }
+    if (cats.length) {
+      html += '<span class="filter-divider" aria-hidden="true">·</span>';
+      for (var ca = 0; ca < cats.length; ca++) {
+        var catKey = cats[ca];
+        var catInfo = CATEGORY_INFO[catKey] || { label: catKey, nibrs: '' };
+        html += '<button class="filter-pill filter-category" ' +
+          'data-filter-type="category" data-filter-value="' + catKey + '" ' +
+          'title="Approximated from ' + catInfo.nibrs + '">' +
+          escapeHTML(catInfo.label) +
+          ' <span class="filter-count">' + byCat[catKey].count + '</span></button>';
+      }
+    }
+    if (codes.length) {
+      html += '<span class="filter-divider" aria-hidden="true">·</span>';
+      for (var ci = 0; ci < codes.length; ci++) {
+        var slug2 = codes[ci];
+        var ci2 = byCode[slug2];
+        html += '<button class="filter-pill filter-code' +
+          '" data-filter-type="code" data-filter-value="' + slug2 + '">' +
+          escapeHTML(ci2.label) +
+          ' <span class="filter-count">' + ci2.count + '</span></button>';
+      }
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // Aggregate items into a list of pseudo-rows keyed by code or
+  // category. Each output row has the same shape as a phrase row
+  // ([phrase, count, codes, detail]) so the renderer can stay generic.
+  // Multi-code phrases contribute their full count to each constituent
+  // code/category — the totals can exceed search count for that reason.
+  function aggregateItems(items, mode) {
+    if (mode === 'phrase') return items;
+    var byKey = {};
+    var totalUncoded = 0;
+    var totalBlank = 0;
+    for (var i = 0; i < items.length; i++) {
+      var phrase = items[i][0];
+      var count = items[i][1];
+      var codes = items[i][2] || [];
+      // (blank) gets its own bucket — it's a meaningfully different
+      // category from "phrase had words but none were a known code"
+      // (uncoded). Same treatment in both code and category modes.
+      if (phrase === '(blank)') {
+        totalBlank += count;
+        continue;
+      }
+      if (mode === 'code') {
+        if (!codes.length) {
+          totalUncoded += count;
+          continue;
+        }
+        for (var j = 0; j < codes.length; j++) {
+          var label = codes[j][1];
+          var k = codeSlug(label);
+          if (!byKey[k]) {
+            byKey[k] = {
+              display: label, count: 0, codes: [codes[j]],
+              drillType: 'code', drillValue: k,
+            };
+          }
+          byKey[k].count += count;
+        }
+      } else if (mode === 'category') {
+        var cats = categoriesForCodes(codes, phrase);
+        if (!cats.length) {
+          totalUncoded += count;
+          continue;
+        }
+        for (var c = 0; c < cats.length; c++) {
+          var cat = cats[c];
+          var info = CATEGORY_INFO[cat] || { label: cat };
+          if (!byKey[cat]) {
+            byKey[cat] = {
+              display: info.label, count: 0, codes: [],
+              drillType: 'category', drillValue: cat,
+            };
+          }
+          byKey[cat].count += count;
+        }
+      }
+    }
+    var keys = Object.keys(byKey);
+    keys.sort(function (a, b) { return byKey[b].count - byKey[a].count; });
+    var out = [];
+    for (var ki = 0; ki < keys.length; ki++) {
+      var key = keys[ki];
+      var row = byKey[key];
+      // Aggregated rows aren't expandable into per-phrase detail —
+      // the underlying daily/hourly grids would need a re-aggregation
+      // pass. Instead, clicking drills down: switch to Phrase mode
+      // with a matching filter applied. drillType/drillValue carry
+      // the target filter to the click handler.
+      out.push([row.display, row.count, row.codes, null,
+        { type: row.drillType, value: row.drillValue }]);
+    }
+    if (totalUncoded > 0) {
+      out.push(['(uncoded)', totalUncoded, [], null, null]);
+    }
+    if (totalBlank > 0) {
+      // Drill-down for (blank) goes back to phrase mode and selects
+      // the literal (blank) row. No filter pill matches "(blank)"
+      // directly, so we hand off via phrase navigation rather than a
+      // pill click.
+      out.push(['(blank)', totalBlank, [], null,
+        { type: 'phrase', value: '(blank)' }]);
+    }
+    return out;
+  }
+
+  var currentViewMode = 'phrase';
+
+  function renderViewModeToggle() {
+    var modes = [
+      { key: 'phrase',   label: 'Phrase' },
+      { key: 'code',     label: 'By code' },
+      { key: 'category', label: 'By category' },
+    ];
+    var html = '<div class="view-mode-toggle">' +
+      '<span class="view-mode-label">Group by:</span>';
+    for (var i = 0; i < modes.length; i++) {
+      var m = modes[i];
+      var cls = 'view-mode-btn' + (m.key === currentViewMode ? ' active' : '');
+      html += '<button class="' + cls + '" data-view-mode="' + m.key + '">' +
+        m.label + '</button>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // For the small set of agencies whose audit CSV schema entirely
+  // omits any justification field — not even an empty column — we
+  // render a structural-transparency callout instead of bars.
+  // Listing "(blank)" as the dominant phrase would be misleading:
+  // there is no field to be blank.
+  function renderNoJustificationCallout(agencyData) {
+    var fields = agencyData.audit_schema || [];
+    var fieldsHtml = fields.map(function (f) {
+      return '<code>' + escapeHTML(f) + '</code>';
+    }).join(', ');
+    return '<div class="no-justification-callout">' +
+      '<div class="no-justification-head">' +
+      'The only fields published in this agency&rsquo;s audit are ' + fieldsHtml +
+      '</div>' +
+      '<div class="no-justification-body">' +
+      '<p>Other CA agencies&rsquo; audits include one or more of ' +
+      '<code>reason</code> (free-text), <code>offenseType</code> ' +
+      '(NIBRS-aligned dropdown), or <code>caseNumber</code> (case ID). ' +
+      'This agency&rsquo;s audit publishes none of those, so the ' +
+      'audit records that <strong>' + agencyData.row_count.toLocaleString() +
+      '</strong> searches occurred but not why any of them was run.</p>' +
+      '<p><strong>Officer-level accountability is also unavailable.</strong> ' +
+      'The <code>userId</code> field is redacted to <code>***</code> by Flock ' +
+      'across every agency&rsquo;s public audit, so the officer who ran each ' +
+      'search cannot be identified from this published record alone &mdash; ' +
+      'true for all ' + currentAgencyCount + ' audit-publishing agencies, ' +
+      'not just this one.</p>' +
+      '</div></div>';
+  }
+
+  function renderBars(items, total) {
+    if (!items.length) {
+      return '<div class="empty">No phrases to display for this agency.</div>';
+    }
+    var displayItems = aggregateItems(items, currentViewMode);
+    var filterBarHtml = currentViewMode === 'phrase' ? renderFilterBar(items) : '';
+    var hint = currentViewMode === 'phrase'
+      ? 'Click any row for per-phrase detail (timing, network reach, daily cadence).'
+      : 'Aggregated view &mdash; phrases with multiple codes are counted under each, so totals can exceed search count. ' +
+        'Switch back to <em>Phrase</em> grouping for clickable rows with detail.';
+    var html = renderViewModeToggle() +
+      filterBarHtml +
+      '<div class="bar-list-hint">' + hint + '</div>' +
+      '<div class="bar-list">';
+    items = displayItems;
+    for (var i = 0; i < items.length; i++) {
+      var phrase = items[i][0];
+      var count = items[i][1];
+      var codes = items[i][2] || [];
+      var detail = items[i][3];
+      var sharePct = total > 0 ? (100 * count / total) : 0;
+      // Bar fill is the absolute share of total searches — a 12%
+      // phrase fills 12% of the track. The cap of 100% naturally
+      // applies; min 1% so even tiny entries show a visible nub.
+      var w = Math.max(1, Math.round(sharePct));
+
+      // Code-identification pills (orange) sit next to the phrase so
+      // the "what is this" answer is right beside the text. Behavior
+      // flags (long-lived, heavy use, broad reach, etc.) go in the
+      // right column where the reader can scan for notable patterns
+      // without re-reading every phrase.
+      var flags = flagsForDetail(detail, count, phrase);
+      // Pills sit on a second line within each row — code-id pills
+      // first (orange, "what is this"), then behavior flags
+      // (red/amber/blue, "what's notable"). Single line per kind so
+      // the bar list still scans cleanly column-wise.
+      var pillsBelow = '';
+      if (codes.length || flags.length) {
+        pillsBelow = '<div class="pill-row">';
+        for (var j = 0; j < codes.length; j++) {
+          pillsBelow += renderCodePill(codes[j]);
+        }
+        if (flags.length) pillsBelow += renderFlags(flags);
+        pillsBelow += '</div>';
+      }
+
+      var isAggregated = currentViewMode !== 'phrase';
+      var isBlank = phrase === '(blank)';
+      var rowCls = 'bar-row bar-item' + (isBlank ? ' bar-row-blank' : '') +
+        (isAggregated ? ' bar-row-aggregated' : '');
+      var flagKinds = '';
+      for (var fi = 0; fi < flags.length; fi++) {
+        if (flags[fi].kind) flagKinds += ' ' + flags[fi].kind;
+      }
+      flagKinds = flagKinds.trim();
+      var codeLabels = '';
+      for (var cli = 0; cli < codes.length; cli++) {
+        codeLabels += ' ' + codeSlug(codes[cli][1]);
+      }
+      codeLabels = codeLabels.trim();
+      var rowCats = categoriesForCodes(codes, phrase).join(' ');
+      var labelHtml = isBlank
+        ? '<span class="blank-label" title="Officer did not enter a reason for this search">' +
+          escapeHTML(phrase) + '</span>'
+        : escapeHTML(phrase);
+      var rowAttrs = ' data-phrase="' + escapeHTML(phrase) + '"' +
+        ' data-flag-kinds="' + escapeHTML(flagKinds) + '"' +
+        ' data-code-labels="' + escapeHTML(codeLabels) + '"' +
+        ' data-categories="' + escapeHTML(rowCats) + '"';
+      var drilldown = items[i][4];
+      if (isAggregated) {
+        rowAttrs += ' data-aggregated="1"';
+        if (drilldown && drilldown.type) {
+          rowAttrs += ' data-drilldown-type="' + escapeHTML(drilldown.type) + '"' +
+            ' data-drilldown-value="' + escapeHTML(drilldown.value) + '"' +
+            ' role="button" tabindex="0" aria-label="Drill into ' +
+            escapeHTML(phrase) + '"';
+        }
+      } else {
+        rowAttrs += ' role="button" tabindex="0" aria-label="Click to expand details for ' +
+          escapeHTML(phrase) + '"';
+      }
+      var hintHtml;
+      if (isAggregated) {
+        hintHtml = (drilldown && drilldown.type)
+          ? '<span class="expand-hint" aria-hidden="true">Drill in <span class="drill-arrow">&rsaquo;</span></span>'
+          : '';
+      } else {
+        hintHtml = '<span class="expand-hint" aria-hidden="true">Details <span class="expand-arrow">&#9662;</span></span>';
+      }
+      html += '<div class="' + rowCls + '"' + rowAttrs + '>' +
+        '<div class="bar-item-main">' +
+        '<span class="bar-track">' +
+        '<span class="bar" style="width:' + w + '%"></span>' +
+        '<span class="bar-pct">' + sharePct.toFixed(1) + '%</span>' +
+        '</span>' +
+        '<span class="bar-count">' + count.toLocaleString() + '</span>' +
+        '<span class="phrase-text">' + labelHtml + '</span>' +
+        hintHtml +
+        '</div>' +
+        pillsBelow +
+        '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // Per-phrase detail panel: a stat line, a hourly mini-histogram,
+  // and a weekly one. Rendered into the detail row when a phrase is
+  // expanded. Returns the HTML string, not a node, so it can be
+  // injected via innerHTML alongside the rest of the table.
+  // ── Flags ──
+  // High-level pattern callouts derived from a phrase's detail data
+  // and the phrase string itself. Each flag has a tone (info / warn /
+  // concern) for color, a label for the badge, and a longer tooltip.
+  // The same flag set renders both as small badges on the long-active
+  // callout rows and at the top of the expanded detail panel.
+
+  var CASE_NUMBER_RE_JS = /^\d{2,4}-\d{3,8}$/;
+
+  function flagsForDetail(detail, count, phrase) {
+    var flags = [];
+    if (!detail) return flags;
+    var span = detail.span_days || 0;
+    var days = detail.days || 0;
+
+    // Span / longevity tiers. Strongest tier wins (don't double-flag).
+    if (span >= 90) {
+      flags.push({
+        label: 'long-lived (3+ mo)',
+        kind: 'long-lived',
+        tone: 'concern',
+        ruleTitle: 'Span ≥ 90 days',
+        ruleBody: 'Triggered when the calendar window from first to last search exceeds 90 days &mdash; one case-number justification sustained across a full quarter.',
+        observed: 'This phrase: <strong>' + span + '-day span</strong> (first ' +
+          (detail.from || '?') + ', last ' + (detail.to || '?') + ').',
+      });
+    } else if (span >= 30) {
+      flags.push({
+        label: 'long-lived',
+        kind: 'long-lived',
+        tone: 'warn',
+        ruleTitle: 'Span ≥ 30 days',
+        ruleBody: 'Triggered when the calendar window from first to last search exceeds 30 days. A single case-number justification reused that long warrants proportionality review.',
+        observed: 'This phrase: <strong>' + span + '-day span</strong> (first ' +
+          (detail.from || '?') + ', last ' + (detail.to || '?') + ').',
+      });
+    }
+
+    // Heavy use: high absolute count AND a meaningful per-active-day
+    // rate. Either alone isn't striking; both together suggest a
+    // sustained operational dependence on one justification text.
+    if (count >= 50) {
+      var perActiveDay = days > 0 ? count / days : 0;
+      if (perActiveDay >= 3) {
+        flags.push({
+          label: 'heavy use',
+          kind: 'heavy-use',
+          tone: 'concern',
+          ruleTitle: 'Searches ≥ 50 and ≥ 3 per active day',
+          ruleBody: 'Triggered when the phrase has at least 50 total searches AND averages 3+ searches on each active day. Either alone isn’t striking; both together suggest a sustained operational dependence on one justification text.',
+          observed: 'This phrase: <strong>' + count.toLocaleString() + ' searches</strong> over ' +
+            days + ' active days (<strong>' + perActiveDay.toFixed(1) + ' per active day</strong>).',
+        });
+      }
+    }
+
+    // Multi-officer pattern: round-the-clock + most days. Hard to
+    // produce single-officer; consistent with shift coverage / RTIC
+    // dispatch / hotlist alerting rather than one investigator's work.
+    var hourActive = 0;
+    if (detail.hourly) {
+      for (var i = 0; i < 24; i++) if (detail.hourly[i] > 0) hourActive++;
+    }
+    var dayActive = 0;
+    if (detail.weekly) {
+      for (var i2 = 0; i2 < 7; i2++) if (detail.weekly[i2] > 0) dayActive++;
+    }
+    if (hourActive >= 16 && dayActive >= 6 && count >= 20) {
+      flags.push({
+        label: 'multi-officer pattern',
+        kind: 'multi-officer',
+        tone: 'info',
+        ruleTitle: '≥ 16 hours of day and ≥ 6 days of week active',
+        ruleBody: 'Triggered when activity reaches at least 16 distinct hours of day AND at least 6 days of the week (with ≥ 20 total searches). Hard to produce from a single officer; consistent with multiple officers, shift coverage, or automated alerting rather than one investigator.',
+        observed: 'This phrase: <strong>' + hourActive + ' hours of day</strong>, <strong>' +
+          dayActive + ' days of week</strong>.',
+      });
+    }
+
+    // Network reach. nc_med exposure to "above direct partners" is the
+    // disclosure question; flagged as concern. nc_max <= 10 means the
+    // search stayed within a small partner set; that's expected and
+    // gets a quieter info tag.
+    if (detail.nc_med != null) {
+      if (detail.nc_med >= 100) {
+        flags.push({
+          label: 'broad reach',
+          kind: 'broad-reach',
+          tone: 'concern',
+          ruleTitle: 'Median networkCount ≥ 100',
+          ruleBody: 'Triggered when the median search reaches at least 100 networks. No California agency publishes 100+ direct sharing partners, so this routinely exceeds the agency’s declared bilateral sharing.',
+          observed: 'This phrase: <strong>median ' + detail.nc_med.toLocaleString() +
+            ' networks</strong> per search (range ' + detail.nc_min.toLocaleString() +
+            '&ndash;' + detail.nc_max.toLocaleString() + ').',
+        });
+      } else if (detail.nc_max != null && detail.nc_max <= 10) {
+        flags.push({
+          label: 'narrow reach',
+          kind: 'narrow-reach',
+          tone: 'info',
+          ruleTitle: 'Max networkCount ≤ 10',
+          ruleBody: 'Triggered when even the broadest search for this phrase stays within 10 networks &mdash; consistent with use limited to direct sharing partners.',
+          observed: 'This phrase: <strong>max ' + detail.nc_max.toLocaleString() +
+            ' networks</strong> (median ' + detail.nc_med.toLocaleString() + ').',
+        });
+      }
+    }
+
+    // Case-number staleness (PR-prefixed). YY-NNNNN: 2-digit prefix,
+    // assume 2000s. YYYY-NNNNN: take the year directly. We're only
+    // confident for case numbers where the prefix is plausibly a year
+    // (<= current year + 1).
+    if (CASE_NUMBER_RE_JS.test(phrase)) {
+      var m = phrase.match(/^(\d{2,4})-/);
+      if (m) {
+        var prefix = parseInt(m[1], 10);
+        var currentYear = new Date().getFullYear();
+        var yearGuess = null;
+        if (prefix >= 1900 && prefix <= currentYear + 1) {
+          yearGuess = prefix;
+        } else if (prefix < 100) {
+          yearGuess = prefix < 50 ? 2000 + prefix : 1900 + prefix;
+        }
+        if (yearGuess && yearGuess >= 1990 && yearGuess <= currentYear) {
+          var ageYears = currentYear - yearGuess;
+          if (ageYears >= 2) {
+            flags.push({
+              label: 'stale case (' + ageYears + 'y old)',
+              kind: 'stale-case',
+              tone: 'concern',
+              ruleTitle: 'Case-number prefix ≥ 2 years before audit window',
+              ruleBody: 'Triggered when the case-number prefix &mdash; commonly the year a case was opened &mdash; is interpreted as a year at least 2 years older than the current audit window. Heuristic: many agencies but not all use YY- or YYYY- prefixes for the case year.',
+              observed: 'Prefix <code>' + escapeHTML(m[1]) + '</code> &rarr; year <strong>' +
+                yearGuess + '</strong>, <strong>' + ageYears + ' years old</strong> as of today.',
+            });
+          }
+        }
+      }
+    }
+
+    return flags;
+  }
+
+  // Map a CA code-book abbreviation to its full title. The label
+  // already has the abbreviation in parens (e.g. "Burglary (PC)") —
+  // we expand it for the tooltip so a non-LE-savvy reader can see
+  // what the suffix means without having to look it up.
+  var CODE_BOOK_NAMES = {
+    PC: 'California Penal Code',
+    CVC: 'California Vehicle Code',
+    HSC: 'California Health & Safety Code',
+    WIC: 'California Welfare & Institutions Code',
+  };
+
+  function codeBookFromLabel(label) {
+    // Match the trailing "(PC)" / "(CVC)" / etc. — preserve the
+    // raw match so we can show "(historic)" qualifiers verbatim.
+    var m = String(label).match(/\(([A-Z]+)(?:,[^)]*)?\)\s*$/);
+    if (!m) return null;
+    return m[1];
+  }
+
+  function renderCodePill(codeRow) {
+    var code = codeRow[0];
+    var label = codeRow[1];
+    var book = codeBookFromLabel(label);
+    var bookFull = book ? (CODE_BOOK_NAMES[book] || book) : '';
+    var ruleLine = bookFull ? bookFull + ' &sect; ' + escapeHTML(code)
+                            : 'Section ' + escapeHTML(code);
+    var bodyLine = 'Detected by matching the bare section number in the ' +
+      'phrase against a static lookup of common ALPR-audit penal, vehicle, ' +
+      'health-and-safety, and welfare-and-institutions code references. ' +
+      'The label is what the lookup table assigns to that section.';
+    var observedLine = 'Phrase resolved to code <code>' + escapeHTML(code) +
+      '</code> &rarr; "' + escapeHTML(label) + '".';
+    return '<span class="code-pill" tabindex="0">' +
+      escapeHTML(label) +
+      '<span class="flag-tip" role="tooltip">' +
+      '<span class="flag-tip-rule">' + ruleLine + '</span>' +
+      '<span class="flag-tip-body">' + bodyLine + '</span>' +
+      '<span class="flag-tip-observed">' + observedLine + '</span>' +
+      '</span>' +
+      '</span>';
+  }
+
+  function renderFlags(flags) {
+    if (!flags || !flags.length) return '';
+    var html = '<span class="flag-tags">';
+    for (var i = 0; i < flags.length; i++) {
+      var f = flags[i];
+      html += '<span class="flag-tag flag-' + f.tone + '" tabindex="0">' +
+        escapeHTML(f.label) +
+        '<span class="flag-tip" role="tooltip">' +
+        '<span class="flag-tip-rule">' + f.ruleTitle + '</span>' +
+        '<span class="flag-tip-body">' + f.ruleBody + '</span>' +
+        '<span class="flag-tip-observed">' + f.observed + '</span>' +
+        '</span>' +
+        '</span>';
+    }
+    html += '</span>';
+    return html;
+  }
+
+  // ── Pattern-summary helpers ──
+  // Convert a weekday distribution (Mon=0..Sun=6) and an hour-of-day
+  // distribution (0..23) into prose. Keeps the per-phrase detail panel
+  // legible without three competing tiny charts.
+
+  var DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+  function listToProse(arr) {
+    if (arr.length === 0) return '';
+    if (arr.length === 1) return arr[0];
+    if (arr.length === 2) return arr[0] + ' and ' + arr[1];
+    return arr.slice(0, -1).join(', ') + ', and ' + arr[arr.length - 1];
+  }
+
+  function formatHour(h) {
+    h = ((h % 24) + 24) % 24;
+    if (h === 0) return 'midnight';
+    if (h === 12) return 'noon';
+    if (h < 12) return h + 'am';
+    return (h - 12) + 'pm';
+  }
+
+  function describeWeekday(weekly) {
+    if (!weekly) return '';
+    var total = 0;
+    for (var i = 0; i < 7; i++) total += weekly[i];
+    if (total === 0) return '';
+
+    // Coefficient-of-variation as a uniformity gauge: a roughly even
+    // distribution gets the "spread evenly" framing rather than a
+    // forced peak-day call-out.
+    var mean = total / 7;
+    var variance = 0;
+    for (var i2 = 0; i2 < 7; i2++) {
+      variance += (weekly[i2] - mean) * (weekly[i2] - mean);
+    }
+    variance /= 7;
+    var cv = mean > 0 ? Math.sqrt(variance) / mean : 0;
+
+    if (cv < 0.45) {
+      return 'Searches are spread fairly evenly across all days of the week.';
+    }
+
+    // Days with at least half the mean's worth of activity count as
+    // "active." Cap a small floor so a single search on Sunday in a
+    // 200-search dataset doesn't muddy the call-out.
+    var threshold = Math.max(2, mean * 0.5);
+    var active = [];
+    for (var i3 = 0; i3 < 7; i3++) {
+      if (weekly[i3] >= threshold) active.push(i3);
+    }
+    if (active.length === 0 || active.length === 7) {
+      return 'Searches occur across the whole week.';
+    }
+    if (active.length === 1) {
+      return 'Searches are concentrated on ' + DAY_NAMES[active[0]] + '.';
+    }
+
+    // Try contiguous-range framing in both linear and cyclic order
+    // (so e.g. Sun–Thu — wrap-around — phrases naturally).
+    var sortedActive = active.slice().sort(function (a, b) { return a - b; });
+    var contig = true;
+    for (var k = 1; k < sortedActive.length; k++) {
+      if (sortedActive[k] - sortedActive[k - 1] !== 1) { contig = false; break; }
+    }
+    if (contig) {
+      return 'The bulk of searches happen ' +
+        DAY_NAMES[sortedActive[0]] + ' through ' +
+        DAY_NAMES[sortedActive[sortedActive.length - 1]] + '.';
+    }
+    // Cyclic contiguous (e.g. Sun, Mon, Tue, Wed, Thu)
+    var rotated = sortedActive.map(function (d) { return (d + 1) % 7; }).sort(function (a, b) { return a - b; });
+    var contigCyc = true;
+    for (var k2 = 1; k2 < rotated.length; k2++) {
+      if (rotated[k2] - rotated[k2 - 1] !== 1) { contigCyc = false; break; }
+    }
+    if (contigCyc) {
+      var firstRot = rotated[0] === 0 ? 6 : rotated[0] - 1;
+      var lastRot = rotated[rotated.length - 1] === 0 ? 6 : rotated[rotated.length - 1] - 1;
+      return 'The bulk of searches happen ' +
+        DAY_NAMES[firstRot] + ' through ' +
+        DAY_NAMES[lastRot] + '.';
+    }
+    return 'Searches concentrate on ' +
+      listToProse(active.map(function (d) { return DAY_NAMES[d]; })) + '.';
+  }
+
+  function describeHour(hourly) {
+    if (!hourly) return '';
+    var total = 0;
+    for (var i = 0; i < 24; i++) total += hourly[i];
+    if (total === 0) return '';
+
+    // Smallest cyclic window containing 80% of activity. Cyclic so
+    // a graveyard pattern (10pm–6am) reads as one contiguous block,
+    // not as "before 6am" + "after 10pm."
+    var target = total * 0.8;
+    var bestStart = 0, bestWidth = 24;
+    for (var start = 0; start < 24; start++) {
+      var sum = 0;
+      for (var len = 1; len <= 24; len++) {
+        sum += hourly[(start + len - 1) % 24];
+        if (sum >= target) {
+          if (len < bestWidth) {
+            bestWidth = len;
+            bestStart = start;
+          }
+          break;
+        }
+      }
+    }
+
+    if (bestWidth >= 22) return 'Searches occur round the clock.';
+    if (bestWidth >= 18) return 'Searches are spread broadly across the day.';
+    var endHour = (bestStart + bestWidth) % 24;
+    return 'The bulk of searches happen between ' +
+      formatHour(bestStart) + ' and ' + formatHour(endHour) + '.';
+  }
+
+  function describeCalendar(daily, days, span) {
+    if (!daily || !daily.length || !span) return '';
+    // Longest run of zero days bracketed by activity.
+    var maxGap = 0, gap = 0, started = false;
+    for (var i = 0; i < daily.length; i++) {
+      if (daily[i] === 0) {
+        if (started) gap++;
+      } else {
+        started = true;
+        if (gap > maxGap) maxGap = gap;
+        gap = 0;
+      }
+    }
+    if (maxGap >= 14) {
+      return 'Activity is intermittent &mdash; there is a stretch of ' +
+        maxGap + ' consecutive days with no searches at all.';
+    }
+    var density = days / span;
+    if (density >= 0.7) {
+      return 'Searches happen on most days within the span.';
+    }
+    if (density <= 0.3) {
+      return 'Activity is sparse &mdash; only ' + Math.round(100 * density) +
+        '% of days within the span had any search activity.';
+    }
+    return '';
+  }
+
+  // Translate a span in days to a human framing the reader can grasp
+  // at a glance — "53 days" lands less than "8 weeks" or "1 month",
+  // and the whole point of the long-active callout is the span.
+  function spanFraming(spanDays) {
+    if (!spanDays || spanDays < 2) return '';
+    if (spanDays < 14) return spanDays + '-day span';
+    if (spanDays < 60) {
+      var w = Math.round(spanDays / 7);
+      return spanDays + '-day span (~' + w + ' week' + (w === 1 ? '' : 's') + ')';
+    }
+    if (spanDays < 365) {
+      var m = Math.round(spanDays / 30.4);
+      return spanDays + '-day span (~' + m + ' month' + (m === 1 ? '' : 's') + ')';
+    }
+    var y = (spanDays / 365.25).toFixed(1);
+    return spanDays + '-day span (~' + y + ' years)';
+  }
+
+  function renderPhraseDetail(detail, phrase, count) {
+    if (!detail) {
+      return '<div class="empty">No timestamped rows for this phrase.</div>';
+    }
+    var dateLine = '';
+    if (detail.from && detail.to) {
+      var span = spanFraming(detail.span_days);
+      dateLine = (span ? '<strong>' + span + '</strong>: ' : '') +
+        detail.from + ' through ' + detail.to +
+        ' &middot; active on ' + detail.days + ' of ' +
+        (detail.span_days || detail.days) + ' day' +
+        ((detail.span_days || detail.days) === 1 ? '' : 's');
+    }
+    var ncLine = '';
+    if (detail.nc_med != null) {
+      ncLine = '<strong>Network reach</strong>: median ' +
+        detail.nc_med.toLocaleString() +
+        ' (range ' + detail.nc_min.toLocaleString() +
+        '&ndash;' + detail.nc_max.toLocaleString() + ')';
+      if (detail.nc_over_100) {
+        ncLine += ' &middot; <span class="reach-broad">' + detail.nc_over_100.toLocaleString() +
+          ' search' + (detail.nc_over_100 === 1 ? '' : 'es') +
+          ' reached &ge;100 networks</span>';
+      }
+    }
+
+    var summarySentences = [];
+    var s1 = describeWeekday(detail.weekly);
+    if (s1) summarySentences.push(s1);
+    var s2 = describeHour(detail.hourly);
+    if (s2) summarySentences.push(s2);
+    var s3 = describeCalendar(detail.daily, detail.days, detail.span_days);
+    if (s3) summarySentences.push(s3);
+    var summaryHtml = summarySentences.length
+      ? '<div class="phrase-detail-row phrase-detail-summary">' +
+        summarySentences.join(' ') + '</div>'
+      : '';
+
+    var dailyHtml = '';
+    if (detail.daily && detail.daily.length) {
+      var unit = detail.daily_unit === 'week' ? 'week' : 'day';
+      dailyHtml = '<div class="phrase-detail-row">' +
+        '<div class="phrase-detail-chart phrase-detail-chart-full">' +
+        '<div class="phrase-detail-label">Searches per ' + unit +
+        ' (' + detail.daily.length + ' ' + unit + 's)</div>' +
+        renderDailySpark(detail.daily, detail.from, detail.daily_unit) +
+        '</div></div>';
+    }
+
+    var flags = flagsForDetail(detail, count, phrase);
+    var flagsHtml = flags.length ? renderFlags(flags) : '';
+    var codes = currentCodes[phrase] || [];
+    var codePillsHtml = '';
+    if (codes.length) {
+      codePillsHtml = '<div class="phrase-detail-codes">';
+      for (var ci = 0; ci < codes.length; ci++) {
+        codePillsHtml += renderCodePill(codes[ci]);
+      }
+      codePillsHtml += '</div>';
+    }
+
+    return '<div class="phrase-detail">' +
+      '<div class="phrase-detail-head">' +
+      '<strong>' + count.toLocaleString() + ' searches</strong>' +
+      (dateLine ? ' &middot; ' + dateLine : '') +
+      codePillsHtml +
+      (flagsHtml ? '<div class="phrase-detail-flags">' + flagsHtml + '</div>' : '') +
+      '</div>' +
+      (ncLine ? '<div class="phrase-detail-row">' + ncLine + '</div>' : '') +
+      summaryHtml +
+      dailyHtml +
+      '</div>';
+  }
+
+  // Daily-or-weekly density sparkline: one cell per period, height
+  // proportional to count. Empty cells stay visible (faint baseline)
+  // so gaps in activity don't visually compress the span.
+  function renderDailySpark(series, fromIso, unit) {
+    if (!series || !series.length) return '';
+    var max = 1;
+    for (var i = 0; i < series.length; i++) if (series[i] > max) max = series[i];
+    var fromDate = fromIso ? new Date(fromIso + 'T12:00:00Z') : null;
+    var step = unit === 'week' ? 7 : 1;
+    var html = '<div class="daily-spark">';
+    for (var i2 = 0; i2 < series.length; i2++) {
+      var v = series[i2];
+      var ph = max > 0 ? Math.round(100 * v / max) : 0;
+      var label = '';
+      if (fromDate) {
+        var d = new Date(fromDate.getTime() + i2 * step * 86400000);
+        label = d.toISOString().slice(0, 10);
+      }
+      var titleText = (label ? label + ': ' : '') + v +
+        ' search' + (v === 1 ? '' : 'es');
+      var cls = 'spark-bar' + (v === 0 ? ' empty' : '');
+      html += '<div class="' + cls + '" title="' + titleText + '">' +
+        '<div class="spark-fill" style="height:' + ph + '%"></div>' +
+        '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  // Click-handler for bar rows / cloud words / case-callout rows.
+  // Toggles a sibling detail row containing renderPhraseDetail output
+  // for the clicked phrase. Single delegated listener attached at
+  // init time.
+  function handleExpandClick(ev) {
+    // View-mode toggle buttons — change mode and re-render.
+    var modeBtn = ev.target.closest('.view-mode-btn');
+    if (modeBtn) {
+      var mode = modeBtn.getAttribute('data-view-mode');
+      if (mode && mode !== currentViewMode && currentAgencyData) {
+        currentViewMode = mode;
+        document.getElementById('page').innerHTML =
+          renderAgency(currentAgencyData, currentSlug);
+      }
+      return;
+    }
+    // Filter-pill clicks next — they aren't expandable rows.
+    var pill = ev.target.closest('.filter-pill');
+    if (pill) {
+      handleFilterClick(pill);
+      return;
+    }
+    var target = ev.target.closest('[data-phrase]');
+    if (!target) return;
+    // Aggregated rows drill down rather than expand: switch to Phrase
+    // mode and activate the matching filter pill (or for (blank),
+    // scroll to the row in the unfiltered phrase list).
+    if (target.getAttribute('data-aggregated') === '1') {
+      var drillType = target.getAttribute('data-drilldown-type');
+      var drillValue = target.getAttribute('data-drilldown-value');
+      if (!drillType || !drillValue || !currentAgencyData) return;
+      currentViewMode = 'phrase';
+      document.getElementById('page').innerHTML =
+        renderAgency(currentAgencyData, currentSlug);
+      if (drillType === 'phrase') {
+        var row = document.querySelector(
+          '.bar-item[data-phrase="' + drillValue.replace(/"/g, '\\"') + '"]'
+        );
+        if (row) {
+          row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          row.classList.add('expanded');
+          window.setTimeout(function () { row.classList.remove('expanded'); }, 1500);
+        }
+        return;
+      }
+      var pill = document.querySelector(
+        '.filter-pill[data-filter-type="' + drillType +
+        '"][data-filter-value="' + drillValue + '"]'
+      );
+      if (pill) handleFilterClick(pill);
+      return;
+    }
+    var phrase = target.getAttribute('data-phrase');
+    if (!phrase) return;
+    var details = currentDetails;
+    if (!details) return;
+    var detail = details[phrase];
+    var count = currentCounts[phrase] || 0;
+
+    // Cloud word click: scroll to the matching bar row and toggle its
+    // expansion. Keeps a single source of truth for the expanded state.
+    if (target.classList.contains('word')) {
+      var barRow = document.querySelector(
+        '.bar-row[data-phrase="' + phraseAttr(phrase) + '"]'
+      );
+      if (barRow) {
+        barRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        toggleRowExpansion(barRow, detail, phrase, count);
+      }
+      return;
+    }
+    // Bar list uses div rows; long-active callout still uses table rows.
+    var row = target.closest('.bar-item, tr.bar-row');
+    if (row) {
+      toggleRowExpansion(row, detail, phrase, count);
+    }
+  }
+
+  function phraseAttr(s) {
+    // Match the escapeHTML output for use inside a CSS attribute selector.
+    return s.replace(/"/g, '&quot;');
+  }
+
+  // Filter-pill click: dim non-matching rows in the bars table.
+  // Clicking the same kind again (or "All") clears the filter.
+  function handleFilterClick(pill) {
+    var type = pill.getAttribute('data-filter-type') || '';
+    var value = pill.getAttribute('data-filter-value') || '';
+    var bar = pill.parentNode;
+    if (!bar) return;
+    var list = null;
+    var sib = bar.nextElementSibling;
+    while (sib) {
+      if (sib.classList && sib.classList.contains('bar-list')) {
+        list = sib;
+        break;
+      }
+      sib = sib.nextElementSibling;
+    }
+    if (!list) return;
+
+    var alreadyActive = pill.classList.contains('active');
+    var allPills = bar.querySelectorAll('.filter-pill');
+    for (var i = 0; i < allPills.length; i++) {
+      allPills[i].classList.remove('active');
+    }
+
+    var clearing = (alreadyActive || type === 'all');
+    if (clearing) {
+      var allPill = bar.querySelector('.filter-all');
+      if (allPill) allPill.classList.add('active');
+    } else {
+      pill.classList.add('active');
+    }
+
+    // Imperatively hide non-matching rows. CSS attribute selectors
+    // can't enumerate code labels or category sets at build time (the
+    // sets are dynamic per agency), so the JS approach handles all
+    // filter types uniformly.
+    var attrName = type === 'code' ? 'data-code-labels'
+      : type === 'category' ? 'data-categories'
+      : 'data-flag-kinds';
+    var rows = list.querySelectorAll('.bar-item');
+    for (var r = 0; r < rows.length; r++) {
+      if (clearing) {
+        rows[r].style.display = '';
+        continue;
+      }
+      var attr = rows[r].getAttribute(attrName) || '';
+      var match = (' ' + attr + ' ').indexOf(' ' + value + ' ') !== -1;
+      rows[r].style.display = match ? '' : 'none';
+    }
+
+    // Close any expansion in the filtered set so a hidden row
+    // doesn't carry along an orphan detail row.
+    var details = list.querySelectorAll('.detail-row');
+    for (var d = 0; d < details.length; d++) {
+      if (details[d].previousElementSibling) {
+        details[d].previousElementSibling.classList.remove('expanded');
+      }
+      details[d].parentNode.removeChild(details[d]);
+    }
+  }
+
+  function toggleRowExpansion(row, detail, phrase, count) {
+    var next = row.nextElementSibling;
+    if (next && next.classList.contains('detail-row')) {
+      next.parentNode.removeChild(next);
+      row.classList.remove('expanded');
+      return;
+    }
+    // Close any other expansion in the same container first so only
+    // one is open at a time per container — keeps the page tidy.
+    var container = row.parentNode;
+    var existing = container.querySelectorAll('.detail-row');
+    for (var i = 0; i < existing.length; i++) {
+      var er = existing[i];
+      if (er.previousElementSibling) er.previousElementSibling.classList.remove('expanded');
+      er.parentNode.removeChild(er);
+    }
+    var detailHtml = renderPhraseDetail(detail, phrase, count);
+    var dr;
+    // Bars list uses div-based rows; long-active callout still uses
+    // a real table. Detail row shape needs to match the parent so
+    // the markup stays valid.
+    if (row.tagName === 'TR') {
+      dr = document.createElement('tr');
+      dr.className = 'detail-row';
+      var colspan = row.children.length;
+      dr.innerHTML = '<td colspan="' + colspan + '">' + detailHtml + '</td>';
+    } else {
+      dr = document.createElement('div');
+      dr.className = 'detail-row';
+      dr.innerHTML = detailHtml;
+    }
+    container.insertBefore(dr, row.nextSibling);
+    row.classList.add('expanded');
+  }
+
+  var currentDetails = null;
+  var currentCounts = {};
+  var currentCodes = {};
+  var currentAgencyData = null;
+  var currentSlug = '';
+  var currentAgencyCount = 0;
+
+  // Populate the per-phrase context maps that handleExpandClick reads.
+  // Counts come from verbatim AND long-active-cases so all three
+  // entry points resolve their phrase to a count, even if the phrase
+  // didn't make the verbatim top-50.
+  function installPhraseContext(agencyData) {
+    currentAgencyData = agencyData || null;
+    currentDetails = (agencyData && agencyData.phrase_details) || {};
+    currentCounts = {};
+    currentCodes = {};
+    if (agencyData && agencyData.verbatim) {
+      for (var i = 0; i < agencyData.verbatim.length; i++) {
+        var v = agencyData.verbatim[i];
+        currentCounts[v[0]] = v[1];
+        if (v[2]) currentCodes[v[0]] = v[2];
+      }
+    }
+    if (agencyData && agencyData.long_active_cases) {
+      for (var j = 0; j < agencyData.long_active_cases.length; j++) {
+        var lac = agencyData.long_active_cases[j];
+        currentCounts[lac[0]] = lac[1];
+      }
+    }
+  }
+
+  // 7-day x 24-hour heatmap. Hours are in PT (build-side conversion).
+  // Cell intensity is sqrt-scaled to keep low-but-nonzero cells visible
+  // alongside a dominant peak (linear scale would wash out off-peak
+  // activity for agencies with one busy hour). Empty cells stay
+  // visibly empty (light gray) so gaps in coverage are legible.
+  function renderHeatmap(grid, timedRows) {
+    if (!grid || !grid.length || !timedRows) {
+      return '<div class="empty">No timestamped searches available for this agency.</div>';
+    }
+    var max = 0;
+    for (var d = 0; d < 7; d++) {
+      for (var h = 0; h < 24; h++) {
+        if (grid[d][h] > max) max = grid[d][h];
+      }
+    }
+    var days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    var html = '<div class="heatmap-wrap">' +
+      '<table class="heatmap"><thead><tr><th></th>';
+    for (var h = 0; h < 24; h++) {
+      // Show every 3 hours to avoid header crowding.
+      html += '<th>' + (h % 3 === 0 ? (h < 10 ? '0' + h : h) : '') + '</th>';
+    }
+    html += '</tr></thead><tbody>';
+    for (var d2 = 0; d2 < 7; d2++) {
+      html += '<tr><th class="day-label">' + days[d2] + '</th>';
+      for (var h2 = 0; h2 < 24; h2++) {
+        var c = grid[d2][h2] || 0;
+        var t = max > 0 ? Math.sqrt(c / max) : 0;
+        // Light gray for zero, blue ramp for nonzero so the eye can
+        // pick out absent cells from low-but-present ones.
+        var bg = c === 0
+          ? '#f1f5f9'
+          : 'rgba(37, 99, 235, ' + (0.12 + 0.82 * t).toFixed(3) + ')';
+        var fg = t > 0.55 ? '#fff' : '#1e293b';
+        html += '<td title="' + days[d2] + ' ' + h2 + ':00 — ' + c +
+          ' search' + (c === 1 ? '' : 'es') + '"' +
+          ' style="background:' + bg + ';color:' + fg + '">' +
+          (c >= 1 ? c : '') +
+          '</td>';
+      }
+      html += '</tr>';
+    }
+    html += '</tbody></table></div>' +
+      '<div class="heatmap-caption">Day × hour of day, Pacific Time. ' +
+      timedRows.toLocaleString() + ' search' +
+      (timedRows === 1 ? '' : 'es') + ' with timestamps.</div>';
+    return html;
+  }
+
+  function renderCodes(items) {
+    if (!items.length) {
+      return '<div class="empty">No California penal/vehicle codes detected in the justification text for this agency.</div>';
+    }
+    var html = '<table class="codes-table">' +
+      '<thead><tr><th>Code</th><th>Description</th><th class="count">Searches</th></tr></thead>' +
+      '<tbody>';
+    for (var i = 0; i < items.length; i++) {
+      html += '<tr>' +
+        '<td class="code">' + escapeHTML(items[i][0]) + '</td>' +
+        '<td>' + escapeHTML(items[i][1]) + '</td>' +
+        '<td class="count">' + items[i][2] + '</td>' +
+        '</tr>';
+    }
+    html += '</tbody></table>';
+    return html;
+  }
+
+  function templatingCommentary(top1Pct, unique, total) {
+    // Translate the top-1 share + unique-reason ratio into a one-line
+    // qualitative read: highly templated, mixed, or freeform.
+    if (!total) return '';
+    var ratio = unique / total;
+    if (top1Pct >= 30 || unique <= 30) {
+      return 'High templating: a single phrase covers ' + top1Pct.toFixed(0) +
+        '% of searches, suggesting a small dropdown or copy-paste set rather than case-specific narratives.';
+    }
+    if (top1Pct >= 15 || ratio < 0.05) {
+      return 'Mixed: a small set of phrases dominates, but with meaningful long-tail variation.';
+    }
+    return 'Predominantly free-text: many distinct reasons, no single phrase carries the bulk of searches.';
+  }
+
+  function renderAgency(agencyData, slug) {
+    currentSlug = slug || '';
+    if (!agencyData) {
+      return '<h1>Search Justifications</h1>' +
+        '<p class="subtitle">No data for <code>' + escapeHTML(slug) + '</code>.</p>';
+    }
+    var dateRange = '';
+    if (agencyData.search_date_min && agencyData.search_date_max) {
+      dateRange = ' (' + agencyData.search_date_min + ' through ' + agencyData.search_date_max + ')';
+    }
+    var commentary = templatingCommentary(
+      agencyData.top1_share_pct,
+      agencyData.unique_reasons,
+      agencyData.row_count
+    );
+    var windowBanner = '';
+    if (agencyData.search_date_min && agencyData.search_date_max) {
+      var dms = Date.parse(agencyData.search_date_min + 'T12:00:00Z');
+      var dms2 = Date.parse(agencyData.search_date_max + 'T12:00:00Z');
+      var spanD = (!isNaN(dms) && !isNaN(dms2))
+        ? Math.round((dms2 - dms) / 86400000) + 1
+        : null;
+      var rawLink = 'data/audit/' + encodeURIComponent(agencyData.slug) + '.json';
+      windowBanner = '<div class="audit-window">' +
+        '<span class="audit-window-label">Data window</span>' +
+        '<strong>' + escapeHTML(agencyData.search_date_min) +
+        ' &rarr; ' + escapeHTML(agencyData.search_date_max) + '</strong>' +
+        (spanD ? ' <span class="audit-window-span">(' + spanD +
+          ' day' + (spanD === 1 ? '' : 's') + ')</span>' : '') +
+        ' <a class="audit-window-raw" href="' + rawLink +
+        '" target="_blank" rel="noopener">View raw audit data &rarr;</a>' +
+        '<span class="audit-window-note">' +
+        'Built from every scrape of this agency&rsquo;s public search audit on file. ' +
+        'Flock exposes a rolling ~30-day window; older rows persist here only ' +
+        'because they were captured before they aged out.' +
+        '</span></div>';
+    }
+    var blurb =
+      '<p class="blurb">Aggregated free-text reasons that ' +
+      escapeHTML(agencyData.display_name) +
+      ' attached to ALPR plate searches in the data window above. ' +
+      'Reasons are entered by the searching officer and are the agency’s own justification record. ' +
+      commentary +
+      '</p>';
+
+    var shown = agencyData.verbatim_shown || 0;
+    var unique = agencyData.unique_reasons;
+    var stats =
+      '<div class="stats-grid">' +
+      stat('Searches', fmt(agencyData.row_count), 'in audit window') +
+      stat('Unique reasons', fmt(unique),
+        shown < unique
+          ? 'top ' + fmt(shown) + ' shown below'
+          : 'all shown below') +
+      stat('Top phrase share', pct(agencyData.top1_share_pct),
+        'top 3: ' + pct(agencyData.top3_share_pct),
+        agencyData.top1_share_pct >= 30 ? 'warn' : '') +
+      stat('Blank reasons', fmt(agencyData.blank_reasons),
+        agencyData.row_count > 0
+          ? pct(100 * agencyData.blank_reasons / agencyData.row_count) + ' of total'
+          : '') +
+      '</div>';
+
+    return '<h1>' + escapeHTML(agencyData.display_name) + '</h1>' +
+      '<p class="subtitle">ALPR search justifications</p>' +
+      windowBanner +
+      blurb +
+      stats +
+      renderUses(agencyData) +
+      renderLongActiveCases(agencyData.long_active_cases, agencyData.display_name) +
+      '<h2>Top reasons by count</h2>' +
+      (agencyData.has_justification_column === false
+        ? renderNoJustificationCallout(agencyData)
+        : '<p class="bars-disclaimer">' +
+          'These reasons are typed in (or chosen from a dropdown) by the searching officer. ' +
+          'Nothing in the audit system validates that the entered reason aligns with the actual ' +
+          'reason for the search, or that the search was authorized.' +
+          '</p>' +
+          renderBars(agencyData.verbatim, agencyData.row_count)) +
+      '<h2>Search timing (day &times; hour, Pacific Time)</h2>' +
+      renderHeatmap(agencyData.hour_dow, agencyData.timed_rows) +
+      '<h2>Detected California penal / vehicle codes</h2>' +
+      renderCodes(agencyData.penal_codes) +
+      '<div class="footnote">' +
+      'Source: this agency’s Public Search Audit CSV, embedded in its Flock Safety transparency portal. ' +
+      'Rows are deduplicated by ID across every scrape we have, so the audit window can extend ' +
+      'beyond Flock’s ~30-day rolling cutoff. Cloud and bars show the top 50 reasons by count. ' +
+      'See <a href="https://github.com/none-below/sm-alpr/blob/main/scripts/build_justifications.py">' +
+      'build_justifications.py</a> for processing details.' +
+      '</div>';
+  }
+
+  function stat(label, value, sub, cls) {
+    cls = cls || '';
+    return '<div class="stat ' + cls + '">' +
+      '<div class="label">' + escapeHTML(label) + '</div>' +
+      '<div class="value">' + value + '</div>' +
+      (sub ? '<div class="sub">' + escapeHTML(sub) + '</div>' : '') +
+      '</div>';
+  }
+
+  function populateSelect(agencies, currentSlug) {
+    var sel = document.getElementById('agency-select');
+    sel.innerHTML = '';
+    var slugs = Object.keys(agencies);
+    slugs.sort(function (a, b) {
+      return agencies[a].display_name.localeCompare(agencies[b].display_name);
+    });
+    for (var i = 0; i < slugs.length; i++) {
+      var s = slugs[i];
+      var opt = document.createElement('option');
+      opt.value = s;
+      opt.textContent = agencies[s].display_name +
+        ' (' + agencies[s].row_count.toLocaleString() + ' searches)';
+      if (s === currentSlug) opt.selected = true;
+      sel.appendChild(opt);
+    }
+    sel.addEventListener('change', function () {
+      var newSlug = sel.value;
+      // Use replaceState rather than pushState so back-button doesn't
+      // cycle through every agency the user previewed.
+      history.replaceState(null, '', '?agency=' + encodeURIComponent(newSlug));
+      var data = agencies[newSlug];
+      installPhraseContext(data);
+      document.getElementById('page').innerHTML =
+        renderAgency(data, newSlug);
+    });
+  }
+
+  function getInitialSlug(agencies) {
+    var params = new URLSearchParams(window.location.search);
+    var slug = params.get('agency');
+    if (slug && agencies[slug]) return slug;
+    if (agencies[DEFAULT_SLUG]) return DEFAULT_SLUG;
+    var keys = Object.keys(agencies);
+    return keys.length ? keys[0] : null;
+  }
+
+  function init() {
+    fetch(DATA_URL)
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var agencies = data.agencies || {};
+        currentAgencyCount = data.agency_count || Object.keys(agencies).length;
+        var slug = getInitialSlug(agencies);
+        populateSelect(agencies, slug);
+        installPhraseContext(slug ? agencies[slug] : null);
+        document.getElementById('page').innerHTML =
+          renderAgency(slug ? agencies[slug] : null, slug || '');
+        document.getElementById('page').addEventListener('click', handleExpandClick);
+        document.getElementById('page').addEventListener('keydown', function (ev) {
+          if (ev.key !== 'Enter' && ev.key !== ' ') return;
+          var row = ev.target.closest('.bar-item, tr.bar-row');
+          if (!row) return;
+          ev.preventDefault();
+          handleExpandClick({ target: row });
+        });
+      })
+      .catch(function (err) {
+        document.getElementById('page').innerHTML =
+          '<h1>Search Justifications</h1>' +
+          '<p class="subtitle">Failed to load data: ' + escapeHTML(err.message) + '</p>' +
+          '<p>Run <code>uv run python scripts/build_justifications.py</code> to generate ' +
+          '<code>docs/data/justifications.json</code>, then reload.</p>';
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/justifications.html
+++ b/docs/justifications.html
@@ -94,6 +94,25 @@
     color: #155e75;
     margin-top: 4px;
   }
+  .audit-window-scope {
+    display: block;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #a5f3fc;
+    font-size: 9.5pt;
+    color: #155e75;
+    line-height: 1.5;
+  }
+  .audit-window-scope strong {
+    color: #0e7490;
+    font-size: 9.5pt;
+  }
+  .audit-window-scope a {
+    color: #0e7490;
+    text-decoration: none;
+    border-bottom: 1px dotted #0e7490;
+  }
+  .audit-window-scope a:hover { border-bottom-style: solid; }
   .audit-window-raw {
     margin-left: 12px;
     font-size: 9.5pt;

--- a/docs/justifications.html
+++ b/docs/justifications.html
@@ -1,0 +1,1020 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com;">
+<title>ALPR Search Justifications — California</title>
+<style>
+  body {
+    font-family: -apple-system, system-ui, sans-serif;
+    background: #f3f4f6;
+    color: #111;
+    margin: 0;
+    padding: 30px 16px;
+    line-height: 1.5;
+  }
+  .toolbar {
+    max-width: 960px;
+    margin: 0 auto 12px auto;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 0 8px;
+    flex-wrap: wrap;
+  }
+  .toolbar a, .toolbar select {
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    text-decoration: none;
+    border: 1px solid #d1d5db;
+    background: white;
+    color: #111;
+    font-family: inherit;
+  }
+  .toolbar a:hover { background: #eff6ff; }
+  .toolbar select { min-width: 280px; }
+  .toolbar .spacer { flex: 1; }
+  .page {
+    max-width: 960px;
+    margin: 0 auto;
+    background: white;
+    padding: 24px 28px;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+  }
+  h1 { font-size: 20pt; margin: 0 0 4px 0; border-bottom: 2px solid #111; padding-bottom: 8px; }
+  h2 { font-size: 13pt; margin: 22px 0 8px 0; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+  h2 .portal-link {
+    float: right;
+    font-size: 10pt;
+    font-weight: 400;
+    color: #2563eb;
+    text-decoration: none;
+    line-height: 1.6;
+  }
+  h2 .portal-link:hover { text-decoration: underline; }
+  .subtitle { color: #666; font-size: 11pt; margin: 0 0 16px 0; }
+  .blurb { font-size: 10.5pt; color: #444; margin: 8px 0 12px; }
+  .blurb a { color: #2563eb; }
+
+  .audit-window {
+    margin: 10px 0 12px;
+    padding: 10px 14px;
+    background: #ecfeff;
+    border: 1px solid #a5f3fc;
+    border-left: 4px solid #0891b2;
+    border-radius: 4px;
+    font-size: 10.5pt;
+    line-height: 1.5;
+  }
+  .audit-window-label {
+    display: block;
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-weight: 700;
+    color: #155e75;
+    margin-bottom: 2px;
+  }
+  .audit-window strong {
+    color: #0e7490;
+    font-variant-numeric: tabular-nums;
+    font-size: 11.5pt;
+  }
+  .audit-window-span {
+    color: #155e75;
+    margin-left: 6px;
+    font-variant-numeric: tabular-nums;
+  }
+  .audit-window-note {
+    display: block;
+    font-size: 9pt;
+    color: #155e75;
+    margin-top: 4px;
+  }
+  .audit-window-raw {
+    margin-left: 12px;
+    font-size: 9.5pt;
+    color: #0e7490;
+    text-decoration: none;
+    border-bottom: 1px dotted #0e7490;
+  }
+  .audit-window-raw:hover {
+    border-bottom-style: solid;
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin: 14px 0;
+  }
+  .stat {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 10px 12px;
+  }
+  .stat .label {
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #64748b;
+    font-weight: 600;
+  }
+  .stat .value {
+    font-size: 18pt;
+    font-weight: bold;
+    line-height: 1.1;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat .sub {
+    font-size: 9pt;
+    color: #475569;
+    margin-top: 2px;
+  }
+  .stat.warn { background: #fef3c7; border-color: #f59e0b; }
+  .stat.warn .value { color: #92400e; }
+  .stat.warn .sub { color: #78350f; }
+
+  .long-active-block {
+    margin: 14px 0;
+    padding: 12px 14px;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-left: 4px solid #dc2626;
+    border-radius: 4px;
+  }
+  .long-active-head {
+    font-size: 11pt;
+    font-weight: 700;
+    color: #991b1b;
+    margin-bottom: 4px;
+  }
+  .long-active-sub {
+    font-size: 9.5pt;
+    color: #7f1d1d;
+    margin-bottom: 8px;
+    line-height: 1.5;
+  }
+  .long-active-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 10pt;
+  }
+  .long-active-table th {
+    text-align: left;
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #7f1d1d;
+    font-weight: 600;
+    padding: 4px 8px;
+    border-bottom: 1px solid #fca5a5;
+  }
+  .long-active-table th.num { text-align: right; }
+  .long-active-table td {
+    padding: 5px 8px;
+    border-bottom: 1px solid #fee2e2;
+    vertical-align: middle;
+  }
+  .long-active-table td.case {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-weight: 600;
+    color: #7f1d1d;
+  }
+  .long-active-table td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .long-active-table .reach-broad {
+    background: #fee2e2;
+    color: #991b1b;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+  .long-active-table .muted { color: #9ca3af; }
+
+  .uses-block {
+    margin: 6px 0 14px 0;
+  }
+  .uses-row {
+    display: grid;
+    grid-template-columns: 130px 1fr;
+    gap: 12px;
+    align-items: start;
+    padding: 8px 12px;
+    border: 1px solid #e2e8f0;
+    border-left-width: 3px;
+    background: #f8fafc;
+    font-size: 10.5pt;
+  }
+  .uses-row + .uses-row { margin-top: 6px; }
+  .uses-acceptable {
+    border-left-color: #059669;
+    background: #f0fdf4;
+  }
+  .uses-prohibited {
+    border-left-color: #dc2626;
+    background: #fef2f2;
+  }
+  .uses-label {
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-weight: 700;
+    color: #475569;
+    padding-top: 2px;
+  }
+  .uses-acceptable .uses-label { color: #047857; }
+  .uses-prohibited .uses-label { color: #b91c1c; }
+  .uses-text {
+    color: #1f2937;
+    line-height: 1.5;
+  }
+  @media (max-width: 720px) {
+    .uses-row { grid-template-columns: 1fr; gap: 4px; }
+  }
+
+  .cloud {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 16px 18px;
+    text-align: center;
+    line-height: 2.0;
+  }
+  .cloud .word {
+    display: inline-block;
+    margin: 4px 5px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    color: #1e3a8a;
+    font-weight: 500;
+    cursor: default;
+    transition: transform 0.08s, box-shadow 0.08s;
+    background: #e0e7ff;
+    border: 1px solid #c7d2fe;
+  }
+  /* Color palette for prose phrases — six variants. JS picks an index
+     from a stable hash of the phrase text so the same phrase keeps its
+     color across reloads, but adjacent entries (which are sorted by
+     count) end up visually distinct because their hashes diverge. */
+  .cloud .word.c0 { background: #e0e7ff; border-color: #c7d2fe; color: #1e3a8a; }
+  .cloud .word.c1 { background: #d1fae5; border-color: #a7f3d0; color: #065f46; }
+  .cloud .word.c2 { background: #fce7f3; border-color: #fbcfe8; color: #9d174d; }
+  .cloud .word.c3 { background: #ede9fe; border-color: #ddd6fe; color: #5b21b6; }
+  .cloud .word.c4 { background: #cffafe; border-color: #a5f3fc; color: #155e75; }
+  .cloud .word.c5 { background: #fef3c7; border-color: #fde68a; color: #92400e; }
+  .cloud .word.code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    background: #ffedd5;
+    border-color: #fed7aa;
+    color: #7c2d12;
+  }
+  .cloud .word:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  }
+  .cloud .word .count {
+    font-size: 0.62em;
+    color: rgba(0, 0, 0, 0.45);
+    margin-left: 4px;
+    font-variant-numeric: tabular-nums;
+    font-weight: normal;
+  }
+
+  .view-mode-toggle {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+    margin: 8px 0 6px;
+    font-size: 9pt;
+  }
+  .view-mode-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #475569;
+    margin-right: 6px;
+    font-size: 9pt;
+  }
+  .view-mode-btn {
+    padding: 4px 12px;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    background: white;
+    color: #1f2937;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 9pt;
+    font-weight: 600;
+  }
+  .view-mode-btn:hover { background: #f8fafc; }
+  .view-mode-btn.active {
+    background: #2563eb;
+    border-color: #2563eb;
+    color: white;
+  }
+
+  .bar-row-aggregated[data-drilldown-type] { cursor: pointer; }
+  .bar-row-aggregated[data-drilldown-type]:hover { background: #f8fafc; }
+  .bar-row-aggregated:not([data-drilldown-type]) { cursor: default; }
+  .bar-row-aggregated:not([data-drilldown-type]):hover { background: transparent; }
+  .bar-row-aggregated .phrase-text {
+    text-decoration: none;
+  }
+  .bar-row-aggregated[data-drilldown-type] .phrase-text {
+    text-decoration: underline dotted;
+    text-decoration-color: #cbd5e1;
+  }
+  .drill-arrow {
+    display: inline-block;
+    font-size: 12pt;
+    line-height: 1;
+    vertical-align: middle;
+    margin-left: 2px;
+    transition: transform 0.12s;
+  }
+  .bar-row-aggregated[data-drilldown-type]:hover .drill-arrow {
+    transform: translateX(3px);
+  }
+
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    margin: 8px 0;
+    padding: 8px 10px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+  }
+  .filter-bar-label {
+    font-size: 9pt;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #475569;
+    margin-right: 4px;
+  }
+  .filter-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 9pt;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 999px;
+    border: 1px solid;
+    cursor: pointer;
+    line-height: 1.3;
+    background: white;
+    border-color: #cbd5e1;
+    color: #1f2937;
+    font-family: inherit;
+  }
+  .filter-pill:hover { box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+  .filter-pill.flag-info {
+    background: #e0e7ff;
+    color: #1e3a8a;
+    border-color: #c7d2fe;
+  }
+  .filter-pill.flag-warn {
+    background: #fef3c7;
+    color: #92400e;
+    border-color: #fde68a;
+  }
+  .filter-pill.flag-concern {
+    background: #fee2e2;
+    color: #991b1b;
+    border-color: #fecaca;
+  }
+  .filter-pill.active {
+    box-shadow: 0 0 0 2px #2563eb;
+    transform: translateY(-1px);
+  }
+  .filter-pill .filter-count {
+    font-variant-numeric: tabular-nums;
+    font-weight: 500;
+    opacity: 0.75;
+  }
+  /* Filter rendering is now JS-imperative (style.display) so the
+     non-matching rows fully drop out of the list rather than just
+     dimming. CSS rules below are only for the orange code-label
+     filter pills; flag pills already inherit tone styles. */
+  .filter-pill.filter-code {
+    background: #ffedd5;
+    color: #7c2d12;
+    border-color: #fed7aa;
+  }
+  .filter-pill.filter-category {
+    background: #f1f5f9;
+    color: #0f172a;
+    border-color: #cbd5e1;
+    font-weight: 700;
+  }
+  .filter-pill.filter-category.active {
+    background: #cbd5e1;
+  }
+  .filter-divider {
+    color: #cbd5e1;
+    font-size: 12pt;
+    padding: 0 4px;
+    user-select: none;
+  }
+
+  .no-justification-callout {
+    margin: 14px 0;
+    padding: 14px 18px;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-left: 4px solid #dc2626;
+    border-radius: 4px;
+  }
+  .no-justification-head {
+    font-size: 12pt;
+    font-weight: 700;
+    color: #991b1b;
+    margin-bottom: 8px;
+  }
+  .no-justification-body {
+    font-size: 10.5pt;
+    color: #7f1d1d;
+    line-height: 1.55;
+  }
+  .no-justification-body p { margin: 0 0 8px 0; }
+  .no-justification-body p:last-child { margin-bottom: 0; }
+  .no-justification-body code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    background: rgba(255, 255, 255, 0.6);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 9.5pt;
+  }
+  .no-justification-schema {
+    font-size: 10pt;
+    margin: 6px 0 !important;
+  }
+
+  .bars-disclaimer {
+    margin: 6px 0 10px 0;
+    padding: 8px 12px;
+    background: #fef3c7;
+    border-left: 3px solid #f59e0b;
+    border-radius: 4px;
+    font-size: 9.5pt;
+    color: #78350f;
+    line-height: 1.5;
+  }
+  .bar-list {
+    margin: 6px 0;
+    border-top: 1px solid #e2e8f0;
+    font-size: 10.5pt;
+  }
+  .bar-item {
+    border-bottom: 1px solid #f1f5f9;
+    padding: 8px 10px;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+  .bar-item:hover { background: #f8fafc; }
+  .bar-item:focus-visible { outline: 2px solid #2563eb; outline-offset: -2px; }
+  .bar-item.expanded { background: #eff6ff; }
+  .bar-item-main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: nowrap;
+  }
+  .bar-item .phrase-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-weight: 500;
+    word-break: break-word;
+    color: #1e3a8a;
+    text-decoration: underline dotted;
+    text-decoration-color: #cbd5e1;
+    text-underline-offset: 3px;
+  }
+  .bar-item:hover .phrase-text { text-decoration-color: #2563eb; }
+  .bar-item .bar-track {
+    flex: 0 0 100px;
+    height: 18px;
+    background: #e2e8f0;
+    border-radius: 3px;
+    overflow: hidden;
+    display: inline-block;
+    position: relative;
+  }
+  .bar-item .bar-track .bar {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    background: #2563eb;
+    border-radius: 3px 0 0 3px;
+    min-width: 1px;
+    max-width: none;
+  }
+  .bar-item .bar-track .bar-pct {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 255, 255, 0.92);
+    color: #334155;
+    font-size: 7.5pt;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    padding: 0 6px;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    line-height: 1.5;
+    z-index: 1;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+  .bar-item .bar-count {
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+    color: #475569;
+    font-size: 9.5pt;
+    font-family: -apple-system, system-ui, sans-serif;
+    white-space: nowrap;
+  }
+  .bar-item .pct { color: #94a3b8; }
+  .bar-item .expand-hint {
+    flex: 0 0 auto;
+    font-size: 9pt;
+    color: #94a3b8;
+    transition: color 0.12s;
+    white-space: nowrap;
+  }
+  .bar-item:hover .expand-hint { color: #2563eb; }
+  .bar-item.expanded .expand-hint { color: #2563eb; }
+  .bar-item.expanded .expand-hint::after { content: ""; }
+  /* Pills indent to the column under count + phrase, leaving the
+     bar-track gutter at the left empty. Bar is 100px + 12px gap, so
+     112px keeps the pills flush with where the count starts. */
+  .bar-list .pill-row {
+    margin-top: 4px;
+    line-height: 1.6;
+    padding-left: 112px;
+  }
+  .bar-list .pill-row + .pill-row { margin-top: 4px; }
+  @media (max-width: 720px) {
+    .bar-list .pill-row { padding-left: 72px; }
+  }
+  .bar-row-blank .bar-item-main .phrase-text {
+    background: #fef3c7;
+    padding: 1px 6px;
+    border-radius: 3px;
+    border-left: 2px solid #f59e0b;
+  }
+  .bar-list .detail-row {
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    padding: 0;
+  }
+  /* Hint text above the list so users know rows are interactive. */
+  .bar-list-hint {
+    font-size: 9pt;
+    color: #64748b;
+    margin: 4px 2px 6px;
+    font-style: italic;
+  }
+  @media (max-width: 720px) {
+    .bar-item .bar-track { flex: 0 0 60px; }
+    .bar-item .expand-hint { font-size: 0; }
+    .bar-item .expand-hint::before { content: "▾"; font-size: 11pt; }
+  }
+  @media (max-width: 720px) {
+    .bar-table col.bar-col-phrase { width: 65%; }
+    .bar-table col.bar-col-bar { width: 35%; }
+    .bar-table .bar-count {
+      display: block;
+      margin-left: 0;
+      margin-top: 2px;
+    }
+    .bar-table .bar { max-width: 60px; }
+  }
+  .code-pill {
+    display: inline-block;
+    margin-right: 4px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #ffedd5;
+    color: #7c2d12;
+    border: 1px solid #fed7aa;
+    font-family: -apple-system, system-ui, sans-serif;
+    font-size: 8.5pt;
+    font-weight: 500;
+    white-space: nowrap;
+    position: relative;
+    cursor: help;
+  }
+  .code-pill:hover .flag-tip,
+  .code-pill:focus .flag-tip,
+  .code-pill:focus-within .flag-tip {
+    opacity: 1;
+    visibility: visible;
+  }
+  .bar-table td.label { line-height: 1.4; vertical-align: top; }
+  .bar-table td.bar-cell { vertical-align: top; padding-top: 8px; }
+  .blank-label {
+    font-style: italic;
+    color: #78350f;
+    cursor: help;
+  }
+  .bar-row-blank td.label {
+    background: #fef3c7;
+    border-left: 2px solid #f59e0b;
+  }
+  .bar-row { cursor: pointer; }
+  .bar-row:hover td { background: #f8fafc; }
+  .bar-row.expanded td { background: #eff6ff; }
+  .bar-row .expand-hint {
+    display: inline-block;
+    color: #94a3b8;
+    margin-left: 4px;
+    font-size: 8.5pt;
+  }
+  .expand-arrow {
+    display: inline-block;
+    transition: transform 0.12s;
+  }
+  .bar-item.expanded .expand-arrow,
+  .bar-row.expanded .expand-arrow {
+    transform: rotate(180deg);
+  }
+  .bar-item.expanded .expand-hint,
+  .bar-row.expanded .expand-hint {
+    color: #2563eb;
+  }
+  .cloud .word { cursor: pointer; }
+
+  .detail-row td {
+    padding: 0 !important;
+    border-bottom: 1px solid #e2e8f0;
+    background: #f8fafc;
+  }
+  .phrase-detail {
+    padding: 12px 14px 14px 18px;
+    font-size: 10pt;
+    color: #1f2937;
+  }
+  .phrase-detail-head {
+    font-size: 10.5pt;
+    margin-bottom: 6px;
+    color: #111827;
+  }
+  .phrase-detail-row {
+    margin-top: 4px;
+    line-height: 1.5;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    align-items: flex-start;
+  }
+  .phrase-detail-summary {
+    background: #eff6ff;
+    border-left: 3px solid #2563eb;
+    padding: 6px 10px;
+    color: #1e3a8a;
+    font-size: 10pt;
+    display: block;
+  }
+  .phrase-detail-flags {
+    margin-top: 6px;
+  }
+  .flag-tags {
+    display: inline;
+    line-height: 1.9;
+  }
+  .flag-tag {
+    display: inline-block;
+    font-size: 8pt;
+    font-weight: 600;
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid;
+    cursor: help;
+    line-height: 1.4;
+    position: relative;
+    white-space: nowrap;
+  }
+  .pills-cell .flag-tag { margin: 1px 2px 1px 0; }
+  .pills-cell .flag-tags { line-height: 1.6; }
+  .flag-tag .flag-tip,
+  .code-pill .flag-tip {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 200;
+    width: 280px;
+    background: #1f2937;
+    color: #f9fafb;
+    padding: 8px 10px;
+    border-radius: 6px;
+    font-size: 9pt;
+    font-weight: 400;
+    line-height: 1.45;
+    white-space: normal;
+    text-align: left;
+    box-shadow: 0 6px 16px rgba(0,0,0,0.18);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.12s, visibility 0.12s;
+  }
+  .flag-tag .flag-tip::after,
+  .code-pill .flag-tip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #1f2937;
+  }
+  .flag-tag:hover .flag-tip,
+  .flag-tag:focus .flag-tip,
+  .flag-tag:focus-within .flag-tip {
+    opacity: 1;
+    visibility: visible;
+  }
+  .flag-tip-rule {
+    display: block;
+    font-weight: 700;
+    color: #fef9c3;
+    margin-bottom: 4px;
+    font-size: 9pt;
+  }
+  .flag-tip-body {
+    display: block;
+    margin-bottom: 6px;
+    color: #e5e7eb;
+  }
+  .flag-tip-observed {
+    display: block;
+    padding-top: 6px;
+    border-top: 1px solid #374151;
+    color: #f9fafb;
+    font-size: 8.5pt;
+  }
+  .flag-tip code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    background: rgba(255,255,255,0.1);
+    padding: 0 4px;
+    border-radius: 3px;
+  }
+  .flag-tag.flag-info {
+    background: #e0e7ff;
+    color: #1e3a8a;
+    border-color: #c7d2fe;
+  }
+  .flag-tag.flag-warn {
+    background: #fef3c7;
+    color: #92400e;
+    border-color: #fde68a;
+  }
+  .flag-tag.flag-concern {
+    background: #fee2e2;
+    color: #991b1b;
+    border-color: #fecaca;
+  }
+  .phrase-detail-row .reach-broad {
+    background: #fee2e2;
+    color: #991b1b;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-weight: 600;
+    font-size: 9.5pt;
+  }
+  .phrase-detail-chart {
+    flex: 1 1 280px;
+    min-width: 220px;
+    max-width: 480px;
+  }
+  .phrase-detail-chart-week {
+    flex: 0 0 130px;
+    min-width: 130px;
+  }
+  .phrase-detail-label {
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-weight: 600;
+    color: #64748b;
+    margin-bottom: 4px;
+  }
+  .mini-bars {
+    display: flex;
+    align-items: flex-end;
+    height: 48px;
+    gap: 2px;
+    border-bottom: 1px solid #cbd5e1;
+  }
+  .mini-bar-col {
+    flex: 1 1 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    height: 100%;
+    min-width: 0;
+  }
+  .mini-bar-fill {
+    width: 90%;
+    background: #2563eb;
+    border-radius: 1px 1px 0 0;
+    min-height: 1px;
+  }
+  .mini-bars-labels {
+    display: flex;
+    gap: 2px;
+    margin-top: 3px;
+  }
+  .mini-bars-labels .mini-bar-label {
+    flex: 1 1 0;
+    text-align: center;
+    font-size: 7.5pt;
+    color: #94a3b8;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    min-width: 0;
+  }
+  .phrase-detail-chart-full {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
+  .daily-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 48px;
+    padding: 2px 0 0 0;
+    margin-top: 4px;
+    border-bottom: 1px solid #cbd5e1;
+    background: transparent;
+  }
+  .daily-spark .spark-bar {
+    flex: 1 1 0;
+    height: 100%;
+    min-width: 2px;
+    display: flex;
+    align-items: flex-end;
+    background: transparent;
+  }
+  .daily-spark .spark-fill {
+    width: 100%;
+    background: #2563eb;
+    border-radius: 1px 1px 0 0;
+    min-height: 1px;
+  }
+  .daily-spark .spark-bar.empty .spark-fill { background: transparent; min-height: 0; }
+
+  .long-active-table .span-dates {
+    font-size: 8.5pt;
+    color: #7f1d1d;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+    font-weight: normal;
+  }
+  .bar-table td.bar-cell {
+    width: 60%;
+    position: relative;
+  }
+  .bar-table .bar {
+    display: inline-block;
+    vertical-align: middle;
+    background: #2563eb;
+    height: 6px;
+    border-radius: 3px;
+    min-width: 2px;
+    max-width: 100px;
+  }
+  .bar-table td.bar-cell { white-space: nowrap; }
+  .bar-table td.count {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: #475569;
+    width: 60px;
+  }
+  .bar-table .pct {
+    color: #94a3b8;
+    font-size: 9pt;
+    margin-left: 4px;
+  }
+
+  .heatmap-wrap {
+    overflow-x: auto;
+    margin: 6px 0 4px 0;
+  }
+  .heatmap {
+    border-collapse: collapse;
+    font-size: 9pt;
+    font-variant-numeric: tabular-nums;
+    margin: 0 auto;
+  }
+  .heatmap th {
+    font-weight: 600;
+    color: #64748b;
+    font-size: 8.5pt;
+    padding: 2px 0;
+    background: transparent;
+    border: none;
+    width: 22px;
+    text-align: center;
+  }
+  .heatmap th.day-label {
+    text-align: right;
+    padding: 0 8px 0 0;
+    width: auto;
+    min-width: 36px;
+  }
+  .heatmap td {
+    width: 22px;
+    height: 22px;
+    text-align: center;
+    border: 1px solid #e2e8f0;
+    padding: 0;
+    font-size: 8pt;
+    cursor: default;
+  }
+  .heatmap-caption {
+    font-size: 9pt;
+    color: #64748b;
+    margin: 4px 0 12px 0;
+    text-align: center;
+  }
+
+  .codes-table { width: 100%; border-collapse: collapse; font-size: 10.5pt; }
+  .codes-table th, .codes-table td {
+    border-bottom: 1px solid #f1f5f9;
+    padding: 4px 8px;
+    text-align: left;
+  }
+  .codes-table th { background: #f8fafc; font-size: 9.5pt; color: #475569; }
+  .codes-table td.code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-weight: 600;
+    color: #7c2d12;
+  }
+  .codes-table td.count {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    width: 70px;
+  }
+
+  .empty {
+    color: #94a3b8;
+    font-style: italic;
+    font-size: 10pt;
+    padding: 8px 0;
+  }
+  .footnote {
+    font-size: 9.5pt;
+    color: #64748b;
+    margin-top: 16px;
+    padding-top: 10px;
+    border-top: 1px solid #e2e8f0;
+    line-height: 1.5;
+  }
+  .footnote code {
+    background: #f1f5f9;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 9pt;
+  }
+  @media (max-width: 720px) {
+    .toolbar select { width: 100%; min-width: 0; }
+  }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <a href="index.html">&larr; Investigation home</a>
+  <a href="sharing_map.html">Sharing map</a>
+  <select id="agency-select" aria-label="Select agency">
+    <option>Loading agencies&hellip;</option>
+  </select>
+  <div class="spacer"></div>
+</div>
+
+<div id="page" class="page">
+  <p class="subtitle">Loading&hellip;</p>
+</div>
+
+<script src="js/justifications.js"></script>
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="https://gc.zgo.at/count.js"></script>
+</body>
+</html>

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""
+Build per-agency justification frequency data from audit-log JSONs.
+
+For each agency that publishes a Public Search Audit (CSV embedded in the
+Flock transparency portal), aggregates the free-text "reason" field into:
+
+  - `verbatim`: top whole-string reasons by count (case-folded)
+  - `tokens`: top word frequencies after tokenization
+  - `penal_codes`: detected California penal/vehicle-code numbers with
+    short descriptions (e.g. "10851" -> "Vehicle theft (CVC)")
+  - `stats`: row count, unique reason count, blank-reason rate,
+    median reason length, share of rows covered by the top-1 reason
+
+Display sizing: capped at TOP_VERBATIM / TOP_TOKENS by frequency. The
+underlying audit text is already public on the agency's Flock
+transparency portal, so we don't impose an additional minimum-count
+floor — the cap alone keeps payload size and visual density sane.
+
+Token-level scrubbing still runs as a sanity guard against accidental
+inclusion of plate fragments or case-number-shaped strings in the
+token cloud:
+  - Long pure-digit strings (>=8 digits) are excluded as likely case
+    numbers / dates / plate fragments.
+  - Plate-pattern strings (mixed letter+digit, 5-8 chars) are excluded.
+
+Output: docs/data/justifications.json
+"""
+
+import json
+import re
+import statistics
+import sys
+from collections import Counter
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import load_registry, portal_jsons  # noqa: E402
+
+AUDIT_DIR = Path("docs/data/audit")
+PORTAL_DIR = Path("assets/transparency.flocksafety.com")
+OUT_PATH = Path("docs/data/justifications.json")
+
+TOP_VERBATIM = 50
+TOP_TOKENS = 50
+
+# Words that don't carry signal in a justification cloud — common
+# English stopwords plus ALPR-specific filler ("vehicle", "search",
+# "case", "plate") that would otherwise dominate every cloud.
+STOPWORDS = {
+    "a", "an", "and", "the", "of", "to", "in", "on", "for", "with",
+    "by", "at", "or", "is", "was", "be", "as", "from", "this", "that",
+    "it", "its", "into", "out", "no", "not",
+    # ALPR filler — uncomment lines below if a stopword turns out to be
+    # interesting in some agency's data; we'd rather over-include words
+    # in the prototype than silently delete signal.
+    "vehicle", "veh", "vehicles", "plate", "plates", "license", "lic",
+    "search", "searches", "lookup", "lookups", "case", "report",
+    # Code-section suffixes (PC = Penal Code, CVC = Vehicle Code,
+    # HSC = Health & Safety, WIC = Welfare & Institutions). These
+    # appear glued to code numbers in some agencies' templates and
+    # would otherwise dominate the cloud without carrying signal —
+    # the code number itself, surfaced separately in penal_codes,
+    # carries the meaning.
+    "pc", "cvc", "hsc", "wic", "vc", "cvv", "hs",
+}
+
+# Case-folded raw reason strings to drop entirely (pure noise — punct
+# stripped, the empty result, and the literal word "test").
+DROP_VERBATIM = {"", "-", ".", "n/a", "na", "none", "test", "testing"}
+
+# California penal / vehicle / health-and-safety codes commonly seen as
+# ALPR justifications. Numbers only — letters in case numbers (suffix
+# like 484a, 211(a)(2)) get normalized to the bare number for matching.
+# Keep this list tight and well-cited; an out-of-date or wrong gloss
+# would be embarrassing in a public tool. See CA Penal Code, CA Vehicle
+# Code, CA Health & Safety Code, CA Welfare & Institutions Code.
+PENAL_CODES = {
+    # Vehicle Code
+    "10851": "Vehicle theft (CVC)",
+    "20001": "Hit and run with injury (CVC)",
+    "20002": "Hit and run, property (CVC)",
+    "23103": "Reckless driving (CVC)",
+    "23152": "DUI (CVC)",
+    "23153": "DUI causing injury (CVC)",
+    "2800":  "Failure to yield to officer (CVC)",
+    "14601": "Driving on suspended license (CVC)",
+    # Penal Code — violence
+    "187":   "Murder (PC)",
+    "192":   "Manslaughter (PC)",
+    "211":   "Robbery (PC)",
+    "215":   "Carjacking (PC)",
+    "220":   "Assault to commit a felony (PC)",
+    "240":   "Assault (PC)",
+    "242":   "Battery (PC)",
+    "243":   "Battery — specific (PC)",
+    "245":   "Assault with a deadly weapon (PC)",
+    "246":   "Shooting at occupied vehicle/dwelling (PC)",
+    "261":   "Rape (PC)",
+    "273.5": "Domestic violence (PC)",
+    "288":   "Lewd act on child (PC)",
+    # Penal Code — property
+    "459":   "Burglary (PC)",
+    "460":   "Burglary — degree (PC)",
+    "466":   "Burglary tools (PC)",
+    "470":   "Forgery (PC)",
+    "484":   "Theft (PC)",
+    "487":   "Grand theft (PC)",
+    "488":   "Petty theft (PC)",
+    "490.4": "Organized retail theft (PC)",
+    "496":   "Receiving stolen property (PC)",
+    "496d":  "Receiving stolen vehicle (PC)",
+    "530.5": "Identity theft (PC)",
+    "594":   "Vandalism (PC)",
+    # Penal Code — other
+    "207":   "Kidnapping (PC)",
+    "314":   "Indecent exposure (PC)",
+    "415":   "Disturbing the peace (PC)",
+    "422":   "Criminal threats (PC)",
+    "451":   "Arson (PC)",
+    "452":   "Reckless burning (PC)",
+    # Penal Code — weapons
+    "417":   "Brandishing a weapon (PC)",
+    "25400": "Carrying a concealed firearm (PC)",
+    "25850": "Carrying a loaded firearm (PC)",
+    "29800": "Felon in possession of firearm (PC)",
+    # Health & Safety Code (drugs)
+    "11350": "Possession of controlled substance (HSC)",
+    "11351": "Possession for sale (HSC)",
+    "11352": "Sale/transport, narcotics (HSC)",
+    "11377": "Possession of methamphetamine (HSC)",
+    "11378": "Possession for sale, methamphetamine (HSC)",
+    "11379": "Sale/transport, methamphetamine (HSC)",
+    # Welfare & Institutions Code
+    "5150":  "Mental-health hold (WIC)",
+    "300":   "Dependent child (WIC)",
+    "601":   "Status offense — minor (WIC)",
+    "602":   "Delinquent minor (WIC)",
+    # Common radio / status codes (10-codes vary by agency, but these
+    # are widely standardized in CA law-enforcement usage)
+    "1030":  "Stolen vehicle (radio code)",
+    "1065":  "Missing person (radio)",
+    "10-65": "Missing person (radio)",
+    # CVC sections that no longer exist as primary statutes (repealed
+    # / renumbered) but still appear in agency justification text as
+    # informal shorthand. Labelled "(historic)" so the reader knows the
+    # current code section is different.
+    "23101": "Reckless / DUI causing injury (CVC, historic)",
+}
+
+PUNCT_RE = re.compile(r"[^\w\s./()-]+", re.UNICODE)
+TOKEN_RE = re.compile(r"[A-Za-z]{2,}|[0-9]{2,5}(?:\.[0-9]+)?")
+CODE_RE = re.compile(r"\b([0-9]{3,5}(?:\.[0-9]+)?)\b")
+LONG_DIGITS_RE = re.compile(r"\b\d{8,}\b")
+# Code-section abbreviations seen in agency audit data. "vc" is short
+# for CVC; "cvv" is a common typo for CVC. Order in the alternation
+# matters only for greedy matching — we put longer ones first so
+# "cvc" matches before "vc" would. Strip these so the bare number
+# can be tokenized and matched against PENAL_CODES regardless of
+# whether the agency writes them prefix-first ("PC459") or suffix-
+# style ("459PC", "10851VC"). Without the strip, the combined string
+# is mixed letter+digit, 5-8 chars — plate-shaped — and PLATE_RE
+# would silently drop it.
+_CODE_AFFIX = r"(?:cvc|cvv|hsc|wic|hs|pc|vc)"
+CODE_PREFIX_RE = re.compile(r"\b" + _CODE_AFFIX + r"\s*(\d+(?:\.\d+)?)\b")
+CODE_SUFFIX_RE = re.compile(r"\b(\d+(?:\.\d+)?)\s*" + _CODE_AFFIX + r"\b")
+# Case/report numbers used as the entire justification — typical formats
+# are YY-NNNNN, YYYY-NNNNN, or RDNN-NNNNN. A case number identifies a
+# single incident, so re-using one across many searches over many days
+# is the pattern audit systems are supposed to surface for review.
+CASE_NUMBER_RE = re.compile(r"^\d{2,4}-\d{3,8}$")
+# Plate-like: a mix of letters and digits, 6-8 chars total (CA plates
+# are typically 7 chars). 5-char strings caught up too many short
+# code-shaped tokens like "1030f" or "459pc" (without an affix to
+# strip), so we tightened from 5- to 6-char minimum. The cost is that
+# rare 5-char specialty plates can leak through; the win is that
+# agency dispatch codes don't get silently dropped.
+PLATE_RE = re.compile(r"\b(?=[A-Za-z0-9]{6,8}\b)(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z0-9]+\b")
+
+
+def normalize_reason(raw):
+    """Return a normalized whole-reason string.
+
+    Truly empty / whitespace-only input becomes BLANK_LABEL so it
+    surfaces in the chart as a discrete row. Filler entries that are
+    in DROP_VERBATIM (test, n/a, etc.) return None and are dropped
+    from the chart entirely.
+    """
+    if raw is None:
+        return BLANK_LABEL
+    s = str(raw).strip().lower()
+    if not s:
+        return BLANK_LABEL
+    s = PUNCT_RE.sub(" ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    if not s:
+        return BLANK_LABEL
+    if s in DROP_VERBATIM:
+        return None
+    return s
+
+
+def tokenize(reason_norm):
+    """Yield meaningful tokens from a normalized reason string.
+
+    Drops stopwords, plate-pattern fragments, and >=8-digit runs.
+    Keeps short numeric codes (3-5 digits) for penal-code matching.
+    """
+    if not reason_norm:
+        return
+    s = CODE_PREFIX_RE.sub(r"\1", reason_norm)
+    s = CODE_SUFFIX_RE.sub(r"\1", s)
+    s = LONG_DIGITS_RE.sub(" ", s)
+    s = PLATE_RE.sub(" ", s)
+    for m in TOKEN_RE.finditer(s):
+        tok = m.group(0)
+        if tok in STOPWORDS:
+            continue
+        yield tok
+
+
+def detect_codes(phrase):
+    """Return ordered list of [code, label] for codes detected in a phrase.
+
+    `phrase` is the already-normalized (lowercased, punct-tamed) reason
+    string. Runs the same prefix-strip + plate/long-digit guards as the
+    aggregate tokenizer so a phrase like "pc459/cvc10851" yields both
+    Burglary and Vehicle theft labels in their original order.
+    """
+    if not phrase:
+        return []
+    s = CODE_PREFIX_RE.sub(r"\1", phrase)
+    s = CODE_SUFFIX_RE.sub(r"\1", s)
+    s = LONG_DIGITS_RE.sub(" ", s)
+    s = PLATE_RE.sub(" ", s)
+    out = []
+    seen = set()
+    for m in TOKEN_RE.finditer(s):
+        tok = m.group(0)
+        label = PENAL_CODES.get(tok)
+        if label and tok not in seen:
+            seen.add(tok)
+            out.append([tok, label])
+    return out
+
+
+def codes_from_tokens(token_counter):
+    """Pull penal-code-like tokens out of the token counter.
+
+    Only emits codes we have a label for, so unmatched numbers stay in
+    the generic token list.
+    """
+    out = []
+    for tok, count in token_counter.most_common():
+        label = PENAL_CODES.get(tok)
+        if label:
+            out.append([tok, label, count])
+    return out
+
+
+def latest_portal_uses(slug):
+    """Return (acceptable_use_policy, prohibited_uses) from the most recent
+    portal JSON for `slug`, or (None, None) if no portal data is available.
+
+    The agency's own published statement of permissible / prohibited uses
+    is the contract the cloud's free-text reasons should be measured
+    against — surfacing it inline lets the reader judge fit without
+    cross-referencing the transparency portal.
+    """
+    portal_dir = PORTAL_DIR / slug
+    if not portal_dir.is_dir():
+        return None, None
+    paths = portal_jsons(portal_dir)
+    if not paths:
+        return None, None
+    try:
+        d = json.loads(paths[-1].read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, None
+    aup = (d.get("acceptable_use_policy") or "").strip() or None
+    pu = (d.get("prohibited_uses") or "").strip() or None
+    return aup, pu
+
+
+PT = ZoneInfo("America/Los_Angeles")
+
+# Sentinel for "the agency entered no reason / blank justification."
+# Surfacing this as a real chart row makes the blank-rate visible at
+# a glance — the alternative (a side stat tile) buries the signal.
+BLANK_LABEL = "(blank)"
+
+
+def parse_search_date_pt(s):
+    """Parse a Flock searchDate ISO timestamp and return aware-local PT.
+
+    Flock emits ISO-8601 with a trailing 'Z' (UTC). Returns None on
+    parse failure so a single bad row doesn't tank the whole agency.
+    """
+    if not s:
+        return None
+    try:
+        # datetime.fromisoformat in 3.11+ accepts trailing 'Z'; for
+        # older versions, swap it for +00:00 explicitly.
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        return None
+    return dt.astimezone(PT)
+
+
+LONG_ACTIVE_MIN_COUNT = 10
+LONG_ACTIVE_MIN_DAYS = 7
+LONG_ACTIVE_TOP = 8
+
+
+def compute_phrase_details(phrases_of_interest, rows):
+    """Return {phrase: detail-dict} for each phrase in the input set.
+
+    detail-dict: {days, hourly[24], weekly[7], from, to,
+    nc_min, nc_med, nc_max, nc_over_100} — a per-phrase analog of the
+    agency-wide stats. Phrases not present in the rows yield None.
+    Single pass over rows so cost is O(N) per agency, not O(N*K).
+    """
+    if not phrases_of_interest:
+        return {}
+    accum = {
+        p: {"hourly": [0] * 24, "weekly": [0] * 7, "ncs": [],
+            "dates": Counter()}
+        for p in phrases_of_interest
+    }
+    for r in rows:
+        raw = r.get("reason")
+        if raw is None or not str(raw).strip():
+            raw = r.get("offenseType")
+        if raw is None or not str(raw).strip():
+            raw = r.get("caseNumber")
+        norm = normalize_reason(raw)
+        if norm not in accum:
+            continue
+        a = accum[norm]
+        dt = parse_search_date_pt(r.get("searchDate"))
+        if dt is not None:
+            a["hourly"][dt.hour] += 1
+            a["weekly"][dt.weekday()] += 1
+            a["dates"][dt.date().isoformat()] += 1
+        nc_raw = r.get("networkCount")
+        try:
+            if nc_raw not in (None, ""):
+                a["ncs"].append(int(nc_raw))
+        except (TypeError, ValueError):
+            pass
+    out = {}
+    for phrase, a in accum.items():
+        ncs = sorted(a["ncs"])
+        n = len(ncs)
+        date_counts = a["dates"]
+        d = {
+            "days": len(date_counts),
+            "hourly": a["hourly"],
+            "weekly": a["weekly"],
+        }
+        if date_counts:
+            from_iso = min(date_counts)
+            to_iso = max(date_counts)
+            from_d = date.fromisoformat(from_iso)
+            to_d = date.fromisoformat(to_iso)
+            span = (to_d - from_d).days + 1
+            d["from"] = from_iso
+            d["to"] = to_iso
+            d["span_days"] = span
+            # daily series across the calendar span (zero-filled), so
+            # the JS sparkline shows gaps as empty cells. Cap at 365
+            # to keep payload bounded for multi-year cases; if longer,
+            # downsample to weekly buckets.
+            if span <= 365:
+                series = []
+                cur = from_d
+                while cur <= to_d:
+                    series.append(date_counts.get(cur.isoformat(), 0))
+                    cur += timedelta(days=1)
+                d["daily"] = series
+                d["daily_unit"] = "day"
+            else:
+                # Weekly buckets: each entry is searches in a 7-day
+                # window starting at from_d.
+                series = []
+                cur = from_d
+                while cur <= to_d:
+                    week_total = 0
+                    for offset in range(7):
+                        week_total += date_counts.get(
+                            (cur + timedelta(days=offset)).isoformat(), 0
+                        )
+                    series.append(week_total)
+                    cur += timedelta(days=7)
+                d["daily"] = series
+                d["daily_unit"] = "week"
+        if ncs:
+            d["nc_min"] = ncs[0]
+            d["nc_med"] = ncs[n // 2]
+            d["nc_max"] = ncs[-1]
+            d["nc_over_100"] = sum(1 for x in ncs if x >= 100)
+        out[phrase] = d
+    return out
+
+
+def find_long_active_cases(rows):
+    """Return case-number-shaped phrases reused across many searches and days.
+
+    Each entry: [phrase, count, distinct_days, date_min, date_max,
+    median_network_count]. Capped at LONG_ACTIVE_TOP, sorted by count.
+    A case number is meant to identify one incident; reuse across many
+    searches over a long span is what audit-trail review is supposed
+    to flag.
+    """
+    by_phrase = {}
+    for r in rows:
+        raw = r.get("reason")
+        if raw is None or not str(raw).strip():
+            raw = r.get("offenseType")
+        if raw is None or not str(raw).strip():
+            raw = r.get("caseNumber")
+        if not raw:
+            continue
+        norm = normalize_reason(raw)
+        if not norm or not CASE_NUMBER_RE.match(norm):
+            continue
+        date = (r.get("searchDate") or "")[:10]
+        nc_raw = r.get("networkCount")
+        try:
+            nc = int(nc_raw) if nc_raw not in (None, "") else None
+        except (TypeError, ValueError):
+            nc = None
+        bucket = by_phrase.setdefault(norm, {"dates": [], "ncs": []})
+        if date:
+            bucket["dates"].append(date)
+        if nc is not None:
+            bucket["ncs"].append(nc)
+    out = []
+    for phrase, b in by_phrase.items():
+        dates = b["dates"]
+        if not dates:
+            continue
+        distinct = len(set(dates))
+        count = len(dates)
+        if count < LONG_ACTIVE_MIN_COUNT or distinct < LONG_ACTIVE_MIN_DAYS:
+            continue
+        ncs = sorted(b["ncs"])
+        median_nc = ncs[len(ncs) // 2] if ncs else None
+        out.append([
+            phrase,
+            count,
+            distinct,
+            min(dates),
+            max(dates),
+            median_nc,
+        ])
+    out.sort(key=lambda x: -x[1])
+    return out[:LONG_ACTIVE_TOP]
+
+
+def process_agency(audit_path):
+    """Return a per-agency dict, or None if the agency has no usable rows."""
+    try:
+        data = json.loads(audit_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    rows = data.get("rows") or []
+    if not rows:
+        return None
+
+    verbatim_counts = Counter()
+    token_counts = Counter()
+    blank = 0
+    lengths = []
+    # 7 (Mon=0..Sun=6) x 24 (hour-of-day, PT). Sized at build time so
+    # agencies with no overlap with a particular cell still emit a 0
+    # in that slot — the heatmap renders sparser cells correctly.
+    hour_dow = [[0] * 24 for _ in range(7)]
+    timed_rows = 0
+
+    for r in rows:
+        # Field-fallback chain so each agency's most populated field
+        # gets used: reason (free-text) > offenseType (NIBRS-aligned
+        # dropdown) > caseNumber (raw case ID). Different agencies
+        # publish different combinations; some publish only one of
+        # the three. The conceptual differences are real but for an
+        # aggregate justification view they serve the same role.
+        raw = r.get("reason")
+        if raw is None or not str(raw).strip():
+            raw = r.get("offenseType")
+        if raw is None or not str(raw).strip():
+            raw = r.get("caseNumber")
+        norm = normalize_reason(raw)
+        if norm is None:
+            # Filler (test / n/a) — counted as blank-equivalent for the
+            # blank-rate stat but not surfaced as its own row.
+            blank += 1
+        elif norm == BLANK_LABEL:
+            blank += 1
+            verbatim_counts[norm] += 1
+        else:
+            verbatim_counts[norm] += 1
+            lengths.append(len(norm))
+            for tok in tokenize(norm):
+                token_counts[tok] += 1
+        dt = parse_search_date_pt(r.get("searchDate"))
+        if dt is not None:
+            hour_dow[dt.weekday()][dt.hour] += 1
+            timed_rows += 1
+
+    if not verbatim_counts:
+        return None
+
+    # Verbatim row format: [phrase, count, codes_or_null, detail]
+    # codes_or_null is [[code, label], ...] or null.
+    # detail is a per-phrase stats dict (see compute_phrase_details).
+    top_verbatim_pairs = list(verbatim_counts.most_common(TOP_VERBATIM))
+    top_phrase_set = {p for p, _ in top_verbatim_pairs}
+    # Also include long-active case-number phrases so the callout
+    # rows can expand to the same detail panel as bars/cloud.
+    long_active = find_long_active_cases(rows)
+    for entry in long_active:
+        top_phrase_set.add(entry[0])
+    phrase_details = compute_phrase_details(top_phrase_set, rows)
+    top_verbatim_filtered = []
+    for phrase, c in top_verbatim_pairs:
+        # BLANK_LABEL is a synthetic phrase — it has no meaningful
+        # tokens or codes to detect, so don't run the matcher on the
+        # literal string "(blank)".
+        codes = [] if phrase == BLANK_LABEL else detect_codes(phrase)
+        top_verbatim_filtered.append([
+            phrase,
+            c,
+            codes if codes else None,
+            phrase_details.get(phrase),
+        ])
+    top_tokens_filtered = [
+        [tok, c]
+        for tok, c in token_counts.most_common(TOP_TOKENS)
+        if tok not in PENAL_CODES
+    ]
+    code_rows = codes_from_tokens(token_counts)
+
+    total = len(rows)
+    top1 = verbatim_counts.most_common(1)[0][1] if verbatim_counts else 0
+    top3 = sum(c for _, c in verbatim_counts.most_common(3))
+
+    # Schema-level transparency check: did the agency's audit CSV
+    # include any of the three fields that could record WHY a search
+    # was run? Some agencies (Fontana, Menlo Park) publish audits
+    # whose schema is just [id, networkCount, searchDate, userId] —
+    # the justification field is structurally absent, not just blank.
+    schema = set(data.get("schema_seen") or [])
+    has_justification_column = bool(
+        schema & {"reason", "offenseType", "caseNumber"}
+    )
+
+    return {
+        "row_count": total,
+        "audit_schema": sorted(schema),
+        "has_justification_column": has_justification_column,
+        "blank_reasons": blank,
+        "unique_reasons": len(verbatim_counts),
+        "verbatim_shown": len(top_verbatim_filtered),
+        "tokens_shown": len(top_tokens_filtered),
+        "median_length_chars": int(statistics.median(lengths)) if lengths else 0,
+        "top1_share_pct": round(100.0 * top1 / total, 1) if total else 0.0,
+        "top3_share_pct": round(100.0 * top3 / total, 1) if total else 0.0,
+        "search_date_min": data.get("search_date_min"),
+        "search_date_max": data.get("search_date_max"),
+        "verbatim": top_verbatim_filtered,
+        "tokens": top_tokens_filtered,
+        "penal_codes": code_rows,
+        # Day-of-week × hour-of-day heatmap, in America/Los_Angeles.
+        # Rows are weekdays Monday=0..Sunday=6 (ISO ordering).
+        "hour_dow": hour_dow,
+        "timed_rows": timed_rows,
+        # Case-number-only phrases reused across many searches and days.
+        "long_active_cases": long_active,
+        # Per-phrase detail keyed by the verbatim phrase string. The
+        # JS expand panel reads from this so all three entry points
+        # (bar row, cloud word, callout row) hit the same data.
+        "phrase_details": phrase_details,
+    }
+
+
+def main():
+    if not AUDIT_DIR.exists():
+        print(f"missing {AUDIT_DIR}; run build_audit_log.py first", file=sys.stderr)
+        return 1
+    registry = load_registry()
+    by_slug = {}
+    for entry in registry:
+        slug = entry.get("slug")
+        if not slug:
+            continue
+        by_slug[slug] = entry
+        for fs in entry.get("flock_slugs") or []:
+            by_slug.setdefault(fs, entry)
+
+    out = {}
+    skipped = 0
+    for path in sorted(AUDIT_DIR.glob("*.json")):
+        slug = path.stem
+        entry = by_slug.get(slug)
+        agency_data = process_agency(path)
+        if agency_data is None:
+            skipped += 1
+            continue
+        agency_data["slug"] = slug
+        agency_data["display_name"] = (
+            (entry.get("display_name") if entry else None)
+            or (entry.get("flock_names") or [None])[0] if entry else None
+        ) or slug
+        aup, pu = latest_portal_uses(slug)
+        if aup:
+            agency_data["acceptable_use_policy"] = aup
+        if pu:
+            agency_data["prohibited_uses"] = pu
+        out[slug] = agency_data
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generated_from": str(AUDIT_DIR),
+        "top_verbatim_cap": TOP_VERBATIM,
+        "top_tokens_cap": TOP_TOKENS,
+        "agency_count": len(out),
+        "agencies": out,
+    }
+    OUT_PATH.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n")
+    print(f"wrote {OUT_PATH}: {len(out)} agencies, skipped {skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -265,7 +265,7 @@ def latest_portal_uses(slug):
     portal JSON for `slug`, or (None, None) if no portal data is available.
 
     The agency's own published statement of permissible / prohibited uses
-    is the contract the cloud's free-text reasons should be measured
+    is the contract the page's free-text reasons should be measured
     against — surfacing it inline lets the reader judge fit without
     cross-referencing the transparency portal.
     """

--- a/scripts/publish_docs.sh
+++ b/scripts/publish_docs.sh
@@ -9,6 +9,7 @@ uv run python scripts/build_sharing_graph.py
 uv run python scripts/build_map.py
 uv run python scripts/build_scoreboard.py
 uv run python scripts/build_audit_log.py
+uv run python scripts/build_justifications.py
 uv run python scripts/build_contract_map.py
 
 # Copy findings
@@ -19,6 +20,7 @@ echo "Done. docs/ ready for GitHub Pages."
 echo "  docs/index.html"
 echo "  docs/sharing_map.html"
 echo "  docs/scoreboard.html"
+echo "  docs/justifications.html"
 echo "  docs/contracts.html"
 echo "  docs/SMPD_ALPR_Findings.pdf"
 echo "  docs/SMPD_ALPR_Findings.md"


### PR DESCRIPTION
## Summary

New page at `docs/justifications.html` (linked from build artifacts via `docs/data/justifications.json`) that turns the deduplicated rolling audit logs into an exploration tool for what California ALPR agencies record as their search justifications.

For each of the 80 audit-publishing agencies, the page surfaces:

- **Audit data window** — date span, day count, and a direct \"View raw audit data\" link to the agency's `data/audit/<slug>.json` so anyone can verify what we have.
- **Scope clarification** — explicit note that the audit only shows the agency's own searches; partners with shared access search this data too, but those searches appear in *their* audits, not here. Links to the per-agency report which sums cross-agency volume.
- **Stated uses** — the agency's own published acceptable-use / prohibited-uses text from the Flock transparency portal, with a \"View on Flock transparency portal →\" link.
- **Long-active case-number callout** — case-IDs reused across many searches and many days, with flag pills (long-lived, heavy use, broad reach, stale case, multi-officer pattern, narrow reach) and click-to-expand per-phrase detail.
- **Top-50 reasons by count** — bar list with per-phrase code identification (PC/CVC/HSC/WIC, including suffix-style `459pc` and prefix-style `PC459` variants), behavior flags, and click-to-expand detail (24-bar hour-of-day, daily cadence sparkline, prose pattern summary).
- **7×24 PT day-of-week × hour-of-day heatmap** at the agency level.
- **Filter bar** — All / flag-kind / 7 functional crime categories (Violent / Property / Drug / Weapons / Traffic-DUI / Case IDs / Other, approximated from NIBRS Group A) / per-code pills. Click any pill to hide non-matching rows.
- **Group-by toggle** — Phrase / By code / By category. Aggregated rows drill down to phrase view with the matching filter applied.

Field-fallback chain (`reason` → `offenseType` → `caseNumber`) so agencies that publish only one of those fields (Santa Clara, San Bruno, Ontario, Antioch, Albany, Chula Vista, Pasadena, etc.) still yield meaningful aggregations.

Agencies whose audit schema omits all three justification fields entirely (Fontana, Menlo Park) get a structural-omission callout instead of a misleading \"(blank)\" row, noting that the `userId` field is uniformly redacted to `***` across every CA agency's public audit.

Disclaimer at the top of the bar list reminds the reader that entered reasons aren't validated against the actual reason for the search.

## Test plan

- [ ] `uv run python scripts/build_justifications.py` runs cleanly and writes `docs/data/justifications.json`
- [ ] Page loads at `/justifications.html` and `?agency=<slug>` selects the agency
- [ ] Click a row → detail panel expands with hour-of-day, daily sparkline, network-reach summary
- [ ] Click a flag / category / code filter pill → matching rows shown, others hidden
- [ ] Group-by Phrase/Code/Category renders correctly; aggregated rows drill into phrase view with filter applied
- [ ] Fontana and Menlo Park show the no-justification-column callout instead of a `(blank)` row
- [ ] San Bruno (offenseType only) and Chula Vista (caseNumber only) show populated bars from the fallback chain
- [ ] Long-active case-number callout appears for Bakersfield (`26-13287`), Reedley (`26-0132`), Butte County
- [ ] \"View raw audit data\" link opens the per-agency JSON file
- [ ] \"View on Flock transparency portal\" link opens the agency's public Flock page
- [ ] Per-agency-report link in the scope sub-line opens `report.html?agency=<slug>`

## Follow-ups (queued, not in this PR)

- Surface the structural \"audit lacks justification column\" finding in `scripts/build_report_data.py` so each agency's transparency report carries the flag too
- FBI Crime Data Explorer NIBRS comparison (code-mix in audits vs reported crime distribution) — needs an `api.data.gov` API key
- 90-day recency filter for stale phrases once we have ≥6 months of accumulated audit data