### PR TITLE
ci: build audit log and justifications data in deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,15 @@ jobs:
           fi
           exit 0
 
-      - name: Build sharing graph, map, scoreboard, report data, and findings PDF
+      - name: Build sharing graph, audit log, map, scoreboard, report data, justifications, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
+          uv run python scripts/build_audit_log.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_scoreboard.py &
           uv run python scripts/build_report_data.py &
+          uv run python scripts/build_justifications.py &
           uv run python scripts/md_to_pdf.py &
           wait
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,14 +47,16 @@ jobs:
           packages: tesseract-ocr
           version: 1.0
 
-      - name: Build sharing graph, map, scoreboard, report data, contracts map, and findings PDF
+      - name: Build sharing graph, audit log, map, scoreboard, report data, contracts map, justifications, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
+          uv run python scripts/build_audit_log.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_scoreboard.py &
           uv run python scripts/build_report_data.py &
           uv run python scripts/build_contract_map.py &
+          uv run python scripts/build_justifications.py &
           uv run python scripts/md_to_pdf.py docs/SMPD_ALPR_Findings.md "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" &
           wait
 

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -134,8 +134,10 @@ jobs:
         run: |
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
+          uv run python scripts/build_audit_log.py
           uv run python scripts/build_map.py &
           uv run python scripts/build_report_data.py &
+          uv run python scripts/build_justifications.py &
           uv run python scripts/md_to_pdf.py &
           wait
           uv run pytest tests/test_map_smoke.py -v


### PR DESCRIPTION
## Summary

The justifications page (PR #232) was failing at runtime with HTTP 404 on `data/justifications.json` — the build script wasn't wired into the GitHub Pages deploy workflow. Same gap had quietly existed for `data/audit/<slug>.json` files that the per-agency report depends on.

Adds the missing builds to `deploy.yml`, `ci.yml`, and `refresh-flock-data.yml`:
- `build_audit_log.py` runs sequentially (not in parallel) because `build_report_data.py` reads from it for the audit-vs-inbound check.
- `build_justifications.py` runs in the existing parallel group (only depends on the audit log + portal scrapes).

## Test plan

- [ ] After merge, GH Pages deploy completes
- [ ] `https://none-below.github.io/sm-alpr/justifications.html` loads without 404
- [ ] `https://none-below.github.io/sm-alpr/data/justifications.json` is reachable
- [ ] `https://none-below.github.io/sm-alpr/data/audit/east-palo-alto-ca-pd.json` is reachable
- [ ] Per-agency report's audit-vs-inbound flag now populates (was always falsy on prod since the file didn't exist)