### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -307,6 +307,14 @@
         "blue-lake-rancheria-tribal-po": "http_404"
       }
     },
+    "3be8eb08-59e0-52cc-ae43-8ae880a39155": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T21:45:45.139939+00:00",
+      "tried": {
+        "carroll-county-ga-sd": "http_404"
+      }
+    },
     "3dbed6a1-dadc-5951-b32d-32d3f816d17d": {
       "exhausted": false,
       "found": null,
@@ -525,11 +533,12 @@
     "69489e25-1027-5396-86a7-c68d5111eecd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T11:27:46.660202+00:00",
+      "last_probed": "2026-05-05T21:45:54.785791+00:00",
       "tried": {
         "calexico-ca-po": "http_404",
         "calexico-ca-police": "http_404",
-        "calexico-ca-police-department": "http_404"
+        "calexico-ca-police-department": "http_404",
+        "calexico-ca-ps": "http_404"
       }
     },
     "6978140c-1211-52e1-8c04-94d5a9791efe": {
@@ -1136,9 +1145,10 @@
     "e9d63958-c540-592f-aeb5-6fc9953296ef": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T15:27:27.301633+00:00",
+      "last_probed": "2026-05-05T21:45:49.759589+00:00",
       "tried": {
-        "hermosa-beach-ca-pd": "http_404"
+        "hermosa-beach-ca-pd": "http_404",
+        "hermosa-beach-ca-po": "http_404"
       }
     },
     "ea91bafe-b935-5f29-bf40-896f155a1d1c": {
@@ -1265,6 +1275,6 @@
       }
     }
   },
-  "updated": "2026-05-05T20:45:25.901930+00:00",
+  "updated": "2026-05-05T21:45:54.820918+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried.