### PR TITLE
feat(slug-probe): tier A discovery + eyesonflock hint + save-on-hit

### DIFF
--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -89,10 +89,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # On a hit, slug_probe also runs archive_agency to save the
+          # captured page (.txt/.html/.json/.pdf) under the new slug's
+          # directory, and updates .content_hashes.json. Stage the whole
+          # transparency.flocksafety.com tree so those artifacts come
+          # along with the registry/state changes.
           git add \
             assets/agency_registry.json \
-            assets/transparency.flocksafety.com/.slug_probe_state.json \
-            assets/transparency.flocksafety.com/.failed_slugs.json
+            assets/transparency.flocksafety.com/
           if git diff --cached --quiet; then
             echo "No changes to commit"
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -116,7 +120,7 @@ jobs:
           if [ -z "$existing" ]; then
             gh pr create \
               --title "chore: slug probe finds" \
-              --body "Automated rolling slug probe. Each run attempts up to 3 candidate slugs for agencies whose current Flock portal slug 404s. On a hit, the registry is updated (flock_slugs += found, flock_active_slug := found) and the old slug is removed from failed_slugs.json so the primary crawler will try it. Probe state persists so candidates aren't retried." \
+              --body "Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run." \
               --head slug-probe \
               --base main
           fi

--- a/scripts/slug_probe.py
+++ b/scripts/slug_probe.py
@@ -329,22 +329,116 @@ def agency_state(state, agency_id):
 
 
 def select_targets(registry, failed_slugs, state, only_agency=None):
-    """Return registry entries whose active slug is failing and not yet found."""
-    targets = []
+    """Return target agencies split into two priority tiers.
+
+    Tier A — registry entries with no `flock_active_slug` set yet but at
+    least one `flock_names` entry. These are agencies discovered through
+    peer-outbound sharing whose actual slug we haven't found. Single-try
+    hit rate from `name_to_slug`-style guesses tends to be high (~50%
+    among police), so this tier earns the larger share of the budget.
+
+    Tier B — registry entries whose active slug is in failed_slugs. We
+    confirmed once the guess didn't work; now we slog through variants.
+    Lower hit rate per probe but still worth working through.
+
+    Caller drives the budget split between tiers; this function just
+    classifies them and skips already-resolved/exhausted agencies.
+    """
+    tier_a = []
+    tier_b = []
     for e in registry:
         aid = e["agency_id"]
         if only_agency and aid != only_agency:
             continue
-        if state.get("agencies", {}).get(aid, {}).get("found"):
+        st = state.get("agencies", {}).get(aid, {})
+        if st.get("found"):
             continue
-        if state.get("agencies", {}).get(aid, {}).get("exhausted"):
+        if st.get("exhausted"):
             continue
         active = e.get("flock_active_slug")
-        if not active:
-            continue
-        if active in failed_slugs:
-            targets.append(e)
-    return targets
+        if active is None:
+            # Need a name to derive candidates from — entries with no
+            # name and no slug aren't probeable yet.
+            if e.get("flock_names") or e.get("display_name"):
+                tier_a.append(e)
+        elif active in failed_slugs:
+            tier_b.append(e)
+        # else: active is set and not failed → cmd_crawl handles refresh,
+        # probe stays out of the way.
+    return tier_a, tier_b
+
+
+def eyesonflock_hint(entry, eof_index):
+    """Return eyesonflock's authoritative slug for `entry` if there's a
+    clean geographic + role match, else None.
+
+    Conservative mapping: only place/police → PD and county/sheriff → SD
+    are matched, since those are the kinds eyesonflock's payload carries.
+    Other registry shapes (cousub township police, ambiguous boundaries,
+    state-level agencies) have no eyesonflock counterpart so we don't try
+    to match them — the cost of a wrong match (poisoned slug promoted to
+    the registry) is much higher than the cost of falling through to
+    variant generation.
+
+    `eof_index` is the dict produced by eyesonflock_lookup.index_by_geo().
+    Pass {} to disable lookup (e.g. when the API fetch failed).
+    """
+    if not eof_index:
+        return None
+    from eyesonflock_lookup import locality_key
+    geo = entry.get("geo") or {}
+    name = geo.get("name")
+    state = geo.get("state")
+    if not name or not state:
+        return None
+    role = entry.get("agency_role")
+    kind = geo.get("kind")
+    if kind == "place" and role == "police":
+        eof_type = "PD"
+    elif kind == "county" and role == "sheriff":
+        eof_type = "SD"
+    else:
+        return None
+    return eof_index.get((locality_key(name), state.upper(), eof_type))
+
+
+def load_eyesonflock_index():
+    """Fetch + validate eyesonflock's portal API and return the geo index.
+    Returns {} on any failure — slug_probe falls through to variant
+    generation as if eyesonflock didn't exist. The lookup is a hint, not
+    a dependency; an outage shouldn't break the run.
+    """
+    try:
+        from eyesonflock_lookup import fetch_api, index_by_geo, parse_payload
+        text = fetch_api()
+        records = parse_payload(text)
+        index, conflicts = index_by_geo(records)
+        if conflicts:
+            print(f"  eyesonflock: {len(conflicts)} (city,state,type) conflicts skipped")
+        return index
+    except Exception as e:
+        print(f"  eyesonflock: lookup unavailable ({type(e).__name__}: {e})")
+        return {}
+
+
+def allocate_tier_budget(limit, tier_a_count, tier_b_count, tier_b_share=1/3):
+    """Split a per-run probe budget between tier A and tier B.
+
+    Returns (a_budget, b_budget) summing to at most `limit`. Defaults
+    favor tier A (`tier_b_share=1/3` → at limit=3, the split is 2 A + 1 B)
+    because tier-A single-try hit rate is meaningfully higher than tier B's
+    variant-search hit rate. When either tier is empty the other tier
+    gets the full budget.
+    """
+    if tier_a_count == 0 and tier_b_count == 0:
+        return 0, 0
+    if tier_a_count == 0:
+        return 0, limit
+    if tier_b_count == 0:
+        return limit, 0
+    b_budget = max(1, int(limit * tier_b_share))
+    a_budget = max(0, limit - b_budget)
+    return a_budget, b_budget
 
 
 # ═══════════════════════════════════════════════════════════
@@ -399,47 +493,83 @@ def main():
         save_state(data_dir, state)
         print(f"Cleared 'exhausted' flags for {len(state.get('agencies', {}))} agencies")
 
-    targets = select_targets(registry, failed_slugs, state, only_agency=args.agency)
-    print(f"Found {len(targets)} target agencies (slug in failed_slugs, not yet resolved)")
+    tier_a, tier_b = select_targets(registry, failed_slugs, state,
+                                    only_agency=args.agency)
+    print(f"Tier A (no slug yet, peer-outbound discoveries): {len(tier_a)}")
+    print(f"Tier B (slug in failed_slugs, variant search):   {len(tier_b)}")
 
-    if args.agency and not targets:
+    if args.agency and not tier_a and not tier_b:
         print(f"  (no target for agency_id={args.agency})")
         return
+
+    a_budget, b_budget = allocate_tier_budget(args.limit, len(tier_a), len(tier_b))
+    print(f"Budget split: tier A = {a_budget}, tier B = {b_budget}")
 
     probes_done = 0
     hits = []
 
-    # Round-robin across agencies so one agency's long candidate list doesn't
-    # starve the others. Build per-agency candidate queues up front.
-    queues = []
-    for e in targets:
-        aid = e["agency_id"]
-        tried = state["agencies"].get(aid, {}).get("tried", {})
-        # Skip candidates already in the failed_slugs.json — we know those 404.
-        # The primary crawler populated that file; no point re-probing.
-        candidates = [
-            c for c in generate_candidates(e)
-            if c not in tried and c not in failed_slugs
-        ]
-        if not candidates:
-            agency_state(state, aid)["exhausted"] = True
-            continue
-        queues.append((e, candidates))
+    # Authoritative-hint lookup: an external crawler (eyesonflock.com)
+    # publishes confirmed Flock portal slugs for ~900 agencies. When their
+    # geo/type matches one of our entries we try their slug first — much
+    # higher hit rate than name_to_slug variant generation. Sanitization
+    # gate in eyesonflock_lookup.py keeps poisoned input out.
+    if not args.dry_run:
+        eof_index = load_eyesonflock_index()
+        print(f"Eyesonflock index: {len(eof_index)} (locality,state,type) keys")
+    else:
+        eof_index = {}
 
-    # Shuffle queue order so we don't always probe the same few agencies first.
-    random.shuffle(queues)
+    def build_queues(targets):
+        """Build per-agency candidate queues. Skip candidates already
+        tried (from state) or known to 404 (in failed_slugs). Prepend
+        the eyesonflock hint when we have a clean geo+role match —
+        single highest-confidence guess goes first, variant generation
+        is the fallback."""
+        queues = []
+        for e in targets:
+            aid = e["agency_id"]
+            tried = state["agencies"].get(aid, {}).get("tried", {})
+            ordered = []
+            hint = eyesonflock_hint(e, eof_index)
+            if hint:
+                ordered.append(hint)
+            ordered.extend(generate_candidates(e))
+            candidates = []
+            seen = set()
+            for c in ordered:
+                if c in seen or c in tried or c in failed_slugs:
+                    continue
+                seen.add(c)
+                candidates.append(c)
+            if not candidates:
+                agency_state(state, aid)["exhausted"] = True
+                continue
+            queues.append((e, candidates))
+        random.shuffle(queues)
+        return queues
+
+    queues_a = build_queues(tier_a)
+    queues_b = build_queues(tier_b)
 
     if args.dry_run:
-        for entry, candidates in queues[:10]:
-            name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
-            print(f"\n{name}  [{entry['agency_id']}]")
-            print(f"  current active: {entry.get('flock_active_slug')}")
-            print(f"  candidates ({len(candidates)}):")
-            for c in candidates[:20]:
-                print(f"    {c}")
-            if len(candidates) > 20:
-                print(f"    ... and {len(candidates) - 20} more")
+        for label, queues in (("TIER A", queues_a), ("TIER B", queues_b)):
+            if not queues:
+                continue
+            print(f"\n=== {label} ===")
+            for entry, candidates in queues[:10]:
+                name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
+                print(f"\n{name}  [{entry['agency_id']}]")
+                print(f"  current active: {entry.get('flock_active_slug')}")
+                print(f"  candidates ({len(candidates)}):")
+                for c in candidates[:20]:
+                    print(f"    {c}")
+                if len(candidates) > 20:
+                    print(f"    ... and {len(candidates) - 20} more")
         return
+
+    # Lazy import: archive_agency lives in flock_transparency, which pulls
+    # in playwright/parsing — only import when we'll actually probe.
+    from flock_transparency import HASH_FILE, archive_agency
 
     from playwright.sync_api import sync_playwright
     with sync_playwright() as p:
@@ -450,60 +580,86 @@ def main():
         )
         page = context.new_page()
 
-        # Round-robin: pull one candidate from each queue in turn until limit hit
-        q_idx = 0
-        while probes_done < args.limit and queues:
-            entry, candidates = queues[q_idx % len(queues)]
-            if not candidates:
-                queues.pop(q_idx % len(queues))
-                if not queues:
-                    break
-                continue
-            candidate = candidates.pop(0)
-            aid = entry["agency_id"]
-            name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
+        # Wrap the inner loop so we can run it twice (tier A then tier B)
+        # against separate queues with separate budgets. Return value is
+        # whether we hit a rate_limit and should stop the whole run.
+        def run_tier(queues, budget, label):
+            nonlocal probes_done
+            q_idx = 0
+            consumed = 0
+            while consumed < budget and queues:
+                entry, candidates = queues[q_idx % len(queues)]
+                if not candidates:
+                    queues.pop(q_idx % len(queues))
+                    if not queues:
+                        break
+                    continue
+                candidate = candidates.pop(0)
+                aid = entry["agency_id"]
+                name = entry.get("display_name") or (entry.get("flock_names") or ["?"])[-1]
 
-            print(f"\n[{probes_done + 1}/{args.limit}] {name}  ->  {candidate}")
-            result, detail = probe(page, candidate)
-            st = agency_state(state, aid)
-            st["tried"][candidate] = detail
-            st["last_probed"] = datetime.now(timezone.utc).isoformat()
-            probes_done += 1
+                print(f"\n[{label} {probes_done + 1}/{args.limit}] {name}  ->  {candidate}")
+                result, detail = probe(page, candidate)
+                st = agency_state(state, aid)
+                st["tried"][candidate] = detail
+                st["last_probed"] = datetime.now(timezone.utc).isoformat()
+                probes_done += 1
+                consumed += 1
 
-            if result == "hit":
-                print(f"    HIT ({detail}) — promoting to registry")
-                st["found"] = candidate
-                old_slug = entry.get("flock_active_slug")
-                promote_slug(registry, aid, candidate)
-                if old_slug:
-                    clear_failed(failed_slugs, old_slug)
-                clear_failed(failed_slugs, candidate)
-                hits.append((name, candidate))
-                queues.pop(q_idx % len(queues))
-            elif result == "miss":
-                print(f"    miss ({detail})")
-                q_idx += 1
-            elif result == "rate_limited":
-                print(f"    RATE LIMITED — stopping this run")
-                # Roll back the consumed candidate — we don't want to mark it
-                # tried without actually knowing the answer.
-                st["tried"].pop(candidate, None)
-                probes_done -= 1
-                break
-            else:  # error
-                print(f"    error ({detail}) — leaving as tried to avoid retry loops")
-                q_idx += 1
+                if result == "hit":
+                    print(f"    HIT ({detail}) — promoting to registry")
+                    st["found"] = candidate
+                    old_slug = entry.get("flock_active_slug")
+                    promote_slug(registry, aid, candidate)
+                    if old_slug:
+                        clear_failed(failed_slugs, old_slug)
+                    clear_failed(failed_slugs, candidate)
+                    hits.append((name, candidate))
+                    queues.pop(q_idx % len(queues))
 
-            # Save after every probe so a crash mid-run doesn't lose progress
-            save_state(data_dir, state)
-            save_json(data_dir / FAILED_FILE, failed_slugs)
-            if hits:
-                REGISTRY_PATH.write_text(json.dumps(registry, indent=2) + "\n")
+                    # Save the page so cmd_crawl doesn't have to come back
+                    # to confirm what we just confirmed. archive_agency
+                    # re-navigates (5s dwell) but cleanly produces .txt /
+                    # .html / .json / .pdf and updates the content hash —
+                    # the slug becomes a normal tier-1 refresh target on
+                    # the next cmd_crawl run.
+                    hashes = load_json(data_dir / HASH_FILE)
+                    archive_agency(page, candidate, data_dir,
+                                   force=True, hashes=hashes)
+                    save_json(data_dir / HASH_FILE, hashes)
+                elif result == "miss":
+                    print(f"    miss ({detail})")
+                    q_idx += 1
+                elif result == "rate_limited":
+                    print(f"    RATE LIMITED — stopping this run")
+                    # Roll back the consumed candidate — we don't want to mark it
+                    # tried without actually knowing the answer.
+                    st["tried"].pop(candidate, None)
+                    probes_done -= 1
+                    consumed -= 1
+                    return True  # signal: stop the whole run
+                else:  # error
+                    print(f"    error ({detail}) — leaving as tried to avoid retry loops")
+                    q_idx += 1
 
-            if probes_done < args.limit and queues:
-                sleep_for = args.delay * random.uniform(0.7, 1.3)
-                print(f"    sleeping {sleep_for:.0f}s...")
-                time.sleep(sleep_for)
+                # Save after every probe so a crash mid-run doesn't lose progress
+                save_state(data_dir, state)
+                save_json(data_dir / FAILED_FILE, failed_slugs)
+                if hits:
+                    REGISTRY_PATH.write_text(json.dumps(registry, indent=2) + "\n")
+
+                if probes_done < args.limit and queues:
+                    sleep_for = args.delay * random.uniform(0.7, 1.3)
+                    print(f"    sleeping {sleep_for:.0f}s...")
+                    time.sleep(sleep_for)
+            return False  # not rate-limited
+
+        if a_budget:
+            stopped = run_tier(queues_a, a_budget, "A")
+            if not stopped and b_budget:
+                run_tier(queues_b, b_budget, "B")
+        elif b_budget:
+            run_tier(queues_b, b_budget, "B")
 
         browser.close()
 

--- a/tests/test_slug_probe.py
+++ b/tests/test_slug_probe.py
@@ -11,9 +11,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from slug_probe import (
+    allocate_tier_budget,
     extract_hints,
+    eyesonflock_hint,
     generate_candidates,
     normalize_name,
+    select_targets,
 )
 
 
@@ -154,3 +157,243 @@ def test_candidates_priority_default_first():
     }
     candidates = generate_candidates(entry)
     assert candidates[0] == "alhambra-ca-pd"
+
+
+# ── select_targets tier split ───────────────────────────────────
+
+
+def _entry(aid, **overrides):
+    """Helper for building a minimal registry entry for tier tests."""
+    e = {
+        "agency_id": aid,
+        "flock_names": ["Alameda CA PD"],
+        "display_name": None,
+        "flock_active_slug": "alameda-ca-pd",
+        "flock_slugs": ["alameda-ca-pd"],
+        "agency_role": "police",
+        "geo": {"state": "CA"},
+    }
+    e.update(overrides)
+    return e
+
+
+def test_select_targets_tier_a_picks_null_active_with_name():
+    """Tier A is registry entries with no confirmed slug yet — these are
+    peer-outbound discoveries that probe should try first because their
+    single-try hit rate from name_to_slug-style guesses is high."""
+    registry = [
+        _entry("x", flock_active_slug=None, flock_slugs=[]),
+    ]
+    tier_a, tier_b = select_targets(registry, failed_slugs={}, state={})
+    assert [e["agency_id"] for e in tier_a] == ["x"]
+    assert tier_b == []
+
+
+def test_select_targets_tier_a_skips_entries_with_no_name_signal():
+    """Without flock_names or display_name, generate_candidates can't
+    derive variants — there's nothing for probe to work with, so the
+    entry should be skipped at selection."""
+    registry = [
+        _entry("x", flock_active_slug=None, flock_names=[], display_name=None),
+    ]
+    tier_a, tier_b = select_targets(registry, failed_slugs={}, state={})
+    assert tier_a == []
+    assert tier_b == []
+
+
+def test_select_targets_tier_b_picks_active_in_failed_slugs():
+    """Existing behavior, now tier B: registry entries whose
+    flock_active_slug is in failed_slugs.json get variant-searched."""
+    registry = [_entry("x", flock_active_slug="alameda-ca-pd")]
+    tier_a, tier_b = select_targets(
+        registry, failed_slugs={"alameda-ca-pd": {"reason": "404"}}, state={}
+    )
+    assert tier_a == []
+    assert [e["agency_id"] for e in tier_b] == ["x"]
+
+
+def test_select_targets_skips_active_set_and_not_failed():
+    """If active is set and not in failed_slugs, the main crawler handles
+    refresh — probe stays out of the way to preserve its rate budget."""
+    registry = [_entry("x", flock_active_slug="alameda-ca-pd")]
+    tier_a, tier_b = select_targets(registry, failed_slugs={}, state={})
+    assert tier_a == []
+    assert tier_b == []
+
+
+def test_select_targets_skips_already_found():
+    """state.found means probe has already resolved this agency; don't
+    re-probe."""
+    registry = [_entry("x", flock_active_slug=None)]
+    state = {"agencies": {"x": {"found": "alameda-ca-pd"}}}
+    tier_a, tier_b = select_targets(registry, failed_slugs={}, state=state)
+    assert tier_a == [] and tier_b == []
+
+
+def test_select_targets_skips_exhausted():
+    """Agencies whose entire candidate space was tried get marked
+    exhausted; selection skips them so the limited probe budget goes
+    to agencies still in play."""
+    registry = [_entry("x", flock_active_slug=None)]
+    state = {"agencies": {"x": {"exhausted": True}}}
+    tier_a, tier_b = select_targets(registry, failed_slugs={}, state=state)
+    assert tier_a == [] and tier_b == []
+
+
+def test_select_targets_only_agency_filter_applies_to_both_tiers():
+    registry = [
+        _entry("a", flock_active_slug=None),
+        _entry("b", flock_active_slug="alameda-ca-pd"),
+    ]
+    failed = {"alameda-ca-pd": {"reason": "404"}}
+    tier_a, tier_b = select_targets(registry, failed, state={}, only_agency="a")
+    assert [e["agency_id"] for e in tier_a] == ["a"]
+    assert tier_b == []
+    tier_a, tier_b = select_targets(registry, failed, state={}, only_agency="b")
+    assert tier_a == []
+    assert [e["agency_id"] for e in tier_b] == ["b"]
+
+
+# ── allocate_tier_budget ────────────────────────────────────────
+
+
+def test_allocate_tier_budget_default_split_at_three():
+    """At the workflow's hourly limit of 3 probes, the default split is
+    2 + 1 — biased toward tier A because its single-try hit rate is
+    meaningfully higher than tier B's variant-search hit rate."""
+    assert allocate_tier_budget(3, tier_a_count=10, tier_b_count=10) == (2, 1)
+
+
+def test_allocate_tier_budget_full_to_a_when_b_empty():
+    """No tier B work → full budget to tier A. Don't waste slots."""
+    assert allocate_tier_budget(3, tier_a_count=5, tier_b_count=0) == (3, 0)
+
+
+def test_allocate_tier_budget_full_to_b_when_a_empty():
+    """No tier A work → full budget to tier B (the original behavior
+    before tiers existed)."""
+    assert allocate_tier_budget(3, tier_a_count=0, tier_b_count=5) == (0, 3)
+
+
+def test_allocate_tier_budget_zero_when_both_empty():
+    assert allocate_tier_budget(3, tier_a_count=0, tier_b_count=0) == (0, 0)
+
+
+def test_allocate_tier_budget_minimum_one_for_b_when_present():
+    """Even at limit=1 with both tiers populated, tier B still gets a
+    slot — otherwise a heavily-populated tier A could starve tier B
+    indefinitely. The asymmetry is acceptable: 1 of the 3 hourly slots
+    on slogging is the explicit design choice."""
+    assert allocate_tier_budget(1, tier_a_count=10, tier_b_count=10) == (0, 1)
+
+
+def test_allocate_tier_budget_scales_with_limit():
+    """At higher limits the same 1/3 share holds (rounded down)."""
+    a, b = allocate_tier_budget(10, tier_a_count=10, tier_b_count=10)
+    assert (a, b) == (7, 3)
+    assert a + b == 10
+
+
+def test_allocate_tier_budget_custom_share():
+    """Callers can override the default share — e.g. crank tier B up
+    when tier A is mostly exhausted and we want to drain the slog list."""
+    assert allocate_tier_budget(
+        3, tier_a_count=10, tier_b_count=10, tier_b_share=0.5
+    ) == (2, 1)
+    assert allocate_tier_budget(
+        4, tier_a_count=10, tier_b_count=10, tier_b_share=0.5
+    ) == (2, 2)
+
+
+# ── eyesonflock_hint ────────────────────────────────────────────
+
+
+def test_eyesonflock_hint_matches_place_police_to_pd():
+    """A registry entry with kind=place + role=police must look up
+    against eyesonflock's PD records (city-keyed)."""
+    entry = {
+        "agency_id": "x",
+        "agency_role": "police",
+        "geo": {"kind": "place", "name": "Alameda", "state": "CA"},
+    }
+    eof_index = {("alameda", "CA", "PD"): "alameda-ca-pd"}
+    assert eyesonflock_hint(entry, eof_index) == "alameda-ca-pd"
+
+
+def test_eyesonflock_hint_matches_county_sheriff_to_sd():
+    """kind=county + role=sheriff must look up against eyesonflock's SD
+    records (county-keyed). Distinct from PD lookup so 'Alameda' the
+    city and 'Alameda' the county don't collide."""
+    entry = {
+        "agency_id": "x",
+        "agency_role": "sheriff",
+        "geo": {"kind": "county", "name": "Alameda", "state": "CA"},
+    }
+    eof_index = {("alameda", "CA", "SD"): "alameda-county-ca-so"}
+    assert eyesonflock_hint(entry, eof_index) == "alameda-county-ca-so"
+
+
+def test_eyesonflock_hint_returns_none_for_other_kinds():
+    """Conservative: only place/police and county/sheriff get matched.
+    cousub township police, ambiguous boundaries, manual coordinates,
+    state-level agencies — no eyesonflock counterpart, don't try to
+    match. Wrong-match cost (poisoned slug promoted to registry) is
+    higher than no-match cost (fall through to variant generation)."""
+    eof_index = {("brownstown", "MI", "PD"): "should-not-match"}
+    for kind in ("cousub", "manual", "state-only", "state", "ambiguous"):
+        entry = {
+            "agency_id": "x",
+            "agency_role": "police",
+            "geo": {"kind": kind, "name": "Brownstown", "state": "MI"},
+        }
+        assert eyesonflock_hint(entry, eof_index) is None, (
+            f"kind={kind} should not match eyesonflock"
+        )
+
+
+def test_eyesonflock_hint_role_kind_must_align():
+    """A place with sheriff role, or a county with police role — neither
+    should match. The mismatch is suspicious enough to skip rather than
+    cross-match against the wrong eyesonflock type."""
+    eof_index = {
+        ("alameda", "CA", "PD"): "alameda-ca-pd",
+        ("alameda", "CA", "SD"): "alameda-county-ca-so",
+    }
+    place_sheriff = {
+        "agency_id": "x",
+        "agency_role": "sheriff",
+        "geo": {"kind": "place", "name": "Alameda", "state": "CA"},
+    }
+    county_police = {
+        "agency_id": "x",
+        "agency_role": "police",
+        "geo": {"kind": "county", "name": "Alameda", "state": "CA"},
+    }
+    assert eyesonflock_hint(place_sheriff, eof_index) is None
+    assert eyesonflock_hint(county_police, eof_index) is None
+
+
+def test_eyesonflock_hint_returns_none_when_index_empty():
+    """Empty eof_index (e.g. lookup failed) is treated as 'no hint
+    available' — slug_probe falls through to variant generation. The
+    lookup is a hint, not a dependency."""
+    entry = {
+        "agency_id": "x",
+        "agency_role": "police",
+        "geo": {"kind": "place", "name": "Alameda", "state": "CA"},
+    }
+    assert eyesonflock_hint(entry, {}) is None
+    assert eyesonflock_hint(entry, None) is None
+
+
+def test_eyesonflock_hint_returns_none_without_geo_block():
+    """Entries without geo data (some federal/test entries) can't be
+    matched geographically and must skip the lookup."""
+    eof_index = {("alameda", "CA", "PD"): "alameda-ca-pd"}
+    assert eyesonflock_hint({"agency_role": "police", "geo": None}, eof_index) is None
+    assert eyesonflock_hint({"agency_role": "police"}, eof_index) is None
+    # Partial geo (no name) also doesn't match
+    assert eyesonflock_hint(
+        {"agency_role": "police", "geo": {"kind": "place", "state": "CA"}},
+        eof_index,
+    ) is None


### PR DESCRIPTION
Step 2a of the slug-cleanup plan. Moves slug discovery responsibility into \`slug_probe\` so the next step (registry prune of speculative slugs) doesn't strand newly-discovered agencies.

## What changes

### 1. \`select_targets\` returns two tiers

- **Tier A** — \`flock_active_slug=None\` entries with at least one \`flock_names\`. These are peer-outbound discoveries we have a name for but no confirmed slug. **Empty today** (registry currently has only 10 such entries because \`build_agency_registry\` fills in a guess); this gets populated when the prune commit lands.
- **Tier B** — entries whose \`flock_active_slug\` is in \`failed_slugs.json\`. Existing behavior, now explicitly named.

Default budget split is **2:1 favoring tier A** at \`--limit 3\` (the workflow's hourly cap). Tier-A single-try hit rate is empirically ~50% (49% on attempted police, 45% sheriff); tier-B variant search is much lower. \`tier_b_share\` is configurable.

### 2. Eyesonflock authoritative-hint lookup

When the validated [eyesonflock.com](https://eyesonflock.com) index has a clean \`(locality_key, state, type)\` match for a target, their slug becomes the first candidate before any variant generation. The mapping is conservative — only \`place\`/police → PD and \`county\`/sheriff → SD — to avoid cross-matching cousub townships, ambiguous boundaries, etc.

Lookup failure (API down, schema mismatch, network blocked) is non-fatal: \`load_eyesonflock_index\` catches and returns \`{}\`, and the probe falls through to the existing variant-generation behavior.

### 3. \`archive_agency\` on hit

Previously, a probe hit updated the registry but left no captured page on disk. \`cmd_crawl\` then had to come back to confirm-and-capture, costing an extra slot. Now probe runs \`archive_agency\` directly on hit (same code path as the main crawler), saving \`.txt/.html/.json/.pdf\` and updating \`.content_hashes.json\`. The slug becomes a normal tier-1 refresh target on the next \`cmd_crawl\` run.

The workflow's commit step had to widen — was three explicit files, now stages the whole \`assets/transparency.flocksafety.com/\` tree so the new captured artifacts come along.

## Sequencing

This PR has no behavior change to the main crawler. It enables the next PR (the prune) to land safely:

- Without this, nullifying \`flock_active_slug\` on the 2,698 unconfirmed registry entries would make them invisible to both crawler and probe.
- With this, those entries become tier A as soon as they're nullified — probe picks them up using the higher-confidence eyesonflock hint first, falling back to variant generation.

## Test plan

- [x] \`uv run pytest tests/test_slug_probe.py tests/test_eyesonflock_lookup.py\` (65 tests)
- [x] \`uv run python scripts/slug_probe.py --dry-run\` against live registry — prints tier counts and budget split correctly
- [ ] After merge: confirm next probe run hits eyesonflock, picks tier-A target, and the resulting captured artifacts commit cleanly