### PR TITLE
feat(registry): prune speculative slugs; crawler stops guessing

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -2455,7 +2455,6 @@
     "slug": "town-of-los-gatos-ca",
     "flock_active_slug": "los-gatos-ca-pd",
     "flock_slugs": [
-      "town-of-los-gatos-ca",
       "los-gatos-ca-pd"
     ],
     "flock_names": [
@@ -3806,7 +3805,6 @@
     "slug": "riverside-county-ca-so",
     "flock_active_slug": "riverside-county-ca-sd",
     "flock_slugs": [
-      "riverside-county-ca-so",
       "riverside-county-ca-sd"
     ],
     "flock_names": [
@@ -5233,10 +5231,8 @@
   {
     "agency_id": "c9811955-3e45-5ff9-bd62-25a4f54afa6a",
     "slug": "18th-judicial-district-drug-task-force-tn-pd",
-    "flock_active_slug": "18th-judicial-district-drug-task-force-tn-pd",
-    "flock_slugs": [
-      "18th-judicial-district-drug-task-force-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "18th Judicial District Drug Task Force - TN PD"
     ],
@@ -5259,10 +5255,8 @@
   {
     "agency_id": "b43ab3a3-c012-54da-8c6e-27850735725e",
     "slug": "abilene-ks-pd",
-    "flock_active_slug": "abilene-ks-pd",
-    "flock_slugs": [
-      "abilene-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Abilene KS PD"
     ],
@@ -5286,10 +5280,8 @@
   {
     "agency_id": "4f24faa5-8467-56e1-8da2-eed169abe05d",
     "slug": "abilene-tx-pd",
-    "flock_active_slug": "abilene-tx-pd",
-    "flock_slugs": [
-      "abilene-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Abilene TX PD"
     ],
@@ -5313,10 +5305,8 @@
   {
     "agency_id": "10e42614-89c7-527e-a699-46bb7874a1e8",
     "slug": "ada-ok-pd",
-    "flock_active_slug": "ada-ok-pd",
-    "flock_slugs": [
-      "ada-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ada OK PD"
     ],
@@ -5340,10 +5330,8 @@
   {
     "agency_id": "d4ab5782-c1b8-5989-a62d-737c10caa433",
     "slug": "adairville-ky-pd",
-    "flock_active_slug": "adairville-ky-pd",
-    "flock_slugs": [
-      "adairville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adairville KY PD"
     ],
@@ -5367,10 +5355,8 @@
   {
     "agency_id": "7dc13e58-7d9b-5850-9251-b2a356d6b986",
     "slug": "adamsville-al-pd",
-    "flock_active_slug": "adamsville-al-pd",
-    "flock_slugs": [
-      "adamsville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adamsville AL PD"
     ],
@@ -5394,10 +5380,8 @@
   {
     "agency_id": "0886f98f-5e05-5272-a845-c7f2088f46a9",
     "slug": "addis-la-pd",
-    "flock_active_slug": "addis-la-pd",
-    "flock_slugs": [
-      "addis-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Addis LA PD"
     ],
@@ -5421,10 +5405,8 @@
   {
     "agency_id": "89e32b43-bbcc-5b4d-bb6e-da95d0ccd810",
     "slug": "addison-tx-pd",
-    "flock_active_slug": "addison-tx-pd",
-    "flock_slugs": [
-      "addison-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Addison TX PD"
     ],
@@ -5448,10 +5430,8 @@
   {
     "agency_id": "8ade9098-89a0-5b06-bced-209d62911724",
     "slug": "al-andalusia-pd",
-    "flock_active_slug": "al-andalusia-pd",
-    "flock_slugs": [
-      "al-andalusia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Andalusia PD"
     ],
@@ -5475,10 +5455,8 @@
   {
     "agency_id": "08deb4cb-6b2b-5cbf-ab90-02d95ebb5385",
     "slug": "al-autauga-county-so",
-    "flock_active_slug": "al-autauga-county-so",
-    "flock_slugs": [
-      "al-autauga-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Autauga County SO"
     ],
@@ -5502,10 +5480,8 @@
   {
     "agency_id": "f3585015-32c6-5e70-b1d0-8c64e510374e",
     "slug": "al-bear-creek-pd",
-    "flock_active_slug": "al-bear-creek-pd",
-    "flock_slugs": [
-      "al-bear-creek-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Bear Creek PD"
     ],
@@ -5529,10 +5505,8 @@
   {
     "agency_id": "fcb2f031-baab-52c8-bd74-d8d8ddf0eb1a",
     "slug": "al-clarke-county-so",
-    "flock_active_slug": "al-clarke-county-so",
-    "flock_slugs": [
-      "al-clarke-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL- Clarke County SO"
     ],
@@ -5556,10 +5530,8 @@
   {
     "agency_id": "86301be9-53b7-560a-8ee7-05a69c64f826",
     "slug": "al-gadsden-pd",
-    "flock_active_slug": "al-gadsden-pd",
-    "flock_slugs": [
-      "al-gadsden-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Gadsden PD"
     ],
@@ -5583,10 +5555,8 @@
   {
     "agency_id": "a6efbc8e-7bf7-52d7-83d2-8c14f351047d",
     "slug": "al-sylacauga-pd",
-    "flock_active_slug": "al-sylacauga-pd",
-    "flock_slugs": [
-      "al-sylacauga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Sylacauga PD"
     ],
@@ -5610,10 +5580,8 @@
   {
     "agency_id": "8e2b03b8-2cd2-528d-818b-ad0d33146d31",
     "slug": "al-troy-university-insight",
-    "flock_active_slug": "al-troy-university-insight",
-    "flock_slugs": [
-      "al-troy-university-insight"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AL - Troy University - Insight"
     ],
@@ -5638,10 +5606,8 @@
   {
     "agency_id": "f535b12a-f4b5-5572-9d50-2567fa966c05",
     "slug": "alabama-department-of-revenue",
-    "flock_active_slug": "alabama-department-of-revenue",
-    "flock_slugs": [
-      "alabama-department-of-revenue"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alabama Department of Revenue"
     ],
@@ -5665,10 +5631,8 @@
   {
     "agency_id": "c753700e-a641-5f4b-a85c-14b657a14822",
     "slug": "alabama-drug-enforcement-task-force-region-g",
-    "flock_active_slug": "alabama-drug-enforcement-task-force-region-g",
-    "flock_slugs": [
-      "alabama-drug-enforcement-task-force-region-g"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alabama Drug Enforcement Task Force Region G"
     ],
@@ -5685,10 +5649,8 @@
   {
     "agency_id": "f0d21634-6075-57d9-b5c2-08b1908dcf93",
     "slug": "alabama-law-enforcement-agency-alea",
-    "flock_active_slug": "alabama-law-enforcement-agency-alea",
-    "flock_slugs": [
-      "alabama-law-enforcement-agency-alea"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alabama Law Enforcement Agency (ALEA)"
     ],
@@ -5712,10 +5674,8 @@
   {
     "agency_id": "f7fe56f7-35f0-5f78-b2f2-f1be22a499ca",
     "slug": "albany-county-ny-so",
-    "flock_active_slug": "albany-county-ny-so",
-    "flock_slugs": [
-      "albany-county-ny-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Albany County NY SO"
     ],
@@ -5739,10 +5699,8 @@
   {
     "agency_id": "68022427-6385-511a-9bdb-15bf1772888b",
     "slug": "albany-ga-pd",
-    "flock_active_slug": "albany-ga-pd",
-    "flock_slugs": [
-      "albany-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Albany GA PD"
     ],
@@ -5766,10 +5724,8 @@
   {
     "agency_id": "555dc31a-71ab-52ff-92cc-b2dca627809e",
     "slug": "alexander-ar-pd",
-    "flock_active_slug": "alexander-ar-pd",
-    "flock_slugs": [
-      "alexander-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alexander AR PD"
     ],
@@ -5793,10 +5749,8 @@
   {
     "agency_id": "36a3188d-296b-5644-aa8e-76ed0783b312",
     "slug": "alexandria-la-pd",
-    "flock_active_slug": "alexandria-la-pd",
-    "flock_slugs": [
-      "alexandria-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alexandria LA PD"
     ],
@@ -5820,10 +5774,8 @@
   {
     "agency_id": "fa14c6fe-10fe-5408-9906-98dd8f3783d9",
     "slug": "algood-tn-pd",
-    "flock_active_slug": "algood-tn-pd",
-    "flock_slugs": [
-      "algood-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Algood TN PD"
     ],
@@ -5847,10 +5799,8 @@
   {
     "agency_id": "b88b3a97-30da-5b7d-91bb-b1378ea22e49",
     "slug": "allen-county-ks-so",
-    "flock_active_slug": "allen-county-ks-so",
-    "flock_slugs": [
-      "allen-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Allen County KS SO"
     ],
@@ -5874,10 +5824,8 @@
   {
     "agency_id": "8afba6b8-7bf5-590b-9caa-ea647bc788ea",
     "slug": "allen-county-ky-so",
-    "flock_active_slug": "allen-county-ky-so",
-    "flock_slugs": [
-      "allen-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Allen County KY SO"
     ],
@@ -5901,10 +5849,8 @@
   {
     "agency_id": "7cae5a3a-7101-591e-9e84-61cfffe92160",
     "slug": "allen-tx-pd",
-    "flock_active_slug": "allen-tx-pd",
-    "flock_slugs": [
-      "allen-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Allen TX PD"
     ],
@@ -5928,10 +5874,8 @@
   {
     "agency_id": "820b4449-71e5-5450-8119-32dd01e2a39e",
     "slug": "alpharetta-ga-pd",
-    "flock_active_slug": "alpharetta-ga-pd",
-    "flock_slugs": [
-      "alpharetta-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alpharetta GA PD"
     ],
@@ -5955,10 +5899,8 @@
   {
     "agency_id": "a84d1a3f-68f3-529c-9d11-8e1da89bd6ee",
     "slug": "alvin-tx-pd",
-    "flock_active_slug": "alvin-tx-pd",
-    "flock_slugs": [
-      "alvin-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alvin TX PD"
     ],
@@ -5982,10 +5924,8 @@
   {
     "agency_id": "7d49cb8a-25e4-5204-b4b9-31d1ba63db79",
     "slug": "anderson-county-tn-so",
-    "flock_active_slug": "anderson-county-tn-so",
-    "flock_slugs": [
-      "anderson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anderson County TN SO"
     ],
@@ -6009,10 +5949,8 @@
   {
     "agency_id": "71147ea2-3f7b-5219-a102-d00c723bb3a4",
     "slug": "andover-ks-pd",
-    "flock_active_slug": "andover-ks-pd",
-    "flock_slugs": [
-      "andover-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Andover KS PD"
     ],
@@ -6036,10 +5974,8 @@
   {
     "agency_id": "bbcb1414-d246-5562-8871-75e98136ecf3",
     "slug": "apex-nc-pd",
-    "flock_active_slug": "apex-nc-pd",
-    "flock_slugs": [
-      "apex-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Apex NC PD"
     ],
@@ -6063,10 +5999,8 @@
   {
     "agency_id": "1ee93abc-5639-5d6a-aa74-b64856e73862",
     "slug": "ar-arkadelphia-pd",
-    "flock_active_slug": "ar-arkadelphia-pd",
-    "flock_slugs": [
-      "ar-arkadelphia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AR - Arkadelphia PD"
     ],
@@ -6090,10 +6024,8 @@
   {
     "agency_id": "09cc5991-e08d-5527-8226-fd93a78904e4",
     "slug": "ar-harrisburg-pd",
-    "flock_active_slug": "ar-harrisburg-pd",
-    "flock_slugs": [
-      "ar-harrisburg-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AR - Harrisburg PD"
     ],
@@ -6117,10 +6049,8 @@
   {
     "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
     "slug": "ar-mountain-view-pd",
-    "flock_active_slug": "ar-mountain-view-pd",
-    "flock_slugs": [
-      "ar-mountain-view-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AR - Mountain View PD"
     ],
@@ -6144,10 +6074,8 @@
   {
     "agency_id": "82224cc9-3df9-5f00-9aaf-a777477d5859",
     "slug": "ar-newton-county-so",
-    "flock_active_slug": "ar-newton-county-so",
-    "flock_slugs": [
-      "ar-newton-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AR - Newton County SO"
     ],
@@ -6171,10 +6099,8 @@
   {
     "agency_id": "c6d2e3dd-f33d-5384-8f7b-7591aea0a98d",
     "slug": "arcola-tx-pd",
-    "flock_active_slug": "arcola-tx-pd",
-    "flock_slugs": [
-      "arcola-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arcola TX PD"
     ],
@@ -6198,10 +6124,8 @@
   {
     "agency_id": "1a99f326-3964-5186-8090-c177b759fd7b",
     "slug": "ardmore-al-pd",
-    "flock_active_slug": "ardmore-al-pd",
-    "flock_slugs": [
-      "ardmore-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ardmore AL PD"
     ],
@@ -6225,10 +6149,8 @@
   {
     "agency_id": "0ae4c9fd-52df-5354-88e2-a90a6c6f487d",
     "slug": "argo-al-pd",
-    "flock_active_slug": "argo-al-pd",
-    "flock_slugs": [
-      "argo-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Argo AL PD"
     ],
@@ -6252,10 +6174,8 @@
   {
     "agency_id": "2d6ad4e7-626b-52a6-83be-d477c90305bb",
     "slug": "argyle-tx-pd",
-    "flock_active_slug": "argyle-tx-pd",
-    "flock_slugs": [
-      "argyle-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Argyle TX PD"
     ],
@@ -6279,10 +6199,8 @@
   {
     "agency_id": "b8647e02-0e0c-515f-97f8-2e2878410345",
     "slug": "arkansas-highway-police",
-    "flock_active_slug": "arkansas-highway-police",
-    "flock_slugs": [
-      "arkansas-highway-police"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arkansas Highway Police"
     ],
@@ -6300,10 +6218,8 @@
   {
     "agency_id": "e673f709-a799-589d-981f-b33948e2111f",
     "slug": "ashdown-ar-pd",
-    "flock_active_slug": "ashdown-ar-pd",
-    "flock_slugs": [
-      "ashdown-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ashdown AR PD"
     ],
@@ -6327,10 +6243,8 @@
   {
     "agency_id": "86952492-dad6-5da4-9e22-1916e901d58e",
     "slug": "ashville-al-pd",
-    "flock_active_slug": "ashville-al-pd",
-    "flock_slugs": [
-      "ashville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ashville AL PD"
     ],
@@ -6354,10 +6268,8 @@
   {
     "agency_id": "0adc9798-34b9-58d0-83b8-241372b602ed",
     "slug": "atlanta-ga-pd",
-    "flock_active_slug": "atlanta-ga-pd",
-    "flock_slugs": [
-      "atlanta-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Atlanta GA PD"
     ],
@@ -6381,10 +6293,8 @@
   {
     "agency_id": "a38b5c8f-b263-557d-9d44-7770959a65cd",
     "slug": "atoka-county-so-ok",
-    "flock_active_slug": "atoka-county-so-ok",
-    "flock_slugs": [
-      "atoka-county-so-ok"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Atoka County SO (OK)"
     ],
@@ -6408,10 +6318,8 @@
   {
     "agency_id": "d318f729-f91a-5d6c-b706-05a6ed1b38fd",
     "slug": "atoka-tn-pd",
-    "flock_active_slug": "atoka-tn-pd",
-    "flock_slugs": [
-      "atoka-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Atoka TN PD"
     ],
@@ -6435,10 +6343,8 @@
   {
     "agency_id": "29aaa0cd-ce6e-53d8-bcf4-62d039fed328",
     "slug": "auburn-ga-pd",
-    "flock_active_slug": "auburn-ga-pd",
-    "flock_slugs": [
-      "auburn-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Auburn GA PD"
     ],
@@ -6462,10 +6368,8 @@
   {
     "agency_id": "44ab0bbd-c53f-539e-8e4e-fd46a0f7aaf5",
     "slug": "augusta-ks-dps",
-    "flock_active_slug": "augusta-ks-dps",
-    "flock_slugs": [
-      "augusta-ks-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Augusta KS DPS"
     ],
@@ -6489,10 +6393,8 @@
   {
     "agency_id": "6b509f5e-f60d-59c1-b3a4-a57f640e27d5",
     "slug": "aurora-mo-pd",
-    "flock_active_slug": "aurora-mo-pd",
-    "flock_slugs": [
-      "aurora-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aurora MO PD"
     ],
@@ -6516,10 +6418,8 @@
   {
     "agency_id": "7fbb721c-a1c7-5eed-b6bf-7722a1c7db98",
     "slug": "austin-county-tx-so",
-    "flock_active_slug": "austin-county-tx-so",
-    "flock_slugs": [
-      "austin-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Austin County TX SO"
     ],
@@ -6543,10 +6443,8 @@
   {
     "agency_id": "f66968c9-b28c-58f8-b6b6-6b6ac4471c56",
     "slug": "avery-county-nc-so",
-    "flock_active_slug": "avery-county-nc-so",
-    "flock_slugs": [
-      "avery-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avery County NC SO"
     ],
@@ -6570,10 +6468,8 @@
   {
     "agency_id": "59469f23-26ee-5074-a64c-929fe2891007",
     "slug": "azle-tx-pd",
-    "flock_active_slug": "azle-tx-pd",
-    "flock_slugs": [
-      "azle-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Azle TX PD"
     ],
@@ -6597,10 +6493,8 @@
   {
     "agency_id": "d7171445-90c7-5e5f-ac09-25dc4b66f89d",
     "slug": "baker-la-pd",
-    "flock_active_slug": "baker-la-pd",
-    "flock_slugs": [
-      "baker-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Baker LA PD"
     ],
@@ -6624,10 +6518,8 @@
   {
     "agency_id": "cc622dda-d862-5c70-b454-2a9e7f3a9591",
     "slug": "ballard-county-ky-so",
-    "flock_active_slug": "ballard-county-ky-so",
-    "flock_slugs": [
-      "ballard-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ballard County KY SO"
     ],
@@ -6651,10 +6543,8 @@
   {
     "agency_id": "a5539d2c-7192-5ef1-bee9-77e009362ee1",
     "slug": "banks-county-ga-so",
-    "flock_active_slug": "banks-county-ga-so",
-    "flock_slugs": [
-      "banks-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Banks County GA SO"
     ],
@@ -6678,10 +6568,8 @@
   {
     "agency_id": "4400bdcc-b39a-5748-8594-b0374c359f89",
     "slug": "barber-county-ks-so",
-    "flock_active_slug": "barber-county-ks-so",
-    "flock_slugs": [
-      "barber-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barber County KS SO"
     ],
@@ -6705,10 +6593,8 @@
   {
     "agency_id": "ba11e977-1836-58e5-b6b1-6e277ccd372e",
     "slug": "barbour-county-al-so",
-    "flock_active_slug": "barbour-county-al-so",
-    "flock_slugs": [
-      "barbour-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barbour County AL SO"
     ],
@@ -6732,10 +6618,8 @@
   {
     "agency_id": "38ee3d7f-a74f-5cb9-82dc-2d677bd4edcc",
     "slug": "barling-ar-pd",
-    "flock_active_slug": "barling-ar-pd",
-    "flock_slugs": [
-      "barling-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barling AR PD"
     ],
@@ -6759,10 +6643,8 @@
   {
     "agency_id": "b9ed2590-28a6-5feb-ae0a-a6a75f3aca6f",
     "slug": "barrow-county-ga-so",
-    "flock_active_slug": "barrow-county-ga-so",
-    "flock_slugs": [
-      "barrow-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barrow County GA SO"
     ],
@@ -6786,10 +6668,8 @@
   {
     "agency_id": "c0e8d3dd-1788-59a1-98ab-747fc289adaf",
     "slug": "barry-county-so-mo",
-    "flock_active_slug": "barry-county-so-mo",
-    "flock_slugs": [
-      "barry-county-so-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barry County SO MO"
     ],
@@ -6813,10 +6693,8 @@
   {
     "agency_id": "43d009b4-736c-50a5-bc94-32ace55e3aef",
     "slug": "bartlett-tn-pd",
-    "flock_active_slug": "bartlett-tn-pd",
-    "flock_slugs": [
-      "bartlett-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bartlett TN PD"
     ],
@@ -6840,10 +6718,8 @@
   {
     "agency_id": "0b1422ff-05c0-5eac-87aa-a03e7df22a5d",
     "slug": "barton-county-ks-so",
-    "flock_active_slug": "barton-county-ks-so",
-    "flock_slugs": [
-      "barton-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barton County KS SO"
     ],
@@ -6867,10 +6743,8 @@
   {
     "agency_id": "238689b6-8949-5fd9-a183-3b1fb70c7f50",
     "slug": "bartonville-tx-pd",
-    "flock_active_slug": "bartonville-tx-pd",
-    "flock_slugs": [
-      "bartonville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bartonville TX PD"
     ],
@@ -6894,10 +6768,8 @@
   {
     "agency_id": "9bbba64d-a928-52dd-b7f5-404ca48b412f",
     "slug": "bastrop-county-tx-so",
-    "flock_active_slug": "bastrop-county-tx-so",
-    "flock_slugs": [
-      "bastrop-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bastrop County TX SO"
     ],
@@ -6921,10 +6793,8 @@
   {
     "agency_id": "3edfccbf-8eb3-5afb-85fe-9c4eb5ecb744",
     "slug": "batesville-ms-pd",
-    "flock_active_slug": "batesville-ms-pd",
-    "flock_slugs": [
-      "batesville-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Batesville MS PD"
     ],
@@ -6948,10 +6818,8 @@
   {
     "agency_id": "6f2e3c64-76d1-539f-a6a3-df0e3c314512",
     "slug": "baton-rouge-la-pd",
-    "flock_active_slug": "baton-rouge-la-pd",
-    "flock_slugs": [
-      "baton-rouge-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Baton Rouge LA PD"
     ],
@@ -6975,10 +6843,8 @@
   {
     "agency_id": "217b0fd7-91ff-5fe2-b382-a67228cef37b",
     "slug": "bay-ar-pd",
-    "flock_active_slug": "bay-ar-pd",
-    "flock_slugs": [
-      "bay-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bay AR PD"
     ],
@@ -7002,10 +6868,8 @@
   {
     "agency_id": "b3a39272-3355-584d-8de8-bd5debbe86bb",
     "slug": "bay-county-fl-so",
-    "flock_active_slug": "bay-county-fl-so",
-    "flock_slugs": [
-      "bay-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bay County FL SO"
     ],
@@ -7029,10 +6893,8 @@
   {
     "agency_id": "bc36858b-ad3b-59d8-84ec-719a6c34de87",
     "slug": "baylor-scott-white-pd-tx",
-    "flock_active_slug": "baylor-scott-white-pd-tx",
-    "flock_slugs": [
-      "baylor-scott-white-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Baylor Scott & White PD (TX)"
     ],
@@ -7055,10 +6917,8 @@
   {
     "agency_id": "e8bc5b42-7932-54a4-b170-ad18a9c3896c",
     "slug": "bayou-vista-tx-pd",
-    "flock_active_slug": "bayou-vista-tx-pd",
-    "flock_slugs": [
-      "bayou-vista-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bayou Vista TX PD"
     ],
@@ -7082,10 +6942,8 @@
   {
     "agency_id": "0908cd60-da3a-50cb-9220-92afe269c999",
     "slug": "bedford-county-tn-so",
-    "flock_active_slug": "bedford-county-tn-so",
-    "flock_slugs": [
-      "bedford-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bedford County TN SO"
     ],
@@ -7109,10 +6967,8 @@
   {
     "agency_id": "4c9e0af4-f6da-5fe1-867c-765cb30c42cb",
     "slug": "bedford-county-tn-so-duplicate",
-    "flock_active_slug": "bedford-county-tn-so-duplicate",
-    "flock_slugs": [
-      "bedford-county-tn-so-duplicate"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bedford County TN SO (duplicate)"
     ],
@@ -7134,10 +6990,8 @@
   {
     "agency_id": "514726d9-bbf2-5f47-82a4-08857417f046",
     "slug": "bedford-tx-pd",
-    "flock_active_slug": "bedford-tx-pd",
-    "flock_slugs": [
-      "bedford-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bedford TX PD"
     ],
@@ -7161,10 +7015,8 @@
   {
     "agency_id": "ab55efe3-f555-571a-9a12-dec3e1fb7c66",
     "slug": "bedford-va-pd",
-    "flock_active_slug": "bedford-va-pd",
-    "flock_slugs": [
-      "bedford-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bedford VA PD"
     ],
@@ -7188,10 +7040,8 @@
   {
     "agency_id": "4444ef18-fcb9-5e20-93a0-a526327768a6",
     "slug": "bee-cave-tx-pd",
-    "flock_active_slug": "bee-cave-tx-pd",
-    "flock_slugs": [
-      "bee-cave-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bee Cave TX PD"
     ],
@@ -7215,10 +7065,8 @@
   {
     "agency_id": "be0b67e7-57fc-57fb-91d2-aec6d7ca8c65",
     "slug": "beebe-ar-pd",
-    "flock_active_slug": "beebe-ar-pd",
-    "flock_slugs": [
-      "beebe-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Beebe AR PD"
     ],
@@ -7242,10 +7090,8 @@
   {
     "agency_id": "3605ccef-4c03-5aeb-9dd6-8c4408f99752",
     "slug": "beech-grove-in-pd",
-    "flock_active_slug": "beech-grove-in-pd",
-    "flock_slugs": [
-      "beech-grove-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Beech Grove IN PD"
     ],
@@ -7269,10 +7115,8 @@
   {
     "agency_id": "d355785f-8c93-5b5e-a288-ca1ddebb9783",
     "slug": "bel-aire-ks-pd",
-    "flock_active_slug": "bel-aire-ks-pd",
-    "flock_slugs": [
-      "bel-aire-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bel Aire KS PD"
     ],
@@ -7296,10 +7140,8 @@
   {
     "agency_id": "64890e0c-2bbd-5ced-8214-6f8680f8d51b",
     "slug": "bellaire-tx-pd",
-    "flock_active_slug": "bellaire-tx-pd",
-    "flock_slugs": [
-      "bellaire-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bellaire TX PD"
     ],
@@ -7323,10 +7165,8 @@
   {
     "agency_id": "b57681f8-e0de-5cb7-9e8a-dd4f8db9ae06",
     "slug": "bellville-tx-pd",
-    "flock_active_slug": "bellville-tx-pd",
-    "flock_slugs": [
-      "bellville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bellville TX PD"
     ],
@@ -7350,10 +7190,8 @@
   {
     "agency_id": "c8e385fa-d90a-5177-96c6-08b5e466f419",
     "slug": "belton-tx-pd",
-    "flock_active_slug": "belton-tx-pd",
-    "flock_slugs": [
-      "belton-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Belton TX PD"
     ],
@@ -7377,10 +7215,8 @@
   {
     "agency_id": "7e972465-541c-59ec-9643-ed33859f90d4",
     "slug": "bentley-ks-pd",
-    "flock_active_slug": "bentley-ks-pd",
-    "flock_slugs": [
-      "bentley-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bentley KS PD"
     ],
@@ -7404,10 +7240,8 @@
   {
     "agency_id": "27e68c6d-7cd8-540a-9ebe-013384d6250a",
     "slug": "benton-ar-pd",
-    "flock_active_slug": "benton-ar-pd",
-    "flock_slugs": [
-      "benton-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Benton AR PD"
     ],
@@ -7431,10 +7265,8 @@
   {
     "agency_id": "05d916bc-fcb0-5350-a670-3b2c5cd98fb3",
     "slug": "benton-county-ar-so",
-    "flock_active_slug": "benton-county-ar-so",
-    "flock_slugs": [
-      "benton-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Benton County AR SO"
     ],
@@ -7458,10 +7290,8 @@
   {
     "agency_id": "f264b45e-bde6-5167-8514-a2641effd986",
     "slug": "benton-il-pd",
-    "flock_active_slug": "benton-il-pd",
-    "flock_slugs": [
-      "benton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Benton IL PD"
     ],
@@ -7485,10 +7315,8 @@
   {
     "agency_id": "c0893280-094a-5842-baa7-480ac0ae694c",
     "slug": "benton-ks-pd",
-    "flock_active_slug": "benton-ks-pd",
-    "flock_slugs": [
-      "benton-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Benton KS PD"
     ],
@@ -7512,10 +7340,8 @@
   {
     "agency_id": "a7304aa9-ee26-553f-8a19-a45687eb137a",
     "slug": "bentonville-ar-pd",
-    "flock_active_slug": "bentonville-ar-pd",
-    "flock_slugs": [
-      "bentonville-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bentonville AR PD"
     ],
@@ -7539,10 +7365,8 @@
   {
     "agency_id": "60668415-9eed-587f-9cfd-808bc916fd25",
     "slug": "berea-ky-pd",
-    "flock_active_slug": "berea-ky-pd",
-    "flock_slugs": [
-      "berea-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Berea KY PD"
     ],
@@ -7566,10 +7390,8 @@
   {
     "agency_id": "10efb583-c661-598a-9b81-240eaec7db33",
     "slug": "berrien-county-ga-so",
-    "flock_active_slug": "berrien-county-ga-so",
-    "flock_slugs": [
-      "berrien-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Berrien County GA SO"
     ],
@@ -7593,10 +7415,8 @@
   {
     "agency_id": "7069bc66-9f4a-5dc7-b7e8-df0b5e28551f",
     "slug": "bessemer-al-pd",
-    "flock_active_slug": "bessemer-al-pd",
-    "flock_slugs": [
-      "bessemer-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bessemer AL PD"
     ],
@@ -7620,10 +7440,8 @@
   {
     "agency_id": "15e1aaab-a07c-597a-aa11-91bf39c3f63c",
     "slug": "bethany-ok-pd",
-    "flock_active_slug": "bethany-ok-pd",
-    "flock_slugs": [
-      "bethany-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bethany OK PD"
     ],
@@ -7647,10 +7465,8 @@
   {
     "agency_id": "211a593e-8faa-5696-9c66-305717b2169b",
     "slug": "blackshear-ga-pd",
-    "flock_active_slug": "blackshear-ga-pd",
-    "flock_slugs": [
-      "blackshear-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blackshear GA PD"
     ],
@@ -7674,10 +7490,8 @@
   {
     "agency_id": "f5083fff-2c82-5f2b-bc9c-d3b44455a88d",
     "slug": "blount-county-commission-al",
-    "flock_active_slug": "blount-county-commission-al",
-    "flock_slugs": [
-      "blount-county-commission-al"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blount County Commission (AL)"
     ],
@@ -7702,10 +7516,8 @@
   {
     "agency_id": "f7bc8951-e091-58c6-9c6e-367bfc39eed2",
     "slug": "blountsville-al-pd",
-    "flock_active_slug": "blountsville-al-pd",
-    "flock_slugs": [
-      "blountsville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blountsville AL PD"
     ],
@@ -7729,10 +7541,8 @@
   {
     "agency_id": "3c95c6e0-b228-5e03-95bd-8293e3d8cd7c",
     "slug": "blue-mound-tx-pd",
-    "flock_active_slug": "blue-mound-tx-pd",
-    "flock_slugs": [
-      "blue-mound-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blue Mound TX PD"
     ],
@@ -7756,10 +7566,8 @@
   {
     "agency_id": "3b5a65ea-125d-54c5-838a-9e69210f5fa4",
     "slug": "blytheville-ar-pd",
-    "flock_active_slug": "blytheville-ar-pd",
-    "flock_slugs": [
-      "blytheville-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blytheville AR PD"
     ],
@@ -7783,10 +7591,8 @@
   {
     "agency_id": "6c727e0d-a6b3-5bb5-a9db-0bdbf20d3cc2",
     "slug": "boaz-al-pd",
-    "flock_active_slug": "boaz-al-pd",
-    "flock_slugs": [
-      "boaz-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boaz AL PD"
     ],
@@ -7810,10 +7616,8 @@
   {
     "agency_id": "08e909f9-d363-5ea1-8bff-fe3eeb9c0d67",
     "slug": "bogata-tx-pd",
-    "flock_active_slug": "bogata-tx-pd",
-    "flock_slugs": [
-      "bogata-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bogata TX PD"
     ],
@@ -7837,10 +7641,8 @@
   {
     "agency_id": "3da4141c-4ba5-5956-bbc0-8f2ce2fd5ab7",
     "slug": "boone-county-mo-so",
-    "flock_active_slug": "boone-county-mo-so",
-    "flock_slugs": [
-      "boone-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boone County MO SO"
     ],
@@ -7864,10 +7666,8 @@
   {
     "agency_id": "447f4447-46a0-5e12-a124-8f1c46e783fd",
     "slug": "bosque-county-tx-so",
-    "flock_active_slug": "bosque-county-tx-so",
-    "flock_slugs": [
-      "bosque-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bosque County TX SO"
     ],
@@ -7891,10 +7691,8 @@
   {
     "agency_id": "eaf1d453-d8db-5c53-be5f-ce60a2d9c0f5",
     "slug": "bossier-city-la-pd",
-    "flock_active_slug": "bossier-city-la-pd",
-    "flock_slugs": [
-      "bossier-city-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bossier City LA PD"
     ],
@@ -7918,10 +7716,8 @@
   {
     "agency_id": "0f14f642-475d-5169-9510-5bf7a152ddb8",
     "slug": "bossier-parish-la-so",
-    "flock_active_slug": "bossier-parish-la-so",
-    "flock_slugs": [
-      "bossier-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bossier Parish LA SO"
     ],
@@ -7945,10 +7741,8 @@
   {
     "agency_id": "1ec52516-fda0-5c7a-be96-f54442b190e3",
     "slug": "bowdon-ga-pd",
-    "flock_active_slug": "bowdon-ga-pd",
-    "flock_slugs": [
-      "bowdon-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bowdon GA PD"
     ],
@@ -7972,10 +7766,8 @@
   {
     "agency_id": "aa1f296b-9cb5-5635-b839-92db56ec547b",
     "slug": "bowling-green-ky-pd",
-    "flock_active_slug": "bowling-green-ky-pd",
-    "flock_slugs": [
-      "bowling-green-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bowling Green KY PD"
     ],
@@ -7999,10 +7791,8 @@
   {
     "agency_id": "ae4410b3-7fa3-59d8-b969-8eef5215a7c2",
     "slug": "bowling-green-warren-county-drug-task-force-ky",
-    "flock_active_slug": "bowling-green-warren-county-drug-task-force-ky",
-    "flock_slugs": [
-      "bowling-green-warren-county-drug-task-force-ky"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bowling Green Warren County Drug Task Force KY"
     ],
@@ -8027,10 +7817,8 @@
   {
     "agency_id": "86f9f2ec-e2c9-590e-95c7-a0af226ab266",
     "slug": "boyd-tx-pd",
-    "flock_active_slug": "boyd-tx-pd",
-    "flock_slugs": [
-      "boyd-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boyd TX PD"
     ],
@@ -8054,10 +7842,8 @@
   {
     "agency_id": "b735fd9f-dfb3-5fc3-80bf-715cea3256ae",
     "slug": "boynton-beach-fl-pd",
-    "flock_active_slug": "boynton-beach-fl-pd",
-    "flock_slugs": [
-      "boynton-beach-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boynton Beach FL PD"
     ],
@@ -8081,10 +7867,8 @@
   {
     "agency_id": "790ec638-5539-5445-88b6-4bed2e83433f",
     "slug": "bradley-county-ar-so",
-    "flock_active_slug": "bradley-county-ar-so",
-    "flock_slugs": [
-      "bradley-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bradley County AR SO"
     ],
@@ -8108,10 +7892,8 @@
   {
     "agency_id": "14b24fe9-344d-582d-882f-b4af1d17b6aa",
     "slug": "brazoria-county-tx-so",
-    "flock_active_slug": "brazoria-county-tx-so",
-    "flock_slugs": [
-      "brazoria-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brazoria County TX SO"
     ],
@@ -8135,10 +7917,8 @@
   {
     "agency_id": "2df8e439-7ece-59f1-8c50-a7331caa6f9e",
     "slug": "breckinridge-county-ky-so",
-    "flock_active_slug": "breckinridge-county-ky-so",
-    "flock_slugs": [
-      "breckinridge-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Breckinridge County KY SO"
     ],
@@ -8162,10 +7942,8 @@
   {
     "agency_id": "ad3a1ab5-b65e-5de7-b285-47cff75a8da3",
     "slug": "bremen-ga-pd",
-    "flock_active_slug": "bremen-ga-pd",
-    "flock_slugs": [
-      "bremen-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bremen GA PD"
     ],
@@ -8189,10 +7967,8 @@
   {
     "agency_id": "8604bd18-2b0b-5606-932f-8097cca99d8d",
     "slug": "brent-al-pd",
-    "flock_active_slug": "brent-al-pd",
-    "flock_slugs": [
-      "brent-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brent AL PD"
     ],
@@ -8216,10 +7992,8 @@
   {
     "agency_id": "6a9c0e3c-3615-59a5-ab14-7815994a00e9",
     "slug": "bristow-ok-pd",
-    "flock_active_slug": "bristow-ok-pd",
-    "flock_slugs": [
-      "bristow-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bristow OK PD"
     ],
@@ -8243,10 +8017,8 @@
   {
     "agency_id": "045420df-095a-59c6-bc54-da172eb253f0",
     "slug": "brookland-ar-pd",
-    "flock_active_slug": "brookland-ar-pd",
-    "flock_slugs": [
-      "brookland-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brookland AR PD"
     ],
@@ -8270,10 +8042,8 @@
   {
     "agency_id": "3c21b16e-d4ca-52fb-b949-a39c69488c03",
     "slug": "broward-county-fl-so",
-    "flock_active_slug": "broward-county-fl-so",
-    "flock_slugs": [
-      "broward-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Broward County FL SO"
     ],
@@ -8297,10 +8067,8 @@
   {
     "agency_id": "eb4df6c0-aa08-5818-8f38-b7b72bd6c9c8",
     "slug": "brownsburg-in-pd",
-    "flock_active_slug": "brownsburg-in-pd",
-    "flock_slugs": [
-      "brownsburg-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brownsburg IN PD"
     ],
@@ -8324,10 +8092,8 @@
   {
     "agency_id": "f58aabd8-c15e-550f-aab3-1f70459946b1",
     "slug": "brownstown-twp-pd-mi",
-    "flock_active_slug": "brownstown-twp-pd-mi",
-    "flock_slugs": [
-      "brownstown-twp-pd-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brownstown Twp PD MI"
     ],
@@ -8351,10 +8117,8 @@
   {
     "agency_id": "2c123e91-a791-598e-86ce-3e35ff500b6f",
     "slug": "brunswick-county-nc-so",
-    "flock_active_slug": "brunswick-county-nc-so",
-    "flock_slugs": [
-      "brunswick-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brunswick County NC SO"
     ],
@@ -8378,10 +8142,8 @@
   {
     "agency_id": "b99093bb-8f20-5c98-a18f-50d6f95f9893",
     "slug": "bryan-county-ga-so",
-    "flock_active_slug": "bryan-county-ga-so",
-    "flock_slugs": [
-      "bryan-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bryan County GA SO"
     ],
@@ -8405,10 +8167,8 @@
   {
     "agency_id": "a57096a4-2ccc-5e07-aeb0-4211b32bd06c",
     "slug": "bryant-ar-pd",
-    "flock_active_slug": "bryant-ar-pd",
-    "flock_slugs": [
-      "bryant-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bryant AR PD"
     ],
@@ -8432,10 +8192,8 @@
   {
     "agency_id": "62ce4269-bebc-5d09-88f0-e69799aeb94a",
     "slug": "buda-tx-pd",
-    "flock_active_slug": "buda-tx-pd",
-    "flock_slugs": [
-      "buda-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Buda TX PD"
     ],
@@ -8459,10 +8217,8 @@
   {
     "agency_id": "f366e126-b3f3-515d-9a6e-012e345aa071",
     "slug": "buhler-ks-pd",
-    "flock_active_slug": "buhler-ks-pd",
-    "flock_slugs": [
-      "buhler-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Buhler KS PD"
     ],
@@ -8486,10 +8242,8 @@
   {
     "agency_id": "7b6591b9-3146-5d06-9e62-b1229e0f82b9",
     "slug": "bulloch-county-ga-so",
-    "flock_active_slug": "bulloch-county-ga-so",
-    "flock_slugs": [
-      "bulloch-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bulloch County GA SO"
     ],
@@ -8513,10 +8267,8 @@
   {
     "agency_id": "24f87fee-49e5-53be-b909-4265d1ed6bd8",
     "slug": "burleson-tx-pd",
-    "flock_active_slug": "burleson-tx-pd",
-    "flock_slugs": [
-      "burleson-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burleson TX PD"
     ],
@@ -8540,10 +8292,8 @@
   {
     "agency_id": "1c8ecec2-01c6-5f08-bcdf-0b4ba64aa7fc",
     "slug": "burlington-nc-pd",
-    "flock_active_slug": "burlington-nc-pd",
-    "flock_slugs": [
-      "burlington-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burlington NC PD"
     ],
@@ -8567,10 +8317,8 @@
   {
     "agency_id": "425437ba-a5dd-5df9-a262-a52cd8940d10",
     "slug": "butler-ga-pd",
-    "flock_active_slug": "butler-ga-pd",
-    "flock_slugs": [
-      "butler-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Butler GA PD"
     ],
@@ -8594,10 +8342,8 @@
   {
     "agency_id": "8c454e6c-aa29-564e-be6f-de636bef589a",
     "slug": "butts-county-ga-so",
-    "flock_active_slug": "butts-county-ga-so",
-    "flock_slugs": [
-      "butts-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Butts County GA SO"
     ],
@@ -8621,10 +8367,8 @@
   {
     "agency_id": "b83dfed3-9f68-5271-913d-0786132760dc",
     "slug": "byram-ms-pd",
-    "flock_active_slug": "byram-ms-pd",
-    "flock_slugs": [
-      "byram-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Byram MS PD"
     ],
@@ -8648,10 +8392,8 @@
   {
     "agency_id": "5d6c9c0b-19ee-55e0-a25b-f98b81ff015d",
     "slug": "ca-topgolf-usa-el-segundo-llc",
-    "flock_active_slug": "ca-topgolf-usa-el-segundo-llc",
-    "flock_slugs": [
-      "ca-topgolf-usa-el-segundo-llc"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CA - Topgolf USA El Segundo, LLC"
     ],
@@ -8671,10 +8413,8 @@
   {
     "agency_id": "3c0c064a-e6fe-5876-9c16-4cf99ee7b2c6",
     "slug": "caddo-parish-la-so",
-    "flock_active_slug": "caddo-parish-la-so",
-    "flock_slugs": [
-      "caddo-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Caddo Parish LA SO"
     ],
@@ -8698,10 +8438,8 @@
   {
     "agency_id": "d9a54998-e748-5dc7-8fc8-38165553802e",
     "slug": "calcasieu-parish-so-la",
-    "flock_active_slug": "calcasieu-parish-so-la",
-    "flock_slugs": [
-      "calcasieu-parish-so-la"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calcasieu Parish SO LA"
     ],
@@ -8725,10 +8463,8 @@
   {
     "agency_id": "fe5ebbf9-0b9b-5c9b-acd9-ceda431205e1",
     "slug": "caldwell-co-tx-so",
-    "flock_active_slug": "caldwell-co-tx-so",
-    "flock_slugs": [
-      "caldwell-co-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Caldwell CO TX SO"
     ],
@@ -8752,10 +8488,8 @@
   {
     "agency_id": "d3bd8473-c638-5853-ba38-16b9d10a2d27",
     "slug": "caldwell-ks-pd",
-    "flock_active_slug": "caldwell-ks-pd",
-    "flock_slugs": [
-      "caldwell-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Caldwell KS PD"
     ],
@@ -8779,10 +8513,8 @@
   {
     "agency_id": "689cb7ed-a463-5929-8a7e-8d7cdab04845",
     "slug": "calhoun-county-ar-so",
-    "flock_active_slug": "calhoun-county-ar-so",
-    "flock_slugs": [
-      "calhoun-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calhoun County AR SO"
     ],
@@ -8806,10 +8538,8 @@
   {
     "agency_id": "115a6325-032b-52a2-8f80-aae698a4fad8",
     "slug": "calloway-county-ky-so",
-    "flock_active_slug": "calloway-county-ky-so",
-    "flock_slugs": [
-      "calloway-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calloway County KY SO"
     ],
@@ -8833,10 +8563,8 @@
   {
     "agency_id": "dbc6519d-f57b-57da-aa78-38aa8c86a3e3",
     "slug": "camden-ar-pd",
-    "flock_active_slug": "camden-ar-pd",
-    "flock_slugs": [
-      "camden-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Camden AR PD"
     ],
@@ -8860,10 +8588,8 @@
   {
     "agency_id": "25eca66f-1d41-5bfe-a1bd-923f1b111f4f",
     "slug": "cameron-co-tx-so",
-    "flock_active_slug": "cameron-co-tx-so",
-    "flock_slugs": [
-      "cameron-co-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cameron CO TX SO"
     ],
@@ -8887,10 +8613,8 @@
   {
     "agency_id": "67a49698-c0ff-5c16-8136-cd39194cfa11",
     "slug": "cammack-village-ar-pd",
-    "flock_active_slug": "cammack-village-ar-pd",
-    "flock_slugs": [
-      "cammack-village-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cammack Village AR PD"
     ],
@@ -8914,10 +8638,8 @@
   {
     "agency_id": "9c3f31c5-37b8-558f-a075-d27375b5d158",
     "slug": "caney-ks-pd",
-    "flock_active_slug": "caney-ks-pd",
-    "flock_slugs": [
-      "caney-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Caney KS PD"
     ],
@@ -8941,10 +8663,8 @@
   {
     "agency_id": "cc02874e-bdcd-5ff5-897f-ae1828b257f3",
     "slug": "canton-tx-pd",
-    "flock_active_slug": "canton-tx-pd",
-    "flock_slugs": [
-      "canton-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Canton TX PD"
     ],
@@ -8968,10 +8688,8 @@
   {
     "agency_id": "ddce8e60-75f3-52a8-856e-b340cfdaacae",
     "slug": "cape-girardeau-county-mo-so",
-    "flock_active_slug": "cape-girardeau-county-mo-so",
-    "flock_slugs": [
-      "cape-girardeau-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cape Girardeau County MO SO"
     ],
@@ -8995,10 +8713,8 @@
   {
     "agency_id": "c8c14234-8395-53c7-984b-a7d4d89ffec7",
     "slug": "carbondale-il-pd",
-    "flock_active_slug": "carbondale-il-pd",
-    "flock_slugs": [
-      "carbondale-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carbondale IL PD"
     ],
@@ -9022,10 +8738,8 @@
   {
     "agency_id": "4e41f28b-ecd6-5aac-8f9c-e71d5d9d71fd",
     "slug": "carrollton-ga-pd",
-    "flock_active_slug": "carrollton-ga-pd",
-    "flock_slugs": [
-      "carrollton-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carrollton GA PD"
     ],
@@ -9049,10 +8763,8 @@
   {
     "agency_id": "df254d76-637c-5903-be4d-1c1e9cadc6e6",
     "slug": "carrollton-tx-pd",
-    "flock_active_slug": "carrollton-tx-pd",
-    "flock_slugs": [
-      "carrollton-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carrollton TX PD"
     ],
@@ -9076,10 +8788,8 @@
   {
     "agency_id": "9357f6cb-d5c1-57a8-974c-39128142f549",
     "slug": "carson-county-tx-so",
-    "flock_active_slug": "carson-county-tx-so",
-    "flock_slugs": [
-      "carson-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carson County TX SO"
     ],
@@ -9103,10 +8813,8 @@
   {
     "agency_id": "dd12950a-9cb2-5951-9f3e-24121e4a3f5c",
     "slug": "carterville-il-pd",
-    "flock_active_slug": "carterville-il-pd",
-    "flock_slugs": [
-      "carterville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carterville IL PD"
     ],
@@ -9130,10 +8838,8 @@
   {
     "agency_id": "45aa5710-8766-5544-b5c2-4c2b45b473a9",
     "slug": "carthage-ms-pd",
-    "flock_active_slug": "carthage-ms-pd",
-    "flock_slugs": [
-      "carthage-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carthage MS PD"
     ],
@@ -9157,10 +8863,8 @@
   {
     "agency_id": "d14ba7a0-9900-51e5-b85e-dda832db72ce",
     "slug": "caruthersville-mo-pd",
-    "flock_active_slug": "caruthersville-mo-pd",
-    "flock_slugs": [
-      "caruthersville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Caruthersville MO PD"
     ],
@@ -9184,10 +8888,8 @@
   {
     "agency_id": "5056bfe7-ecb1-5305-9884-0e5ef9b835f0",
     "slug": "cass-county-tx-so",
-    "flock_active_slug": "cass-county-tx-so",
-    "flock_slugs": [
-      "cass-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cass County TX SO"
     ],
@@ -9211,10 +8913,8 @@
   {
     "agency_id": "202629df-73d6-5255-9d2b-a03c7f8d206a",
     "slug": "catawba-county-nc-so",
-    "flock_active_slug": "catawba-county-nc-so",
-    "flock_slugs": [
-      "catawba-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Catawba County NC SO"
     ],
@@ -9238,10 +8938,8 @@
   {
     "agency_id": "22a6e96d-d681-51e0-b1f4-6a1ca5446b13",
     "slug": "catoosa-ok-pd",
-    "flock_active_slug": "catoosa-ok-pd",
-    "flock_slugs": [
-      "catoosa-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Catoosa OK PD"
     ],
@@ -9265,10 +8963,8 @@
   {
     "agency_id": "223dc6ab-0628-5523-aa3a-9509d7b87434",
     "slug": "cedar-hill-tx-pd",
-    "flock_active_slug": "cedar-hill-tx-pd",
-    "flock_slugs": [
-      "cedar-hill-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedar Hill TX PD"
     ],
@@ -9292,10 +8988,8 @@
   {
     "agency_id": "71af8f63-431f-5173-8d58-dcc213e99de8",
     "slug": "cedar-park-tx-pd",
-    "flock_active_slug": "cedar-park-tx-pd",
-    "flock_slugs": [
-      "cedar-park-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedar Park TX PD"
     ],
@@ -9319,10 +9013,8 @@
   {
     "agency_id": "ec938401-adce-513f-a651-b52d3f8387b5",
     "slug": "cedartown-ga-pd",
-    "flock_active_slug": "cedartown-ga-pd",
-    "flock_slugs": [
-      "cedartown-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedartown GA PD"
     ],
@@ -9346,10 +9038,8 @@
   {
     "agency_id": "c59e74e7-2146-5fcb-806e-7d50b38bf81b",
     "slug": "centerton-ar-pd",
-    "flock_active_slug": "centerton-ar-pd",
-    "flock_slugs": [
-      "centerton-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Centerton AR PD"
     ],
@@ -9373,10 +9063,8 @@
   {
     "agency_id": "196ffec4-7052-51df-ba33-37c3c413cb8a",
     "slug": "central-city-ky-pd",
-    "flock_active_slug": "central-city-ky-pd",
-    "flock_slugs": [
-      "central-city-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Central City KY PD"
     ],
@@ -9400,10 +9088,8 @@
   {
     "agency_id": "59b47e3d-afc5-514a-9c3a-a91777918662",
     "slug": "centralia-il-pd",
-    "flock_active_slug": "centralia-il-pd",
-    "flock_slugs": [
-      "centralia-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Centralia IL PD"
     ],
@@ -9427,10 +9113,8 @@
   {
     "agency_id": "689d83dc-bdf2-5b04-aa56-419ca56a07ca",
     "slug": "chambers-county-tx-so",
-    "flock_active_slug": "chambers-county-tx-so",
-    "flock_slugs": [
-      "chambers-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chambers County TX SO"
     ],
@@ -9454,10 +9138,8 @@
   {
     "agency_id": "8c5be782-b108-52a7-b310-b5f7739c9ab4",
     "slug": "channelview-isd-pd-tx",
-    "flock_active_slug": "channelview-isd-pd-tx",
-    "flock_slugs": [
-      "channelview-isd-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Channelview ISD PD TX"
     ],
@@ -9481,10 +9163,8 @@
   {
     "agency_id": "d8f7fefe-1537-5b2e-8458-f01e948a7877",
     "slug": "charlestown-pd-in",
-    "flock_active_slug": "charlestown-pd-in",
-    "flock_slugs": [
-      "charlestown-pd-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Charlestown PD IN"
     ],
@@ -9508,10 +9188,8 @@
   {
     "agency_id": "fec2b9a0-ee16-5d0a-948b-0b58ed4d1c48",
     "slug": "chatham-savannah-counter-narcotics-team",
-    "flock_active_slug": "chatham-savannah-counter-narcotics-team",
-    "flock_slugs": [
-      "chatham-savannah-counter-narcotics-team"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chatham-Savannah Counter Narcotics Team"
     ],
@@ -9534,10 +9212,8 @@
   {
     "agency_id": "66759895-2063-5986-b922-e5dc19e8e7f3",
     "slug": "chatsworth-ga-pd",
-    "flock_active_slug": "chatsworth-ga-pd",
-    "flock_slugs": [
-      "chatsworth-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chatsworth GA PD"
     ],
@@ -9561,10 +9237,8 @@
   {
     "agency_id": "8da138ef-c994-5063-b8ee-6265a9b08b29",
     "slug": "chattooga-county-ga-so",
-    "flock_active_slug": "chattooga-county-ga-so",
-    "flock_slugs": [
-      "chattooga-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chattooga County GA SO"
     ],
@@ -9588,10 +9262,8 @@
   {
     "agency_id": "d284785c-5cf3-55ee-b9ad-8c4170d3176d",
     "slug": "chautauqua-county-ks-so",
-    "flock_active_slug": "chautauqua-county-ks-so",
-    "flock_slugs": [
-      "chautauqua-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chautauqua County KS SO"
     ],
@@ -9615,10 +9287,8 @@
   {
     "agency_id": "5adb35c2-bf2e-523e-8f9f-b9cc840b7290",
     "slug": "cheatham-county-tn-so",
-    "flock_active_slug": "cheatham-county-tn-so",
-    "flock_slugs": [
-      "cheatham-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cheatham County TN SO"
     ],
@@ -9642,10 +9312,8 @@
   {
     "agency_id": "3d3b7ef3-bcda-5624-b0ff-a2206e6323aa",
     "slug": "cherokee-county-al-so",
-    "flock_active_slug": "cherokee-county-al-so",
-    "flock_slugs": [
-      "cherokee-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cherokee County AL SO"
     ],
@@ -9669,10 +9337,8 @@
   {
     "agency_id": "36bde614-fe67-5425-8aef-b1d5b1f0de3f",
     "slug": "cherokee-county-ga-so",
-    "flock_active_slug": "cherokee-county-ga-so",
-    "flock_slugs": [
-      "cherokee-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cherokee County GA SO"
     ],
@@ -9696,10 +9362,8 @@
   {
     "agency_id": "6f88d097-9a0e-5894-bd0c-06ad8c728aa8",
     "slug": "cherryvale-ks-pd",
-    "flock_active_slug": "cherryvale-ks-pd",
-    "flock_slugs": [
-      "cherryvale-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cherryvale KS PD"
     ],
@@ -9723,10 +9387,8 @@
   {
     "agency_id": "f08f3eda-8ca9-5e80-9eff-9a9df4ee282c",
     "slug": "cheviot-oh-pd",
-    "flock_active_slug": "cheviot-oh-pd",
-    "flock_slugs": [
-      "cheviot-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cheviot OH PD"
     ],
@@ -9750,10 +9412,8 @@
   {
     "agency_id": "63940f86-1550-57f6-abea-2c73159e8ea9",
     "slug": "chipley-fl-pd",
-    "flock_active_slug": "chipley-fl-pd",
-    "flock_slugs": [
-      "chipley-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chipley FL PD"
     ],
@@ -9777,10 +9437,8 @@
   {
     "agency_id": "49e2da73-d773-5a61-9703-326e45a924b9",
     "slug": "christian-county-mo-so",
-    "flock_active_slug": "christian-county-mo-so",
-    "flock_slugs": [
-      "christian-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Christian County MO SO"
     ],
@@ -9804,10 +9462,8 @@
   {
     "agency_id": "33eec7e4-e8ed-5375-a673-7685518bd51f",
     "slug": "city-of-oak-ridge-north-tx-pd",
-    "flock_active_slug": "city-of-oak-ridge-north-tx-pd",
-    "flock_slugs": [
-      "city-of-oak-ridge-north-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Oak Ridge North TX PD"
     ],
@@ -9831,10 +9487,8 @@
   {
     "agency_id": "3b3aa3f2-1a52-5fa4-9b7d-e6e940a39991",
     "slug": "city-of-sierra-vista-az",
-    "flock_active_slug": "city-of-sierra-vista-az",
-    "flock_slugs": [
-      "city-of-sierra-vista-az"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Sierra Vista AZ"
     ],
@@ -9859,10 +9513,8 @@
   {
     "agency_id": "505acc42-cf81-527a-84d0-253444f9cd64",
     "slug": "city-of-willard-mo-pd",
-    "flock_active_slug": "city-of-willard-mo-pd",
-    "flock_slugs": [
-      "city-of-willard-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Willard MO PD"
     ],
@@ -9886,10 +9538,8 @@
   {
     "agency_id": "c3113fd4-8a79-562b-9463-93cb2329547c",
     "slug": "claiborne-county-tn-so",
-    "flock_active_slug": "claiborne-county-tn-so",
-    "flock_slugs": [
-      "claiborne-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Claiborne County TN SO"
     ],
@@ -9913,10 +9563,8 @@
   {
     "agency_id": "9fcd0ad9-e6e5-5008-a9db-8cd683fae273",
     "slug": "clarksville-ar-pd",
-    "flock_active_slug": "clarksville-ar-pd",
-    "flock_slugs": [
-      "clarksville-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clarksville AR PD"
     ],
@@ -9940,10 +9588,8 @@
   {
     "agency_id": "602a6d9b-7494-5308-a0ae-c69792b91097",
     "slug": "clay-county-nc-so",
-    "flock_active_slug": "clay-county-nc-so",
-    "flock_slugs": [
-      "clay-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clay County NC SO"
     ],
@@ -9967,10 +9613,8 @@
   {
     "agency_id": "21bbb706-3fcb-5eaa-9d15-5d5d4df5cafd",
     "slug": "clay-county-tx-so",
-    "flock_active_slug": "clay-county-tx-so",
-    "flock_slugs": [
-      "clay-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clay County TX SO"
     ],
@@ -9994,10 +9638,8 @@
   {
     "agency_id": "6514a15a-a4e0-5d0a-b892-2fb5308785b9",
     "slug": "clayton-county-ga-pd",
-    "flock_active_slug": "clayton-county-ga-pd",
-    "flock_slugs": [
-      "clayton-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clayton County GA PD"
     ],
@@ -10021,10 +9663,8 @@
   {
     "agency_id": "85a43105-ed3f-5f18-a794-a8097c71d12e",
     "slug": "clayton-ga-pd",
-    "flock_active_slug": "clayton-ga-pd",
-    "flock_slugs": [
-      "clayton-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clayton GA PD"
     ],
@@ -10048,10 +9688,8 @@
   {
     "agency_id": "ed385b67-4ed5-50c2-98fe-ee16a3ef7bf3",
     "slug": "clearwater-ks-pd",
-    "flock_active_slug": "clearwater-ks-pd",
-    "flock_slugs": [
-      "clearwater-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clearwater KS PD"
     ],
@@ -10075,10 +9713,8 @@
   {
     "agency_id": "fb01a38b-b957-514b-a11a-9a85702f69f0",
     "slug": "cleveland-county-ok-so",
-    "flock_active_slug": "cleveland-county-ok-so",
-    "flock_slugs": [
-      "cleveland-county-ok-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cleveland County OK SO"
     ],
@@ -10102,10 +9738,8 @@
   {
     "agency_id": "2e90d527-125b-581e-b849-2d87d3c5f8d4",
     "slug": "cleveland-ms-pd",
-    "flock_active_slug": "cleveland-ms-pd",
-    "flock_slugs": [
-      "cleveland-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cleveland MS PD"
     ],
@@ -10129,10 +9763,8 @@
   {
     "agency_id": "35ba0bc2-19bc-50ae-9f72-1b692980a725",
     "slug": "cleveland-tn-pd",
-    "flock_active_slug": "cleveland-tn-pd",
-    "flock_slugs": [
-      "cleveland-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cleveland TN PD"
     ],
@@ -10156,10 +9788,8 @@
   {
     "agency_id": "01973434-8e51-54a8-8771-556056b87977",
     "slug": "clinton-tn-pd",
-    "flock_active_slug": "clinton-tn-pd",
-    "flock_slugs": [
-      "clinton-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clinton TN PD"
     ],
@@ -10183,10 +9813,8 @@
   {
     "agency_id": "0d0668e8-82fb-5ba4-b5dc-9fc84f6e481d",
     "slug": "clyde-pd-oh",
-    "flock_active_slug": "clyde-pd-oh",
-    "flock_slugs": [
-      "clyde-pd-oh"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clyde PD OH"
     ],
@@ -10210,10 +9838,8 @@
   {
     "agency_id": "55c047a3-27fe-59a1-ae2e-c6553c0d9646",
     "slug": "co-rangely-pd",
-    "flock_active_slug": "co-rangely-pd",
-    "flock_slugs": [
-      "co-rangely-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CO - Rangely PD"
     ],
@@ -10237,10 +9863,8 @@
   {
     "agency_id": "37d18557-88d7-5be4-bf2d-fea608a13119",
     "slug": "coal-valley-il-pd",
-    "flock_active_slug": "coal-valley-il-pd",
-    "flock_slugs": [
-      "coal-valley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coal Valley IL PD"
     ],
@@ -10264,10 +9888,8 @@
   {
     "agency_id": "6348080d-f337-5389-bfe9-d677077ad7ac",
     "slug": "cockrell-hill-tx-pd",
-    "flock_active_slug": "cockrell-hill-tx-pd",
-    "flock_slugs": [
-      "cockrell-hill-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cockrell Hill TX PD"
     ],
@@ -10291,10 +9913,8 @@
   {
     "agency_id": "57310224-8a52-54fc-a476-a83138d10908",
     "slug": "coffee-county-tn-so",
-    "flock_active_slug": "coffee-county-tn-so",
-    "flock_slugs": [
-      "coffee-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coffee County TN SO"
     ],
@@ -10318,10 +9938,8 @@
   {
     "agency_id": "11ebfca4-3230-57bb-bb1c-282d95d5e77d",
     "slug": "colbert-county-al-so",
-    "flock_active_slug": "colbert-county-al-so",
-    "flock_slugs": [
-      "colbert-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colbert County AL SO"
     ],
@@ -10345,10 +9963,8 @@
   {
     "agency_id": "02284aad-dbb9-5943-a6d8-b38691f38238",
     "slug": "colby-ks-pd",
-    "flock_active_slug": "colby-ks-pd",
-    "flock_slugs": [
-      "colby-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colby KS PD"
     ],
@@ -10372,10 +9988,8 @@
   {
     "agency_id": "e6cce749-5430-5394-83e4-6576ef656f00",
     "slug": "college-park-ga-pd",
-    "flock_active_slug": "college-park-ga-pd",
-    "flock_slugs": [
-      "college-park-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "College Park GA PD"
     ],
@@ -10400,10 +10014,8 @@
   {
     "agency_id": "76e8d379-5d2f-5389-aefc-ce536b49a0d8",
     "slug": "college-station-tx-pd",
-    "flock_active_slug": "college-station-tx-pd",
-    "flock_slugs": [
-      "college-station-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "College Station TX PD"
     ],
@@ -10428,10 +10040,8 @@
   {
     "agency_id": "58127606-c156-5705-99f8-cffa44420fa5",
     "slug": "collegedale-tn-pd",
-    "flock_active_slug": "collegedale-tn-pd",
-    "flock_slugs": [
-      "collegedale-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Collegedale TN PD"
     ],
@@ -10456,10 +10066,8 @@
   {
     "agency_id": "c94979b2-44b1-5895-8ad6-300c4c05a636",
     "slug": "colleyville-pd-tx",
-    "flock_active_slug": "colleyville-pd-tx",
-    "flock_slugs": [
-      "colleyville-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colleyville PD TX"
     ],
@@ -10483,10 +10091,8 @@
   {
     "agency_id": "2a82d604-7f00-503e-804a-c9e879413b06",
     "slug": "collierville-tn-pd",
-    "flock_active_slug": "collierville-tn-pd",
-    "flock_slugs": [
-      "collierville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Collierville TN PD"
     ],
@@ -10510,10 +10116,8 @@
   {
     "agency_id": "a684a599-fbf2-52fd-b2f0-77dea14db968",
     "slug": "collin-county-tx-so",
-    "flock_active_slug": "collin-county-tx-so",
-    "flock_slugs": [
-      "collin-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Collin County TX SO"
     ],
@@ -10537,10 +10141,8 @@
   {
     "agency_id": "f57b3fc9-0914-52c8-a957-bacffcbb2993",
     "slug": "columbia-county-fl-so",
-    "flock_active_slug": "columbia-county-fl-so",
-    "flock_slugs": [
-      "columbia-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbia County FL SO"
     ],
@@ -10564,10 +10166,8 @@
   {
     "agency_id": "e8916623-782f-5794-96eb-aeb62f1daa2d",
     "slug": "columbus-county-nc-so",
-    "flock_active_slug": "columbus-county-nc-so",
-    "flock_slugs": [
-      "columbus-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbus County NC SO"
     ],
@@ -10591,10 +10191,8 @@
   {
     "agency_id": "bdd6a3cf-22c7-53fa-832c-2eed42035038",
     "slug": "columbus-ga-pd",
-    "flock_active_slug": "columbus-ga-pd",
-    "flock_slugs": [
-      "columbus-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbus GA PD"
     ],
@@ -10618,10 +10216,8 @@
   {
     "agency_id": "e9158c2c-2328-56b7-b1de-f7cff9406c52",
     "slug": "columbus-in-pd",
-    "flock_active_slug": "columbus-in-pd",
-    "flock_slugs": [
-      "columbus-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbus IN PD"
     ],
@@ -10645,10 +10241,8 @@
   {
     "agency_id": "e57cd78e-7bb9-522c-bf77-16eba5631a83",
     "slug": "colwich-ks-pd",
-    "flock_active_slug": "colwich-ks-pd",
-    "flock_slugs": [
-      "colwich-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colwich KS PD"
     ],
@@ -10672,10 +10266,8 @@
   {
     "agency_id": "c9ba5659-449f-56e8-b878-acdddad4613d",
     "slug": "commerce-ga-pd",
-    "flock_active_slug": "commerce-ga-pd",
-    "flock_slugs": [
-      "commerce-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Commerce GA PD"
     ],
@@ -10699,10 +10291,8 @@
   {
     "agency_id": "dae9ab57-7c92-5243-9357-47a2e8c6d1ae",
     "slug": "conroe-tx-pd",
-    "flock_active_slug": "conroe-tx-pd",
-    "flock_slugs": [
-      "conroe-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Conroe TX PD"
     ],
@@ -10726,10 +10316,8 @@
   {
     "agency_id": "15f271c3-0f85-5837-b7db-ff4d551a9bb2",
     "slug": "converse-tx-pd",
-    "flock_active_slug": "converse-tx-pd",
-    "flock_slugs": [
-      "converse-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Converse TX PD"
     ],
@@ -10753,10 +10341,8 @@
   {
     "agency_id": "96f13f97-9c26-5159-afb1-9301aa96c93e",
     "slug": "conway-ar-pd",
-    "flock_active_slug": "conway-ar-pd",
-    "flock_slugs": [
-      "conway-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Conway AR PD"
     ],
@@ -10780,10 +10366,8 @@
   {
     "agency_id": "69a892dc-d16f-594b-adad-664621d9d481",
     "slug": "conway-springs-ks-pd",
-    "flock_active_slug": "conway-springs-ks-pd",
-    "flock_slugs": [
-      "conway-springs-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Conway Springs KS PD"
     ],
@@ -10807,10 +10391,8 @@
   {
     "agency_id": "12a63b4b-9e8e-5bab-8b08-8217b170f7d7",
     "slug": "cooke-county-tx-so",
-    "flock_active_slug": "cooke-county-tx-so",
-    "flock_slugs": [
-      "cooke-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cooke County TX SO"
     ],
@@ -10834,10 +10416,8 @@
   {
     "agency_id": "c02e8f2f-b4ca-5578-8eec-cac05e111ac4",
     "slug": "copiah-county-ms-so",
-    "flock_active_slug": "copiah-county-ms-so",
-    "flock_slugs": [
-      "copiah-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Copiah County MS SO"
     ],
@@ -10861,10 +10441,8 @@
   {
     "agency_id": "b1d65d2a-5a88-5131-a4ef-c34b867c9116",
     "slug": "coppell-tx-pd",
-    "flock_active_slug": "coppell-tx-pd",
-    "flock_slugs": [
-      "coppell-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coppell TX PD"
     ],
@@ -10888,10 +10466,8 @@
   {
     "agency_id": "f414bb3b-d6a0-54d8-ab0a-8d07284b091c",
     "slug": "coral-springs-fl-pd",
-    "flock_active_slug": "coral-springs-fl-pd",
-    "flock_slugs": [
-      "coral-springs-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coral Springs FL PD"
     ],
@@ -10915,10 +10491,8 @@
   {
     "agency_id": "0e149396-889a-5331-b13b-168c7edf19c2",
     "slug": "corinth-tx-pd",
-    "flock_active_slug": "corinth-tx-pd",
-    "flock_slugs": [
-      "corinth-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Corinth TX PD"
     ],
@@ -10942,10 +10516,8 @@
   {
     "agency_id": "a28048f2-86fc-58b6-af77-d64286bdd635",
     "slug": "covington-county-al-so",
-    "flock_active_slug": "covington-county-al-so",
-    "flock_slugs": [
-      "covington-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covington County AL SO"
     ],
@@ -10969,10 +10541,8 @@
   {
     "agency_id": "bea53b32-6907-5fd8-ac92-f7551cba88c8",
     "slug": "covington-ga-pd",
-    "flock_active_slug": "covington-ga-pd",
-    "flock_slugs": [
-      "covington-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covington GA PD"
     ],
@@ -10996,10 +10566,8 @@
   {
     "agency_id": "0f2e6391-b91f-5a6f-a48a-72f047342893",
     "slug": "covington-tn-pd",
-    "flock_active_slug": "covington-tn-pd",
-    "flock_slugs": [
-      "covington-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covington TN PD"
     ],
@@ -11023,10 +10591,8 @@
   {
     "agency_id": "542160c4-f416-5ff7-9eba-2eee66072070",
     "slug": "coweta-county-ga-so",
-    "flock_active_slug": "coweta-county-ga-so",
-    "flock_slugs": [
-      "coweta-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coweta County GA SO"
     ],
@@ -11050,10 +10616,8 @@
   {
     "agency_id": "9555a146-cad0-525a-ae32-2048407c4e84",
     "slug": "cowley-county-ks-so",
-    "flock_active_slug": "cowley-county-ks-so",
-    "flock_slugs": [
-      "cowley-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cowley County KS SO"
     ],
@@ -11077,10 +10641,8 @@
   {
     "agency_id": "c62c73c4-a716-51e3-95f8-a3642185c91c",
     "slug": "crainville-il-pd",
-    "flock_active_slug": "crainville-il-pd",
-    "flock_slugs": [
-      "crainville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crainville IL PD"
     ],
@@ -11104,10 +10666,8 @@
   {
     "agency_id": "1648aa4c-93cb-5236-a63a-e41aad1c9d51",
     "slug": "crandall-tx-pd",
-    "flock_active_slug": "crandall-tx-pd",
-    "flock_slugs": [
-      "crandall-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crandall TX PD"
     ],
@@ -11131,10 +10691,8 @@
   {
     "agency_id": "bc25e462-004b-5cef-a64e-e11fc66dbacc",
     "slug": "crawford-county-il-so",
-    "flock_active_slug": "crawford-county-il-so",
-    "flock_slugs": [
-      "crawford-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawford County IL SO"
     ],
@@ -11158,10 +10716,8 @@
   {
     "agency_id": "6ee6bb03-0146-5fea-96fc-5e56a172c1ba",
     "slug": "crawford-county-in-so",
-    "flock_active_slug": "crawford-county-in-so",
-    "flock_slugs": [
-      "crawford-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawford County IN SO"
     ],
@@ -11185,10 +10741,8 @@
   {
     "agency_id": "703ddd86-3ac0-5371-9231-5fade7091bcf",
     "slug": "crawford-county-ks-so",
-    "flock_active_slug": "crawford-county-ks-so",
-    "flock_slugs": [
-      "crawford-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawford County KS SO"
     ],
@@ -11212,10 +10766,8 @@
   {
     "agency_id": "82f5477b-21ef-5eaf-a77b-340a5eec7519",
     "slug": "crawford-county-mo",
-    "flock_active_slug": "crawford-county-mo",
-    "flock_slugs": [
-      "crawford-county-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawford County MO"
     ],
@@ -11240,10 +10792,8 @@
   {
     "agency_id": "a8169bed-a7a0-535d-a0b8-76dd831f39c9",
     "slug": "creek-county-ok-so",
-    "flock_active_slug": "creek-county-ok-so",
-    "flock_slugs": [
-      "creek-county-ok-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Creek County OK SO"
     ],
@@ -11267,10 +10817,8 @@
   {
     "agency_id": "089e6b94-6956-5539-a3f2-392bc67f03b4",
     "slug": "crestview-fl-pd",
-    "flock_active_slug": "crestview-fl-pd",
-    "flock_slugs": [
-      "crestview-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crestview FL PD"
     ],
@@ -11294,10 +10842,8 @@
   {
     "agency_id": "db82909d-bcca-5666-a765-436a7fcda522",
     "slug": "crisp-county-ga-so",
-    "flock_active_slug": "crisp-county-ga-so",
-    "flock_slugs": [
-      "crisp-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crisp County GA SO"
     ],
@@ -11321,10 +10867,8 @@
   {
     "agency_id": "ce081e87-32f7-5176-816b-fdf7bd5f0e12",
     "slug": "cross-county-ar-so",
-    "flock_active_slug": "cross-county-ar-so",
-    "flock_slugs": [
-      "cross-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cross County AR SO"
     ],
@@ -11348,10 +10892,8 @@
   {
     "agency_id": "7755d4ef-f38c-53ce-a2c5-5f0da98c0a4e",
     "slug": "crossville-tn-pd",
-    "flock_active_slug": "crossville-tn-pd",
-    "flock_slugs": [
-      "crossville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crossville TN PD"
     ],
@@ -11375,10 +10917,8 @@
   {
     "agency_id": "b7b7524d-1aa3-51a0-96d4-5b4dc100eeeb",
     "slug": "crowell-tx-pd",
-    "flock_active_slug": "crowell-tx-pd",
-    "flock_slugs": [
-      "crowell-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crowell TX PD"
     ],
@@ -11402,10 +10942,8 @@
   {
     "agency_id": "9dea7be8-7f1f-50f1-b7f4-2be3e5c305d9",
     "slug": "crystal-city-mo-pd",
-    "flock_active_slug": "crystal-city-mo-pd",
-    "flock_slugs": [
-      "crystal-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crystal City MO PD"
     ],
@@ -11429,10 +10967,8 @@
   {
     "agency_id": "09d20978-7471-596d-be44-ce10eaef1c7d",
     "slug": "crystal-springs-ms-pd",
-    "flock_active_slug": "crystal-springs-ms-pd",
-    "flock_slugs": [
-      "crystal-springs-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crystal Springs MS PD"
     ],
@@ -11456,10 +10992,8 @@
   {
     "agency_id": "ddad36ac-3cf9-58aa-b0c4-ec087280450b",
     "slug": "csx-railroad-pd",
-    "flock_active_slug": "csx-railroad-pd",
-    "flock_slugs": [
-      "csx-railroad-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CSX Railroad PD"
     ],
@@ -11482,10 +11016,8 @@
   {
     "agency_id": "dcda0db4-01d6-564b-9a43-d5742ca810a4",
     "slug": "cullman-al-pd",
-    "flock_active_slug": "cullman-al-pd",
-    "flock_slugs": [
-      "cullman-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cullman AL PD"
     ],
@@ -11509,10 +11041,8 @@
   {
     "agency_id": "68c6a402-7e17-5ea8-8708-91076d5e8e9e",
     "slug": "cumberland-county-pa-da",
-    "flock_active_slug": "cumberland-county-pa-da",
-    "flock_slugs": [
-      "cumberland-county-pa-da"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cumberland County PA DA"
     ],
@@ -11536,10 +11066,8 @@
   {
     "agency_id": "dd04892e-3271-5183-a937-f6ae3e431ff5",
     "slug": "cumby-tx-pd",
-    "flock_active_slug": "cumby-tx-pd",
-    "flock_slugs": [
-      "cumby-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cumby TX PD"
     ],
@@ -11563,10 +11091,8 @@
   {
     "agency_id": "b6e08702-eb5b-5164-9d46-b6bba89151e1",
     "slug": "cumming-ga-pd",
-    "flock_active_slug": "cumming-ga-pd",
-    "flock_slugs": [
-      "cumming-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cumming GA PD"
     ],
@@ -11590,10 +11116,8 @@
   {
     "agency_id": "e84da15d-26bf-5e57-9669-77ed1b7f12d8",
     "slug": "cynthiana-ky-pd",
-    "flock_active_slug": "cynthiana-ky-pd",
-    "flock_slugs": [
-      "cynthiana-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cynthiana KY PD"
     ],
@@ -11617,10 +11141,8 @@
   {
     "agency_id": "5897e101-9121-5ae3-85ac-6f5de79516b3",
     "slug": "dadeville-al-pd",
-    "flock_active_slug": "dadeville-al-pd",
-    "flock_slugs": [
-      "dadeville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dadeville AL PD"
     ],
@@ -11644,10 +11166,8 @@
   {
     "agency_id": "086af536-6512-5d44-86a6-318134c99b5d",
     "slug": "dale-county-al-so",
-    "flock_active_slug": "dale-county-al-so",
-    "flock_slugs": [
-      "dale-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dale County AL SO"
     ],
@@ -11671,10 +11191,8 @@
   {
     "agency_id": "c247cbb5-4f20-5f68-b9d0-2598538be996",
     "slug": "dallas-county-ar-so",
-    "flock_active_slug": "dallas-county-ar-so",
-    "flock_slugs": [
-      "dallas-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dallas County AR SO"
     ],
@@ -11698,10 +11216,8 @@
   {
     "agency_id": "e60f0164-6d77-5c93-b61f-e6abc470eabb",
     "slug": "dalton-ga-pd",
-    "flock_active_slug": "dalton-ga-pd",
-    "flock_slugs": [
-      "dalton-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dalton GA PD"
     ],
@@ -11725,10 +11241,8 @@
   {
     "agency_id": "098190c2-56b1-5400-a967-055a508233f1",
     "slug": "dandridge-tn-pd",
-    "flock_active_slug": "dandridge-tn-pd",
-    "flock_slugs": [
-      "dandridge-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dandridge TN PD"
     ],
@@ -11752,10 +11266,8 @@
   {
     "agency_id": "8c2addef-1278-50d5-ae3f-3dcf56342d7e",
     "slug": "danville-in-pd",
-    "flock_active_slug": "danville-in-pd",
-    "flock_slugs": [
-      "danville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Danville IN PD"
     ],
@@ -11779,10 +11291,8 @@
   {
     "agency_id": "b924f315-8e48-508a-9558-bd0fc740f0a8",
     "slug": "danville-ky-pd",
-    "flock_active_slug": "danville-ky-pd",
-    "flock_slugs": [
-      "danville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Danville KY PD"
     ],
@@ -11806,10 +11316,8 @@
   {
     "agency_id": "57088faf-e152-57e7-95a4-b774ddbaed91",
     "slug": "daphne-al-pd",
-    "flock_active_slug": "daphne-al-pd",
-    "flock_slugs": [
-      "daphne-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Daphne AL PD"
     ],
@@ -11833,10 +11341,8 @@
   {
     "agency_id": "2f14024e-f639-547f-bac3-9ed8792f8a78",
     "slug": "davidson-nc-pd",
-    "flock_active_slug": "davidson-nc-pd",
-    "flock_slugs": [
-      "davidson-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Davidson NC PD"
     ],
@@ -11860,10 +11366,8 @@
   {
     "agency_id": "92f33710-241b-50e1-818c-8c65fd821154",
     "slug": "dayton-tn-pd",
-    "flock_active_slug": "dayton-tn-pd",
-    "flock_slugs": [
-      "dayton-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dayton TN PD"
     ],
@@ -11887,10 +11391,8 @@
   {
     "agency_id": "9b27a267-c745-5c87-8297-c399ea704996",
     "slug": "de-queen-ar-pd",
-    "flock_active_slug": "de-queen-ar-pd",
-    "flock_slugs": [
-      "de-queen-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "De Queen AR PD"
     ],
@@ -11914,10 +11416,8 @@
   {
     "agency_id": "51a975eb-88a7-5f28-8a00-e236a77fcbfc",
     "slug": "dearborn-county-in-so",
-    "flock_active_slug": "dearborn-county-in-so",
-    "flock_slugs": [
-      "dearborn-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dearborn County IN SO"
     ],
@@ -11941,10 +11441,8 @@
   {
     "agency_id": "a205be2d-b201-5d98-8aa2-213c41d17367",
     "slug": "decatur-al-pd",
-    "flock_active_slug": "decatur-al-pd",
-    "flock_slugs": [
-      "decatur-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Decatur AL PD"
     ],
@@ -11968,10 +11466,8 @@
   {
     "agency_id": "bde50179-1511-5cde-a89b-c04228d0b2a9",
     "slug": "decatur-in-pd",
-    "flock_active_slug": "decatur-in-pd",
-    "flock_slugs": [
-      "decatur-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Decatur IN PD"
     ],
@@ -11995,10 +11491,8 @@
   {
     "agency_id": "f70bf2ff-efe9-5fe4-8627-9539f869ec75",
     "slug": "deer-park-tx-pd",
-    "flock_active_slug": "deer-park-tx-pd",
-    "flock_slugs": [
-      "deer-park-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Deer Park TX PD"
     ],
@@ -12022,10 +11516,8 @@
   {
     "agency_id": "7e107cde-aae6-5902-9790-85021216099e",
     "slug": "dekalb-county-ga-pd",
-    "flock_active_slug": "dekalb-county-ga-pd",
-    "flock_slugs": [
-      "dekalb-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DeKalb County GA PD"
     ],
@@ -12049,10 +11541,8 @@
   {
     "agency_id": "6aa1115d-85f2-56a4-942b-9c84030a1ff3",
     "slug": "del-city-ok-pd",
-    "flock_active_slug": "del-city-ok-pd",
-    "flock_slugs": [
-      "del-city-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Del City OK PD"
     ],
@@ -12076,10 +11566,8 @@
   {
     "agency_id": "647b832a-3f68-5054-aaaa-5c2e6fa78668",
     "slug": "delaware-county-oh-so",
-    "flock_active_slug": "delaware-county-oh-so",
-    "flock_slugs": [
-      "delaware-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Delaware County OH SO"
     ],
@@ -12103,10 +11591,8 @@
   {
     "agency_id": "27cdb11f-6a3a-5920-80e9-42af419443ab",
     "slug": "delhi-twp-oh-pd",
-    "flock_active_slug": "delhi-twp-oh-pd",
-    "flock_slugs": [
-      "delhi-twp-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Delhi Twp OH PD"
     ],
@@ -12130,10 +11616,8 @@
   {
     "agency_id": "8df858b6-de87-5f9e-8c50-eb8124b98924",
     "slug": "delphi-in-pd",
-    "flock_active_slug": "delphi-in-pd",
-    "flock_slugs": [
-      "delphi-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Delphi IN PD"
     ],
@@ -12157,10 +11641,8 @@
   {
     "agency_id": "ce0c70f9-4ee2-54b1-ba3c-0f521eb5015a",
     "slug": "dent-county-mo-so",
-    "flock_active_slug": "dent-county-mo-so",
-    "flock_slugs": [
-      "dent-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dent County MO SO"
     ],
@@ -12184,10 +11666,8 @@
   {
     "agency_id": "ed39e0cd-4605-5253-b62a-cdf2ad72bbf5",
     "slug": "denton-county-tx-so",
-    "flock_active_slug": "denton-county-tx-so",
-    "flock_slugs": [
-      "denton-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Denton County TX SO"
     ],
@@ -12211,10 +11691,8 @@
   {
     "agency_id": "ea5513bc-6cd6-57d7-9322-92ff656a41bd",
     "slug": "denton-tx-pd",
-    "flock_active_slug": "denton-tx-pd",
-    "flock_slugs": [
-      "denton-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Denton TX PD"
     ],
@@ -12238,10 +11716,8 @@
   {
     "agency_id": "f5050383-0182-59bf-90f6-a7782fb75f0c",
     "slug": "department-of-natural-resources-ga",
-    "flock_active_slug": "department-of-natural-resources-ga",
-    "flock_slugs": [
-      "department-of-natural-resources-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Department of Natural Resources - GA"
     ],
@@ -12265,10 +11741,8 @@
   {
     "agency_id": "0579ee28-f35e-5397-a915-0e4c27b0192d",
     "slug": "des-peres-mo-dps",
-    "flock_active_slug": "des-peres-mo-dps",
-    "flock_slugs": [
-      "des-peres-mo-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Des Peres MO DPS"
     ],
@@ -12292,10 +11766,8 @@
   {
     "agency_id": "49337455-c49f-54d1-875b-95241069cbab",
     "slug": "desoto-county-ms-so",
-    "flock_active_slug": "desoto-county-ms-so",
-    "flock_slugs": [
-      "desoto-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DeSoto County MS SO"
     ],
@@ -12319,10 +11791,8 @@
   {
     "agency_id": "3ee5acd2-b155-5635-9715-f2c56c58ac76",
     "slug": "desoto-tx-pd",
-    "flock_active_slug": "desoto-tx-pd",
-    "flock_slugs": [
-      "desoto-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DeSoto TX PD"
     ],
@@ -12346,10 +11816,8 @@
   {
     "agency_id": "680fc3ac-d8e4-56f1-8538-678d32cd53dd",
     "slug": "dexter-mo-pd",
-    "flock_active_slug": "dexter-mo-pd",
-    "flock_slugs": [
-      "dexter-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dexter MO PD"
     ],
@@ -12373,10 +11841,8 @@
   {
     "agency_id": "2dcc85fd-cdca-56b1-b84a-342926fee8c4",
     "slug": "dickenson-county-va-so",
-    "flock_active_slug": "dickenson-county-va-so",
-    "flock_slugs": [
-      "dickenson-county-va-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dickenson County VA SO"
     ],
@@ -12400,10 +11866,8 @@
   {
     "agency_id": "81c576a9-4266-5258-9fb4-512123200180",
     "slug": "dickinson-tx-pd",
-    "flock_active_slug": "dickinson-tx-pd",
-    "flock_slugs": [
-      "dickinson-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dickinson TX PD"
     ],
@@ -12427,10 +11891,8 @@
   {
     "agency_id": "3a9d6bec-c7e9-5cdc-961f-a54fddaa3c37",
     "slug": "dickson-tn-pd",
-    "flock_active_slug": "dickson-tn-pd",
-    "flock_slugs": [
-      "dickson-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dickson TN PD"
     ],
@@ -12454,10 +11916,8 @@
   {
     "agency_id": "de4176aa-985e-5792-b18a-752226525041",
     "slug": "dillard-ga-pd",
-    "flock_active_slug": "dillard-ga-pd",
-    "flock_slugs": [
-      "dillard-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dillard GA PD"
     ],
@@ -12481,10 +11941,8 @@
   {
     "agency_id": "57a0925a-056f-5030-ab07-f4c390aecb1d",
     "slug": "dixie-county-fl-so",
-    "flock_active_slug": "dixie-county-fl-so",
-    "flock_slugs": [
-      "dixie-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dixie County FL SO"
     ],
@@ -12508,10 +11966,8 @@
   {
     "agency_id": "cbdd0de6-a208-5549-baaa-c536afd5d68b",
     "slug": "dodge-city-ks-pd",
-    "flock_active_slug": "dodge-city-ks-pd",
-    "flock_slugs": [
-      "dodge-city-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dodge City KS PD"
     ],
@@ -12535,10 +11991,8 @@
   {
     "agency_id": "0b433910-e4ca-5bd7-8bf8-d2c0e748fbc5",
     "slug": "dodge-county-ga-so",
-    "flock_active_slug": "dodge-county-ga-so",
-    "flock_slugs": [
-      "dodge-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dodge County GA SO"
     ],
@@ -12562,10 +12016,8 @@
   {
     "agency_id": "7c7d9b71-a3ab-5f42-833a-22817fd73ea3",
     "slug": "doraville-ga-pd",
-    "flock_active_slug": "doraville-ga-pd",
-    "flock_slugs": [
-      "doraville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Doraville GA PD"
     ],
@@ -12589,10 +12041,8 @@
   {
     "agency_id": "2c114012-eb2c-5ce9-a26e-87671933216e",
     "slug": "dothan-al-pd",
-    "flock_active_slug": "dothan-al-pd",
-    "flock_slugs": [
-      "dothan-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dothan AL PD"
     ],
@@ -12616,10 +12066,8 @@
   {
     "agency_id": "68fd93a5-351c-5510-8b4c-c1db9375ac3a",
     "slug": "dougherty-county-ga-pd",
-    "flock_active_slug": "dougherty-county-ga-pd",
-    "flock_slugs": [
-      "dougherty-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dougherty County GA PD"
     ],
@@ -12643,10 +12091,8 @@
   {
     "agency_id": "c3e4d44e-7d2a-5479-9e07-9c6c02a09a75",
     "slug": "douglas-county-ga-so",
-    "flock_active_slug": "douglas-county-ga-so",
-    "flock_slugs": [
-      "douglas-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Douglas County GA SO"
     ],
@@ -12670,10 +12116,8 @@
   {
     "agency_id": "9945cf87-a2f2-5332-b67e-9bae770091d0",
     "slug": "duluth-ga-pd",
-    "flock_active_slug": "duluth-ga-pd",
-    "flock_slugs": [
-      "duluth-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Duluth GA PD"
     ],
@@ -12697,10 +12141,8 @@
   {
     "agency_id": "e3f8ccb6-9fc6-541a-9c6e-dd0031557f0f",
     "slug": "duncan-ok-pd",
-    "flock_active_slug": "duncan-ok-pd",
-    "flock_slugs": [
-      "duncan-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Duncan OK PD"
     ],
@@ -12724,10 +12166,8 @@
   {
     "agency_id": "67524cb0-676a-5330-b168-fafbdb73ab5a",
     "slug": "duncanville-tx-pd",
-    "flock_active_slug": "duncanville-tx-pd",
-    "flock_slugs": [
-      "duncanville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Duncanville TX PD"
     ],
@@ -12751,10 +12191,8 @@
   {
     "agency_id": "f92e4dc2-3f02-5b2b-ad4c-b29c08cfdc58",
     "slug": "dupont-wa-pd",
-    "flock_active_slug": "dupont-wa-pd",
-    "flock_slugs": [
-      "dupont-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dupont WA PD"
     ],
@@ -12778,10 +12216,8 @@
   {
     "agency_id": "f6154ea6-99e0-5b95-9055-82a1f522cf3a",
     "slug": "duquesne-mo-pd",
-    "flock_active_slug": "duquesne-mo-pd",
-    "flock_slugs": [
-      "duquesne-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Duquesne MO PD"
     ],
@@ -12805,10 +12241,8 @@
   {
     "agency_id": "262cbd1b-7604-50e0-af14-7874cccfe7f8",
     "slug": "dyer-county-tn-so",
-    "flock_active_slug": "dyer-county-tn-so",
-    "flock_slugs": [
-      "dyer-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dyer County TN SO"
     ],
@@ -12832,10 +12266,8 @@
   {
     "agency_id": "878894fa-103c-54a2-866d-e4b7a42f1640",
     "slug": "dyersburg-tn-pd",
-    "flock_active_slug": "dyersburg-tn-pd",
-    "flock_slugs": [
-      "dyersburg-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dyersburg TN PD"
     ],
@@ -12859,10 +12291,8 @@
   {
     "agency_id": "4f57d504-d5eb-5750-804e-44ce4a04418d",
     "slug": "east-point-ga-pd",
-    "flock_active_slug": "east-point-ga-pd",
-    "flock_slugs": [
-      "east-point-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Point GA PD"
     ],
@@ -12886,10 +12316,8 @@
   {
     "agency_id": "25e3b0e5-84b4-5dc5-a44b-8cd465105b19",
     "slug": "eastpointe-mi-pd",
-    "flock_active_slug": "eastpointe-mi-pd",
-    "flock_slugs": [
-      "eastpointe-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eastpointe MI PD"
     ],
@@ -12913,10 +12341,8 @@
   {
     "agency_id": "5c7e6b6a-f2da-55ea-afc2-da8a1f137a11",
     "slug": "el-dorado-ar-pd",
-    "flock_active_slug": "el-dorado-ar-pd",
-    "flock_slugs": [
-      "el-dorado-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Dorado AR PD"
     ],
@@ -12940,10 +12366,8 @@
   {
     "agency_id": "eb5daedd-ae9f-53b2-8682-e470a54af75f",
     "slug": "el-dorado-ks-pd",
-    "flock_active_slug": "el-dorado-ks-pd",
-    "flock_slugs": [
-      "el-dorado-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Dorado KS PD"
     ],
@@ -12967,10 +12391,8 @@
   {
     "agency_id": "49c5481c-d25a-5023-8a46-24d8a14ec54d",
     "slug": "el-reno-ok-pd",
-    "flock_active_slug": "el-reno-ok-pd",
-    "flock_slugs": [
-      "el-reno-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Reno OK PD"
     ],
@@ -12994,10 +12416,8 @@
   {
     "agency_id": "a4358f63-bb8e-5464-a2ec-7bb1e92e1c1a",
     "slug": "elizabethton-tn-pd",
-    "flock_active_slug": "elizabethton-tn-pd",
-    "flock_slugs": [
-      "elizabethton-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elizabethton TN PD"
     ],
@@ -13021,10 +12441,8 @@
   {
     "agency_id": "e2bb5108-7d86-5a7c-bf1c-8b54f5ddd0a4",
     "slug": "elk-county-ks-so",
-    "flock_active_slug": "elk-county-ks-so",
-    "flock_slugs": [
-      "elk-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elk County KS SO"
     ],
@@ -13048,10 +12466,8 @@
   {
     "agency_id": "1141bacd-1c61-5fba-b28c-3461f4eb6831",
     "slug": "ellijay-ga-pd",
-    "flock_active_slug": "ellijay-ga-pd",
-    "flock_slugs": [
-      "ellijay-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ellijay GA PD"
     ],
@@ -13075,10 +12491,8 @@
   {
     "agency_id": "71e1eef0-8045-51b9-863b-cc5cc0fdd570",
     "slug": "ellsworth-county-ks-so",
-    "flock_active_slug": "ellsworth-county-ks-so",
-    "flock_slugs": [
-      "ellsworth-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ellsworth County KS SO"
     ],
@@ -13102,10 +12516,8 @@
   {
     "agency_id": "238ad3de-f4cd-5cbf-9aaf-121bb1243444",
     "slug": "elm-ridge-tx-pd",
-    "flock_active_slug": "elm-ridge-tx-pd",
-    "flock_slugs": [
-      "elm-ridge-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elm Ridge TX PD"
     ],
@@ -13125,10 +12537,8 @@
   {
     "agency_id": "b31065d0-ecd5-5d6c-b8fa-6f3ee7a94a62",
     "slug": "elmore-county-al-so",
-    "flock_active_slug": "elmore-county-al-so",
-    "flock_slugs": [
-      "elmore-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elmore County AL SO"
     ],
@@ -13152,10 +12562,8 @@
   {
     "agency_id": "2411b743-a9cd-5505-923a-95c55b29f74c",
     "slug": "elwood-in-pd",
-    "flock_active_slug": "elwood-in-pd",
-    "flock_slugs": [
-      "elwood-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elwood IN PD"
     ],
@@ -13179,10 +12587,8 @@
   {
     "agency_id": "ba8bf93f-8905-5f55-bd0b-8db6201f554f",
     "slug": "emerson-ga-pd",
-    "flock_active_slug": "emerson-ga-pd",
-    "flock_slugs": [
-      "emerson-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Emerson GA PD"
     ],
@@ -13206,10 +12612,8 @@
   {
     "agency_id": "f37d0f09-6a70-5017-8b66-0bda25f8c5a4",
     "slug": "emory-university-campus-pd-ga",
-    "flock_active_slug": "emory-university-campus-pd-ga",
-    "flock_slugs": [
-      "emory-university-campus-pd-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Emory University Campus PD GA"
     ],
@@ -13234,10 +12638,8 @@
   {
     "agency_id": "733f750c-f7c9-5634-ab1b-a91950a83192",
     "slug": "energy-il-pd",
-    "flock_active_slug": "energy-il-pd",
-    "flock_slugs": [
-      "energy-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Energy IL PD"
     ],
@@ -13261,10 +12663,8 @@
   {
     "agency_id": "29877f51-99f5-502c-9b5d-970876ec0d4f",
     "slug": "erath-county-tx-so",
-    "flock_active_slug": "erath-county-tx-so",
-    "flock_slugs": [
-      "erath-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Erath County TX SO"
     ],
@@ -13288,10 +12688,8 @@
   {
     "agency_id": "1edac42d-83bf-501e-a8c7-cee63715ed9a",
     "slug": "erlanger-ky-pd",
-    "flock_active_slug": "erlanger-ky-pd",
-    "flock_slugs": [
-      "erlanger-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Erlanger KY PD"
     ],
@@ -13315,10 +12713,8 @@
   {
     "agency_id": "0a2fbdd7-9610-562c-95e5-5a1c9b924546",
     "slug": "etowah-county-al-so",
-    "flock_active_slug": "etowah-county-al-so",
-    "flock_slugs": [
-      "etowah-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Etowah County AL SO"
     ],
@@ -13342,10 +12738,8 @@
   {
     "agency_id": "d6de07a8-e13f-5660-b117-9ddfe9dfb497",
     "slug": "eufaula-al-pd",
-    "flock_active_slug": "eufaula-al-pd",
-    "flock_slugs": [
-      "eufaula-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eufaula AL PD"
     ],
@@ -13369,10 +12763,8 @@
   {
     "agency_id": "7a1d0d66-47a8-522d-a444-84c0ecf6085d",
     "slug": "euharlee-ga-pd",
-    "flock_active_slug": "euharlee-ga-pd",
-    "flock_slugs": [
-      "euharlee-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Euharlee GA PD"
     ],
@@ -13396,10 +12788,8 @@
   {
     "agency_id": "8946bf41-9889-59dd-af23-92ba10a856ad",
     "slug": "euless-tx-pd",
-    "flock_active_slug": "euless-tx-pd",
-    "flock_slugs": [
-      "euless-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Euless TX PD"
     ],
@@ -13423,10 +12813,8 @@
   {
     "agency_id": "f0c9f908-6c4c-5555-ba8b-e70d2ca023ef",
     "slug": "extended-stay-america-esa-management-llc",
-    "flock_active_slug": "extended-stay-america-esa-management-llc",
-    "flock_slugs": [
-      "extended-stay-america-esa-management-llc"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Extended Stay America (ESA) Management, LLC"
     ],
@@ -13443,10 +12831,8 @@
   {
     "agency_id": "2cd6cde2-43b6-58c3-b7f4-481670319c70",
     "slug": "fairburn-ga-pd",
-    "flock_active_slug": "fairburn-ga-pd",
-    "flock_slugs": [
-      "fairburn-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairburn GA PD"
     ],
@@ -13470,10 +12856,8 @@
   {
     "agency_id": "d087d915-ed42-5872-a8f2-86e415838080",
     "slug": "fairfax-oh-pd",
-    "flock_active_slug": "fairfax-oh-pd",
-    "flock_slugs": [
-      "fairfax-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairfax OH PD"
     ],
@@ -13497,10 +12881,8 @@
   {
     "agency_id": "65f1349c-d933-5e5f-8183-59fcf5816023",
     "slug": "fairlawn-oh-pd",
-    "flock_active_slug": "fairlawn-oh-pd",
-    "flock_slugs": [
-      "fairlawn-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairlawn OH PD"
     ],
@@ -13524,10 +12906,8 @@
   {
     "agency_id": "14370a69-8fcc-5538-8154-3600b0b2ddd5",
     "slug": "fannin-county-ga-so",
-    "flock_active_slug": "fannin-county-ga-so",
-    "flock_slugs": [
-      "fannin-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fannin County GA SO"
     ],
@@ -13551,10 +12931,8 @@
   {
     "agency_id": "516efddb-7f89-5bfa-aca8-c6d66353cf6f",
     "slug": "farmers-branch-tx-pd",
-    "flock_active_slug": "farmers-branch-tx-pd",
-    "flock_slugs": [
-      "farmers-branch-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Farmers Branch TX PD"
     ],
@@ -13578,10 +12956,8 @@
   {
     "agency_id": "494b2572-4cf9-50ba-9cf5-c3a7f2921595",
     "slug": "farmersville-tx-pd",
-    "flock_active_slug": "farmersville-tx-pd",
-    "flock_slugs": [
-      "farmersville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Farmersville TX PD"
     ],
@@ -13605,10 +12981,8 @@
   {
     "agency_id": "833c2ee4-f619-5d1e-b96b-4b0dd465d8f2",
     "slug": "farmington-pd-ar",
-    "flock_active_slug": "farmington-pd-ar",
-    "flock_slugs": [
-      "farmington-pd-ar"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Farmington PD AR"
     ],
@@ -13632,10 +13006,8 @@
   {
     "agency_id": "bee454f5-680f-5bf4-8fcd-bc9970283e3e",
     "slug": "fayette-county-ky-so",
-    "flock_active_slug": "fayette-county-ky-so",
-    "flock_slugs": [
-      "fayette-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fayette County KY SO"
     ],
@@ -13659,10 +13031,8 @@
   {
     "agency_id": "156a591d-b15e-56a3-9125-7195e4520337",
     "slug": "fayette-county-tn-so",
-    "flock_active_slug": "fayette-county-tn-so",
-    "flock_slugs": [
-      "fayette-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fayette County TN SO"
     ],
@@ -13686,10 +13056,8 @@
   {
     "agency_id": "de502c01-5ad0-5ea2-81ba-5a0b36a66196",
     "slug": "federal-federal-bureau-of-investigation-fbi",
-    "flock_active_slug": "federal-federal-bureau-of-investigation-fbi",
-    "flock_slugs": [
-      "federal-federal-bureau-of-investigation-fbi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] Federal Bureau of Investigation (FBI)"
     ],
@@ -13707,10 +13075,8 @@
   {
     "agency_id": "5e134bfe-46e5-5983-9f79-a999dd725da6",
     "slug": "federal-natchez-trace-parkway-ms-national-park-service",
-    "flock_active_slug": "federal-natchez-trace-parkway-ms-national-park-service",
-    "flock_slugs": [
-      "federal-natchez-trace-parkway-ms-national-park-service"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] Natchez Trace Parkway MS - National Park Service"
     ],
@@ -13731,10 +13097,8 @@
   {
     "agency_id": "ae54abb9-913d-5bcb-96cb-e4e54a1dceb7",
     "slug": "federal-tennessee-valley-authority-police",
-    "flock_active_slug": "federal-tennessee-valley-authority-police",
-    "flock_slugs": [
-      "federal-tennessee-valley-authority-police"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] Tennessee Valley Authority Police"
     ],
@@ -13752,10 +13116,8 @@
   {
     "agency_id": "0e4678e7-cfa4-5b91-83f3-9daf5e3653ea",
     "slug": "federal-us-postal-inspection-service",
-    "flock_active_slug": "federal-us-postal-inspection-service",
-    "flock_slugs": [
-      "federal-us-postal-inspection-service"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] US Postal Inspection Service"
     ],
@@ -13773,10 +13135,8 @@
   {
     "agency_id": "2d68d9d4-1a4b-599f-a455-9640d4882085",
     "slug": "federal-wright-patterson-oh-air-force-base",
-    "flock_active_slug": "federal-wright-patterson-oh-air-force-base",
-    "flock_slugs": [
-      "federal-wright-patterson-oh-air-force-base"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] Wright Patterson OH Air Force Base"
     ],
@@ -13797,10 +13157,8 @@
   {
     "agency_id": "bc71f6fb-d7a8-5a0e-a582-0e8b7f30be0b",
     "slug": "fletcher-nc-pd",
-    "flock_active_slug": "fletcher-nc-pd",
-    "flock_slugs": [
-      "fletcher-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fletcher NC PD"
     ],
@@ -13824,10 +13182,8 @@
   {
     "agency_id": "a852b23e-1033-5091-ab96-066272842c60",
     "slug": "flora-il-pd",
-    "flock_active_slug": "flora-il-pd",
-    "flock_slugs": [
-      "flora-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flora- IL - PD"
     ],
@@ -13851,10 +13207,8 @@
   {
     "agency_id": "efe30bd1-9989-5f1e-9c29-cf8f43722ef1",
     "slug": "florida-state-university-campus-pd-fl",
-    "flock_active_slug": "florida-state-university-campus-pd-fl",
-    "flock_slugs": [
-      "florida-state-university-campus-pd-fl"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Florida State University Campus PD FL"
     ],
@@ -13879,10 +13233,8 @@
   {
     "agency_id": "3f72a9bd-713b-55ad-a20f-5b93ad010fc3",
     "slug": "flowery-branch-ga-pd",
-    "flock_active_slug": "flowery-branch-ga-pd",
-    "flock_slugs": [
-      "flowery-branch-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flowery Branch GA PD"
     ],
@@ -13906,10 +13258,8 @@
   {
     "agency_id": "34be81d1-1725-51f7-8cb2-0ed876168661",
     "slug": "floyd-county-ga-pd",
-    "flock_active_slug": "floyd-county-ga-pd",
-    "flock_slugs": [
-      "floyd-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Floyd County GA PD"
     ],
@@ -13933,10 +13283,8 @@
   {
     "agency_id": "5b905d9f-a44d-584a-8500-a49bf1fb6999",
     "slug": "foley-al-pd",
-    "flock_active_slug": "foley-al-pd",
-    "flock_slugs": [
-      "foley-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Foley AL PD"
     ],
@@ -13960,10 +13308,8 @@
   {
     "agency_id": "d41f6741-766a-5e12-ba4d-ad13b33ac80a",
     "slug": "ford-county-ks-so",
-    "flock_active_slug": "ford-county-ks-so",
-    "flock_slugs": [
-      "ford-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ford County KS SO"
     ],
@@ -13987,10 +13333,8 @@
   {
     "agency_id": "99ecf4fa-b2e9-5e0a-84a3-0bf2fd681a98",
     "slug": "forrest-county-ms-so",
-    "flock_active_slug": "forrest-county-ms-so",
-    "flock_slugs": [
-      "forrest-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Forrest County MS SO"
     ],
@@ -14014,10 +13358,8 @@
   {
     "agency_id": "f329559d-0775-55b2-a78b-1d0bbe6413d6",
     "slug": "forsyth-county-ga-so",
-    "flock_active_slug": "forsyth-county-ga-so",
-    "flock_slugs": [
-      "forsyth-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Forsyth County GA SO"
     ],
@@ -14041,10 +13383,8 @@
   {
     "agency_id": "95830be8-4965-5698-a7ef-0c2147cf7ce6",
     "slug": "fort-bend-county-tx-district-attorneys-office",
-    "flock_active_slug": "fort-bend-county-tx-district-attorneys-office",
-    "flock_slugs": [
-      "fort-bend-county-tx-district-attorneys-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Bend County TX District Attorney's Office"
     ],
@@ -14065,10 +13405,8 @@
   {
     "agency_id": "50417c9d-23b9-5562-94bb-84c637575f5c",
     "slug": "fort-bend-county-tx-so",
-    "flock_active_slug": "fort-bend-county-tx-so",
-    "flock_slugs": [
-      "fort-bend-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Bend County TX SO"
     ],
@@ -14092,10 +13430,8 @@
   {
     "agency_id": "7eb95741-cefe-5d84-ad1b-6d2a50a895df",
     "slug": "fort-oglethorpe-ga-pd",
-    "flock_active_slug": "fort-oglethorpe-ga-pd",
-    "flock_slugs": [
-      "fort-oglethorpe-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Oglethorpe GA PD"
     ],
@@ -14119,10 +13455,8 @@
   {
     "agency_id": "6a308d48-694f-5bf1-881a-dd436e910605",
     "slug": "fort-smith-ar-pd",
-    "flock_active_slug": "fort-smith-ar-pd",
-    "flock_slugs": [
-      "fort-smith-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Smith AR PD"
     ],
@@ -14146,10 +13480,8 @@
   {
     "agency_id": "24e89b98-5361-59fa-be8d-2f9f2c0267b9",
     "slug": "fort-stockton-tx-pd",
-    "flock_active_slug": "fort-stockton-tx-pd",
-    "flock_slugs": [
-      "fort-stockton-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Stockton TX PD"
     ],
@@ -14173,10 +13505,8 @@
   {
     "agency_id": "6508532f-3ff0-565c-9917-c792547d648a",
     "slug": "fort-walton-beach-fl-pd",
-    "flock_active_slug": "fort-walton-beach-fl-pd",
-    "flock_slugs": [
-      "fort-walton-beach-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Walton Beach FL PD"
     ],
@@ -14200,10 +13530,8 @@
   {
     "agency_id": "927bb2ee-90a0-56b1-8602-8ba43ce11dc9",
     "slug": "franklin-county-il-so",
-    "flock_active_slug": "franklin-county-il-so",
-    "flock_slugs": [
-      "franklin-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin County IL SO"
     ],
@@ -14227,10 +13555,8 @@
   {
     "agency_id": "3c54d4ec-8ab9-5a07-ae9b-c0906faadebe",
     "slug": "franklin-county-pa-so",
-    "flock_active_slug": "franklin-county-pa-so",
-    "flock_slugs": [
-      "franklin-county-pa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin County PA SO"
     ],
@@ -14254,10 +13580,8 @@
   {
     "agency_id": "61dcc5f2-a7c7-562f-bf79-c5844b549ba1",
     "slug": "franklin-county-tx-so",
-    "flock_active_slug": "franklin-county-tx-so",
-    "flock_slugs": [
-      "franklin-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin County TX SO"
     ],
@@ -14281,10 +13605,8 @@
   {
     "agency_id": "bcf00535-3ec8-5ad6-870a-75ce0052c890",
     "slug": "franklin-ga-pd",
-    "flock_active_slug": "franklin-ga-pd",
-    "flock_slugs": [
-      "franklin-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin GA PD"
     ],
@@ -14308,10 +13630,8 @@
   {
     "agency_id": "9577a4a4-d678-550b-be77-9cda5e93c76a",
     "slug": "fredericksburg-city-va-pd",
-    "flock_active_slug": "fredericksburg-city-va-pd",
-    "flock_slugs": [
-      "fredericksburg-city-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fredericksburg City VA PD"
     ],
@@ -14335,10 +13655,8 @@
   {
     "agency_id": "43cf7e1d-2253-5d0d-b3d7-af78e20b14b6",
     "slug": "friendswood-tx-pd",
-    "flock_active_slug": "friendswood-tx-pd",
-    "flock_slugs": [
-      "friendswood-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Friendswood TX PD"
     ],
@@ -14362,10 +13680,8 @@
   {
     "agency_id": "8e64671b-4141-5662-b8ec-f36a26f84175",
     "slug": "frisco-tx-pd",
-    "flock_active_slug": "frisco-tx-pd",
-    "flock_slugs": [
-      "frisco-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Frisco TX PD"
     ],
@@ -14389,10 +13705,8 @@
   {
     "agency_id": "a1a17339-4088-5b52-8b03-9e66a33107b7",
     "slug": "frontenac-ks-pd",
-    "flock_active_slug": "frontenac-ks-pd",
-    "flock_slugs": [
-      "frontenac-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Frontenac KS PD"
     ],
@@ -14416,10 +13730,8 @@
   {
     "agency_id": "214e355b-37a4-54a0-899f-3f98b975aea1",
     "slug": "fulton-county-ga-so",
-    "flock_active_slug": "fulton-county-ga-so",
-    "flock_slugs": [
-      "fulton-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulton County GA SO"
     ],
@@ -14443,10 +13755,8 @@
   {
     "agency_id": "0a579c92-8d06-517c-afa1-80214dcc424e",
     "slug": "fulton-ms-pd",
-    "flock_active_slug": "fulton-ms-pd",
-    "flock_slugs": [
-      "fulton-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulton MS PD"
     ],
@@ -14470,10 +13780,8 @@
   {
     "agency_id": "31c48831-5e70-5a51-8bdf-3056ffc7dc87",
     "slug": "fultondale-al-pd",
-    "flock_active_slug": "fultondale-al-pd",
-    "flock_slugs": [
-      "fultondale-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fultondale AL PD"
     ],
@@ -14497,10 +13805,8 @@
   {
     "agency_id": "06b5f3d5-7de0-5b82-b437-2e7675842f2c",
     "slug": "ga-georgia-piedmont-technical-college",
-    "flock_active_slug": "ga-georgia-piedmont-technical-college",
-    "flock_slugs": [
-      "ga-georgia-piedmont-technical-college"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "GA - Georgia Piedmont Technical College"
     ],
@@ -14525,10 +13831,8 @@
   {
     "agency_id": "132123cb-eb61-5dc5-be29-ab9fd39fefde",
     "slug": "ga-mcsocuintelligence",
-    "flock_active_slug": "ga-mcsocuintelligence",
-    "flock_slugs": [
-      "ga-mcsocuintelligence"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "GA - MCS/OCU/Intelligence"
     ],
@@ -14548,10 +13852,8 @@
   {
     "agency_id": "945ee183-beca-54f8-b94d-3380284fe616",
     "slug": "gainesville-fl-pd",
-    "flock_active_slug": "gainesville-fl-pd",
-    "flock_slugs": [
-      "gainesville-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gainesville FL PD"
     ],
@@ -14575,10 +13877,8 @@
   {
     "agency_id": "509d1831-3fbf-53fd-93ad-8a9a9da7add2",
     "slug": "gainesville-ga-pd",
-    "flock_active_slug": "gainesville-ga-pd",
-    "flock_slugs": [
-      "gainesville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gainesville GA PD"
     ],
@@ -14602,10 +13902,8 @@
   {
     "agency_id": "b79fcdbe-0174-5ff0-b9ef-5c5dd6c6bff6",
     "slug": "gallatin-tn-pd",
-    "flock_active_slug": "gallatin-tn-pd",
-    "flock_slugs": [
-      "gallatin-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gallatin TN PD"
     ],
@@ -14629,10 +13927,8 @@
   {
     "agency_id": "cc60add9-7a6f-57da-9c8a-5527f21e802c",
     "slug": "galveston-county-tx-so",
-    "flock_active_slug": "galveston-county-tx-so",
-    "flock_slugs": [
-      "galveston-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Galveston County TX SO"
     ],
@@ -14656,10 +13952,8 @@
   {
     "agency_id": "a70f2e5f-8084-5b3d-83a8-5304abeef14f",
     "slug": "gardendale-al-pd",
-    "flock_active_slug": "gardendale-al-pd",
-    "flock_slugs": [
-      "gardendale-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gardendale AL PD"
     ],
@@ -14683,10 +13977,8 @@
   {
     "agency_id": "1ddafb10-28d0-5d3c-8122-7be1acc2d31e",
     "slug": "garland-tx-pd",
-    "flock_active_slug": "garland-tx-pd",
-    "flock_slugs": [
-      "garland-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Garland TX PD"
     ],
@@ -14710,10 +14002,8 @@
   {
     "agency_id": "e2b58ebc-4516-5fd3-a171-ebdac631662a",
     "slug": "garrard-county-ky-so",
-    "flock_active_slug": "garrard-county-ky-so",
-    "flock_slugs": [
-      "garrard-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Garrard County KY SO"
     ],
@@ -14737,10 +14027,8 @@
   {
     "agency_id": "c66aae24-7647-5469-a3e5-96308a301b8d",
     "slug": "gastonia-nc-pd",
-    "flock_active_slug": "gastonia-nc-pd",
-    "flock_slugs": [
-      "gastonia-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gastonia NC PD"
     ],
@@ -14764,10 +14052,8 @@
   {
     "agency_id": "404b1713-2fc4-55a7-a9c9-59dc6e50f440",
     "slug": "gatlinburg-tn-pd",
-    "flock_active_slug": "gatlinburg-tn-pd",
-    "flock_slugs": [
-      "gatlinburg-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gatlinburg TN PD"
     ],
@@ -14791,10 +14077,8 @@
   {
     "agency_id": "39048805-6e2f-58a5-810b-42c1b6dedfd4",
     "slug": "gautier-ms-pd",
-    "flock_active_slug": "gautier-ms-pd",
-    "flock_slugs": [
-      "gautier-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gautier MS PD"
     ],
@@ -14818,10 +14102,8 @@
   {
     "agency_id": "2fdfae2f-3c24-53dc-b974-ef8abc0b4e35",
     "slug": "georgetown-in-pd",
-    "flock_active_slug": "georgetown-in-pd",
-    "flock_slugs": [
-      "georgetown-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgetown IN PD"
     ],
@@ -14845,10 +14127,8 @@
   {
     "agency_id": "83a0fd53-3083-5278-baed-f1f4d76a8003",
     "slug": "georgetown-ky-pd",
-    "flock_active_slug": "georgetown-ky-pd",
-    "flock_slugs": [
-      "georgetown-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgetown KY PD"
     ],
@@ -14872,10 +14152,8 @@
   {
     "agency_id": "62fcf9d7-b895-5fa4-becc-02c57ade5d70",
     "slug": "georgia-attorney-generals-office-ga",
-    "flock_active_slug": "georgia-attorney-generals-office-ga",
-    "flock_slugs": [
-      "georgia-attorney-generals-office-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgia Attorney General's Office - GA"
     ],
@@ -14896,10 +14174,8 @@
   {
     "agency_id": "8fcf3e5f-7ac2-56db-ab27-92234d7850fa",
     "slug": "georgia-dept-of-corrections-intelligence-unit-ga",
-    "flock_active_slug": "georgia-dept-of-corrections-intelligence-unit-ga",
-    "flock_slugs": [
-      "georgia-dept-of-corrections-intelligence-unit-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgia Dept. of Corrections Intelligence Unit (GA)"
     ],
@@ -14923,10 +14199,8 @@
   {
     "agency_id": "b29ba7ad-c2f1-56ff-bc53-a7751d93a179",
     "slug": "georgia-southwestern-state-university-campus-pd",
-    "flock_active_slug": "georgia-southwestern-state-university-campus-pd",
-    "flock_slugs": [
-      "georgia-southwestern-state-university-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgia Southwestern State University Campus PD"
     ],
@@ -14951,10 +14225,8 @@
   {
     "agency_id": "68a8472b-1087-500e-b140-f02bb713e9db",
     "slug": "gibson-county-tn-so",
-    "flock_active_slug": "gibson-county-tn-so",
-    "flock_slugs": [
-      "gibson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gibson County TN SO"
     ],
@@ -14978,10 +14250,8 @@
   {
     "agency_id": "6bd332df-da0d-5ac6-98ab-4c3249745333",
     "slug": "giles-county-tn-so",
-    "flock_active_slug": "giles-county-tn-so",
-    "flock_slugs": [
-      "giles-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Giles County TN SO"
     ],
@@ -15005,10 +14275,8 @@
   {
     "agency_id": "1a317e3d-40ce-5c15-abfb-5f033a2f8cb7",
     "slug": "glenpool-ok-pd",
-    "flock_active_slug": "glenpool-ok-pd",
-    "flock_slugs": [
-      "glenpool-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glenpool OK PD"
     ],
@@ -15032,10 +14300,8 @@
   {
     "agency_id": "4b7134ff-6619-5a7d-8493-0bd735ebe942",
     "slug": "goodlettsville-tn-pd",
-    "flock_active_slug": "goodlettsville-tn-pd",
-    "flock_slugs": [
-      "goodlettsville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goodlettsville TN PD"
     ],
@@ -15059,10 +14325,8 @@
   {
     "agency_id": "799d79ad-ee36-5cbb-9019-08c6623c2dfa",
     "slug": "goodyear-az-pd",
-    "flock_active_slug": "goodyear-az-pd",
-    "flock_slugs": [
-      "goodyear-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goodyear AZ PD"
     ],
@@ -15086,10 +14350,8 @@
   {
     "agency_id": "a8e5f9ad-47c2-58d7-8af8-a552bb1b16ad",
     "slug": "goose-creek-sc-pd",
-    "flock_active_slug": "goose-creek-sc-pd",
-    "flock_slugs": [
-      "goose-creek-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goose Creek SC PD"
     ],
@@ -15113,10 +14375,8 @@
   {
     "agency_id": "1b8a9ad4-ef4c-5185-8171-7a5dd3d91ccd",
     "slug": "granbury-tx-pd",
-    "flock_active_slug": "granbury-tx-pd",
-    "flock_slugs": [
-      "granbury-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Granbury TX PD"
     ],
@@ -15140,10 +14400,8 @@
   {
     "agency_id": "b89c4869-a586-536c-abbe-a6466d3dff86",
     "slug": "grant-county-ar-so",
-    "flock_active_slug": "grant-county-ar-so",
-    "flock_slugs": [
-      "grant-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grant County AR SO"
     ],
@@ -15167,10 +14425,8 @@
   {
     "agency_id": "aab5c575-2a5c-593b-9369-2359c211ca2e",
     "slug": "grant-county-ar-so1",
-    "flock_active_slug": "grant-county-ar-so1",
-    "flock_slugs": [
-      "grant-county-ar-so1"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grant County AR SO1"
     ],
@@ -15195,10 +14451,8 @@
   {
     "agency_id": "44e71698-e6c9-5a91-8447-015deec52203",
     "slug": "grantville-ga-pd",
-    "flock_active_slug": "grantville-ga-pd",
-    "flock_slugs": [
-      "grantville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grantville GA PD"
     ],
@@ -15222,10 +14476,8 @@
   {
     "agency_id": "a2bfc766-dfda-5ab4-b1d7-919a2b86eef4",
     "slug": "graves-county-ky-so",
-    "flock_active_slug": "graves-county-ky-so",
-    "flock_slugs": [
-      "graves-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Graves County KY SO"
     ],
@@ -15249,10 +14501,8 @@
   {
     "agency_id": "8c63f4d0-849f-52b8-9b32-718fe148dee7",
     "slug": "gray-county-ks-so",
-    "flock_active_slug": "gray-county-ks-so",
-    "flock_slugs": [
-      "gray-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gray County KS SO"
     ],
@@ -15276,10 +14526,8 @@
   {
     "agency_id": "36f58b39-9591-5412-969a-e4101be33747",
     "slug": "grayson-county-tx-so",
-    "flock_active_slug": "grayson-county-tx-so",
-    "flock_slugs": [
-      "grayson-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grayson County TX SO"
     ],
@@ -15303,10 +14551,8 @@
   {
     "agency_id": "990df05a-663f-593b-8115-48fdb22cdc30",
     "slug": "great-bend-ks-pd",
-    "flock_active_slug": "great-bend-ks-pd",
-    "flock_slugs": [
-      "great-bend-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Great Bend KS PD"
     ],
@@ -15330,10 +14576,8 @@
   {
     "agency_id": "904fb444-0f13-5403-90d4-beb4f84bba6e",
     "slug": "greenbrier-tn-pd",
-    "flock_active_slug": "greenbrier-tn-pd",
-    "flock_slugs": [
-      "greenbrier-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenbrier TN PD"
     ],
@@ -15357,10 +14601,8 @@
   {
     "agency_id": "36c042f6-0f44-5afc-9baa-9bf64a7b6572",
     "slug": "greenfield-in-pd",
-    "flock_active_slug": "greenfield-in-pd",
-    "flock_slugs": [
-      "greenfield-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenfield IN PD"
     ],
@@ -15384,10 +14626,8 @@
   {
     "agency_id": "3707fe3f-94c4-527c-82ec-7037db1438fb",
     "slug": "greenville-county-sc-so",
-    "flock_active_slug": "greenville-county-sc-so",
-    "flock_slugs": [
-      "greenville-county-sc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenville County SC SO"
     ],
@@ -15411,10 +14651,8 @@
   {
     "agency_id": "486a7280-ad21-5303-8010-7c493e526978",
     "slug": "greenville-ms-pd",
-    "flock_active_slug": "greenville-ms-pd",
-    "flock_slugs": [
-      "greenville-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenville MS PD"
     ],
@@ -15438,10 +14676,8 @@
   {
     "agency_id": "b825e84e-1a48-56d1-bd08-3fd591ee2a33",
     "slug": "greenwood-ar-pd",
-    "flock_active_slug": "greenwood-ar-pd",
-    "flock_slugs": [
-      "greenwood-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenwood AR PD"
     ],
@@ -15465,10 +14701,8 @@
   {
     "agency_id": "be63bcdd-3088-575f-9023-2c11c6c2ce52",
     "slug": "greenwood-in-pd",
-    "flock_active_slug": "greenwood-in-pd",
-    "flock_slugs": [
-      "greenwood-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenwood IN PD"
     ],
@@ -15492,10 +14726,8 @@
   {
     "agency_id": "b229e4f8-b513-52f9-9bcd-419b0d6fc150",
     "slug": "greers-ferry-ar-pd",
-    "flock_active_slug": "greers-ferry-ar-pd",
-    "flock_slugs": [
-      "greers-ferry-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greers Ferry AR PD"
     ],
@@ -15519,10 +14751,8 @@
   {
     "agency_id": "7f83eca5-8fb7-5942-8cd4-a7887a146ec6",
     "slug": "gretna-la-pd",
-    "flock_active_slug": "gretna-la-pd",
-    "flock_slugs": [
-      "gretna-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gretna LA PD"
     ],
@@ -15546,10 +14776,8 @@
   {
     "agency_id": "25df913b-7b02-5410-8bb8-c33285586778",
     "slug": "groesbeck-tx-pd",
-    "flock_active_slug": "groesbeck-tx-pd",
-    "flock_slugs": [
-      "groesbeck-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Groesbeck TX PD"
     ],
@@ -15573,10 +14801,8 @@
   {
     "agency_id": "9e8513a9-2cfe-5b3a-ba6f-1dd698dba14f",
     "slug": "guilford-county-nc-so",
-    "flock_active_slug": "guilford-county-nc-so",
-    "flock_slugs": [
-      "guilford-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Guilford County NC SO"
     ],
@@ -15600,10 +14826,8 @@
   {
     "agency_id": "2ca4991d-5af1-5d85-bb53-46004aad77cc",
     "slug": "gulf-shores-al-pd",
-    "flock_active_slug": "gulf-shores-al-pd",
-    "flock_slugs": [
-      "gulf-shores-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gulf Shores AL PD"
     ],
@@ -15627,10 +14851,8 @@
   {
     "agency_id": "b1876bcf-b241-598a-be26-7d31d0acc8b1",
     "slug": "gulfport-ms-pd",
-    "flock_active_slug": "gulfport-ms-pd",
-    "flock_slugs": [
-      "gulfport-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gulfport MS PD"
     ],
@@ -15654,10 +14876,8 @@
   {
     "agency_id": "d2cd0d92-7602-5223-b784-994ae9ad2317",
     "slug": "guntersville-al-pd",
-    "flock_active_slug": "guntersville-al-pd",
-    "flock_slugs": [
-      "guntersville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Guntersville AL PD"
     ],
@@ -15681,10 +14901,8 @@
   {
     "agency_id": "ee737cc9-9148-5672-a2a8-90f654847729",
     "slug": "gwinnett-county-das-office",
-    "flock_active_slug": "gwinnett-county-das-office",
-    "flock_slugs": [
-      "gwinnett-county-das-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gwinnett County DAs Office"
     ],
@@ -15702,10 +14920,8 @@
   {
     "agency_id": "12ebac5a-3621-5549-a2a4-fa67729aa9ec",
     "slug": "gwinnett-county-ga-so",
-    "flock_active_slug": "gwinnett-county-ga-so",
-    "flock_slugs": [
-      "gwinnett-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gwinnett County GA SO"
     ],
@@ -15729,10 +14945,8 @@
   {
     "agency_id": "4c431642-2f5c-5c7c-9c69-6587fff1becf",
     "slug": "gwinnett-county-school-pd",
-    "flock_active_slug": "gwinnett-county-school-pd",
-    "flock_slugs": [
-      "gwinnett-county-school-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gwinnett County School PD"
     ],
@@ -15755,10 +14969,8 @@
   {
     "agency_id": "78f990ee-458f-59ec-80e8-a8594f7e1f5d",
     "slug": "habersham-county-ga-so",
-    "flock_active_slug": "habersham-county-ga-so",
-    "flock_slugs": [
-      "habersham-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Habersham County GA SO"
     ],
@@ -15782,10 +14994,8 @@
   {
     "agency_id": "1f4015e4-e989-57b7-b190-e31e7146d950",
     "slug": "hackleburg-al-pd",
-    "flock_active_slug": "hackleburg-al-pd",
-    "flock_slugs": [
-      "hackleburg-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hackleburg AL PD"
     ],
@@ -15809,10 +15019,8 @@
   {
     "agency_id": "757c632a-ccf6-5ee3-9684-480feda37f20",
     "slug": "hall-county-ga-so",
-    "flock_active_slug": "hall-county-ga-so",
-    "flock_slugs": [
-      "hall-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hall County GA SO"
     ],
@@ -15836,10 +15044,8 @@
   {
     "agency_id": "11c012a2-acde-5f22-9367-759261899f8d",
     "slug": "halls-tn-pd",
-    "flock_active_slug": "halls-tn-pd",
-    "flock_slugs": [
-      "halls-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Halls TN PD"
     ],
@@ -15863,10 +15069,8 @@
   {
     "agency_id": "823c0c99-5c81-5498-bac8-8137c07f78c4",
     "slug": "hamblen-county-tn-so",
-    "flock_active_slug": "hamblen-county-tn-so",
-    "flock_slugs": [
-      "hamblen-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamblen County TN SO"
     ],
@@ -15890,10 +15094,8 @@
   {
     "agency_id": "a8b91ff3-8854-5c6f-ad26-2ef90de19cdc",
     "slug": "hamilton-county-in-so",
-    "flock_active_slug": "hamilton-county-in-so",
-    "flock_slugs": [
-      "hamilton-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamilton County IN SO"
     ],
@@ -15917,10 +15119,8 @@
   {
     "agency_id": "4ccd873f-bb47-5aef-b716-adda10401fbc",
     "slug": "hamilton-county-ks-so",
-    "flock_active_slug": "hamilton-county-ks-so",
-    "flock_slugs": [
-      "hamilton-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamilton County KS SO"
     ],
@@ -15944,10 +15144,8 @@
   {
     "agency_id": "fd4d9608-578c-515b-baf8-7838db3e42c8",
     "slug": "hamilton-county-tn-so",
-    "flock_active_slug": "hamilton-county-tn-so",
-    "flock_slugs": [
-      "hamilton-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamilton County TN SO"
     ],
@@ -15971,10 +15169,8 @@
   {
     "agency_id": "abd3e1f3-f641-53d5-924a-b711d7e98126",
     "slug": "hancock-county-in-so",
-    "flock_active_slug": "hancock-county-in-so",
-    "flock_slugs": [
-      "hancock-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hancock County IN SO"
     ],
@@ -15998,10 +15194,8 @@
   {
     "agency_id": "7328ed8e-aabd-556b-ac94-244961f9e57a",
     "slug": "hapeville-ga-pd",
-    "flock_active_slug": "hapeville-ga-pd",
-    "flock_slugs": [
-      "hapeville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hapeville GA PD"
     ],
@@ -16025,10 +15219,8 @@
   {
     "agency_id": "bc05c669-7bc4-557f-8639-322574d87d4d",
     "slug": "haralson-county-ga-so",
-    "flock_active_slug": "haralson-county-ga-so",
-    "flock_slugs": [
-      "haralson-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Haralson County GA SO"
     ],
@@ -16052,10 +15244,8 @@
   {
     "agency_id": "c36da4cf-45cd-5c1f-9910-17b92224cbc4",
     "slug": "hardin-county-ky-so",
-    "flock_active_slug": "hardin-county-ky-so",
-    "flock_slugs": [
-      "hardin-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hardin County KY SO"
     ],
@@ -16079,10 +15269,8 @@
   {
     "agency_id": "ec8bdba2-d67e-515c-8595-bcf3d932ef83",
     "slug": "hardinsburg-ky-pd",
-    "flock_active_slug": "hardinsburg-ky-pd",
-    "flock_slugs": [
-      "hardinsburg-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hardinsburg KY PD"
     ],
@@ -16106,10 +15294,8 @@
   {
     "agency_id": "0297c20d-14fa-5d73-9a18-9a04db8adf62",
     "slug": "harriman-tn-pd",
-    "flock_active_slug": "harriman-tn-pd",
-    "flock_slugs": [
-      "harriman-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harriman TN PD"
     ],
@@ -16133,10 +15319,8 @@
   {
     "agency_id": "72ffa63c-4176-5350-84fa-5b00b083035c",
     "slug": "harris-county-const-tx-pct-2",
-    "flock_active_slug": "harris-county-const-tx-pct-2",
-    "flock_slugs": [
-      "harris-county-const-tx-pct-2"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County Const TX Pct 2"
     ],
@@ -16161,10 +15345,8 @@
   {
     "agency_id": "675805bf-82e3-5974-baa7-521ed722b6d4",
     "slug": "harris-county-fire-marshal-tx",
-    "flock_active_slug": "harris-county-fire-marshal-tx",
-    "flock_slugs": [
-      "harris-county-fire-marshal-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County Fire Marshal TX"
     ],
@@ -16189,10 +15371,8 @@
   {
     "agency_id": "2791a70b-8cd4-5bdf-b5ac-e28a15c0e4d2",
     "slug": "harris-county-ga-so",
-    "flock_active_slug": "harris-county-ga-so",
-    "flock_slugs": [
-      "harris-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County GA SO"
     ],
@@ -16216,10 +15396,8 @@
   {
     "agency_id": "7805c3d8-243d-53e5-9556-064383798185",
     "slug": "harrison-ar-pd",
-    "flock_active_slug": "harrison-ar-pd",
-    "flock_slugs": [
-      "harrison-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrison AR PD"
     ],
@@ -16243,10 +15421,8 @@
   {
     "agency_id": "6ee7c56e-c972-591d-89d4-ac167cd1e943",
     "slug": "harrison-county-so-ms",
-    "flock_active_slug": "harrison-county-so-ms",
-    "flock_slugs": [
-      "harrison-county-so-ms"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrison County SO MS"
     ],
@@ -16270,10 +15446,8 @@
   {
     "agency_id": "53e7a893-2750-5260-87c1-86e89ad97218",
     "slug": "harrison-county-tx-so",
-    "flock_active_slug": "harrison-county-tx-so",
-    "flock_slugs": [
-      "harrison-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrison County TX SO"
     ],
@@ -16297,10 +15471,8 @@
   {
     "agency_id": "b8d8ac25-2dd9-5fbf-a079-3cfd3096e65f",
     "slug": "harrison-oh-pd",
-    "flock_active_slug": "harrison-oh-pd",
-    "flock_slugs": [
-      "harrison-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrison OH PD"
     ],
@@ -16324,10 +15496,8 @@
   {
     "agency_id": "a48f3da6-688d-55ed-bc0e-592371dc903d",
     "slug": "hartselle-al-pd",
-    "flock_active_slug": "hartselle-al-pd",
-    "flock_slugs": [
-      "hartselle-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hartselle AL PD"
     ],
@@ -16351,10 +15521,8 @@
   {
     "agency_id": "b540f3b8-6202-5609-a99b-31cc8c0ea9e2",
     "slug": "hartsville-sc-pd",
-    "flock_active_slug": "hartsville-sc-pd",
-    "flock_slugs": [
-      "hartsville-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hartsville SC PD"
     ],
@@ -16378,10 +15546,8 @@
   {
     "agency_id": "c0e97bc4-9a81-57f4-9c34-d3f16e86f3bb",
     "slug": "haskell-ar-pd",
-    "flock_active_slug": "haskell-ar-pd",
-    "flock_slugs": [
-      "haskell-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Haskell AR PD"
     ],
@@ -16405,10 +15571,8 @@
   {
     "agency_id": "5a74fdc5-4c11-5b4f-98cc-77cd8b67599e",
     "slug": "haysville-ks-pd",
-    "flock_active_slug": "haysville-ks-pd",
-    "flock_slugs": [
-      "haysville-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Haysville KS PD"
     ],
@@ -16432,10 +15596,8 @@
   {
     "agency_id": "39104dbe-4508-5948-a8f7-64b866e941b7",
     "slug": "heard-county-ga-so",
-    "flock_active_slug": "heard-county-ga-so",
-    "flock_slugs": [
-      "heard-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Heard County GA SO"
     ],
@@ -16459,10 +15621,8 @@
   {
     "agency_id": "42729f32-7dd5-5f30-8c66-5da324cdb973",
     "slug": "heber-springs-ar-pd",
-    "flock_active_slug": "heber-springs-ar-pd",
-    "flock_slugs": [
-      "heber-springs-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Heber Springs AR PD"
     ],
@@ -16486,10 +15646,8 @@
   {
     "agency_id": "8a5d087e-f64c-5539-8672-4b21505f6425",
     "slug": "hedwig-village-tx-pd",
-    "flock_active_slug": "hedwig-village-tx-pd",
-    "flock_slugs": [
-      "hedwig-village-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hedwig Village TX PD"
     ],
@@ -16513,10 +15671,8 @@
   {
     "agency_id": "5023bf58-7984-5452-8a4d-047874911d6d",
     "slug": "hempstead-village-ny-pd",
-    "flock_active_slug": "hempstead-village-ny-pd",
-    "flock_slugs": [
-      "hempstead-village-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hempstead Village NY PD"
     ],
@@ -16540,10 +15696,8 @@
   {
     "agency_id": "2e40d207-7ce7-5cc8-92c0-4d5a85166c07",
     "slug": "henderson-county-ky-so",
-    "flock_active_slug": "henderson-county-ky-so",
-    "flock_slugs": [
-      "henderson-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henderson County KY SO"
     ],
@@ -16567,10 +15721,8 @@
   {
     "agency_id": "750280a8-ddbf-5923-a648-a55887e830d8",
     "slug": "henderson-county-nc-so",
-    "flock_active_slug": "henderson-county-nc-so",
-    "flock_slugs": [
-      "henderson-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henderson County NC SO"
     ],
@@ -16594,10 +15746,8 @@
   {
     "agency_id": "09d1a48b-e042-5205-b362-f5d78fdea8c9",
     "slug": "henderson-ky-pd",
-    "flock_active_slug": "henderson-ky-pd",
-    "flock_slugs": [
-      "henderson-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henderson KY PD"
     ],
@@ -16621,10 +15771,8 @@
   {
     "agency_id": "52003e2c-f621-5aaf-b9d8-5c850c812080",
     "slug": "henderson-tx-pd",
-    "flock_active_slug": "henderson-tx-pd",
-    "flock_slugs": [
-      "henderson-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henderson TX PD"
     ],
@@ -16648,10 +15796,8 @@
   {
     "agency_id": "3760af35-93f0-5d79-894e-1d094bd0b640",
     "slug": "hendersonville-tn-pd",
-    "flock_active_slug": "hendersonville-tn-pd",
-    "flock_slugs": [
-      "hendersonville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hendersonville TN PD"
     ],
@@ -16675,10 +15821,8 @@
   {
     "agency_id": "0b49933c-abd8-5cb0-932e-6a16da0f9961",
     "slug": "henry-county-al-so",
-    "flock_active_slug": "henry-county-al-so",
-    "flock_slugs": [
-      "henry-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henry County AL SO"
     ],
@@ -16702,10 +15846,8 @@
   {
     "agency_id": "97714423-17cd-5597-82f0-47c3554d66e2",
     "slug": "henry-county-ga-pd",
-    "flock_active_slug": "henry-county-ga-pd",
-    "flock_slugs": [
-      "henry-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henry County GA PD"
     ],
@@ -16729,10 +15871,8 @@
   {
     "agency_id": "b27fb811-babd-5b9e-bfbf-863d9ecdea3d",
     "slug": "hernando-ms-pd",
-    "flock_active_slug": "hernando-ms-pd",
-    "flock_slugs": [
-      "hernando-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hernando MS PD"
     ],
@@ -16756,10 +15896,8 @@
   {
     "agency_id": "d7003e24-7469-5336-ba5e-94b7e72ee834",
     "slug": "herrin-il-pd",
-    "flock_active_slug": "herrin-il-pd",
-    "flock_slugs": [
-      "herrin-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Herrin IL PD"
     ],
@@ -16783,10 +15921,8 @@
   {
     "agency_id": "64b3766c-adfd-51d0-9c32-43a15df830de",
     "slug": "hesston-ks-pd",
-    "flock_active_slug": "hesston-ks-pd",
-    "flock_slugs": [
-      "hesston-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hesston KS PD"
     ],
@@ -16810,10 +15946,8 @@
   {
     "agency_id": "0c3f66f3-0a6b-5c08-bffe-c4ec2a66b5e5",
     "slug": "hickory-creek-tx-pd",
-    "flock_active_slug": "hickory-creek-tx-pd",
-    "flock_slugs": [
-      "hickory-creek-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hickory Creek TX PD"
     ],
@@ -16837,10 +15971,8 @@
   {
     "agency_id": "ed8ea725-dbe1-5b59-b5a2-968c0b853c7c",
     "slug": "highland-park-tx-pd",
-    "flock_active_slug": "highland-park-tx-pd",
-    "flock_slugs": [
-      "highland-park-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Highland Park TX PD"
     ],
@@ -16864,10 +15996,8 @@
   {
     "agency_id": "f12c463c-9272-5a4a-a793-b9a3d530402b",
     "slug": "hillsboro-ks-pd",
-    "flock_active_slug": "hillsboro-ks-pd",
-    "flock_slugs": [
-      "hillsboro-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hillsboro KS PD"
     ],
@@ -16891,10 +16021,8 @@
   {
     "agency_id": "5a68cbda-83a0-570e-8198-56d808d035e9",
     "slug": "hiram-ga-pd",
-    "flock_active_slug": "hiram-ga-pd",
-    "flock_slugs": [
-      "hiram-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hiram GA PD"
     ],
@@ -16918,10 +16046,8 @@
   {
     "agency_id": "71627991-85e6-5b17-8e25-1f853008d087",
     "slug": "hoisington-ks-pd",
-    "flock_active_slug": "hoisington-ks-pd",
-    "flock_slugs": [
-      "hoisington-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hoisington KS PD"
     ],
@@ -16945,10 +16071,8 @@
   {
     "agency_id": "3f3b9f56-5310-5485-838f-cf227df4a31b",
     "slug": "holland-tx-pd",
-    "flock_active_slug": "holland-tx-pd",
-    "flock_slugs": [
-      "holland-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Holland TX PD"
     ],
@@ -16972,10 +16096,8 @@
   {
     "agency_id": "e33a2909-8318-53d3-bfc5-ae6cdef47fb8",
     "slug": "hollister-mo-pd",
-    "flock_active_slug": "hollister-mo-pd",
-    "flock_slugs": [
-      "hollister-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hollister MO PD"
     ],
@@ -16999,10 +16121,8 @@
   {
     "agency_id": "6ade54e2-d393-5634-a54e-ad75234f9391",
     "slug": "homecroft-in-pd",
-    "flock_active_slug": "homecroft-in-pd",
-    "flock_slugs": [
-      "homecroft-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Homecroft IN PD"
     ],
@@ -17026,10 +16146,8 @@
   {
     "agency_id": "d580f0ed-6f02-5872-a904-a7a52ab36ed9",
     "slug": "homewood-al-pd",
-    "flock_active_slug": "homewood-al-pd",
-    "flock_slugs": [
-      "homewood-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Homewood AL PD"
     ],
@@ -17053,10 +16171,8 @@
   {
     "agency_id": "f339d07b-886d-57a3-8d4f-e61933754c14",
     "slug": "hoover-al-pd",
-    "flock_active_slug": "hoover-al-pd",
-    "flock_slugs": [
-      "hoover-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hoover AL PD"
     ],
@@ -17080,10 +16196,8 @@
   {
     "agency_id": "23189d5d-eea8-514d-bac2-10b89657325c",
     "slug": "horn-lake-ms-pd",
-    "flock_active_slug": "horn-lake-ms-pd",
-    "flock_slugs": [
-      "horn-lake-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Horn Lake MS PD"
     ],
@@ -17107,10 +16221,8 @@
   {
     "agency_id": "fc323bdb-c0e7-514c-b4f6-e6ed06ae21b4",
     "slug": "hot-springs-ar-pd",
-    "flock_active_slug": "hot-springs-ar-pd",
-    "flock_slugs": [
-      "hot-springs-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hot Springs AR PD"
     ],
@@ -17134,10 +16246,8 @@
   {
     "agency_id": "69abe4e0-3ea2-574e-85d4-54b42317bd55",
     "slug": "houston-county-al-so",
-    "flock_active_slug": "houston-county-al-so",
-    "flock_slugs": [
-      "houston-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Houston County AL SO"
     ],
@@ -17161,10 +16271,8 @@
   {
     "agency_id": "7b2785dc-47f8-55e8-8a78-971372074581",
     "slug": "hueytown-al-pd",
-    "flock_active_slug": "hueytown-al-pd",
-    "flock_slugs": [
-      "hueytown-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hueytown AL PD"
     ],
@@ -17188,10 +16296,8 @@
   {
     "agency_id": "1058049c-16b5-5a6f-af45-17fa4b1bad77",
     "slug": "hugo-ok-pd",
-    "flock_active_slug": "hugo-ok-pd",
-    "flock_slugs": [
-      "hugo-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hugo OK PD"
     ],
@@ -17215,10 +16321,8 @@
   {
     "agency_id": "94475d00-8cb7-5358-9bbc-a6088c7e6b45",
     "slug": "humble-isd-pd-tx",
-    "flock_active_slug": "humble-isd-pd-tx",
-    "flock_slugs": [
-      "humble-isd-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Humble ISD PD TX"
     ],
@@ -17242,10 +16346,8 @@
   {
     "agency_id": "9aa748ec-4977-58a8-abca-09575e5fbf35",
     "slug": "hunt-county-tx-so",
-    "flock_active_slug": "hunt-county-tx-so",
-    "flock_slugs": [
-      "hunt-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hunt County TX SO"
     ],
@@ -17269,10 +16371,8 @@
   {
     "agency_id": "2106df16-7eb3-5485-800a-601ebbefd1dc",
     "slug": "huntingburg-in-pd",
-    "flock_active_slug": "huntingburg-in-pd",
-    "flock_slugs": [
-      "huntingburg-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntingburg IN PD"
     ],
@@ -17296,10 +16396,8 @@
   {
     "agency_id": "4249ff72-bd1e-59e2-85eb-a28c4ceb012a",
     "slug": "huntington-county-in-so",
-    "flock_active_slug": "huntington-county-in-so",
-    "flock_slugs": [
-      "huntington-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntington County IN SO"
     ],
@@ -17323,10 +16421,8 @@
   {
     "agency_id": "5a2749a0-72a0-5a5b-b8a6-0bd4b70bea5f",
     "slug": "huntsville-airport-al-pd",
-    "flock_active_slug": "huntsville-airport-al-pd",
-    "flock_slugs": [
-      "huntsville-airport-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntsville Airport AL PD"
     ],
@@ -17350,10 +16446,8 @@
   {
     "agency_id": "ddbdf164-941a-5234-bfc8-87f8d0bcb4f5",
     "slug": "huntsville-tx-pd",
-    "flock_active_slug": "huntsville-tx-pd",
-    "flock_slugs": [
-      "huntsville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntsville TX PD"
     ],
@@ -17377,10 +16471,8 @@
   {
     "agency_id": "61c453b1-b04e-5e66-af67-6d56bcc1ee90",
     "slug": "hutchinson-ks-pd",
-    "flock_active_slug": "hutchinson-ks-pd",
-    "flock_slugs": [
-      "hutchinson-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hutchinson KS PD"
     ],
@@ -17404,10 +16496,8 @@
   {
     "agency_id": "1a82283b-ffd8-5b61-9d42-f01c79c9cb01",
     "slug": "iberville-parish-la-so",
-    "flock_active_slug": "iberville-parish-la-so",
-    "flock_slugs": [
-      "iberville-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iberville Parish LA SO"
     ],
@@ -17431,10 +16521,8 @@
   {
     "agency_id": "cccc36c9-8a3e-5ff1-985b-073368fe427a",
     "slug": "idaho-state-police-id",
-    "flock_active_slug": "idaho-state-police-id",
-    "flock_slugs": [
-      "idaho-state-police-id"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Idaho State Police ID"
     ],
@@ -17455,10 +16543,8 @@
   {
     "agency_id": "5626d94a-5b00-50f0-aa13-496d342534e8",
     "slug": "independence-ky-pd",
-    "flock_active_slug": "independence-ky-pd",
-    "flock_slugs": [
-      "independence-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Independence KY PD"
     ],
@@ -17482,10 +16568,8 @@
   {
     "agency_id": "1bb0c25f-5681-51a3-92f5-6e1e2de886ff",
     "slug": "indian-hills-ky-pd",
-    "flock_active_slug": "indian-hills-ky-pd",
-    "flock_slugs": [
-      "indian-hills-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indian Hills KY PD"
     ],
@@ -17509,10 +16593,8 @@
   {
     "agency_id": "c029a3ff-38cc-5b37-abfe-f23cf70d7373",
     "slug": "indian-point-mo-pd",
-    "flock_active_slug": "indian-point-mo-pd",
-    "flock_slugs": [
-      "indian-point-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indian Point MO PD"
     ],
@@ -17536,10 +16618,8 @@
   {
     "agency_id": "ae7300bf-3f19-525d-9d85-cad6af8a837c",
     "slug": "indiana-department-of-corrections",
-    "flock_active_slug": "indiana-department-of-corrections",
-    "flock_slugs": [
-      "indiana-department-of-corrections"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indiana Department of Corrections"
     ],
@@ -17563,10 +16643,8 @@
   {
     "agency_id": "b9570ce9-d780-5abc-9137-4ee2f02fc499",
     "slug": "indianapolis-metro-pd-in",
-    "flock_active_slug": "indianapolis-metro-pd-in",
-    "flock_slugs": [
-      "indianapolis-metro-pd-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indianapolis Metro PD IN"
     ],
@@ -17590,10 +16668,8 @@
   {
     "agency_id": "94956afc-327b-5206-b647-5e63e5075f65",
     "slug": "jack-county-tx-so",
-    "flock_active_slug": "jack-county-tx-so",
-    "flock_slugs": [
-      "jack-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jack County TX SO"
     ],
@@ -17617,10 +16693,8 @@
   {
     "agency_id": "4b00a36d-cf2a-5597-a8e7-102a4f00ed04",
     "slug": "jackson-county-fl-so",
-    "flock_active_slug": "jackson-county-fl-so",
-    "flock_slugs": [
-      "jackson-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County FL SO"
     ],
@@ -17644,10 +16718,8 @@
   {
     "agency_id": "f52ec7e9-4482-5abf-85ac-2cb92cb6dab1",
     "slug": "jackson-county-ga-so",
-    "flock_active_slug": "jackson-county-ga-so",
-    "flock_slugs": [
-      "jackson-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County GA SO"
     ],
@@ -17671,10 +16743,8 @@
   {
     "agency_id": "27ad8219-dc79-5983-9ee8-9f72cf4a6a5f",
     "slug": "jackson-county-ms-so",
-    "flock_active_slug": "jackson-county-ms-so",
-    "flock_slugs": [
-      "jackson-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County MS SO"
     ],
@@ -17698,10 +16768,8 @@
   {
     "agency_id": "b82180bd-b102-5c6a-8e9b-4b24aa0c1b67",
     "slug": "jackson-county-nc-so",
-    "flock_active_slug": "jackson-county-nc-so",
-    "flock_slugs": [
-      "jackson-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County NC SO"
     ],
@@ -17725,10 +16793,8 @@
   {
     "agency_id": "9066aa13-1876-5f1d-a994-28e710b1287c",
     "slug": "jackson-mo-pd",
-    "flock_active_slug": "jackson-mo-pd",
-    "flock_slugs": [
-      "jackson-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson MO PD"
     ],
@@ -17752,10 +16818,8 @@
   {
     "agency_id": "36bccbfd-6749-54b0-93e2-e78c48e56dda",
     "slug": "jackson-ms-pd",
-    "flock_active_slug": "jackson-ms-pd",
-    "flock_slugs": [
-      "jackson-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson MS PD"
     ],
@@ -17779,10 +16843,8 @@
   {
     "agency_id": "ceaac53a-133e-5146-afc1-3b9424b5261a",
     "slug": "jackson-parish-la-so",
-    "flock_active_slug": "jackson-parish-la-so",
-    "flock_slugs": [
-      "jackson-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson Parish LA SO"
     ],
@@ -17806,10 +16868,8 @@
   {
     "agency_id": "ab8e5629-c4fb-57c0-9354-dc3d32c7a92e",
     "slug": "jackson-tn-pd",
-    "flock_active_slug": "jackson-tn-pd",
-    "flock_slugs": [
-      "jackson-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson TN PD"
     ],
@@ -17833,10 +16893,8 @@
   {
     "agency_id": "c36d0583-c7d3-5579-8ed7-31b0d73c5cf0",
     "slug": "jacksonville-ar-pd",
-    "flock_active_slug": "jacksonville-ar-pd",
-    "flock_slugs": [
-      "jacksonville-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jacksonville AR PD"
     ],
@@ -17860,10 +16918,8 @@
   {
     "agency_id": "5e7eb0c2-090f-5cd4-8c94-c5736d0a63af",
     "slug": "jasper-al-pd",
-    "flock_active_slug": "jasper-al-pd",
-    "flock_slugs": [
-      "jasper-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jasper AL PD"
     ],
@@ -17887,10 +16943,8 @@
   {
     "agency_id": "e668c431-d7e2-5cd3-b908-7aa1ff04decf",
     "slug": "jasper-ga-pd",
-    "flock_active_slug": "jasper-ga-pd",
-    "flock_slugs": [
-      "jasper-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jasper GA PD"
     ],
@@ -17914,10 +16968,8 @@
   {
     "agency_id": "b4278b5b-3d5d-5962-9ef9-cba8207b2863",
     "slug": "jasper-in-pd",
-    "flock_active_slug": "jasper-in-pd",
-    "flock_slugs": [
-      "jasper-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jasper IN PD"
     ],
@@ -17941,10 +16993,8 @@
   {
     "agency_id": "e6e1239b-bc33-5cd9-a4d8-7cafeaede26f",
     "slug": "jefferson-county-al-so",
-    "flock_active_slug": "jefferson-county-al-so",
-    "flock_slugs": [
-      "jefferson-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County AL SO"
     ],
@@ -17968,10 +17018,8 @@
   {
     "agency_id": "9828af70-29e1-5791-a419-14e94060a661",
     "slug": "jefferson-county-ar-so",
-    "flock_active_slug": "jefferson-county-ar-so",
-    "flock_slugs": [
-      "jefferson-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County AR SO"
     ],
@@ -17995,10 +17043,8 @@
   {
     "agency_id": "79068b3b-df7b-530c-8691-54686cac4bf8",
     "slug": "jefferson-county-ky-so",
-    "flock_active_slug": "jefferson-county-ky-so",
-    "flock_slugs": [
-      "jefferson-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County KY SO"
     ],
@@ -18022,10 +17068,8 @@
   {
     "agency_id": "2181bf53-9bdb-5ba0-99dc-0a3b26519872",
     "slug": "jefferson-county-so-in",
-    "flock_active_slug": "jefferson-county-so-in",
-    "flock_slugs": [
-      "jefferson-county-so-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County SO IN"
     ],
@@ -18049,10 +17093,8 @@
   {
     "agency_id": "ac36596e-02f0-5255-bca4-5f9ecf174553",
     "slug": "jefferson-county-tn-so",
-    "flock_active_slug": "jefferson-county-tn-so",
-    "flock_slugs": [
-      "jefferson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County TN SO"
     ],
@@ -18076,10 +17118,8 @@
   {
     "agency_id": "392d9acd-21d8-58a9-9072-627ef75c3389",
     "slug": "jefferson-ga-pd",
-    "flock_active_slug": "jefferson-ga-pd",
-    "flock_slugs": [
-      "jefferson-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson GA PD"
     ],
@@ -18103,10 +17143,8 @@
   {
     "agency_id": "bd639ec4-0f46-5a64-8a12-e5eb4187a9fa",
     "slug": "jefferson-tx-isd-pd",
-    "flock_active_slug": "jefferson-tx-isd-pd",
-    "flock_slugs": [
-      "jefferson-tx-isd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson TX ISD PD"
     ],
@@ -18130,10 +17168,8 @@
   {
     "agency_id": "c1f2ba28-1be3-5b7d-9461-41977548dc15",
     "slug": "jeffersontown-ky-pd",
-    "flock_active_slug": "jeffersontown-ky-pd",
-    "flock_slugs": [
-      "jeffersontown-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jeffersontown KY PD"
     ],
@@ -18157,10 +17193,8 @@
   {
     "agency_id": "9e988b25-4dd0-562c-86ef-d5728c74a9d8",
     "slug": "jeffersonville-in-pd",
-    "flock_active_slug": "jeffersonville-in-pd",
-    "flock_slugs": [
-      "jeffersonville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jeffersonville IN PD"
     ],
@@ -18184,10 +17218,8 @@
   {
     "agency_id": "ae9a8f1d-8a6c-5457-bbd0-fd0541903437",
     "slug": "jemison-al-pd",
-    "flock_active_slug": "jemison-al-pd",
-    "flock_slugs": [
-      "jemison-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jemison AL PD"
     ],
@@ -18211,10 +17243,8 @@
   {
     "agency_id": "493d6dba-1492-5c37-a92d-91940b6eccdf",
     "slug": "jersey-village-tx-pd",
-    "flock_active_slug": "jersey-village-tx-pd",
-    "flock_slugs": [
-      "jersey-village-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jersey Village TX PD"
     ],
@@ -18238,10 +17268,8 @@
   {
     "agency_id": "a400d881-0529-531e-b308-f0e330c8e95a",
     "slug": "jessamine-county-ky-so",
-    "flock_active_slug": "jessamine-county-ky-so",
-    "flock_slugs": [
-      "jessamine-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jessamine County KY SO"
     ],
@@ -18265,10 +17293,8 @@
   {
     "agency_id": "f48027dc-39d6-5f7f-9cdc-3afce349e416",
     "slug": "johns-creek-ga-pd",
-    "flock_active_slug": "johns-creek-ga-pd",
-    "flock_slugs": [
-      "johns-creek-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johns Creek GA PD"
     ],
@@ -18292,10 +17318,8 @@
   {
     "agency_id": "726e8e4f-8295-5b33-b5c2-f8f389677337",
     "slug": "johnson-county-in-so",
-    "flock_active_slug": "johnson-county-in-so",
-    "flock_slugs": [
-      "johnson-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnson County IN SO"
     ],
@@ -18319,10 +17343,8 @@
   {
     "agency_id": "1b636375-9885-5da1-9cfe-6abf93b81879",
     "slug": "johnston-city-il-pd",
-    "flock_active_slug": "johnston-city-il-pd",
-    "flock_slugs": [
-      "johnston-city-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnston City IL PD"
     ],
@@ -18346,10 +17368,8 @@
   {
     "agency_id": "08a18503-790f-5fda-9e91-8bcf1bf1c41b",
     "slug": "jonesboro-ga-pd",
-    "flock_active_slug": "jonesboro-ga-pd",
-    "flock_slugs": [
-      "jonesboro-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jonesboro GA PD"
     ],
@@ -18373,10 +17393,8 @@
   {
     "agency_id": "3fae867a-13ee-55b7-9f5d-d22f8e79be90",
     "slug": "joplin-mo-pd",
-    "flock_active_slug": "joplin-mo-pd",
-    "flock_slugs": [
-      "joplin-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Joplin MO PD"
     ],
@@ -18400,10 +17418,8 @@
   {
     "agency_id": "76ddf835-eb5b-5586-a9a7-a6369d84e81a",
     "slug": "kansas-highway-patrol",
-    "flock_active_slug": "kansas-highway-patrol",
-    "flock_slugs": [
-      "kansas-highway-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kansas Highway Patrol"
     ],
@@ -18427,10 +17443,8 @@
   {
     "agency_id": "a42ab1eb-ab72-5f03-a863-19aea93f9353",
     "slug": "kaufman-county-tx-so",
-    "flock_active_slug": "kaufman-county-tx-so",
-    "flock_slugs": [
-      "kaufman-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kaufman County TX SO"
     ],
@@ -18454,10 +17468,8 @@
   {
     "agency_id": "dae8e56b-3c49-5479-bdb9-2aef2a935b10",
     "slug": "kemper-county-ms-so",
-    "flock_active_slug": "kemper-county-ms-so",
-    "flock_slugs": [
-      "kemper-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kemper County MS SO"
     ],
@@ -18481,10 +17493,8 @@
   {
     "agency_id": "d81b5d99-010a-54b1-9628-9d28644f18ce",
     "slug": "kendall-county-tx-so",
-    "flock_active_slug": "kendall-county-tx-so",
-    "flock_slugs": [
-      "kendall-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kendall County TX SO"
     ],
@@ -18508,10 +17518,8 @@
   {
     "agency_id": "e14efb5d-214c-5e9f-a12a-62d74bc42454",
     "slug": "kenner-la-pd",
-    "flock_active_slug": "kenner-la-pd",
-    "flock_slugs": [
-      "kenner-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kenner LA PD"
     ],
@@ -18535,10 +17543,8 @@
   {
     "agency_id": "923b70a9-1645-5451-8d03-f44eccad3f14",
     "slug": "kennesaw-ga-pd",
-    "flock_active_slug": "kennesaw-ga-pd",
-    "flock_slugs": [
-      "kennesaw-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kennesaw GA PD"
     ],
@@ -18562,10 +17568,8 @@
   {
     "agency_id": "c797a3c9-8848-590f-aa2a-4c131aa377d7",
     "slug": "kennesaw-state-university-ga-pd",
-    "flock_active_slug": "kennesaw-state-university-ga-pd",
-    "flock_slugs": [
-      "kennesaw-state-university-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kennesaw State University GA PD"
     ],
@@ -18590,10 +17594,8 @@
   {
     "agency_id": "3426db40-2e14-5207-be2f-077991bb6b2f",
     "slug": "kentucky-state-ky-pd",
-    "flock_active_slug": "kentucky-state-ky-pd",
-    "flock_slugs": [
-      "kentucky-state-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kentucky State KY PD"
     ],
@@ -18617,10 +17619,8 @@
   {
     "agency_id": "0860b7e0-5f28-51b2-97e0-75887a516e6f",
     "slug": "killeen-tx-pd",
-    "flock_active_slug": "killeen-tx-pd",
-    "flock_slugs": [
-      "killeen-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Killeen TX PD"
     ],
@@ -18644,10 +17644,8 @@
   {
     "agency_id": "418d8fea-7eb3-5135-9ffd-914220a1a9b1",
     "slug": "kimberling-city-mo-pd",
-    "flock_active_slug": "kimberling-city-mo-pd",
-    "flock_slugs": [
-      "kimberling-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kimberling City MO PD"
     ],
@@ -18671,10 +17669,8 @@
   {
     "agency_id": "8e9fe152-78e8-5e1c-8e00-23f356a695dc",
     "slug": "kimmswick-mo-pd",
-    "flock_active_slug": "kimmswick-mo-pd",
-    "flock_slugs": [
-      "kimmswick-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kimmswick MO PD"
     ],
@@ -18698,10 +17694,8 @@
   {
     "agency_id": "8b9c5e7f-8229-52dd-9cb7-4adb28eeaea7",
     "slug": "kingman-county-ks-so",
-    "flock_active_slug": "kingman-county-ks-so",
-    "flock_slugs": [
-      "kingman-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kingman County KS SO"
     ],
@@ -18725,10 +17719,8 @@
   {
     "agency_id": "83a440f8-fc46-5112-827a-9c63136ae1d3",
     "slug": "kingman-ks-pd",
-    "flock_active_slug": "kingman-ks-pd",
-    "flock_slugs": [
-      "kingman-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kingman KS PD"
     ],
@@ -18752,10 +17744,8 @@
   {
     "agency_id": "ff0118d5-1608-5d2c-8299-c7fb007452d3",
     "slug": "kingston-springs-tn-pd",
-    "flock_active_slug": "kingston-springs-tn-pd",
-    "flock_slugs": [
-      "kingston-springs-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kingston Springs TN PD"
     ],
@@ -18779,10 +17769,8 @@
   {
     "agency_id": "0e6c0a4c-7649-5ba9-88dc-3ec6dda20b3a",
     "slug": "kingston-tn-pd",
-    "flock_active_slug": "kingston-tn-pd",
-    "flock_slugs": [
-      "kingston-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kingston TN PD"
     ],
@@ -18806,10 +17794,8 @@
   {
     "agency_id": "cbf53caa-89d7-5667-8a7f-96a5d22f1e71",
     "slug": "kiowa-county-ks-so",
-    "flock_active_slug": "kiowa-county-ks-so",
-    "flock_slugs": [
-      "kiowa-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kiowa County KS SO"
     ],
@@ -18833,10 +17819,8 @@
   {
     "agency_id": "7dfffc50-2ad9-5cf8-8a91-9502be1d8989",
     "slug": "kleberg-tx-county-attorneys-task-force",
-    "flock_active_slug": "kleberg-tx-county-attorneys-task-force",
-    "flock_slugs": [
-      "kleberg-tx-county-attorneys-task-force"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kleberg TX County Attorney's Task Force"
     ],
@@ -18861,10 +17845,8 @@
   {
     "agency_id": "5e4dfee4-9365-50d7-aaa8-1b5400c98754",
     "slug": "knox-county-in-so",
-    "flock_active_slug": "knox-county-in-so",
-    "flock_slugs": [
-      "knox-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Knox County IN SO"
     ],
@@ -18888,10 +17870,8 @@
   {
     "agency_id": "4af8a9d0-fc4a-5bea-bdef-e84e15d7d03e",
     "slug": "knox-county-tn-so",
-    "flock_active_slug": "knox-county-tn-so",
-    "flock_slugs": [
-      "knox-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Knox County TN SO"
     ],
@@ -18915,10 +17895,8 @@
   {
     "agency_id": "4b8a3892-6ef1-5698-ae57-fe1a72902ec2",
     "slug": "ks-city-of-st-john",
-    "flock_active_slug": "ks-city-of-st-john",
-    "flock_slugs": [
-      "ks-city-of-st-john"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KS - City of St. John"
     ],
@@ -18942,10 +17920,8 @@
   {
     "agency_id": "1d4d73c5-7cf3-572b-b3f5-93a78c7af703",
     "slug": "ks-hugoton-pd",
-    "flock_active_slug": "ks-hugoton-pd",
-    "flock_slugs": [
-      "ks-hugoton-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KS - Hugoton PD"
     ],
@@ -18969,10 +17945,8 @@
   {
     "agency_id": "9040847f-ed58-5c1e-9a9c-ec0274de3d1f",
     "slug": "ks-seward-county-so",
-    "flock_active_slug": "ks-seward-county-so",
-    "flock_slugs": [
-      "ks-seward-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KS - Seward County SO"
     ],
@@ -18996,10 +17970,8 @@
   {
     "agency_id": "2a642c83-7602-5269-9be4-550b7632c36d",
     "slug": "kyle-tx-pd",
-    "flock_active_slug": "kyle-tx-pd",
-    "flock_slugs": [
-      "kyle-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kyle TX PD"
     ],
@@ -19023,10 +17995,8 @@
   {
     "agency_id": "9f7b128f-d11c-53a1-909b-84316a71139c",
     "slug": "la-follette-tn-pd",
-    "flock_active_slug": "la-follette-tn-pd",
-    "flock_slugs": [
-      "la-follette-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Follette TN PD"
     ],
@@ -19050,10 +18020,8 @@
   {
     "agency_id": "7d31a798-e0dc-57e6-b9a4-e69d7631bc64",
     "slug": "la-marque-tx-pd",
-    "flock_active_slug": "la-marque-tx-pd",
-    "flock_slugs": [
-      "la-marque-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Marque TX PD"
     ],
@@ -19077,10 +18045,8 @@
   {
     "agency_id": "07cded63-cba1-5fbd-8ffa-3a8d153ed6bd",
     "slug": "la-morgan-city-pd",
-    "flock_active_slug": "la-morgan-city-pd",
-    "flock_slugs": [
-      "la-morgan-city-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "LA - Morgan City PD"
     ],
@@ -19104,10 +18070,8 @@
   {
     "agency_id": "0538be5b-0dac-5f8e-82f1-c695399bf2d1",
     "slug": "la-porte-tx-pd",
-    "flock_active_slug": "la-porte-tx-pd",
-    "flock_slugs": [
-      "la-porte-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Porte TX PD"
     ],
@@ -19131,10 +18095,8 @@
   {
     "agency_id": "974673d8-27e0-5d15-90ef-1387cf1a305a",
     "slug": "la-vergne-tn-pd",
-    "flock_active_slug": "la-vergne-tn-pd",
-    "flock_slugs": [
-      "la-vergne-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Vergne TN PD"
     ],
@@ -19158,10 +18120,8 @@
   {
     "agency_id": "c846c47d-4b72-51c7-95a2-c12cc403f83d",
     "slug": "lafayette-county-ms-so",
-    "flock_active_slug": "lafayette-county-ms-so",
-    "flock_slugs": [
-      "lafayette-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lafayette County MS SO"
     ],
@@ -19185,10 +18145,8 @@
   {
     "agency_id": "ab5c5b8b-859f-5304-8520-0ed8c740f2f9",
     "slug": "lafayette-la-pd",
-    "flock_active_slug": "lafayette-la-pd",
-    "flock_slugs": [
-      "lafayette-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lafayette LA PD"
     ],
@@ -19212,10 +18170,8 @@
   {
     "agency_id": "b3d436b8-f13b-5435-9525-aba7daca1664",
     "slug": "lafayette-parish-la-so",
-    "flock_active_slug": "lafayette-parish-la-so",
-    "flock_slugs": [
-      "lafayette-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lafayette Parish LA SO"
     ],
@@ -19239,10 +18195,8 @@
   {
     "agency_id": "7bbc10e4-2274-544f-a376-192d1143fc68",
     "slug": "lafayette-tn-pd",
-    "flock_active_slug": "lafayette-tn-pd",
-    "flock_slugs": [
-      "lafayette-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lafayette TN PD"
     ],
@@ -19266,10 +18220,8 @@
   {
     "agency_id": "71c32005-2bb6-598e-86f1-9eb60e89c29b",
     "slug": "lagrange-ga-pd",
-    "flock_active_slug": "lagrange-ga-pd",
-    "flock_slugs": [
-      "lagrange-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "LaGrange GA PD"
     ],
@@ -19293,10 +18245,8 @@
   {
     "agency_id": "497339ce-8e14-5717-8143-6f50e05c479a",
     "slug": "lake-city-fl-pd",
-    "flock_active_slug": "lake-city-fl-pd",
-    "flock_slugs": [
-      "lake-city-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake City FL PD"
     ],
@@ -19320,10 +18270,8 @@
   {
     "agency_id": "87b17044-4429-5a87-a467-d03e965bfa9c",
     "slug": "lake-county-oh-so",
-    "flock_active_slug": "lake-county-oh-so",
-    "flock_slugs": [
-      "lake-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake County OH SO"
     ],
@@ -19347,10 +18295,8 @@
   {
     "agency_id": "8854466e-3f69-5e62-aadb-8977dde50e18",
     "slug": "lakeside-park-crestview-hills-ky-pd",
-    "flock_active_slug": "lakeside-park-crestview-hills-ky-pd",
-    "flock_slugs": [
-      "lakeside-park-crestview-hills-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakeside Park-Crestview Hills KY PD"
     ],
@@ -19374,10 +18320,8 @@
   {
     "agency_id": "0a03fd9c-ea7b-5b57-8306-f43726209671",
     "slug": "lamar-county-ga-so",
-    "flock_active_slug": "lamar-county-ga-so",
-    "flock_slugs": [
-      "lamar-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lamar County GA SO"
     ],
@@ -19401,10 +18345,8 @@
   {
     "agency_id": "191e3ac2-94b7-542a-b2bc-f51adf6a8303",
     "slug": "lamar-county-tx-so",
-    "flock_active_slug": "lamar-county-tx-so",
-    "flock_slugs": [
-      "lamar-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lamar County TX SO"
     ],
@@ -19428,10 +18370,8 @@
   {
     "agency_id": "10d22db5-9f69-5f77-bcc6-1725c4b96318",
     "slug": "lantana-fl-pd",
-    "flock_active_slug": "lantana-fl-pd",
-    "flock_slugs": [
-      "lantana-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lantana FL PD"
     ],
@@ -19455,10 +18395,8 @@
   {
     "agency_id": "b2c8790a-01ce-51aa-8262-cc9bc3119d1d",
     "slug": "lauderdale-county-al-so",
-    "flock_active_slug": "lauderdale-county-al-so",
-    "flock_slugs": [
-      "lauderdale-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lauderdale County AL SO"
     ],
@@ -19482,10 +18420,8 @@
   {
     "agency_id": "f55a204f-abe9-50d6-9a02-3d5a848d9bba",
     "slug": "lauderdale-county-ms-so",
-    "flock_active_slug": "lauderdale-county-ms-so",
-    "flock_slugs": [
-      "lauderdale-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lauderdale County MS SO"
     ],
@@ -19509,10 +18445,8 @@
   {
     "agency_id": "fe9f90b8-8288-57aa-9d61-217b984decab",
     "slug": "lauderdale-county-tn-so",
-    "flock_active_slug": "lauderdale-county-tn-so",
-    "flock_slugs": [
-      "lauderdale-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lauderdale County TN SO"
     ],
@@ -19536,10 +18470,8 @@
   {
     "agency_id": "6cc83cb4-4cdb-53cd-8215-88939322f162",
     "slug": "lavon-tx-pd",
-    "flock_active_slug": "lavon-tx-pd",
-    "flock_slugs": [
-      "lavon-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lavon TX PD"
     ],
@@ -19563,10 +18495,8 @@
   {
     "agency_id": "9de999fe-8892-55bf-ba03-bf1a95ee2450",
     "slug": "lawrence-county-il-so",
-    "flock_active_slug": "lawrence-county-il-so",
-    "flock_slugs": [
-      "lawrence-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lawrence County IL SO"
     ],
@@ -19590,10 +18520,8 @@
   {
     "agency_id": "721bf043-d5a0-50f3-88e7-a87c1fde2433",
     "slug": "lawrence-county-in-so",
-    "flock_active_slug": "lawrence-county-in-so",
-    "flock_slugs": [
-      "lawrence-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lawrence County IN SO"
     ],
@@ -19617,10 +18545,8 @@
   {
     "agency_id": "9a955dce-ea6d-5216-a315-3215eec650e2",
     "slug": "lawrence-county-mo-so",
-    "flock_active_slug": "lawrence-county-mo-so",
-    "flock_slugs": [
-      "lawrence-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lawrence County MO SO"
     ],
@@ -19644,10 +18570,8 @@
   {
     "agency_id": "0fed0101-b80a-550c-aa7a-e057052156c1",
     "slug": "lawrence-county-tn-so",
-    "flock_active_slug": "lawrence-county-tn-so",
-    "flock_slugs": [
-      "lawrence-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lawrence County TN SO"
     ],
@@ -19671,10 +18595,8 @@
   {
     "agency_id": "13c8204f-97d3-5650-8d9d-29423ecf5061",
     "slug": "lawrenceville-ga-pd",
-    "flock_active_slug": "lawrenceville-ga-pd",
-    "flock_slugs": [
-      "lawrenceville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lawrenceville GA PD"
     ],
@@ -19698,10 +18620,8 @@
   {
     "agency_id": "af146010-f9e5-56bb-8508-578e6a7ae2fc",
     "slug": "league-city-tx-pd",
-    "flock_active_slug": "league-city-tx-pd",
-    "flock_slugs": [
-      "league-city-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "League City TX PD"
     ],
@@ -19725,10 +18645,8 @@
   {
     "agency_id": "9fcd0d71-7eeb-5dd8-9cca-85b36c805588",
     "slug": "leavenworth-ks-pd",
-    "flock_active_slug": "leavenworth-ks-pd",
-    "flock_slugs": [
-      "leavenworth-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Leavenworth KS PD"
     ],
@@ -19752,10 +18670,8 @@
   {
     "agency_id": "9b127511-a6b2-5c8a-9f2e-ad5ed7f396d4",
     "slug": "lebanon-ky-pd",
-    "flock_active_slug": "lebanon-ky-pd",
-    "flock_slugs": [
-      "lebanon-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lebanon KY PD"
     ],
@@ -19779,10 +18695,8 @@
   {
     "agency_id": "0d0c9d09-e1fe-5f74-9c7c-0fa048f5e15d",
     "slug": "lebanon-mo-pd",
-    "flock_active_slug": "lebanon-mo-pd",
-    "flock_slugs": [
-      "lebanon-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lebanon MO PD"
     ],
@@ -19806,10 +18720,8 @@
   {
     "agency_id": "72755e08-9b64-5ffe-beaf-082824f13f7f",
     "slug": "lee-county-al-so",
-    "flock_active_slug": "lee-county-al-so",
-    "flock_slugs": [
-      "lee-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lee County AL SO"
     ],
@@ -19833,10 +18745,8 @@
   {
     "agency_id": "6efb754b-c040-529f-8649-d1b3e92c0257",
     "slug": "leeds-al-pd",
-    "flock_active_slug": "leeds-al-pd",
-    "flock_slugs": [
-      "leeds-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Leeds AL PD"
     ],
@@ -19860,10 +18770,8 @@
   {
     "agency_id": "163388d9-e341-5f1a-812c-621f708b4b15",
     "slug": "leesburg-al-pd",
-    "flock_active_slug": "leesburg-al-pd",
-    "flock_slugs": [
-      "leesburg-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Leesburg AL PD"
     ],
@@ -19887,10 +18795,8 @@
   {
     "agency_id": "f75a5721-0884-569c-b5cb-07ecce6e8ece",
     "slug": "lehigh-county-pa-riic",
-    "flock_active_slug": "lehigh-county-pa-riic",
-    "flock_slugs": [
-      "lehigh-county-pa-riic"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lehigh County PA (RIIC)"
     ],
@@ -19915,10 +18821,8 @@
   {
     "agency_id": "b3ee07bb-0785-585e-ac14-c7cd9aa3a82d",
     "slug": "leitchfield-ky-pd",
-    "flock_active_slug": "leitchfield-ky-pd",
-    "flock_slugs": [
-      "leitchfield-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Leitchfield KY PD"
     ],
@@ -19942,10 +18846,8 @@
   {
     "agency_id": "ac679cfb-5304-5ed9-934e-d55bb5bdac3b",
     "slug": "lenoir-city-tn-pd",
-    "flock_active_slug": "lenoir-city-tn-pd",
-    "flock_slugs": [
-      "lenoir-city-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lenoir City TN PD"
     ],
@@ -19969,10 +18871,8 @@
   {
     "agency_id": "6368fc0a-00e7-542d-88ff-3d3f418ed8fb",
     "slug": "lewisville-tx-pd",
-    "flock_active_slug": "lewisville-tx-pd",
-    "flock_slugs": [
-      "lewisville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lewisville TX PD"
     ],
@@ -19996,10 +18896,8 @@
   {
     "agency_id": "ff628673-eef5-5601-a05d-019be967041d",
     "slug": "lexington-tn-pd",
-    "flock_active_slug": "lexington-tn-pd",
-    "flock_slugs": [
-      "lexington-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lexington TN PD"
     ],
@@ -20023,10 +18921,8 @@
   {
     "agency_id": "c5dcd32c-186d-506c-ba82-3aca418ec758",
     "slug": "licking-county-oh-so",
-    "flock_active_slug": "licking-county-oh-so",
-    "flock_slugs": [
-      "licking-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Licking County OH SO"
     ],
@@ -20050,10 +18946,8 @@
   {
     "agency_id": "244a0965-8f8d-5ffa-8e72-b8df56af25f9",
     "slug": "limestone-county-al-so",
-    "flock_active_slug": "limestone-county-al-so",
-    "flock_slugs": [
-      "limestone-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Limestone County AL SO"
     ],
@@ -20077,10 +18971,8 @@
   {
     "agency_id": "982e11f0-6a62-521e-b7f1-dfb311aaa2b0",
     "slug": "lincoln-al-pd",
-    "flock_active_slug": "lincoln-al-pd",
-    "flock_slugs": [
-      "lincoln-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincoln AL PD"
     ],
@@ -20104,10 +18996,8 @@
   {
     "agency_id": "07369313-36a3-5752-b7ef-beb297b8b291",
     "slug": "lincoln-parish-la-so",
-    "flock_active_slug": "lincoln-parish-la-so",
-    "flock_slugs": [
-      "lincoln-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincoln Parish LA SO"
     ],
@@ -20131,10 +19021,8 @@
   {
     "agency_id": "7847fc1e-7bfe-53b2-a3bb-1d93c1f0d0a1",
     "slug": "lindsborg-ks-pd",
-    "flock_active_slug": "lindsborg-ks-pd",
-    "flock_slugs": [
-      "lindsborg-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lindsborg KS PD"
     ],
@@ -20158,10 +19046,8 @@
   {
     "agency_id": "a098dfc8-cad5-5c9a-89f3-58005fd6c191",
     "slug": "little-flock-ar-pd",
-    "flock_active_slug": "little-flock-ar-pd",
-    "flock_slugs": [
-      "little-flock-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Little Flock AR PD"
     ],
@@ -20185,10 +19071,8 @@
   {
     "agency_id": "407bb03b-ce36-5faa-bc04-ad04b2bec2b4",
     "slug": "livingston-parish-county-la-so",
-    "flock_active_slug": "livingston-parish-county-la-so",
-    "flock_slugs": [
-      "livingston-parish-county-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Livingston Parish County LA SO"
     ],
@@ -20212,10 +19096,8 @@
   {
     "agency_id": "fb42c65e-4919-5f2b-a6ba-2823c418dba9",
     "slug": "llano-tx-pd",
-    "flock_active_slug": "llano-tx-pd",
-    "flock_slugs": [
-      "llano-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Llano TX PD"
     ],
@@ -20239,10 +19121,8 @@
   {
     "agency_id": "e4fa0006-d3c6-5541-9048-ffe72d334b61",
     "slug": "logan-county-ky-so",
-    "flock_active_slug": "logan-county-ky-so",
-    "flock_slugs": [
-      "logan-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Logan County KY SO"
     ],
@@ -20266,10 +19146,8 @@
   {
     "agency_id": "fea71a07-14a2-5c5d-920c-c21d11fb46d6",
     "slug": "loganville-ga-pd",
-    "flock_active_slug": "loganville-ga-pd",
-    "flock_slugs": [
-      "loganville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loganville GA PD"
     ],
@@ -20293,10 +19171,8 @@
   {
     "agency_id": "d779c841-719d-5a3f-8651-e1f7ffc54d82",
     "slug": "lonoke-county-ar-so",
-    "flock_active_slug": "lonoke-county-ar-so",
-    "flock_slugs": [
-      "lonoke-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lonoke County AR SO"
     ],
@@ -20320,10 +19196,8 @@
   {
     "agency_id": "65a6d186-444d-558d-9b0e-dc2652e1660a",
     "slug": "lookout-mountain-tn-pd",
-    "flock_active_slug": "lookout-mountain-tn-pd",
-    "flock_slugs": [
-      "lookout-mountain-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lookout Mountain TN PD"
     ],
@@ -20347,10 +19221,8 @@
   {
     "agency_id": "347b387e-6d62-5b46-8c1a-3dd5400f7a9d",
     "slug": "loris-sc-pd",
-    "flock_active_slug": "loris-sc-pd",
-    "flock_slugs": [
-      "loris-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loris SC PD"
     ],
@@ -20374,10 +19246,8 @@
   {
     "agency_id": "052f2bf8-3eef-5d0d-a38f-4e7355a0db0f",
     "slug": "loudon-county-tn-so",
-    "flock_active_slug": "loudon-county-tn-so",
-    "flock_slugs": [
-      "loudon-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loudon County TN SO"
     ],
@@ -20401,10 +19271,8 @@
   {
     "agency_id": "115991f4-9878-54b2-a869-f76794952547",
     "slug": "loudon-tn-pd",
-    "flock_active_slug": "loudon-tn-pd",
-    "flock_slugs": [
-      "loudon-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loudon TN PD"
     ],
@@ -20428,10 +19296,8 @@
   {
     "agency_id": "8383db21-74c6-5054-a618-f23bc75390ac",
     "slug": "louisville-airport-pd",
-    "flock_active_slug": "louisville-airport-pd",
-    "flock_slugs": [
-      "louisville-airport-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Louisville Airport PD"
     ],
@@ -20454,10 +19320,8 @@
   {
     "agency_id": "50e878f4-8291-5142-a155-917a6bdc4735",
     "slug": "lovejoy-ga-pd",
-    "flock_active_slug": "lovejoy-ga-pd",
-    "flock_slugs": [
-      "lovejoy-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lovejoy GA PD"
     ],
@@ -20481,10 +19345,8 @@
   {
     "agency_id": "1d55bf07-c412-5003-b971-eef23f301307",
     "slug": "lowell-ar-pd",
-    "flock_active_slug": "lowell-ar-pd",
-    "flock_slugs": [
-      "lowell-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lowell AR PD"
     ],
@@ -20508,10 +19370,8 @@
   {
     "agency_id": "d566c802-1173-5468-8196-36f07450877c",
     "slug": "lowndes-county-ga-so",
-    "flock_active_slug": "lowndes-county-ga-so",
-    "flock_slugs": [
-      "lowndes-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lowndes County GA SO"
     ],
@@ -20535,10 +19395,8 @@
   {
     "agency_id": "7bbd5bb0-d717-5308-a9e4-5234ca53e22c",
     "slug": "lucas-county-oh-so",
-    "flock_active_slug": "lucas-county-oh-so",
-    "flock_slugs": [
-      "lucas-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lucas County OH SO"
     ],
@@ -20562,10 +19420,8 @@
   {
     "agency_id": "95b86430-f962-57dc-978f-349b3b91f5b3",
     "slug": "luling-tx-pd",
-    "flock_active_slug": "luling-tx-pd",
-    "flock_slugs": [
-      "luling-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Luling TX PD"
     ],
@@ -20589,10 +19445,8 @@
   {
     "agency_id": "6c49e662-d146-5299-81d2-349882802365",
     "slug": "lumpkin-county-so-ga",
-    "flock_active_slug": "lumpkin-county-so-ga",
-    "flock_slugs": [
-      "lumpkin-county-so-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lumpkin County SO GA"
     ],
@@ -20616,10 +19470,8 @@
   {
     "agency_id": "8968669b-52b9-556c-9b9f-12f47a214036",
     "slug": "luzerne-county-pa-das-office",
-    "flock_active_slug": "luzerne-county-pa-das-office",
-    "flock_slugs": [
-      "luzerne-county-pa-das-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Luzerne County PA DA's Office"
     ],
@@ -20640,10 +19492,8 @@
   {
     "agency_id": "12866091-e95c-592b-8855-3bf2dcfad806",
     "slug": "lyon-county-ks-so",
-    "flock_active_slug": "lyon-county-ks-so",
-    "flock_slugs": [
-      "lyon-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lyon County KS SO"
     ],
@@ -20667,10 +19517,8 @@
   {
     "agency_id": "56940e81-6a4d-5ff0-beb8-c93fa741ed3c",
     "slug": "mabank-tx-pd",
-    "flock_active_slug": "mabank-tx-pd",
-    "flock_slugs": [
-      "mabank-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mabank TX PD"
     ],
@@ -20694,10 +19542,8 @@
   {
     "agency_id": "4e0b7f1d-3cf8-5d97-9581-35b82133ac67",
     "slug": "mabton-wa-pd",
-    "flock_active_slug": "mabton-wa-pd",
-    "flock_slugs": [
-      "mabton-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mabton WA PD"
     ],
@@ -20721,10 +19567,8 @@
   {
     "agency_id": "c0c6c0fb-bc83-54eb-a7a0-c0c65da7daf1",
     "slug": "macon-county-al-so",
-    "flock_active_slug": "macon-county-al-so",
-    "flock_slugs": [
-      "macon-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Macon County AL SO"
     ],
@@ -20748,10 +19592,8 @@
   {
     "agency_id": "3f1bd6e2-d825-58df-af79-3176791f2241",
     "slug": "madison-al-pd",
-    "flock_active_slug": "madison-al-pd",
-    "flock_slugs": [
-      "madison-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison AL PD"
     ],
@@ -20775,10 +19617,8 @@
   {
     "agency_id": "b55fe678-45f1-55c9-bd83-ea3e0f1fbc74",
     "slug": "madison-county-al-so",
-    "flock_active_slug": "madison-county-al-so",
-    "flock_slugs": [
-      "madison-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison County AL SO"
     ],
@@ -20802,10 +19642,8 @@
   {
     "agency_id": "6ecb3fd6-7c35-5cc6-90fd-ac50b3745e1c",
     "slug": "madison-county-in-so",
-    "flock_active_slug": "madison-county-in-so",
-    "flock_slugs": [
-      "madison-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison County IN SO"
     ],
@@ -20829,10 +19667,8 @@
   {
     "agency_id": "d58873c3-9f09-5ec7-a1ad-73c1503f9a37",
     "slug": "madison-county-ms-so",
-    "flock_active_slug": "madison-county-ms-so",
-    "flock_slugs": [
-      "madison-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison County MS SO"
     ],
@@ -20856,10 +19692,8 @@
   {
     "agency_id": "93ad11cc-cab8-5bdb-b546-b277b3f34095",
     "slug": "madison-county-tn-so",
-    "flock_active_slug": "madison-county-tn-so",
-    "flock_slugs": [
-      "madison-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison County TN SO"
     ],
@@ -20883,10 +19717,8 @@
   {
     "agency_id": "0812dc7e-7891-5265-ba3b-936bf8080308",
     "slug": "madison-ga-pd",
-    "flock_active_slug": "madison-ga-pd",
-    "flock_slugs": [
-      "madison-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison GA PD"
     ],
@@ -20910,10 +19742,8 @@
   {
     "agency_id": "e6b8d1a4-1502-573a-be15-05dae5bba454",
     "slug": "madisonville-ky-pd",
-    "flock_active_slug": "madisonville-ky-pd",
-    "flock_slugs": [
-      "madisonville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madisonville KY PD"
     ],
@@ -20937,10 +19767,8 @@
   {
     "agency_id": "b7369eed-e7b5-5a87-880e-fe6480cc6cb3",
     "slug": "madisonville-tn-pd",
-    "flock_active_slug": "madisonville-tn-pd",
-    "flock_slugs": [
-      "madisonville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madisonville TN PD"
     ],
@@ -20964,10 +19792,8 @@
   {
     "agency_id": "d16125b2-32f4-5d5c-a886-23ce095f08f1",
     "slug": "maggie-valley-nc-pd",
-    "flock_active_slug": "maggie-valley-nc-pd",
-    "flock_slugs": [
-      "maggie-valley-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maggie Valley NC PD"
     ],
@@ -20991,10 +19817,8 @@
   {
     "agency_id": "0d267db7-f757-58ed-9169-49ae19132bbf",
     "slug": "maize-ks-pd",
-    "flock_active_slug": "maize-ks-pd",
-    "flock_slugs": [
-      "maize-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maize KS PD"
     ],
@@ -21018,10 +19842,8 @@
   {
     "agency_id": "eebfdc93-0557-5964-adae-534d666af37c",
     "slug": "malvern-ar-pd",
-    "flock_active_slug": "malvern-ar-pd",
-    "flock_slugs": [
-      "malvern-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Malvern AR PD"
     ],
@@ -21045,10 +19867,8 @@
   {
     "agency_id": "12cd6fea-90b5-5a0f-95ff-96b72be9b311",
     "slug": "manchester-tn-pd",
-    "flock_active_slug": "manchester-tn-pd",
-    "flock_slugs": [
-      "manchester-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Manchester TN PD"
     ],
@@ -21072,10 +19892,8 @@
   {
     "agency_id": "7cba075d-e28d-5415-ba62-72d8d2f3ddef",
     "slug": "manila-ar-pd",
-    "flock_active_slug": "manila-ar-pd",
-    "flock_slugs": [
-      "manila-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Manila AR PD"
     ],
@@ -21099,10 +19917,8 @@
   {
     "agency_id": "b3a72518-061d-5080-a03d-b5371fa2efa6",
     "slug": "mansfield-tx-pd",
-    "flock_active_slug": "mansfield-tx-pd",
-    "flock_slugs": [
-      "mansfield-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mansfield TX PD"
     ],
@@ -21126,10 +19942,8 @@
   {
     "agency_id": "a9ee4916-8886-5dd2-bd16-f7e974e203ee",
     "slug": "manvel-tx-pd",
-    "flock_active_slug": "manvel-tx-pd",
-    "flock_slugs": [
-      "manvel-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Manvel TX PD"
     ],
@@ -21153,10 +19967,8 @@
   {
     "agency_id": "03cab81f-b705-503a-96f8-b02e27dece5f",
     "slug": "marble-falls-tx-pd",
-    "flock_active_slug": "marble-falls-tx-pd",
-    "flock_slugs": [
-      "marble-falls-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marble Falls TX PD"
     ],
@@ -21180,10 +19992,8 @@
   {
     "agency_id": "87fef266-0a40-5db0-898f-2f4667e0c41a",
     "slug": "marion-county-al-so",
-    "flock_active_slug": "marion-county-al-so",
-    "flock_slugs": [
-      "marion-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion County AL SO"
     ],
@@ -21207,10 +20017,8 @@
   {
     "agency_id": "8b8818f4-36a1-5711-ba74-dd102982d9f4",
     "slug": "marion-county-il-so",
-    "flock_active_slug": "marion-county-il-so",
-    "flock_slugs": [
-      "marion-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion County IL SO"
     ],
@@ -21234,10 +20042,8 @@
   {
     "agency_id": "252c6e30-d98a-5a5a-abd6-b4cbff8de726",
     "slug": "marion-il-pd",
-    "flock_active_slug": "marion-il-pd",
-    "flock_slugs": [
-      "marion-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion IL PD"
     ],
@@ -21261,10 +20067,8 @@
   {
     "agency_id": "cda15ffc-6dd3-56bb-8e41-53647dfd7bab",
     "slug": "marshall-ar-pd",
-    "flock_active_slug": "marshall-ar-pd",
-    "flock_slugs": [
-      "marshall-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall AR PD"
     ],
@@ -21288,10 +20092,8 @@
   {
     "agency_id": "94a0fc0c-bd6b-55bd-bda9-85a605699d1a",
     "slug": "marshall-county-al-so",
-    "flock_active_slug": "marshall-county-al-so",
-    "flock_slugs": [
-      "marshall-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall County AL SO"
     ],
@@ -21315,10 +20117,8 @@
   {
     "agency_id": "c7f1840e-4434-5615-8127-6e334b2aad31",
     "slug": "marshall-county-drug-task-force-wv",
-    "flock_active_slug": "marshall-county-drug-task-force-wv",
-    "flock_slugs": [
-      "marshall-county-drug-task-force-wv"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall County Drug Task Force WV"
     ],
@@ -21343,10 +20143,8 @@
   {
     "agency_id": "f7c668c8-7b19-523d-8f4f-78b4c546676e",
     "slug": "marshall-county-ms-so",
-    "flock_active_slug": "marshall-county-ms-so",
-    "flock_slugs": [
-      "marshall-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall County MS SO"
     ],
@@ -21370,10 +20168,8 @@
   {
     "agency_id": "db6df3db-02bc-558b-890b-30fdf7126c58",
     "slug": "marta-pd-ga",
-    "flock_active_slug": "marta-pd-ga",
-    "flock_slugs": [
-      "marta-pd-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marta PD GA"
     ],
@@ -21397,10 +20193,8 @@
   {
     "agency_id": "87ee7b2f-4cac-520e-aaac-2cd5e2bf84c6",
     "slug": "martinsville-in-pd",
-    "flock_active_slug": "martinsville-in-pd",
-    "flock_slugs": [
-      "martinsville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Martinsville IN PD"
     ],
@@ -21424,10 +20218,8 @@
   {
     "agency_id": "8e142cf9-3be5-543e-906b-718247a54ce2",
     "slug": "maryville-tn-pd",
-    "flock_active_slug": "maryville-tn-pd",
-    "flock_slugs": [
-      "maryville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maryville TN PD"
     ],
@@ -21451,10 +20243,8 @@
   {
     "agency_id": "34908d55-b5ef-53f8-aec1-2744d962a1d6",
     "slug": "mattapoisett-ma-pd",
-    "flock_active_slug": "mattapoisett-ma-pd",
-    "flock_slugs": [
-      "mattapoisett-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mattapoisett MA PD"
     ],
@@ -21478,10 +20268,8 @@
   {
     "agency_id": "bc152a8e-6bd9-56ba-8ad9-5b8cd3198003",
     "slug": "maury-county-tn-so",
-    "flock_active_slug": "maury-county-tn-so",
-    "flock_slugs": [
-      "maury-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maury County TN SO"
     ],
@@ -21505,10 +20293,8 @@
   {
     "agency_id": "e4bed166-f6af-54ec-93a9-9ce25373db20",
     "slug": "mayfield-ky-pd",
-    "flock_active_slug": "mayfield-ky-pd",
-    "flock_slugs": [
-      "mayfield-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mayfield KY PD"
     ],
@@ -21532,10 +20318,8 @@
   {
     "agency_id": "0530bca7-0e1f-5c49-936e-e847d791ba71",
     "slug": "mayflower-ar-pd",
-    "flock_active_slug": "mayflower-ar-pd",
-    "flock_slugs": [
-      "mayflower-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mayflower AR PD"
     ],
@@ -21559,10 +20343,8 @@
   {
     "agency_id": "7d85d1e2-6e8e-5be1-b034-16700155991f",
     "slug": "mccaysville-ga-pd",
-    "flock_active_slug": "mccaysville-ga-pd",
-    "flock_slugs": [
-      "mccaysville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McCaysville GA PD"
     ],
@@ -21586,10 +20368,8 @@
   {
     "agency_id": "fb941be3-a510-5be0-af47-f1d1db7bd022",
     "slug": "mccracken-county-ky-so",
-    "flock_active_slug": "mccracken-county-ky-so",
-    "flock_slugs": [
-      "mccracken-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McCracken County KY SO"
     ],
@@ -21613,10 +20393,8 @@
   {
     "agency_id": "d0d2e8fc-b090-5f61-b864-6b31c610871c",
     "slug": "mccurtain-county-ok-so",
-    "flock_active_slug": "mccurtain-county-ok-so",
-    "flock_slugs": [
-      "mccurtain-county-ok-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McCurtain County OK SO"
     ],
@@ -21640,10 +20418,8 @@
   {
     "agency_id": "7f58b10f-f786-5034-af7e-fa11f25a6f56",
     "slug": "mcdonough-ga-pd",
-    "flock_active_slug": "mcdonough-ga-pd",
-    "flock_slugs": [
-      "mcdonough-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McDonough GA PD"
     ],
@@ -21667,10 +20443,8 @@
   {
     "agency_id": "60c367bd-9ba8-5fd8-bfed-e00825e3ed12",
     "slug": "mckinney-tx-pd",
-    "flock_active_slug": "mckinney-tx-pd",
-    "flock_slugs": [
-      "mckinney-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McKinney TX PD"
     ],
@@ -21694,10 +20468,8 @@
   {
     "agency_id": "5fda15df-3466-581a-bcca-d74978543e90",
     "slug": "mcminnville-tn-pd",
-    "flock_active_slug": "mcminnville-tn-pd",
-    "flock_slugs": [
-      "mcminnville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McMinnville TN PD"
     ],
@@ -21721,10 +20493,8 @@
   {
     "agency_id": "01a893d7-f31c-5622-b72c-7da0ff168e66",
     "slug": "mcpherson-county-ks-so",
-    "flock_active_slug": "mcpherson-county-ks-so",
-    "flock_slugs": [
-      "mcpherson-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McPherson County KS SO"
     ],
@@ -21748,10 +20518,8 @@
   {
     "agency_id": "7f1084c4-8fa8-5b27-8192-271998cd18c1",
     "slug": "mcpherson-ks-pd",
-    "flock_active_slug": "mcpherson-ks-pd",
-    "flock_slugs": [
-      "mcpherson-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McPherson KS PD"
     ],
@@ -21775,10 +20543,8 @@
   {
     "agency_id": "732f172c-7129-59a8-8b89-55bea48772df",
     "slug": "meadows-place-tx-pd",
-    "flock_active_slug": "meadows-place-tx-pd",
-    "flock_slugs": [
-      "meadows-place-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Meadows Place TX PD"
     ],
@@ -21802,10 +20568,8 @@
   {
     "agency_id": "0e945f46-a15b-57a9-9b32-942d66c25f04",
     "slug": "medicine-lodge-ks-pd",
-    "flock_active_slug": "medicine-lodge-ks-pd",
-    "flock_slugs": [
-      "medicine-lodge-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Medicine Lodge KS PD"
     ],
@@ -21829,10 +20593,8 @@
   {
     "agency_id": "46f0177e-f494-5beb-a62a-242a393c96f4",
     "slug": "melbourne-fl-pd",
-    "flock_active_slug": "melbourne-fl-pd",
-    "flock_slugs": [
-      "melbourne-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Melbourne FL PD"
     ],
@@ -21856,10 +20618,8 @@
   {
     "agency_id": "be2a35be-0069-575f-93a2-dce581925536",
     "slug": "melissa-tx-pd",
-    "flock_active_slug": "melissa-tx-pd",
-    "flock_slugs": [
-      "melissa-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Melissa TX PD"
     ],
@@ -21883,10 +20643,8 @@
   {
     "agency_id": "d5100c71-2e81-53cc-9c6c-d96e89abd32d",
     "slug": "memphis-intl-airport",
-    "flock_active_slug": "memphis-intl-airport",
-    "flock_slugs": [
-      "memphis-intl-airport"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Memphis Intl Airport"
     ],
@@ -21909,10 +20667,8 @@
   {
     "agency_id": "aeaf8d78-4c84-582f-8f67-faac9c5e7e81",
     "slug": "memphis-tn-pd",
-    "flock_active_slug": "memphis-tn-pd",
-    "flock_slugs": [
-      "memphis-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Memphis TN PD"
     ],
@@ -21936,10 +20692,8 @@
   {
     "agency_id": "d63eacd6-8aa4-599a-8226-ab239ec580d8",
     "slug": "mequon-wi-pd",
-    "flock_active_slug": "mequon-wi-pd",
-    "flock_slugs": [
-      "mequon-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mequon WI PD"
     ],
@@ -21963,10 +20717,8 @@
   {
     "agency_id": "1d8cb468-cbbb-535f-a315-a79da4dd4f16",
     "slug": "methodist-health-system-pd-tx",
-    "flock_active_slug": "methodist-health-system-pd-tx",
-    "flock_slugs": [
-      "methodist-health-system-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Methodist Health System PD (TX)"
     ],
@@ -21989,10 +20741,8 @@
   {
     "agency_id": "cfd3a98c-107f-5f88-aaa0-11863e02f68b",
     "slug": "metropolis-il-pd",
-    "flock_active_slug": "metropolis-il-pd",
-    "flock_slugs": [
-      "metropolis-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Metropolis IL PD"
     ],
@@ -22016,10 +20766,8 @@
   {
     "agency_id": "04312c02-6a9a-557d-8e46-3490a8499dfb",
     "slug": "miami-dade-fl-so",
-    "flock_active_slug": "miami-dade-fl-so",
-    "flock_slugs": [
-      "miami-dade-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Miami-Dade FL SO"
     ],
@@ -22043,10 +20791,8 @@
   {
     "agency_id": "14bf0eb0-b37b-529c-b0c8-047ad09324e7",
     "slug": "miami-ok-pd",
-    "flock_active_slug": "miami-ok-pd",
-    "flock_slugs": [
-      "miami-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Miami OK PD"
     ],
@@ -22070,10 +20816,8 @@
   {
     "agency_id": "6f77e739-efa3-5885-bff6-514a5b39f0b0",
     "slug": "middleboro-ma-pd",
-    "flock_active_slug": "middleboro-ma-pd",
-    "flock_slugs": [
-      "middleboro-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middleboro MA PD"
     ],
@@ -22097,10 +20841,8 @@
   {
     "agency_id": "dc92fec4-1a25-5830-9f4e-3d240a0ee1f0",
     "slug": "middletown-ny-pd",
-    "flock_active_slug": "middletown-ny-pd",
-    "flock_slugs": [
-      "middletown-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middletown NY PD"
     ],
@@ -22124,10 +20866,8 @@
   {
     "agency_id": "e9cfcbad-60f1-5f2a-891b-4700392c36b6",
     "slug": "midland-tx-pd",
-    "flock_active_slug": "midland-tx-pd",
-    "flock_slugs": [
-      "midland-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midland TX PD"
     ],
@@ -22151,10 +20891,8 @@
   {
     "agency_id": "8f936150-dd78-5e50-8087-761c004d0ffb",
     "slug": "midwestern-state-university-tx-pd",
-    "flock_active_slug": "midwestern-state-university-tx-pd",
-    "flock_slugs": [
-      "midwestern-state-university-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midwestern State University TX PD"
     ],
@@ -22179,10 +20917,8 @@
   {
     "agency_id": "a8a4e9b4-24b4-5bdb-86cb-77e8467a8f34",
     "slug": "milan-tn-pd",
-    "flock_active_slug": "milan-tn-pd",
-    "flock_slugs": [
-      "milan-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milan TN PD"
     ],
@@ -22206,10 +20942,8 @@
   {
     "agency_id": "d929f5d6-6ade-54ed-9a9e-548678fcf19b",
     "slug": "miller-county-ar-so",
-    "flock_active_slug": "miller-county-ar-so",
-    "flock_slugs": [
-      "miller-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Miller County AR SO"
     ],
@@ -22233,10 +20967,8 @@
   {
     "agency_id": "8edabdbb-37b8-5281-bf1d-6cde2aeb4011",
     "slug": "millington-tn-pd",
-    "flock_active_slug": "millington-tn-pd",
-    "flock_slugs": [
-      "millington-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Millington TN PD"
     ],
@@ -22260,10 +20992,8 @@
   {
     "agency_id": "207ab725-571a-5fac-8701-711b6644d138",
     "slug": "milltown-in-pd",
-    "flock_active_slug": "milltown-in-pd",
-    "flock_slugs": [
-      "milltown-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milltown IN PD"
     ],
@@ -22287,10 +21017,8 @@
   {
     "agency_id": "5db6c9ba-b274-5f9c-a0ae-86a3a37a76e1",
     "slug": "mineola-tx-pd",
-    "flock_active_slug": "mineola-tx-pd",
-    "flock_slugs": [
-      "mineola-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mineola TX PD"
     ],
@@ -22314,10 +21042,8 @@
   {
     "agency_id": "28893c8b-2b9b-5d85-a0a8-6a404cdab8b0",
     "slug": "mineral-area-drug-task-force-mo",
-    "flock_active_slug": "mineral-area-drug-task-force-mo",
-    "flock_slugs": [
-      "mineral-area-drug-task-force-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mineral Area Drug Task Force MO"
     ],
@@ -22340,10 +21066,8 @@
   {
     "agency_id": "ed83d984-58ec-5332-8794-d45bb0c532f4",
     "slug": "mississippi-department-of-public-safety",
-    "flock_active_slug": "mississippi-department-of-public-safety",
-    "flock_slugs": [
-      "mississippi-department-of-public-safety"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mississippi Department of Public Safety"
     ],
@@ -22367,10 +21091,8 @@
   {
     "agency_id": "1840b4a9-c8f6-5bb7-b922-5158fe0fce0c",
     "slug": "mo-sparta-pd",
-    "flock_active_slug": "mo-sparta-pd",
-    "flock_slugs": [
-      "mo-sparta-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MO - Sparta PD"
     ],
@@ -22394,10 +21116,8 @@
   {
     "agency_id": "c5153760-10fc-5d2f-b925-00d737c66599",
     "slug": "molena-ga-pd",
-    "flock_active_slug": "molena-ga-pd",
-    "flock_slugs": [
-      "molena-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Molena GA PD"
     ],
@@ -22421,10 +21141,8 @@
   {
     "agency_id": "3a5a3793-957a-5539-859a-a14f66690f1c",
     "slug": "monett-mo-pd",
-    "flock_active_slug": "monett-mo-pd",
-    "flock_slugs": [
-      "monett-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monett MO PD"
     ],
@@ -22448,10 +21166,8 @@
   {
     "agency_id": "b16292d0-0f92-531c-a27b-844e13c5bfb3",
     "slug": "monroe-county-ga-so",
-    "flock_active_slug": "monroe-county-ga-so",
-    "flock_slugs": [
-      "monroe-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe County GA SO"
     ],
@@ -22475,10 +21191,8 @@
   {
     "agency_id": "dc953578-3cc4-52f9-b116-e820e50d2102",
     "slug": "monroe-county-ms-so",
-    "flock_active_slug": "monroe-county-ms-so",
-    "flock_slugs": [
-      "monroe-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe County MS SO"
     ],
@@ -22502,10 +21216,8 @@
   {
     "agency_id": "802d20d1-f4b3-519f-8643-e218ba35958c",
     "slug": "monroe-county-tn-so",
-    "flock_active_slug": "monroe-county-tn-so",
-    "flock_slugs": [
-      "monroe-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe County TN SO"
     ],
@@ -22529,10 +21241,8 @@
   {
     "agency_id": "1f50ee22-ca5b-5593-b72a-f7616259fd47",
     "slug": "mont-belvieu-tx-pd",
-    "flock_active_slug": "mont-belvieu-tx-pd",
-    "flock_slugs": [
-      "mont-belvieu-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mont Belvieu TX PD"
     ],
@@ -22556,10 +21266,8 @@
   {
     "agency_id": "396cdc45-e844-5143-b4ba-1a254a19cbe2",
     "slug": "monterey-tn-pd",
-    "flock_active_slug": "monterey-tn-pd",
-    "flock_slugs": [
-      "monterey-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monterey TN PD"
     ],
@@ -22583,10 +21291,8 @@
   {
     "agency_id": "235e5b20-c4c6-5978-85a4-16ac9dd6e9ef",
     "slug": "montevallo-al-pd",
-    "flock_active_slug": "montevallo-al-pd",
-    "flock_slugs": [
-      "montevallo-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montevallo AL PD"
     ],
@@ -22610,10 +21316,8 @@
   {
     "agency_id": "8332b4dd-9a7d-56cb-9fb9-bccb711087d0",
     "slug": "montezuma-ga-pd",
-    "flock_active_slug": "montezuma-ga-pd",
-    "flock_slugs": [
-      "montezuma-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montezuma GA PD"
     ],
@@ -22637,10 +21341,8 @@
   {
     "agency_id": "8322abc0-f0f0-588a-9964-ecdabeebb343",
     "slug": "montgomery-county-ks-so",
-    "flock_active_slug": "montgomery-county-ks-so",
-    "flock_slugs": [
-      "montgomery-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County KS SO"
     ],
@@ -22664,10 +21366,8 @@
   {
     "agency_id": "901712ee-12ff-5d44-815c-c650f033fc52",
     "slug": "montgomery-county-tn-so",
-    "flock_active_slug": "montgomery-county-tn-so",
-    "flock_slugs": [
-      "montgomery-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County TN SO"
     ],
@@ -22691,10 +21391,8 @@
   {
     "agency_id": "8154039b-be0c-51f7-ac57-979fa9429d85",
     "slug": "montgomery-tx-pd",
-    "flock_active_slug": "montgomery-tx-pd",
-    "flock_slugs": [
-      "montgomery-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery TX PD"
     ],
@@ -22718,10 +21416,8 @@
   {
     "agency_id": "2a8d856c-9152-560c-9276-92f8ca8f18d8",
     "slug": "moody-al-pd",
-    "flock_active_slug": "moody-al-pd",
-    "flock_slugs": [
-      "moody-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moody AL PD"
     ],
@@ -22745,10 +21441,8 @@
   {
     "agency_id": "abd17552-7dff-54fb-b226-aefcabd2ff11",
     "slug": "morehead-ky-pd",
-    "flock_active_slug": "morehead-ky-pd",
-    "flock_slugs": [
-      "morehead-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morehead KY PD"
     ],
@@ -22772,10 +21466,8 @@
   {
     "agency_id": "e48a99da-96bb-59e7-948e-6d5c0a36b554",
     "slug": "morgan-county-in-so",
-    "flock_active_slug": "morgan-county-in-so",
-    "flock_slugs": [
-      "morgan-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morgan County IN SO"
     ],
@@ -22799,10 +21491,8 @@
   {
     "agency_id": "b5112a0b-3f70-5bb8-a721-2a9bea7d4ad3",
     "slug": "morgan-county-tn-so",
-    "flock_active_slug": "morgan-county-tn-so",
-    "flock_slugs": [
-      "morgan-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morgan County TN SO"
     ],
@@ -22826,10 +21516,8 @@
   {
     "agency_id": "e78167f0-bade-59b6-aa31-cb952fe584cc",
     "slug": "morrilton-ar-pd",
-    "flock_active_slug": "morrilton-ar-pd",
-    "flock_slugs": [
-      "morrilton-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morrilton AR PD"
     ],
@@ -22853,10 +21541,8 @@
   {
     "agency_id": "68c6c5fc-33ad-5d62-a0ea-cfc9a90c2dad",
     "slug": "morristown-tn-pd",
-    "flock_active_slug": "morristown-tn-pd",
-    "flock_slugs": [
-      "morristown-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morristown TN PD"
     ],
@@ -22880,10 +21566,8 @@
   {
     "agency_id": "27f44ff6-b5c9-57df-b6f0-dc61a015ae91",
     "slug": "morrow-ga-pd",
-    "flock_active_slug": "morrow-ga-pd",
-    "flock_slugs": [
-      "morrow-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morrow GA PD"
     ],
@@ -22907,10 +21591,8 @@
   {
     "agency_id": "08042851-ed4e-589d-b62f-b7e673a74c5e",
     "slug": "moss-point-ms-pd",
-    "flock_active_slug": "moss-point-ms-pd",
-    "flock_slugs": [
-      "moss-point-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moss Point MS PD"
     ],
@@ -22934,10 +21616,8 @@
   {
     "agency_id": "004ee7d0-e5c4-5881-be86-8124ac288aa6",
     "slug": "moundridge-ks-pd",
-    "flock_active_slug": "moundridge-ks-pd",
-    "flock_slugs": [
-      "moundridge-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moundridge KS PD"
     ],
@@ -22961,10 +21641,8 @@
   {
     "agency_id": "11be3cc0-d9b2-569a-9fe3-ef457280f4cd",
     "slug": "moundville-al-pd",
-    "flock_active_slug": "moundville-al-pd",
-    "flock_slugs": [
-      "moundville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moundville AL PD"
     ],
@@ -22988,10 +21666,8 @@
   {
     "agency_id": "a8b13691-2a7e-5891-95ca-b899f03ef34c",
     "slug": "mount-holly-nc-pd",
-    "flock_active_slug": "mount-holly-nc-pd",
-    "flock_slugs": [
-      "mount-holly-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Holly NC PD"
     ],
@@ -23015,10 +21691,8 @@
   {
     "agency_id": "fc14b39f-3907-51d7-aa3f-42948e1a7ab3",
     "slug": "mount-vernon-in-pd",
-    "flock_active_slug": "mount-vernon-in-pd",
-    "flock_slugs": [
-      "mount-vernon-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Vernon IN PD"
     ],
@@ -23042,10 +21716,8 @@
   {
     "agency_id": "b93e9655-92e2-5226-8b85-c20c87366b27",
     "slug": "mount-vernon-tx-isd-pd",
-    "flock_active_slug": "mount-vernon-tx-isd-pd",
-    "flock_slugs": [
-      "mount-vernon-tx-isd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Vernon TX ISD PD"
     ],
@@ -23069,10 +21741,8 @@
   {
     "agency_id": "7f145ade-ecd8-5376-a336-fa82a4960877",
     "slug": "mountain-brook-al-pd",
-    "flock_active_slug": "mountain-brook-al-pd",
-    "flock_slugs": [
-      "mountain-brook-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain Brook AL PD"
     ],
@@ -23096,10 +21766,8 @@
   {
     "agency_id": "174cce89-e52a-5d5e-8c7c-6048a4ce8534",
     "slug": "mountain-city-tn-pd",
-    "flock_active_slug": "mountain-city-tn-pd",
-    "flock_slugs": [
-      "mountain-city-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain City TN PD"
     ],
@@ -23123,10 +21791,8 @@
   {
     "agency_id": "696f9507-adf3-50c8-9403-ab79f1b427d0",
     "slug": "mountain-home-ar-pd",
-    "flock_active_slug": "mountain-home-ar-pd",
-    "flock_slugs": [
-      "mountain-home-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain Home AR PD"
     ],
@@ -23150,10 +21816,8 @@
   {
     "agency_id": "cbeaa839-a3bc-5d1a-b2c7-264bbde53c2f",
     "slug": "ms-biloxi-pd",
-    "flock_active_slug": "ms-biloxi-pd",
-    "flock_slugs": [
-      "ms-biloxi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Biloxi PD"
     ],
@@ -23177,10 +21841,8 @@
   {
     "agency_id": "1b8d48e0-3142-572f-9d0e-691c5f5bb5c5",
     "slug": "ms-itawamba-community-college-campus-pd",
-    "flock_active_slug": "ms-itawamba-community-college-campus-pd",
-    "flock_slugs": [
-      "ms-itawamba-community-college-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Itawamba Community College Campus PD"
     ],
@@ -23205,10 +21867,8 @@
   {
     "agency_id": "f7ea91ac-14b4-509e-a193-033ab30c2aae",
     "slug": "ms-office-of-homeland-security",
-    "flock_active_slug": "ms-office-of-homeland-security",
-    "flock_slugs": [
-      "ms-office-of-homeland-security"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS Office of Homeland Security"
     ],
@@ -23229,10 +21889,8 @@
   {
     "agency_id": "219ee95d-7c0e-505d-9347-c803ddac2470",
     "slug": "ms-philadelphia-pd",
-    "flock_active_slug": "ms-philadelphia-pd",
-    "flock_slugs": [
-      "ms-philadelphia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Philadelphia PD"
     ],
@@ -23256,10 +21914,8 @@
   {
     "agency_id": "e02d4705-15c8-55c4-9697-9c0cc6e9ad70",
     "slug": "ms-raymond-pd",
-    "flock_active_slug": "ms-raymond-pd",
-    "flock_slugs": [
-      "ms-raymond-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Raymond PD"
     ],
@@ -23283,10 +21939,8 @@
   {
     "agency_id": "b0328d3f-f731-5f14-9ab7-26d33fddda6a",
     "slug": "ms-senatobia-pd",
-    "flock_active_slug": "ms-senatobia-pd",
-    "flock_slugs": [
-      "ms-senatobia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Senatobia PD"
     ],
@@ -23310,10 +21964,8 @@
   {
     "agency_id": "38ed0fc4-9b19-50f7-9b09-5dfca744112e",
     "slug": "ms-wayne-county-so",
-    "flock_active_slug": "ms-wayne-county-so",
-    "flock_slugs": [
-      "ms-wayne-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Wayne County SO"
     ],
@@ -23337,10 +21989,8 @@
   {
     "agency_id": "7773e839-ea3a-56a4-8275-32b25f1ac9f8",
     "slug": "ms-yazoo-city-pd",
-    "flock_active_slug": "ms-yazoo-city-pd",
-    "flock_slugs": [
-      "ms-yazoo-city-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Yazoo City PD"
     ],
@@ -23364,10 +22014,8 @@
   {
     "agency_id": "f91cde4b-3b5d-5e9c-9c7f-60c9478da224",
     "slug": "mt-juliet-tn-pd",
-    "flock_active_slug": "mt-juliet-tn-pd",
-    "flock_slugs": [
-      "mt-juliet-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mt. Juliet TN PD"
     ],
@@ -23391,10 +22039,8 @@
   {
     "agency_id": "832452a9-62b7-55f0-94cf-aa3d098e11e6",
     "slug": "mt-washington-ky-pd",
-    "flock_active_slug": "mt-washington-ky-pd",
-    "flock_slugs": [
-      "mt-washington-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mt. Washington KY PD"
     ],
@@ -23418,10 +22064,8 @@
   {
     "agency_id": "f39e96ce-c2fc-5c76-bf0c-a54b1f81aacd",
     "slug": "mulvane-ks-pd",
-    "flock_active_slug": "mulvane-ks-pd",
-    "flock_slugs": [
-      "mulvane-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mulvane KS PD"
     ],
@@ -23445,10 +22089,8 @@
   {
     "agency_id": "dfe6f5ae-d772-5bcb-af03-1072f83f3b31",
     "slug": "muncie-in-pd",
-    "flock_active_slug": "muncie-in-pd",
-    "flock_slugs": [
-      "muncie-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muncie IN PD"
     ],
@@ -23472,10 +22114,8 @@
   {
     "agency_id": "453b92d3-7c62-547c-afd1-ecb0cf90ad1f",
     "slug": "munford-al-pd",
-    "flock_active_slug": "munford-al-pd",
-    "flock_slugs": [
-      "munford-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Munford AL PD"
     ],
@@ -23499,10 +22139,8 @@
   {
     "agency_id": "d19f1a1f-46e7-592d-86c7-00c992ef3ae7",
     "slug": "murray-county-ga-so",
-    "flock_active_slug": "murray-county-ga-so",
-    "flock_slugs": [
-      "murray-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Murray County GA SO"
     ],
@@ -23526,10 +22164,8 @@
   {
     "agency_id": "cf496a06-1ce5-5be6-8e11-9514e967a713",
     "slug": "muscle-shoals-al-pd",
-    "flock_active_slug": "muscle-shoals-al-pd",
-    "flock_slugs": [
-      "muscle-shoals-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muscle Shoals AL PD"
     ],
@@ -23553,10 +22189,8 @@
   {
     "agency_id": "7a9eacd4-33ea-56db-9962-062495cdd503",
     "slug": "muskogee-ok-pd",
-    "flock_active_slug": "muskogee-ok-pd",
-    "flock_slugs": [
-      "muskogee-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muskogee OK PD"
     ],
@@ -23580,10 +22214,8 @@
   {
     "agency_id": "8b0f8ec0-4cc5-5aa7-b1d3-32ecc9b222f6",
     "slug": "napavine-wa-pd",
-    "flock_active_slug": "napavine-wa-pd",
-    "flock_slugs": [
-      "napavine-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Napavine WA PD"
     ],
@@ -23607,10 +22239,8 @@
   {
     "agency_id": "2828974b-3ab8-5fca-b211-6d4eb22ddee9",
     "slug": "nash-tx-pd",
-    "flock_active_slug": "nash-tx-pd",
-    "flock_slugs": [
-      "nash-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nash TX PD"
     ],
@@ -23634,10 +22264,8 @@
   {
     "agency_id": "fcdc9955-1fd9-5932-933f-bd2e6c3cb9c1",
     "slug": "natchitoches-la-pd",
-    "flock_active_slug": "natchitoches-la-pd",
-    "flock_slugs": [
-      "natchitoches-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Natchitoches LA PD"
     ],
@@ -23661,10 +22289,8 @@
   {
     "agency_id": "2d9b497c-69ef-575c-ad14-fc3b5880185b",
     "slug": "nelson-county-ky-so",
-    "flock_active_slug": "nelson-county-ky-so",
-    "flock_slugs": [
-      "nelson-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nelson County KY SO"
     ],
@@ -23688,10 +22314,8 @@
   {
     "agency_id": "66e27fcb-5bbd-5912-a155-10d7a7e20bbb",
     "slug": "neodesha-ks-pd",
-    "flock_active_slug": "neodesha-ks-pd",
-    "flock_slugs": [
-      "neodesha-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Neodesha KS PD"
     ],
@@ -23715,10 +22339,8 @@
   {
     "agency_id": "b3bd8ac1-7692-5a4c-a1cd-d6774741692b",
     "slug": "neshoba-county-ms-so",
-    "flock_active_slug": "neshoba-county-ms-so",
-    "flock_slugs": [
-      "neshoba-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Neshoba County MS SO"
     ],
@@ -23742,10 +22364,8 @@
   {
     "agency_id": "3da3e612-1b49-55fb-9b01-4df51511259a",
     "slug": "ness-county-ks-so-inactive",
-    "flock_active_slug": "ness-county-ks-so-inactive",
-    "flock_slugs": [
-      "ness-county-ks-so-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ness County KS SO [Inactive]"
     ],
@@ -23771,10 +22391,8 @@
   {
     "agency_id": "2cc10417-2158-56c5-861c-3f58a91fcc06",
     "slug": "new-madrid-county-mo-so",
-    "flock_active_slug": "new-madrid-county-mo-so",
-    "flock_slugs": [
-      "new-madrid-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Madrid County MO SO"
     ],
@@ -23798,10 +22416,8 @@
   {
     "agency_id": "69401dfa-ca16-5bf2-b1a2-45739b331da6",
     "slug": "new-orleans-la-pd",
-    "flock_active_slug": "new-orleans-la-pd",
-    "flock_slugs": [
-      "new-orleans-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Orleans LA PD"
     ],
@@ -23825,10 +22441,8 @@
   {
     "agency_id": "c5010afc-cc59-5b5a-9232-a92a6815d7ab",
     "slug": "new-york-state-police-ny",
-    "flock_active_slug": "new-york-state-police-ny",
-    "flock_slugs": [
-      "new-york-state-police-ny"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New York State Police NY"
     ],
@@ -23849,10 +22463,8 @@
   {
     "agency_id": "718fcbcf-ae26-5c94-8b57-d23258b2f96d",
     "slug": "newnan-ga-pd",
-    "flock_active_slug": "newnan-ga-pd",
-    "flock_slugs": [
-      "newnan-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newnan GA PD"
     ],
@@ -23876,10 +22488,8 @@
   {
     "agency_id": "8ad828ec-3a4d-550e-b46e-ef91fdf9f826",
     "slug": "newport-ar-pd",
-    "flock_active_slug": "newport-ar-pd",
-    "flock_slugs": [
-      "newport-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newport AR PD"
     ],
@@ -23903,10 +22513,8 @@
   {
     "agency_id": "fe9933d5-3d2c-583b-afe0-1e90c1c0e415",
     "slug": "newport-tn-pd",
-    "flock_active_slug": "newport-tn-pd",
-    "flock_slugs": [
-      "newport-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newport TN PD"
     ],
@@ -23930,10 +22538,8 @@
   {
     "agency_id": "e7f3de3d-2c63-5f4a-a870-0754f9cd3718",
     "slug": "newton-county-ga-so",
-    "flock_active_slug": "newton-county-ga-so",
-    "flock_slugs": [
-      "newton-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newton County GA SO"
     ],
@@ -23957,10 +22563,8 @@
   {
     "agency_id": "bb7a46f6-f641-553f-926a-dcd483005b43",
     "slug": "newton-ms-pd",
-    "flock_active_slug": "newton-ms-pd",
-    "flock_slugs": [
-      "newton-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newton MS PD"
     ],
@@ -23984,10 +22588,8 @@
   {
     "agency_id": "874d2001-26f5-592e-868f-24b03e840ef2",
     "slug": "niagara-falls-city-ny-pd",
-    "flock_active_slug": "niagara-falls-city-ny-pd",
-    "flock_slugs": [
-      "niagara-falls-city-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Niagara Falls City NY PD"
     ],
@@ -24011,10 +22613,8 @@
   {
     "agency_id": "f911369a-faac-5f8e-9f15-101eb0019c59",
     "slug": "niceville-fl-pd",
-    "flock_active_slug": "niceville-fl-pd",
-    "flock_slugs": [
-      "niceville-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Niceville FL PD"
     ],
@@ -24038,10 +22638,8 @@
   {
     "agency_id": "f02fdbc7-bd90-5d55-9f50-8e37c6e4896d",
     "slug": "nicholasville-ky-pd",
-    "flock_active_slug": "nicholasville-ky-pd",
-    "flock_slugs": [
-      "nicholasville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nicholasville KY PD"
     ],
@@ -24065,10 +22663,8 @@
   {
     "agency_id": "70036cd3-a641-51a9-964c-bec9948c17d9",
     "slug": "nixa-mo-pd",
-    "flock_active_slug": "nixa-mo-pd",
-    "flock_slugs": [
-      "nixa-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nixa MO PD"
     ],
@@ -24092,10 +22688,8 @@
   {
     "agency_id": "c86189d6-2de0-54fc-b710-545bea00e812",
     "slug": "noblesville-in-pd",
-    "flock_active_slug": "noblesville-in-pd",
-    "flock_slugs": [
-      "noblesville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Noblesville IN PD"
     ],
@@ -24119,10 +22713,8 @@
   {
     "agency_id": "bd2a2dae-7d32-5f8e-9dde-bf67fbf1ca81",
     "slug": "nolanville-tx-pd",
-    "flock_active_slug": "nolanville-tx-pd",
-    "flock_slugs": [
-      "nolanville-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nolanville TX PD"
     ],
@@ -24146,10 +22738,8 @@
   {
     "agency_id": "11969ecc-01d8-5e38-bf50-6d5e2d757ade",
     "slug": "norcross-ga-pd",
-    "flock_active_slug": "norcross-ga-pd",
-    "flock_slugs": [
-      "norcross-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Norcross GA PD"
     ],
@@ -24173,10 +22763,8 @@
   {
     "agency_id": "5c6e2203-8dde-5bcd-900a-e3cdef4c6454",
     "slug": "north-carolina-state-bureau-of-investigation-ncsbi",
-    "flock_active_slug": "north-carolina-state-bureau-of-investigation-ncsbi",
-    "flock_slugs": [
-      "north-carolina-state-bureau-of-investigation-ncsbi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Carolina State Bureau of Investigation (NCSBI)"
     ],
@@ -24200,10 +22788,8 @@
   {
     "agency_id": "0bac7b08-0496-5f67-b0f1-d4ddb7f55c25",
     "slug": "north-little-rock-ar-pd",
-    "flock_active_slug": "north-little-rock-ar-pd",
-    "flock_slugs": [
-      "north-little-rock-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Little Rock AR PD"
     ],
@@ -24227,10 +22813,8 @@
   {
     "agency_id": "3820d353-6b8b-5e0f-840c-363799fd1b34",
     "slug": "north-richland-hills-tx-pd",
-    "flock_active_slug": "north-richland-hills-tx-pd",
-    "flock_slugs": [
-      "north-richland-hills-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Richland Hills TX PD"
     ],
@@ -24254,10 +22838,8 @@
   {
     "agency_id": "0ee67a83-d9c3-55bd-97cc-7c4b9e78a0ae",
     "slug": "northport-al-pd",
-    "flock_active_slug": "northport-al-pd",
-    "flock_slugs": [
-      "northport-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Northport AL PD"
     ],
@@ -24281,10 +22863,8 @@
   {
     "agency_id": "ee18a416-bc7f-5307-83e7-cfc14adac657",
     "slug": "northwest-arkansas-regional-airport-ar-pd",
-    "flock_active_slug": "northwest-arkansas-regional-airport-ar-pd",
-    "flock_slugs": [
-      "northwest-arkansas-regional-airport-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Northwest Arkansas Regional Airport AR PD"
     ],
@@ -24307,10 +22887,8 @@
   {
     "agency_id": "956b5a6d-a9d8-5eed-b61f-516a6ecf291f",
     "slug": "oak-ridge-tn-pd",
-    "flock_active_slug": "oak-ridge-tn-pd",
-    "flock_slugs": [
-      "oak-ridge-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oak Ridge TN PD"
     ],
@@ -24334,10 +22912,8 @@
   {
     "agency_id": "93a2f97c-bf79-5ba7-be50-3bc3d7fe7dfd",
     "slug": "oakland-tn-pd",
-    "flock_active_slug": "oakland-tn-pd",
-    "flock_slugs": [
-      "oakland-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oakland TN PD"
     ],
@@ -24361,10 +22937,8 @@
   {
     "agency_id": "ed2fe4b4-8f24-51ad-8a4d-ba8d348726b5",
     "slug": "obion-county-tn-so",
-    "flock_active_slug": "obion-county-tn-so",
-    "flock_slugs": [
-      "obion-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Obion County TN SO"
     ],
@@ -24388,10 +22962,8 @@
   {
     "agency_id": "e2aa5042-9ce0-5946-960e-56559c5b0b3d",
     "slug": "oconee-county-ga-so",
-    "flock_active_slug": "oconee-county-ga-so",
-    "flock_slugs": [
-      "oconee-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oconee County GA SO"
     ],
@@ -24415,10 +22987,8 @@
   {
     "agency_id": "5623d2d2-fe77-5491-86aa-1fc5b80e3a8b",
     "slug": "oglethorpe-ga-pd",
-    "flock_active_slug": "oglethorpe-ga-pd",
-    "flock_slugs": [
-      "oglethorpe-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oglethorpe GA PD"
     ],
@@ -24442,10 +23012,8 @@
   {
     "agency_id": "598aca59-bd7e-5d67-80df-e93bcbdef150",
     "slug": "ok-477",
-    "flock_active_slug": "ok-477",
-    "flock_slugs": [
-      "ok-477"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "OK - 477"
     ],
@@ -24465,10 +23033,8 @@
   {
     "agency_id": "70b540c3-ca23-5f03-99ba-70633b790522",
     "slug": "ok-idabel-pd",
-    "flock_active_slug": "ok-idabel-pd",
-    "flock_slugs": [
-      "ok-idabel-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "OK - Idabel PD"
     ],
@@ -24492,10 +23058,8 @@
   {
     "agency_id": "8ae72c57-3e27-5136-9108-6a4c0452c122",
     "slug": "ok-university-of-oklahoma-health-science-center-pd",
-    "flock_active_slug": "ok-university-of-oklahoma-health-science-center-pd",
-    "flock_slugs": [
-      "ok-university-of-oklahoma-health-science-center-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "OK - University of Oklahoma Health Science Center PD"
     ],
@@ -24520,10 +23084,8 @@
   {
     "agency_id": "76eba95a-fd10-56a1-99b8-b26f02b5c57e",
     "slug": "ok-washita-county-so",
-    "flock_active_slug": "ok-washita-county-so",
-    "flock_slugs": [
-      "ok-washita-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "OK - Washita County SO"
     ],
@@ -24547,10 +23109,8 @@
   {
     "agency_id": "e315ed7a-38a7-5d85-8048-28fc54fbbe4a",
     "slug": "oklahoma-city-ok-pd",
-    "flock_active_slug": "oklahoma-city-ok-pd",
-    "flock_slugs": [
-      "oklahoma-city-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oklahoma City OK PD"
     ],
@@ -24574,10 +23134,8 @@
   {
     "agency_id": "3806ff8f-f05c-559d-847d-1d72212ca6c3",
     "slug": "olive-branch-ms-pd",
-    "flock_active_slug": "olive-branch-ms-pd",
-    "flock_slugs": [
-      "olive-branch-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Olive Branch MS PD"
     ],
@@ -24601,10 +23159,8 @@
   {
     "agency_id": "01a6a2fc-4c69-534c-811d-477e70649ab0",
     "slug": "oliver-springs-tn-pd",
-    "flock_active_slug": "oliver-springs-tn-pd",
-    "flock_slugs": [
-      "oliver-springs-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oliver Springs TN PD"
     ],
@@ -24628,10 +23184,8 @@
   {
     "agency_id": "fdffc70c-90ad-586a-8a72-909cc3ac2cd7",
     "slug": "oneonta-al-pd",
-    "flock_active_slug": "oneonta-al-pd",
-    "flock_slugs": [
-      "oneonta-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oneonta AL PD"
     ],
@@ -24655,10 +23209,8 @@
   {
     "agency_id": "6ee65d07-730c-5d9e-a3c8-549b58532ce9",
     "slug": "opelousas-la-pd",
-    "flock_active_slug": "opelousas-la-pd",
-    "flock_slugs": [
-      "opelousas-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Opelousas LA PD"
     ],
@@ -24682,10 +23234,8 @@
   {
     "agency_id": "bf9a43ef-94e7-5ca0-84b3-ca2e1d64d8a0",
     "slug": "orleans-levee-district-pd",
-    "flock_active_slug": "orleans-levee-district-pd",
-    "flock_slugs": [
-      "orleans-levee-district-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orleans Levee District PD"
     ],
@@ -24708,10 +23258,8 @@
   {
     "agency_id": "f56dc26a-2ad7-5d6b-98f8-c79ff5c1c00f",
     "slug": "osceola-ar-pd",
-    "flock_active_slug": "osceola-ar-pd",
-    "flock_slugs": [
-      "osceola-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Osceola AR PD"
     ],
@@ -24735,10 +23283,8 @@
   {
     "agency_id": "6b35f3d4-4c63-5fe3-86c7-2b823f372fee",
     "slug": "ottawa-county-ks-so",
-    "flock_active_slug": "ottawa-county-ks-so",
-    "flock_slugs": [
-      "ottawa-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ottawa County KS SO"
     ],
@@ -24762,10 +23308,8 @@
   {
     "agency_id": "e29c0237-2978-5819-ba3e-3fdf2bc3cd7d",
     "slug": "ottawa-ks-pd",
-    "flock_active_slug": "ottawa-ks-pd",
-    "flock_slugs": [
-      "ottawa-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ottawa KS PD"
     ],
@@ -24789,10 +23333,8 @@
   {
     "agency_id": "5ff85b41-14de-586d-ad80-47202e85e9b1",
     "slug": "overland-park-ks-pd",
-    "flock_active_slug": "overland-park-ks-pd",
-    "flock_slugs": [
-      "overland-park-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Overland Park KS PD"
     ],
@@ -24816,10 +23358,8 @@
   {
     "agency_id": "655a77a0-a0a6-5f67-a53a-a8b3d2c353e1",
     "slug": "owensboro-ky-pd",
-    "flock_active_slug": "owensboro-ky-pd",
-    "flock_slugs": [
-      "owensboro-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Owensboro KY PD"
     ],
@@ -24843,10 +23383,8 @@
   {
     "agency_id": "91046531-8638-5f8a-a674-3b62c36bd70a",
     "slug": "oxford-al-pd",
-    "flock_active_slug": "oxford-al-pd",
-    "flock_slugs": [
-      "oxford-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oxford AL PD"
     ],
@@ -24870,10 +23408,8 @@
   {
     "agency_id": "8809bc5c-8eba-5224-9ba6-11c4f8119c6f",
     "slug": "oxford-ga-pd",
-    "flock_active_slug": "oxford-ga-pd",
-    "flock_slugs": [
-      "oxford-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oxford GA PD"
     ],
@@ -24897,10 +23433,8 @@
   {
     "agency_id": "848b8f45-0a97-5955-9f47-2d88cb03666d",
     "slug": "ozark-ar-pd",
-    "flock_active_slug": "ozark-ar-pd",
-    "flock_slugs": [
-      "ozark-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ozark AR PD"
     ],
@@ -24924,10 +23458,8 @@
   {
     "agency_id": "5df66e45-d782-5d3a-a3b4-1e5ac4042110",
     "slug": "ozark-mo-pd",
-    "flock_active_slug": "ozark-mo-pd",
-    "flock_slugs": [
-      "ozark-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ozark MO PD"
     ],
@@ -24951,10 +23483,8 @@
   {
     "agency_id": "b6e5f1da-fdb5-5b48-95b9-18c3137f2545",
     "slug": "ozarks-drug-enforcement-team-mo",
-    "flock_active_slug": "ozarks-drug-enforcement-team-mo",
-    "flock_slugs": [
-      "ozarks-drug-enforcement-team-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ozarks Drug Enforcement Team MO"
     ],
@@ -24977,10 +23507,8 @@
   {
     "agency_id": "efd6c22f-9f33-5b59-be0d-94f167167b7b",
     "slug": "paducah-ky-pd",
-    "flock_active_slug": "paducah-ky-pd",
-    "flock_slugs": [
-      "paducah-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paducah KY PD"
     ],
@@ -25004,10 +23532,8 @@
   {
     "agency_id": "c2ad7bfe-6ca8-5f59-985f-7592d8526537",
     "slug": "palo-pinto-county-tx-so",
-    "flock_active_slug": "palo-pinto-county-tx-so",
-    "flock_slugs": [
-      "palo-pinto-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palo Pinto County TX SO"
     ],
@@ -25031,10 +23557,8 @@
   {
     "agency_id": "263a5971-51b9-5d89-98cd-7eaf01fe9787",
     "slug": "panola-county-ms-so",
-    "flock_active_slug": "panola-county-ms-so",
-    "flock_slugs": [
-      "panola-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Panola County MS SO"
     ],
@@ -25058,10 +23582,8 @@
   {
     "agency_id": "0435c684-ada1-5241-a8ec-c644694601b7",
     "slug": "paris-ky-pd",
-    "flock_active_slug": "paris-ky-pd",
-    "flock_slugs": [
-      "paris-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paris KY PD"
     ],
@@ -25085,10 +23607,8 @@
   {
     "agency_id": "4b532a2b-9c06-5403-a655-8a5c5b0c8c06",
     "slug": "paris-tn-pd",
-    "flock_active_slug": "paris-tn-pd",
-    "flock_slugs": [
-      "paris-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paris TN PD"
     ],
@@ -25112,10 +23632,8 @@
   {
     "agency_id": "0666071a-0e6a-57bb-94e4-08deb76a519d",
     "slug": "park-hills-mo-pd",
-    "flock_active_slug": "park-hills-mo-pd",
-    "flock_slugs": [
-      "park-hills-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Park Hills MO PD"
     ],
@@ -25139,10 +23657,8 @@
   {
     "agency_id": "ccca3004-28c1-5397-bfda-9b8265ca90c5",
     "slug": "parsons-ks-pd",
-    "flock_active_slug": "parsons-ks-pd",
-    "flock_slugs": [
-      "parsons-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Parsons KS PD"
     ],
@@ -25166,10 +23682,8 @@
   {
     "agency_id": "01ea9acb-821d-5403-b007-322467ac3235",
     "slug": "pascagoula-ms-pd",
-    "flock_active_slug": "pascagoula-ms-pd",
-    "flock_slugs": [
-      "pascagoula-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pascagoula MS PD"
     ],
@@ -25193,10 +23707,8 @@
   {
     "agency_id": "bcabb6b6-940c-5694-a6d6-ea2ff0ce76cd",
     "slug": "pawnee-county-ks-so",
-    "flock_active_slug": "pawnee-county-ks-so",
-    "flock_slugs": [
-      "pawnee-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pawnee County KS SO"
     ],
@@ -25220,10 +23732,8 @@
   {
     "agency_id": "cdb443a7-e51e-5f3b-ac58-094e042f907e",
     "slug": "pea-ridge-ar-pd",
-    "flock_active_slug": "pea-ridge-ar-pd",
-    "flock_slugs": [
-      "pea-ridge-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pea Ridge AR PD"
     ],
@@ -25247,10 +23757,8 @@
   {
     "agency_id": "2598ec87-f7cb-5ab4-982e-44f0ec09bce1",
     "slug": "peachtree-city-ga-pd",
-    "flock_active_slug": "peachtree-city-ga-pd",
-    "flock_slugs": [
-      "peachtree-city-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peachtree City GA PD"
     ],
@@ -25274,10 +23782,8 @@
   {
     "agency_id": "97b0b587-c9cf-59c4-b270-6bbf1496ac12",
     "slug": "peachtree-corners-ga-marshals-office",
-    "flock_active_slug": "peachtree-corners-ga-marshals-office",
-    "flock_slugs": [
-      "peachtree-corners-ga-marshals-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peachtree Corners GA Marshal's Office"
     ],
@@ -25298,10 +23804,8 @@
   {
     "agency_id": "8c6d8756-60ef-55df-b7d0-554f4f577a7f",
     "slug": "pelham-al-pd",
-    "flock_active_slug": "pelham-al-pd",
-    "flock_slugs": [
-      "pelham-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pelham AL PD"
     ],
@@ -25325,10 +23829,8 @@
   {
     "agency_id": "6ad24e17-33d4-518e-9574-3358c8409ca3",
     "slug": "pell-city-al-pd",
-    "flock_active_slug": "pell-city-al-pd",
-    "flock_slugs": [
-      "pell-city-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pell City AL PD"
     ],
@@ -25352,10 +23854,8 @@
   {
     "agency_id": "2660b703-57cb-51ab-b481-f6a215c7d1f4",
     "slug": "pembroke-nc-pd",
-    "flock_active_slug": "pembroke-nc-pd",
-    "flock_slugs": [
-      "pembroke-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pembroke NC PD"
     ],
@@ -25379,10 +23879,8 @@
   {
     "agency_id": "c250b53e-99bb-55c4-9e4a-1734c09e9ad9",
     "slug": "pembroke-pines-fl-pd",
-    "flock_active_slug": "pembroke-pines-fl-pd",
-    "flock_slugs": [
-      "pembroke-pines-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pembroke Pines FL PD"
     ],
@@ -25406,10 +23904,8 @@
   {
     "agency_id": "8767fc43-5aff-5e6a-983d-35d1af8ccca3",
     "slug": "pemiscot-county-mo-so",
-    "flock_active_slug": "pemiscot-county-mo-so",
-    "flock_slugs": [
-      "pemiscot-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pemiscot County MO SO"
     ],
@@ -25433,10 +23929,8 @@
   {
     "agency_id": "7e37436a-9302-5a9e-8b0a-19ea1b980bd7",
     "slug": "pennsylvania-state-pd",
-    "flock_active_slug": "pennsylvania-state-pd",
-    "flock_slugs": [
-      "pennsylvania-state-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pennsylvania State PD"
     ],
@@ -25460,10 +23954,8 @@
   {
     "agency_id": "788afc52-2447-543d-8af5-8a8d199ecb79",
     "slug": "pensacola-fl-pd",
-    "flock_active_slug": "pensacola-fl-pd",
-    "flock_slugs": [
-      "pensacola-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pensacola FL PD"
     ],
@@ -25487,10 +23979,8 @@
   {
     "agency_id": "03bfb0fd-19b7-5d52-985e-632cc60c6aa6",
     "slug": "petersburg-il-pd",
-    "flock_active_slug": "petersburg-il-pd",
-    "flock_slugs": [
-      "petersburg-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Petersburg IL PD"
     ],
@@ -25514,10 +24004,8 @@
   {
     "agency_id": "252f0e3d-e006-5b5d-b005-d1d936ba482a",
     "slug": "phelps-county-mo-so",
-    "flock_active_slug": "phelps-county-mo-so",
-    "flock_slugs": [
-      "phelps-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Phelps County MO SO"
     ],
@@ -25541,10 +24029,8 @@
   {
     "agency_id": "db202529-2df2-5beb-987a-7f3c4f0f635b",
     "slug": "phenix-city-al-pd",
-    "flock_active_slug": "phenix-city-al-pd",
-    "flock_slugs": [
-      "phenix-city-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Phenix City AL PD"
     ],
@@ -25568,10 +24054,8 @@
   {
     "agency_id": "11f1cbb4-0887-5372-aa3c-30eadab40d50",
     "slug": "pickens-county-ga-so",
-    "flock_active_slug": "pickens-county-ga-so",
-    "flock_slugs": [
-      "pickens-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pickens County GA SO"
     ],
@@ -25595,10 +24079,8 @@
   {
     "agency_id": "4f7efcb1-8312-56b3-9578-e33cc71ca43f",
     "slug": "pigeon-forge-tn-pd",
-    "flock_active_slug": "pigeon-forge-tn-pd",
-    "flock_slugs": [
-      "pigeon-forge-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pigeon Forge TN PD"
     ],
@@ -25622,10 +24104,8 @@
   {
     "agency_id": "c13044f5-c102-5eb0-8a54-e16857db9e8b",
     "slug": "pine-bluff-ar-pd",
-    "flock_active_slug": "pine-bluff-ar-pd",
-    "flock_slugs": [
-      "pine-bluff-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pine Bluff AR PD"
     ],
@@ -25649,10 +24129,8 @@
   {
     "agency_id": "b098f866-5805-5dfa-9ce8-9345e4597211",
     "slug": "pine-hill-al-pd",
-    "flock_active_slug": "pine-hill-al-pd",
-    "flock_slugs": [
-      "pine-hill-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pine Hill AL PD"
     ],
@@ -25676,10 +24154,8 @@
   {
     "agency_id": "d66fa12e-6160-5db7-ada8-9756c80ee1b5",
     "slug": "pinellas-county-fl-so",
-    "flock_active_slug": "pinellas-county-fl-so",
-    "flock_slugs": [
-      "pinellas-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pinellas County FL SO"
     ],
@@ -25703,10 +24179,8 @@
   {
     "agency_id": "b34bd4af-190e-5201-af26-c3a9e4e19c88",
     "slug": "piperton-tn-pd",
-    "flock_active_slug": "piperton-tn-pd",
-    "flock_slugs": [
-      "piperton-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Piperton TN PD"
     ],
@@ -25730,10 +24204,8 @@
   {
     "agency_id": "55905c45-e078-5b96-952f-62054dfa332f",
     "slug": "pitt-county-nc-so",
-    "flock_active_slug": "pitt-county-nc-so",
-    "flock_slugs": [
-      "pitt-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pitt County NC SO"
     ],
@@ -25757,10 +24229,8 @@
   {
     "agency_id": "dc0c036a-9119-51ed-8baa-44091490db62",
     "slug": "plainfield-in-pd",
-    "flock_active_slug": "plainfield-in-pd",
-    "flock_slugs": [
-      "plainfield-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plainfield IN PD"
     ],
@@ -25784,10 +24254,8 @@
   {
     "agency_id": "bc92b231-0416-54f3-ad73-e1db1ace2f71",
     "slug": "plaquemines-parish-la-so",
-    "flock_active_slug": "plaquemines-parish-la-so",
-    "flock_slugs": [
-      "plaquemines-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plaquemines Parish LA SO"
     ],
@@ -25811,10 +24279,8 @@
   {
     "agency_id": "b76a7dc8-b249-5630-8874-08d3c07e0f7f",
     "slug": "pocahontas-ar-pd",
-    "flock_active_slug": "pocahontas-ar-pd",
-    "flock_slugs": [
-      "pocahontas-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pocahontas AR PD"
     ],
@@ -25838,10 +24304,8 @@
   {
     "agency_id": "b5a8f310-2b02-5e7b-8291-f8e98503b571",
     "slug": "poinsett-county-ar-so",
-    "flock_active_slug": "poinsett-county-ar-so",
-    "flock_slugs": [
-      "poinsett-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Poinsett County AR SO"
     ],
@@ -25865,10 +24329,8 @@
   {
     "agency_id": "6506c77e-ac49-531e-996e-0335c2b8c72f",
     "slug": "ponder-tx-pd",
-    "flock_active_slug": "ponder-tx-pd",
-    "flock_slugs": [
-      "ponder-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ponder TX PD"
     ],
@@ -25892,10 +24354,8 @@
   {
     "agency_id": "a63ce69d-f2ee-5566-a629-dfb460fccbea",
     "slug": "pontotoc-ms-pd",
-    "flock_active_slug": "pontotoc-ms-pd",
-    "flock_slugs": [
-      "pontotoc-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pontotoc MS PD"
     ],
@@ -25919,10 +24379,8 @@
   {
     "agency_id": "584cf54c-c7f0-52c8-8549-cd3203ab0d09",
     "slug": "pope-county-ar-so",
-    "flock_active_slug": "pope-county-ar-so",
-    "flock_slugs": [
-      "pope-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pope County AR SO"
     ],
@@ -25946,10 +24404,8 @@
   {
     "agency_id": "2be084dc-fee8-51fe-b1f4-5acbd9d6da03",
     "slug": "port-fourchon-harbor-la-pd",
-    "flock_active_slug": "port-fourchon-harbor-la-pd",
-    "flock_slugs": [
-      "port-fourchon-harbor-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Port Fourchon Harbor LA PD"
     ],
@@ -25972,10 +24428,8 @@
   {
     "agency_id": "e64f8056-039e-5cf5-b163-cefc44718885",
     "slug": "powell-oh-pd",
-    "flock_active_slug": "powell-oh-pd",
-    "flock_slugs": [
-      "powell-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Powell OH PD"
     ],
@@ -25999,10 +24453,8 @@
   {
     "agency_id": "d92dadc5-e837-5ff0-838d-33a9c4918bda",
     "slug": "pratt-county-ks-so",
-    "flock_active_slug": "pratt-county-ks-so",
-    "flock_slugs": [
-      "pratt-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pratt County KS SO"
     ],
@@ -26026,10 +24478,8 @@
   {
     "agency_id": "f58e0fce-e510-5889-ba56-2890b892465c",
     "slug": "prattville-al-pd",
-    "flock_active_slug": "prattville-al-pd",
-    "flock_slugs": [
-      "prattville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prattville AL PD"
     ],
@@ -26053,10 +24503,8 @@
   {
     "agency_id": "c555da83-0c47-5b2b-8988-5a09bf3ef980",
     "slug": "precinct-4-tx",
-    "flock_active_slug": "precinct-4-tx",
-    "flock_slugs": [
-      "precinct-4-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Precinct 4 (TX)"
     ],
@@ -26076,10 +24524,8 @@
   {
     "agency_id": "b01b6f68-7fce-570d-bf70-9081477e2895",
     "slug": "priceville-al-pd",
-    "flock_active_slug": "priceville-al-pd",
-    "flock_slugs": [
-      "priceville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Priceville AL PD"
     ],
@@ -26103,10 +24549,8 @@
   {
     "agency_id": "b447d434-5ddc-54d5-b5ad-7bb55291dbc0",
     "slug": "pryor-creek-ok-pd",
-    "flock_active_slug": "pryor-creek-ok-pd",
-    "flock_slugs": [
-      "pryor-creek-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pryor Creek OK PD"
     ],
@@ -26130,10 +24574,8 @@
   {
     "agency_id": "667a4646-dc0f-5657-a544-14438d8e8b99",
     "slug": "pulaski-county-ar-so",
-    "flock_active_slug": "pulaski-county-ar-so",
-    "flock_slugs": [
-      "pulaski-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pulaski County AR SO"
     ],
@@ -26157,10 +24599,8 @@
   {
     "agency_id": "824d0ae3-8512-547e-b75d-744f790038e9",
     "slug": "pulaski-county-mo-so",
-    "flock_active_slug": "pulaski-county-mo-so",
-    "flock_slugs": [
-      "pulaski-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pulaski County MO SO"
     ],
@@ -26184,10 +24624,8 @@
   {
     "agency_id": "8024b075-5dcf-5213-946b-db9a132470d8",
     "slug": "pulaski-tn-pd",
-    "flock_active_slug": "pulaski-tn-pd",
-    "flock_slugs": [
-      "pulaski-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pulaski TN PD"
     ],
@@ -26211,10 +24649,8 @@
   {
     "agency_id": "39abff80-eb0d-5ddf-a039-a68c0ded833c",
     "slug": "putnam-county-in-so",
-    "flock_active_slug": "putnam-county-in-so",
-    "flock_slugs": [
-      "putnam-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Putnam County IN SO"
     ],
@@ -26238,10 +24674,8 @@
   {
     "agency_id": "4dbd0622-ec7c-546f-b018-9c55f83d579f",
     "slug": "putnam-county-tn-so",
-    "flock_active_slug": "putnam-county-tn-so",
-    "flock_slugs": [
-      "putnam-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Putnam County TN SO"
     ],
@@ -26265,10 +24699,8 @@
   {
     "agency_id": "0cab0fd4-839f-593a-8702-9dfc977f77bd",
     "slug": "quapaw-nation-ok-marshals-service",
-    "flock_active_slug": "quapaw-nation-ok-marshals-service",
-    "flock_slugs": [
-      "quapaw-nation-ok-marshals-service"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Quapaw Nation OK Marshals Service"
     ],
@@ -26289,10 +24721,8 @@
   {
     "agency_id": "3012acec-1e40-5a89-89ca-0164baf7347d",
     "slug": "queen-city-tx-pd",
-    "flock_active_slug": "queen-city-tx-pd",
-    "flock_slugs": [
-      "queen-city-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Queen City TX PD"
     ],
@@ -26316,10 +24746,8 @@
   {
     "agency_id": "0efff141-11b2-5d27-aa5d-c86bea27fd08",
     "slug": "rabun-county-ga-so",
-    "flock_active_slug": "rabun-county-ga-so",
-    "flock_slugs": [
-      "rabun-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rabun County GA SO"
     ],
@@ -26343,10 +24771,8 @@
   {
     "agency_id": "26fd89ea-3e41-577b-b6c5-f1d507050c83",
     "slug": "rainbow-city-al-pd",
-    "flock_active_slug": "rainbow-city-al-pd",
-    "flock_slugs": [
-      "rainbow-city-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rainbow City AL PD"
     ],
@@ -26370,10 +24796,8 @@
   {
     "agency_id": "976853ab-6dfd-5c69-899d-f5b79083f0c7",
     "slug": "randolph-county-ar-so",
-    "flock_active_slug": "randolph-county-ar-so",
-    "flock_slugs": [
-      "randolph-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Randolph County AR SO"
     ],
@@ -26397,10 +24821,8 @@
   {
     "agency_id": "56eae1c2-156f-5a6b-840a-3f29e30fac52",
     "slug": "rankin-county-ms-so",
-    "flock_active_slug": "rankin-county-ms-so",
-    "flock_slugs": [
-      "rankin-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rankin County MS SO"
     ],
@@ -26424,10 +24846,8 @@
   {
     "agency_id": "9fdd737e-0fef-578a-b8fa-93afb7af483e",
     "slug": "rapides-parish-la-so",
-    "flock_active_slug": "rapides-parish-la-so",
-    "flock_slugs": [
-      "rapides-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rapides Parish LA SO"
     ],
@@ -26451,10 +24871,8 @@
   {
     "agency_id": "bd8f0843-c8f8-5caf-bef8-bcc9df3256b7",
     "slug": "red-river-tx-so",
-    "flock_active_slug": "red-river-tx-so",
-    "flock_slugs": [
-      "red-river-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Red River TX SO"
     ],
@@ -26478,10 +24896,8 @@
   {
     "agency_id": "ad8027fc-d4ad-5a71-97e5-feed12c99ede",
     "slug": "redfield-ar-pd",
-    "flock_active_slug": "redfield-ar-pd",
-    "flock_slugs": [
-      "redfield-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Redfield AR PD"
     ],
@@ -26505,10 +24921,8 @@
   {
     "agency_id": "9a9496f9-a2c4-56cf-96e2-59478351d725",
     "slug": "reeds-spring-mo-pd",
-    "flock_active_slug": "reeds-spring-mo-pd",
-    "flock_slugs": [
-      "reeds-spring-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reeds Spring MO PD"
     ],
@@ -26532,10 +24946,8 @@
   {
     "agency_id": "8716e502-e668-506c-a375-089463c3fa76",
     "slug": "reeves-co-tx-so",
-    "flock_active_slug": "reeves-co-tx-so",
-    "flock_slugs": [
-      "reeves-co-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reeves CO TX SO"
     ],
@@ -26559,10 +24971,8 @@
   {
     "agency_id": "fbc35468-2384-5644-a0d8-7971e2c6be97",
     "slug": "reno-county-ks-so",
-    "flock_active_slug": "reno-county-ks-so",
-    "flock_slugs": [
-      "reno-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reno County KS SO"
     ],
@@ -26586,10 +24996,8 @@
   {
     "agency_id": "c32430de-513d-5dfd-b132-800d5b8a1738",
     "slug": "reynolds-ga-pd",
-    "flock_active_slug": "reynolds-ga-pd",
-    "flock_slugs": [
-      "reynolds-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reynolds GA PD"
     ],
@@ -26613,10 +25021,8 @@
   {
     "agency_id": "0bc27463-a46c-5bab-b860-cebb03058dce",
     "slug": "rhea-county-tn-so",
-    "flock_active_slug": "rhea-county-tn-so",
-    "flock_slugs": [
-      "rhea-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rhea County TN SO"
     ],
@@ -26640,10 +25046,8 @@
   {
     "agency_id": "cf7f6485-6c56-514c-a879-cc041140b3ad",
     "slug": "rice-county-ks-so",
-    "flock_active_slug": "rice-county-ks-so",
-    "flock_slugs": [
-      "rice-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rice County KS SO"
     ],
@@ -26664,10 +25068,8 @@
   {
     "agency_id": "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
     "slug": "richland-wa-pd",
-    "flock_active_slug": "richland-wa-pd",
-    "flock_slugs": [
-      "richland-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richland WA PD"
     ],
@@ -26691,10 +25093,8 @@
   {
     "agency_id": "faeaae90-2988-5568-bd81-6eff3b9c11e7",
     "slug": "richmond-ky-pd",
-    "flock_active_slug": "richmond-ky-pd",
-    "flock_slugs": [
-      "richmond-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richmond KY PD"
     ],
@@ -26718,10 +25118,8 @@
   {
     "agency_id": "76ff64dc-3ffc-5b1b-afb8-8ab99589a9e8",
     "slug": "ripley-tn-pd",
-    "flock_active_slug": "ripley-tn-pd",
-    "flock_slugs": [
-      "ripley-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ripley TN PD"
     ],
@@ -26745,10 +25143,8 @@
   {
     "agency_id": "3debef57-9838-5f01-8aa4-481dbbf378bb",
     "slug": "riverdale-ga-pd",
-    "flock_active_slug": "riverdale-ga-pd",
-    "flock_slugs": [
-      "riverdale-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Riverdale GA PD"
     ],
@@ -26772,10 +25168,8 @@
   {
     "agency_id": "7a2edff6-6846-5712-8695-706b86f91a21",
     "slug": "robertson-county-tn-so",
-    "flock_active_slug": "robertson-county-tn-so",
-    "flock_slugs": [
-      "robertson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Robertson County TN SO"
     ],
@@ -26799,10 +25193,8 @@
   {
     "agency_id": "37c91724-274c-5eb3-b6fa-006149cea3b5",
     "slug": "robeson-county-nc-so",
-    "flock_active_slug": "robeson-county-nc-so",
-    "flock_slugs": [
-      "robeson-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Robeson County NC SO"
     ],
@@ -26826,10 +25218,8 @@
   {
     "agency_id": "2adc765c-1ed2-5792-8664-46b91fa70aa4",
     "slug": "robinson-il-pd",
-    "flock_active_slug": "robinson-il-pd",
-    "flock_slugs": [
-      "robinson-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Robinson IL PD"
     ],
@@ -26853,10 +25243,8 @@
   {
     "agency_id": "7033f342-1a25-57e8-b5d3-491fa63ea0c5",
     "slug": "rockdale-county-ga-so",
-    "flock_active_slug": "rockdale-county-ga-so",
-    "flock_slugs": [
-      "rockdale-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockdale County GA SO"
     ],
@@ -26880,10 +25268,8 @@
   {
     "agency_id": "7db70117-eec3-5c8d-8877-5cf9ab190dc1",
     "slug": "rockingham-nc-pd",
-    "flock_active_slug": "rockingham-nc-pd",
-    "flock_slugs": [
-      "rockingham-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockingham NC PD"
     ],
@@ -26907,10 +25293,8 @@
   {
     "agency_id": "a110e7e7-083f-564e-9a58-3f9b6d378882",
     "slug": "rockport-in-pd",
-    "flock_active_slug": "rockport-in-pd",
-    "flock_slugs": [
-      "rockport-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockport IN PD"
     ],
@@ -26934,10 +25318,8 @@
   {
     "agency_id": "438d48d1-5b0a-569c-a730-c204458d6132",
     "slug": "rockwall-tx-pd",
-    "flock_active_slug": "rockwall-tx-pd",
-    "flock_slugs": [
-      "rockwall-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockwall TX PD"
     ],
@@ -26961,10 +25343,8 @@
   {
     "agency_id": "abe6b689-124b-5833-8d54-e1e84f7206c3",
     "slug": "rockwood-tn-pd",
-    "flock_active_slug": "rockwood-tn-pd",
-    "flock_slugs": [
-      "rockwood-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockwood TN PD"
     ],
@@ -26988,10 +25368,8 @@
   {
     "agency_id": "452b4e78-2e73-5b84-bd6c-2adbeec67c8c",
     "slug": "rogers-ar-pd",
-    "flock_active_slug": "rogers-ar-pd",
-    "flock_slugs": [
-      "rogers-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rogers AR PD"
     ],
@@ -27015,10 +25393,8 @@
   {
     "agency_id": "adef355b-7574-5b49-9b9c-2f1dab1854fa",
     "slug": "rogers-county-ok-so",
-    "flock_active_slug": "rogers-county-ok-so",
-    "flock_slugs": [
-      "rogers-county-ok-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rogers County OK SO"
     ],
@@ -27042,10 +25418,8 @@
   {
     "agency_id": "2e10f538-3599-505e-a46a-5e6c88c51f66",
     "slug": "rome-ga-pd",
-    "flock_active_slug": "rome-ga-pd",
-    "flock_slugs": [
-      "rome-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rome GA PD"
     ],
@@ -27069,10 +25443,8 @@
   {
     "agency_id": "9ed4c651-7990-5386-9a36-cd90c7aa329e",
     "slug": "rose-hill-ks-pd",
-    "flock_active_slug": "rose-hill-ks-pd",
-    "flock_slugs": [
-      "rose-hill-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rose Hill KS PD"
     ],
@@ -27096,10 +25468,8 @@
   {
     "agency_id": "d2086e22-c382-5fc5-96ac-173e64e0946d",
     "slug": "royse-city-tx-pd",
-    "flock_active_slug": "royse-city-tx-pd",
-    "flock_slugs": [
-      "royse-city-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Royse City TX PD"
     ],
@@ -27123,10 +25493,8 @@
   {
     "agency_id": "f7de83ec-fc60-5762-8058-728874d3118b",
     "slug": "rush-county-in-so",
-    "flock_active_slug": "rush-county-in-so",
-    "flock_slugs": [
-      "rush-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rush County IN SO"
     ],
@@ -27150,10 +25518,8 @@
   {
     "agency_id": "f87441ac-7979-507e-95e8-49200753fec7",
     "slug": "rusk-co-tx-so",
-    "flock_active_slug": "rusk-co-tx-so",
-    "flock_slugs": [
-      "rusk-co-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rusk CO TX SO"
     ],
@@ -27177,10 +25543,8 @@
   {
     "agency_id": "dc9f487a-e4ef-54cb-aa98-402c66a516c0",
     "slug": "russell-county-al-so",
-    "flock_active_slug": "russell-county-al-so",
-    "flock_slugs": [
-      "russell-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Russell County AL SO"
     ],
@@ -27204,10 +25568,8 @@
   {
     "agency_id": "b9d73cdd-2119-553f-8abd-4d3aa5daa776",
     "slug": "russellville-al-pd",
-    "flock_active_slug": "russellville-al-pd",
-    "flock_slugs": [
-      "russellville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Russellville AL PD"
     ],
@@ -27231,10 +25593,8 @@
   {
     "agency_id": "e0ddd213-c4f1-54a3-9e7f-02c92779804d",
     "slug": "russellville-ar-pd",
-    "flock_active_slug": "russellville-ar-pd",
-    "flock_slugs": [
-      "russellville-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Russellville AR PD"
     ],
@@ -27258,10 +25618,8 @@
   {
     "agency_id": "2a89cbba-440e-5df5-9442-c769f584df5d",
     "slug": "russellville-ky-pd",
-    "flock_active_slug": "russellville-ky-pd",
-    "flock_slugs": [
-      "russellville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Russellville KY PD"
     ],
@@ -27285,10 +25643,8 @@
   {
     "agency_id": "b944c216-4f6f-5cad-8a8e-e27e05e3c6d7",
     "slug": "rutherford-county-tn-so",
-    "flock_active_slug": "rutherford-county-tn-so",
-    "flock_slugs": [
-      "rutherford-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rutherford County TN SO"
     ],
@@ -27312,10 +25668,8 @@
   {
     "agency_id": "f0abb6cf-cacf-58e6-8fbe-a4862b2c7e39",
     "slug": "sachse-tx-pd",
-    "flock_active_slug": "sachse-tx-pd",
-    "flock_slugs": [
-      "sachse-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sachse TX PD"
     ],
@@ -27339,10 +25693,8 @@
   {
     "agency_id": "388ae393-79ea-549e-8c9e-a7af18f58822",
     "slug": "salado-tx-pd-inactive",
-    "flock_active_slug": "salado-tx-pd-inactive",
-    "flock_slugs": [
-      "salado-tx-pd-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salado TX PD Inactive"
     ],
@@ -27366,10 +25718,8 @@
   {
     "agency_id": "386055cd-a59b-56a3-9abb-33b7261e3e2b",
     "slug": "salem-il-pd",
-    "flock_active_slug": "salem-il-pd",
-    "flock_slugs": [
-      "salem-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salem IL PD"
     ],
@@ -27393,10 +25743,8 @@
   {
     "agency_id": "7b55247f-a573-5e71-8508-b8d9a342f64b",
     "slug": "saline-county-ar-so",
-    "flock_active_slug": "saline-county-ar-so",
-    "flock_slugs": [
-      "saline-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saline County AR SO"
     ],
@@ -27420,10 +25768,8 @@
   {
     "agency_id": "91ee9d7b-c13f-5aab-9972-c70bb19aa5eb",
     "slug": "saline-county-il-so",
-    "flock_active_slug": "saline-county-il-so",
-    "flock_slugs": [
-      "saline-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saline County IL SO"
     ],
@@ -27447,10 +25793,8 @@
   {
     "agency_id": "9aac4b7a-dc00-5032-91ef-cce788e4f02e",
     "slug": "sandy-springs-ga-pd",
-    "flock_active_slug": "sandy-springs-ga-pd",
-    "flock_slugs": [
-      "sandy-springs-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sandy Springs GA PD"
     ],
@@ -27474,10 +25818,8 @@
   {
     "agency_id": "d747dc2e-30df-5e95-80bf-3d1c87b59c0c",
     "slug": "santa-claus-in-pd",
-    "flock_active_slug": "santa-claus-in-pd",
-    "flock_slugs": [
-      "santa-claus-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Claus IN PD"
     ],
@@ -27501,10 +25843,8 @@
   {
     "agency_id": "18cca6cf-6a0b-5bca-a185-da749c93bb3b",
     "slug": "sarcoxie-mo-pd",
-    "flock_active_slug": "sarcoxie-mo-pd",
-    "flock_slugs": [
-      "sarcoxie-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sarcoxie MO PD"
     ],
@@ -27528,10 +25868,8 @@
   {
     "agency_id": "c7335eaf-bc00-59fa-bfff-e5992d32041d",
     "slug": "sardis-city-al-pd",
-    "flock_active_slug": "sardis-city-al-pd",
-    "flock_slugs": [
-      "sardis-city-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sardis City AL PD"
     ],
@@ -27555,10 +25893,8 @@
   {
     "agency_id": "7db0d434-12c1-5257-9d88-19cf04f2c8e9",
     "slug": "savannah-tn-pd",
-    "flock_active_slug": "savannah-tn-pd",
-    "flock_slugs": [
-      "savannah-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Savannah TN PD"
     ],
@@ -27582,10 +25918,8 @@
   {
     "agency_id": "716e6cd6-2f4b-556a-a73a-0d5e469465f9",
     "slug": "scott-city-mo-pd",
-    "flock_active_slug": "scott-city-mo-pd",
-    "flock_slugs": [
-      "scott-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scott City MO PD"
     ],
@@ -27609,10 +25943,8 @@
   {
     "agency_id": "a0cd36da-a34a-5b1d-96ea-e0ef8be91ebf",
     "slug": "scott-county-mo-so",
-    "flock_active_slug": "scott-county-mo-so",
-    "flock_slugs": [
-      "scott-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scott County MO SO"
     ],
@@ -27636,10 +25968,8 @@
   {
     "agency_id": "7a303d08-e9b7-50df-814e-03b7a7539d8a",
     "slug": "scottsboro-al-pd",
-    "flock_active_slug": "scottsboro-al-pd",
-    "flock_slugs": [
-      "scottsboro-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scottsboro AL PD"
     ],
@@ -27663,10 +25993,8 @@
   {
     "agency_id": "5354d049-4e7e-5afe-86c4-84c5ee94a3ee",
     "slug": "scottsville-ky-pd",
-    "flock_active_slug": "scottsville-ky-pd",
-    "flock_slugs": [
-      "scottsville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scottsville KY PD"
     ],
@@ -27690,10 +26018,8 @@
   {
     "agency_id": "83c7730d-83e4-537d-b2b0-f194289935b5",
     "slug": "seabrook-tx-pd",
-    "flock_active_slug": "seabrook-tx-pd",
-    "flock_slugs": [
-      "seabrook-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seabrook TX PD"
     ],
@@ -27717,10 +26043,8 @@
   {
     "agency_id": "09e782d9-7b55-5e5c-8f0c-e885c0fca646",
     "slug": "searcy-ar-pd",
-    "flock_active_slug": "searcy-ar-pd",
-    "flock_slugs": [
-      "searcy-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Searcy AR PD"
     ],
@@ -27744,10 +26068,8 @@
   {
     "agency_id": "e714b834-a444-5310-b637-f50715b85d67",
     "slug": "searcy-county-ar-so",
-    "flock_active_slug": "searcy-county-ar-so",
-    "flock_slugs": [
-      "searcy-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Searcy County AR SO"
     ],
@@ -27771,10 +26093,8 @@
   {
     "agency_id": "72fee97f-dfdb-5d33-8456-1788edf77f1f",
     "slug": "seatac-wa-pd",
-    "flock_active_slug": "seatac-wa-pd",
-    "flock_slugs": [
-      "seatac-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "SeaTac WA PD"
     ],
@@ -27798,10 +26118,8 @@
   {
     "agency_id": "805a72aa-cbb3-54e4-b146-78280bbdd40a",
     "slug": "sedgwick-county-ks-so",
-    "flock_active_slug": "sedgwick-county-ks-so",
-    "flock_slugs": [
-      "sedgwick-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sedgwick County KS SO"
     ],
@@ -27825,10 +26143,8 @@
   {
     "agency_id": "33d26eeb-df4e-5d73-9e6c-2986bd4bb645",
     "slug": "seguin-tx-pd",
-    "flock_active_slug": "seguin-tx-pd",
-    "flock_slugs": [
-      "seguin-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seguin TX PD"
     ],
@@ -27852,10 +26168,8 @@
   {
     "agency_id": "3f3fcf83-6358-562a-9dbd-3287d005f1c5",
     "slug": "selma-nc-pd",
-    "flock_active_slug": "selma-nc-pd",
-    "flock_slugs": [
-      "selma-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Selma NC PD"
     ],
@@ -27879,10 +26193,8 @@
   {
     "agency_id": "d67be948-7cba-5083-9f2c-1ac82810f687",
     "slug": "seminole-county-fl-so",
-    "flock_active_slug": "seminole-county-fl-so",
-    "flock_slugs": [
-      "seminole-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seminole County FL SO"
     ],
@@ -27906,10 +26218,8 @@
   {
     "agency_id": "1aa44a1e-bfc7-509f-87f9-a6bb0a951727",
     "slug": "seminole-county-ga-so",
-    "flock_active_slug": "seminole-county-ga-so",
-    "flock_slugs": [
-      "seminole-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seminole County GA SO"
     ],
@@ -27933,10 +26243,8 @@
   {
     "agency_id": "23e43879-4b61-5c96-8abd-488f90536244",
     "slug": "semo-drug-task-force-mo",
-    "flock_active_slug": "semo-drug-task-force-mo",
-    "flock_slugs": [
-      "semo-drug-task-force-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "SEMO Drug Task Force MO"
     ],
@@ -27959,10 +26267,8 @@
   {
     "agency_id": "bb7482a8-7d18-5d5d-887f-fe49c63a5b60",
     "slug": "seneca-mo-pd",
-    "flock_active_slug": "seneca-mo-pd",
-    "flock_slugs": [
-      "seneca-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seneca MO PD"
     ],
@@ -27986,10 +26292,8 @@
   {
     "agency_id": "11407708-9ce6-5500-abe6-ea29e677b522",
     "slug": "sevier-county-tn-so",
-    "flock_active_slug": "sevier-county-tn-so",
-    "flock_slugs": [
-      "sevier-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sevier County TN SO"
     ],
@@ -28013,10 +26317,8 @@
   {
     "agency_id": "d882a5ff-b9c2-5ce1-8400-dd4039dae6ed",
     "slug": "sevierville-tn-pd",
-    "flock_active_slug": "sevierville-tn-pd",
-    "flock_slugs": [
-      "sevierville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sevierville TN PD"
     ],
@@ -28040,10 +26342,8 @@
   {
     "agency_id": "8dbdcfae-75ac-529e-8edc-abc9f9944edb",
     "slug": "shelby-county-al-so",
-    "flock_active_slug": "shelby-county-al-so",
-    "flock_slugs": [
-      "shelby-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelby County AL SO"
     ],
@@ -28067,10 +26367,8 @@
   {
     "agency_id": "aa222d21-c729-5605-a32b-915420e41b7c",
     "slug": "shelbyville-in-pd",
-    "flock_active_slug": "shelbyville-in-pd",
-    "flock_slugs": [
-      "shelbyville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelbyville IN PD"
     ],
@@ -28094,10 +26392,8 @@
   {
     "agency_id": "8617ec57-d41d-523e-ae61-2719e70f1872",
     "slug": "shelbyville-ky-pd",
-    "flock_active_slug": "shelbyville-ky-pd",
-    "flock_slugs": [
-      "shelbyville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelbyville KY PD"
     ],
@@ -28121,10 +26417,8 @@
   {
     "agency_id": "f59bbd7c-b6e8-574c-9d7b-d6883b9d4519",
     "slug": "shepherdsville-ky-pd",
-    "flock_active_slug": "shepherdsville-ky-pd",
-    "flock_slugs": [
-      "shepherdsville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shepherdsville KY PD"
     ],
@@ -28148,10 +26442,8 @@
   {
     "agency_id": "a11a9116-861d-5fc8-99a4-a476845b7d50",
     "slug": "sheridan-ar-pd",
-    "flock_active_slug": "sheridan-ar-pd",
-    "flock_slugs": [
-      "sheridan-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sheridan AR PD"
     ],
@@ -28175,10 +26467,8 @@
   {
     "agency_id": "642ac53a-4acd-552c-8f15-3cf661b91e84",
     "slug": "sherwood-ar-pd",
-    "flock_active_slug": "sherwood-ar-pd",
-    "flock_slugs": [
-      "sherwood-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sherwood AR PD"
     ],
@@ -28202,10 +26492,8 @@
   {
     "agency_id": "98685e3c-767e-5ae7-b6b8-2efd33f9bad4",
     "slug": "shiloh-il-pd",
-    "flock_active_slug": "shiloh-il-pd",
-    "flock_slugs": [
-      "shiloh-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shiloh IL PD"
     ],
@@ -28229,10 +26517,8 @@
   {
     "agency_id": "b44e662f-68b3-5af0-80ae-a2e93db92400",
     "slug": "show-low-az-pd",
-    "flock_active_slug": "show-low-az-pd",
-    "flock_slugs": [
-      "show-low-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Show Low AZ PD"
     ],
@@ -28256,10 +26542,8 @@
   {
     "agency_id": "c2afa772-a5e2-53a2-8929-0558a861d85a",
     "slug": "shreveport-la-pd",
-    "flock_active_slug": "shreveport-la-pd",
-    "flock_slugs": [
-      "shreveport-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shreveport LA PD"
     ],
@@ -28283,10 +26567,8 @@
   {
     "agency_id": "fb6f656b-ee54-5854-8433-b4fbc4da2939",
     "slug": "sikeston-mo-dps",
-    "flock_active_slug": "sikeston-mo-dps",
-    "flock_slugs": [
-      "sikeston-mo-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sikeston MO DPS"
     ],
@@ -28310,10 +26592,8 @@
   {
     "agency_id": "8530fa63-f796-5030-946a-9e0a19e309d1",
     "slug": "simpsonville-sc-pd",
-    "flock_active_slug": "simpsonville-sc-pd",
-    "flock_slugs": [
-      "simpsonville-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Simpsonville SC PD"
     ],
@@ -28337,10 +26617,8 @@
   {
     "agency_id": "e41f96b7-98d5-5f58-ae0a-9792b613a284",
     "slug": "smith-county-tx-so",
-    "flock_active_slug": "smith-county-tx-so",
-    "flock_slugs": [
-      "smith-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Smith County TX SO"
     ],
@@ -28364,10 +26642,8 @@
   {
     "agency_id": "d61f35ce-aa31-5d1b-a172-58f1b15a064b",
     "slug": "smyrna-tn-pd",
-    "flock_active_slug": "smyrna-tn-pd",
-    "flock_slugs": [
-      "smyrna-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Smyrna TN PD"
     ],
@@ -28391,10 +26667,8 @@
   {
     "agency_id": "36a8b3e2-16dd-5394-8d41-e2c312c21e6d",
     "slug": "snellville-ga-pd",
-    "flock_active_slug": "snellville-ga-pd",
-    "flock_slugs": [
-      "snellville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Snellville GA PD"
     ],
@@ -28418,10 +26692,8 @@
   {
     "agency_id": "029812b1-3af3-5baf-bcec-7c7bacbda20d",
     "slug": "somerset-ma-pd",
-    "flock_active_slug": "somerset-ma-pd",
-    "flock_slugs": [
-      "somerset-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Somerset MA PD"
     ],
@@ -28445,10 +26717,8 @@
   {
     "agency_id": "82e7bcd3-4ed3-5ac2-b9d9-ee7e2807dad4",
     "slug": "sour-lake-tx-pd",
-    "flock_active_slug": "sour-lake-tx-pd",
-    "flock_slugs": [
-      "sour-lake-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sour Lake TX PD"
     ],
@@ -28472,10 +26742,8 @@
   {
     "agency_id": "15a953dc-dc7b-53c0-80c5-0ee5eba74221",
     "slug": "south-carolina-law-enforcement-division-sled",
-    "flock_active_slug": "south-carolina-law-enforcement-division-sled",
-    "flock_slugs": [
-      "south-carolina-law-enforcement-division-sled"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Carolina Law Enforcement Division - SLED"
     ],
@@ -28499,10 +26767,8 @@
   {
     "agency_id": "13052a9b-73e7-54ac-8289-6818f7a23de0",
     "slug": "south-central-mo-drug-task-force",
-    "flock_active_slug": "south-central-mo-drug-task-force",
-    "flock_slugs": [
-      "south-central-mo-drug-task-force"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Central MO Drug Task Force"
     ],
@@ -28525,10 +26791,8 @@
   {
     "agency_id": "e89617a4-37f0-5169-be5c-cdbd019f1301",
     "slug": "south-hutchinson-ks-pd",
-    "flock_active_slug": "south-hutchinson-ks-pd",
-    "flock_slugs": [
-      "south-hutchinson-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Hutchinson KS PD"
     ],
@@ -28552,10 +26816,8 @@
   {
     "agency_id": "c5e61532-9002-5e62-8754-f08b8a70e231",
     "slug": "southaven-ms-pd",
-    "flock_active_slug": "southaven-ms-pd",
-    "flock_slugs": [
-      "southaven-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southaven MS PD"
     ],
@@ -28579,10 +26841,8 @@
   {
     "agency_id": "f739ac49-8707-575f-9af4-1d8876d1dd39",
     "slug": "southern-illinois-university-il-pd",
-    "flock_active_slug": "southern-illinois-university-il-pd",
-    "flock_slugs": [
-      "southern-illinois-university-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southern Illinois University IL PD"
     ],
@@ -28607,10 +26867,8 @@
   {
     "agency_id": "07ccfe8f-7915-59fd-b090-280305bdee32",
     "slug": "southern-regl-pa-pd",
-    "flock_active_slug": "southern-regl-pa-pd",
-    "flock_slugs": [
-      "southern-regl-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southern Regl PA PD"
     ],
@@ -28633,10 +26891,8 @@
   {
     "agency_id": "1eaf0b65-aba6-52ab-b4ea-2aadf18ebf96",
     "slug": "southmayd-tx-pd",
-    "flock_active_slug": "southmayd-tx-pd",
-    "flock_slugs": [
-      "southmayd-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southmayd TX PD"
     ],
@@ -28660,10 +26916,8 @@
   {
     "agency_id": "e5236842-d9cd-59de-8fef-8f2a5e50f962",
     "slug": "southside-al-pd",
-    "flock_active_slug": "southside-al-pd",
-    "flock_slugs": [
-      "southside-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southside AL PD"
     ],
@@ -28687,10 +26941,8 @@
   {
     "agency_id": "84e22f0a-0c84-5c33-865c-268d24687835",
     "slug": "sparta-tn-pd",
-    "flock_active_slug": "sparta-tn-pd",
-    "flock_slugs": [
-      "sparta-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sparta TN PD"
     ],
@@ -28714,10 +26966,8 @@
   {
     "agency_id": "f10798c8-6663-5157-a2f7-f8c8d82549b1",
     "slug": "speedway-in-pd",
-    "flock_active_slug": "speedway-in-pd",
-    "flock_slugs": [
-      "speedway-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Speedway IN PD"
     ],
@@ -28741,10 +26991,8 @@
   {
     "agency_id": "4b90cc6d-d3dd-571c-b451-d2454ebe99af",
     "slug": "spencer-county-in-so",
-    "flock_active_slug": "spencer-county-in-so",
-    "flock_slugs": [
-      "spencer-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spencer County IN SO"
     ],
@@ -28768,10 +27016,8 @@
   {
     "agency_id": "8754557e-abb8-5da0-bc29-36ff4229dbf1",
     "slug": "spotsylvania-county-va-so",
-    "flock_active_slug": "spotsylvania-county-va-so",
-    "flock_slugs": [
-      "spotsylvania-county-va-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spotsylvania County VA SO"
     ],
@@ -28795,10 +27041,8 @@
   {
     "agency_id": "3fe57273-79b0-5534-b0ec-95e3a0cacfec",
     "slug": "spring-city-tn-pd",
-    "flock_active_slug": "spring-city-tn-pd",
-    "flock_slugs": [
-      "spring-city-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spring City TN PD"
     ],
@@ -28822,10 +27066,8 @@
   {
     "agency_id": "d6d665c7-fa0f-5ee9-b90f-f73a6a418c61",
     "slug": "spring-hill-tn-pd",
-    "flock_active_slug": "spring-hill-tn-pd",
-    "flock_slugs": [
-      "spring-hill-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spring Hill TN PD"
     ],
@@ -28849,10 +27091,8 @@
   {
     "agency_id": "2896f8b4-e931-501b-8db1-8921eacffd28",
     "slug": "springdale-ar-pd",
-    "flock_active_slug": "springdale-ar-pd",
-    "flock_slugs": [
-      "springdale-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springdale AR PD"
     ],
@@ -28876,10 +27116,8 @@
   {
     "agency_id": "03052eda-fa71-5f64-9ba6-577bb9ab6f41",
     "slug": "springdale-oh-pd",
-    "flock_active_slug": "springdale-oh-pd",
-    "flock_slugs": [
-      "springdale-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springdale OH PD"
     ],
@@ -28903,10 +27141,8 @@
   {
     "agency_id": "13e8cfbe-64d0-54c1-837c-82ea571400ad",
     "slug": "springfield-fl-pd",
-    "flock_active_slug": "springfield-fl-pd",
-    "flock_slugs": [
-      "springfield-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springfield FL PD"
     ],
@@ -28930,10 +27166,8 @@
   {
     "agency_id": "2da4471d-cb8b-5631-8ab8-fb3fffcc0bad",
     "slug": "springfield-tn-pd",
-    "flock_active_slug": "springfield-tn-pd",
-    "flock_slugs": [
-      "springfield-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springfield TN PD"
     ],
@@ -28957,10 +27191,8 @@
   {
     "agency_id": "a08dbcd1-bd11-5e04-a93c-7920193a4a70",
     "slug": "st-bernard-parish-la-so",
-    "flock_active_slug": "st-bernard-parish-la-so",
-    "flock_slugs": [
-      "st-bernard-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Bernard Parish LA SO"
     ],
@@ -28984,10 +27216,8 @@
   {
     "agency_id": "22edbd98-543d-51d0-a485-5efded7017ac",
     "slug": "st-charles-parish-la-so",
-    "flock_active_slug": "st-charles-parish-la-so",
-    "flock_slugs": [
-      "st-charles-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Charles Parish LA SO"
     ],
@@ -29011,10 +27241,8 @@
   {
     "agency_id": "b71829bb-3257-5e88-8989-d8cb49e7b29e",
     "slug": "st-clair-county-al-so",
-    "flock_active_slug": "st-clair-county-al-so",
-    "flock_slugs": [
-      "st-clair-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Clair County AL SO"
     ],
@@ -29038,10 +27266,8 @@
   {
     "agency_id": "c06c3778-01bd-53b9-ade1-4e032ebe7162",
     "slug": "st-james-parish-la-so",
-    "flock_active_slug": "st-james-parish-la-so",
-    "flock_slugs": [
-      "st-james-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. James Parish LA SO"
     ],
@@ -29065,10 +27291,8 @@
   {
     "agency_id": "447d3fff-1d7e-58ed-8254-2dc784fc0275",
     "slug": "st-landry-parish-so-la",
-    "flock_active_slug": "st-landry-parish-so-la",
-    "flock_slugs": [
-      "st-landry-parish-so-la"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Landry Parish SO LA"
     ],
@@ -29092,10 +27316,8 @@
   {
     "agency_id": "b7522c15-8a74-59d4-994a-651d9e4bb16e",
     "slug": "st-martin-parish-la-so",
-    "flock_active_slug": "st-martin-parish-la-so",
-    "flock_slugs": [
-      "st-martin-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Martin Parish LA SO"
     ],
@@ -29119,10 +27341,8 @@
   {
     "agency_id": "ee1d5301-612f-5901-a764-d4517ba1a70b",
     "slug": "st-mary-parish-la-so",
-    "flock_active_slug": "st-mary-parish-la-so",
-    "flock_slugs": [
-      "st-mary-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St Mary Parish LA SO"
     ],
@@ -29146,10 +27366,8 @@
   {
     "agency_id": "14c207aa-8d55-5b21-a124-28a53385fd83",
     "slug": "st-matthews-ky-pd",
-    "flock_active_slug": "st-matthews-ky-pd",
-    "flock_slugs": [
-      "st-matthews-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Matthews KY PD"
     ],
@@ -29173,10 +27391,8 @@
   {
     "agency_id": "b0df3341-cb56-5be8-bb26-1d9300b0a445",
     "slug": "stafford-county-ks-so",
-    "flock_active_slug": "stafford-county-ks-so",
-    "flock_slugs": [
-      "stafford-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stafford County KS SO"
     ],
@@ -29200,10 +27416,8 @@
   {
     "agency_id": "09a17f73-6993-52a1-ad4a-b91f7051fea1",
     "slug": "stamping-ground-ky-pd",
-    "flock_active_slug": "stamping-ground-ky-pd",
-    "flock_slugs": [
-      "stamping-ground-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stamping Ground KY PD"
     ],
@@ -29227,10 +27441,8 @@
   {
     "agency_id": "2697aeb8-70a4-5a0e-b0ff-6289475e1c89",
     "slug": "stanton-county-ks-so",
-    "flock_active_slug": "stanton-county-ks-so",
-    "flock_slugs": [
-      "stanton-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stanton County KS SO"
     ],
@@ -29254,10 +27466,8 @@
   {
     "agency_id": "37330114-0b02-5b61-a889-2fc214849095",
     "slug": "stanwood-wa-pd",
-    "flock_active_slug": "stanwood-wa-pd",
-    "flock_slugs": [
-      "stanwood-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stanwood WA PD"
     ],
@@ -29281,10 +27491,8 @@
   {
     "agency_id": "8770c445-7ec4-51bc-b079-21799d8328fb",
     "slug": "ste-genevieve-county-mo-so",
-    "flock_active_slug": "ste-genevieve-county-mo-so",
-    "flock_slugs": [
-      "ste-genevieve-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ste. Genevieve County MO SO"
     ],
@@ -29308,10 +27516,8 @@
   {
     "agency_id": "c4490e49-532a-5098-b935-963ed72f3e94",
     "slug": "steele-al-pd",
-    "flock_active_slug": "steele-al-pd",
-    "flock_slugs": [
-      "steele-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Steele AL PD"
     ],
@@ -29335,10 +27541,8 @@
   {
     "agency_id": "0f3e84fb-0013-5f72-99ee-f6b4d603a5e3",
     "slug": "stockbridge-ga-pd",
-    "flock_active_slug": "stockbridge-ga-pd",
-    "flock_slugs": [
-      "stockbridge-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stockbridge GA PD"
     ],
@@ -29362,10 +27566,8 @@
   {
     "agency_id": "10aebb58-3b65-5a98-a73a-899418290d99",
     "slug": "stoddard-county-mo-so",
-    "flock_active_slug": "stoddard-county-mo-so",
-    "flock_slugs": [
-      "stoddard-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stoddard County MO SO"
     ],
@@ -29389,10 +27591,8 @@
   {
     "agency_id": "c2fad52f-2efd-5176-a242-369f6b9d6c55",
     "slug": "stone-county-ms-so",
-    "flock_active_slug": "stone-county-ms-so",
-    "flock_slugs": [
-      "stone-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stone County MS SO"
     ],
@@ -29416,10 +27616,8 @@
   {
     "agency_id": "2081b786-00c4-591d-b925-697f13a61555",
     "slug": "struthers-oh-pd",
-    "flock_active_slug": "struthers-oh-pd",
-    "flock_slugs": [
-      "struthers-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Struthers OH PD"
     ],
@@ -29443,10 +27641,8 @@
   {
     "agency_id": "ec85bfd3-708c-5e67-90c0-1b97471bb285",
     "slug": "sugar-land-tx-pd",
-    "flock_active_slug": "sugar-land-tx-pd",
-    "flock_slugs": [
-      "sugar-land-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sugar Land TX PD"
     ],
@@ -29470,10 +27666,8 @@
   {
     "agency_id": "7ef27947-8315-5c86-9b16-b439721e9beb",
     "slug": "sullivan-county-in-so",
-    "flock_active_slug": "sullivan-county-in-so",
-    "flock_slugs": [
-      "sullivan-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sullivan County IN SO"
     ],
@@ -29497,10 +27691,8 @@
   {
     "agency_id": "fb4b3185-3276-54d8-87d4-afd666ff7754",
     "slug": "sulphur-springs-tx-pd",
-    "flock_active_slug": "sulphur-springs-tx-pd",
-    "flock_slugs": [
-      "sulphur-springs-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sulphur Springs TX PD"
     ],
@@ -29524,10 +27716,8 @@
   {
     "agency_id": "107b3502-08ff-567e-a920-bcbe024c1744",
     "slug": "summit-county-sheriffs-office-co",
-    "flock_active_slug": "summit-county-sheriffs-office-co",
-    "flock_slugs": [
-      "summit-county-sheriffs-office-co"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Summit County Sheriff's Office (CO)"
     ],
@@ -29548,10 +27738,8 @@
   {
     "agency_id": "da381621-4666-5bce-a2e7-819f76626815",
     "slug": "sumner-county-ks-so",
-    "flock_active_slug": "sumner-county-ks-so",
-    "flock_slugs": [
-      "sumner-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sumner County KS SO"
     ],
@@ -29575,10 +27763,8 @@
   {
     "agency_id": "5040c0a6-d555-58b5-b1a7-55dd41bf3545",
     "slug": "sumter-county-ga-so",
-    "flock_active_slug": "sumter-county-ga-so",
-    "flock_slugs": [
-      "sumter-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sumter County GA SO"
     ],
@@ -29602,10 +27788,8 @@
   {
     "agency_id": "fd90e658-d07f-57d2-a893-28bd2cbaa607",
     "slug": "suwanee-ga-pd",
-    "flock_active_slug": "suwanee-ga-pd",
-    "flock_slugs": [
-      "suwanee-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Suwanee GA PD"
     ],
@@ -29629,10 +27813,8 @@
   {
     "agency_id": "83b5db01-b5ce-5b18-94a4-f5d8c875e5d1",
     "slug": "swainsboro-ga-pd",
-    "flock_active_slug": "swainsboro-ga-pd",
-    "flock_slugs": [
-      "swainsboro-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Swainsboro GA PD"
     ],
@@ -29656,10 +27838,8 @@
   {
     "agency_id": "877a3737-0a7b-588b-a1ab-09901c0ad645",
     "slug": "tahlequah-ok-pd",
-    "flock_active_slug": "tahlequah-ok-pd",
-    "flock_slugs": [
-      "tahlequah-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tahlequah OK PD"
     ],
@@ -29683,10 +27863,8 @@
   {
     "agency_id": "c8292ee5-a094-5f13-9bb7-e117318a72c1",
     "slug": "talladega-county-al-so",
-    "flock_active_slug": "talladega-county-al-so",
-    "flock_slugs": [
-      "talladega-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Talladega County AL SO"
     ],
@@ -29710,10 +27888,8 @@
   {
     "agency_id": "10f517e9-6b9e-5e10-a3fb-4086f5682ee8",
     "slug": "tallahassee-fl-pd",
-    "flock_active_slug": "tallahassee-fl-pd",
-    "flock_slugs": [
-      "tallahassee-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tallahassee FL PD"
     ],
@@ -29737,10 +27913,8 @@
   {
     "agency_id": "cdc90b68-ea2e-55b2-aec3-81b68daf0f78",
     "slug": "tallapoosa-ga-pd",
-    "flock_active_slug": "tallapoosa-ga-pd",
-    "flock_slugs": [
-      "tallapoosa-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tallapoosa GA PD"
     ],
@@ -29764,10 +27938,8 @@
   {
     "agency_id": "3e41a1f8-ef95-5680-b7b4-cb1df450d33a",
     "slug": "tangipahoa-parish-la-so",
-    "flock_active_slug": "tangipahoa-parish-la-so",
-    "flock_slugs": [
-      "tangipahoa-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tangipahoa Parish LA SO"
     ],
@@ -29791,10 +27963,8 @@
   {
     "agency_id": "59d15b48-5a79-553d-bbea-68c8fc91e7ed",
     "slug": "tarrant-county-tx-so",
-    "flock_active_slug": "tarrant-county-tx-so",
-    "flock_slugs": [
-      "tarrant-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tarrant County TX SO"
     ],
@@ -29818,10 +27988,8 @@
   {
     "agency_id": "bee385ab-4061-50f1-89f3-9a3a3c4b2f5e",
     "slug": "taylor-county-ga-so",
-    "flock_active_slug": "taylor-county-ga-so",
-    "flock_slugs": [
-      "taylor-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Taylor County GA SO"
     ],
@@ -29845,10 +28013,8 @@
   {
     "agency_id": "993684b2-bc90-5c98-b865-36c234481930",
     "slug": "temple-ga-pd",
-    "flock_active_slug": "temple-ga-pd",
-    "flock_slugs": [
-      "temple-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Temple GA PD"
     ],
@@ -29872,10 +28038,8 @@
   {
     "agency_id": "dcd753b6-4a28-51c9-bcbf-651efd28860a",
     "slug": "tennessee-bureau-of-investigation",
-    "flock_active_slug": "tennessee-bureau-of-investigation",
-    "flock_slugs": [
-      "tennessee-bureau-of-investigation"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tennessee Bureau of Investigation"
     ],
@@ -29899,10 +28063,8 @@
   {
     "agency_id": "54a1aae2-6311-576d-b8aa-5933b0ec2e92",
     "slug": "terrebonne-parish-la-so",
-    "flock_active_slug": "terrebonne-parish-la-so",
-    "flock_slugs": [
-      "terrebonne-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Terrebonne Parish LA SO"
     ],
@@ -29926,10 +28088,8 @@
   {
     "agency_id": "ceaf1be9-b379-580f-a304-ae5a00eb28e2",
     "slug": "texarkana-ar-pd",
-    "flock_active_slug": "texarkana-ar-pd",
-    "flock_slugs": [
-      "texarkana-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Texarkana AR PD"
     ],
@@ -29953,10 +28113,8 @@
   {
     "agency_id": "f98ebbd1-431a-5582-8a56-ea0a64b68352",
     "slug": "texarkana-tx-pd",
-    "flock_active_slug": "texarkana-tx-pd",
-    "flock_slugs": [
-      "texarkana-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Texarkana TX PD"
     ],
@@ -29980,10 +28138,8 @@
   {
     "agency_id": "6e91f8bd-a571-56a6-a2eb-4882bb8e664b",
     "slug": "thibodaux-la-pd",
-    "flock_active_slug": "thibodaux-la-pd",
-    "flock_slugs": [
-      "thibodaux-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thibodaux LA PD"
     ],
@@ -30007,10 +28163,8 @@
   {
     "agency_id": "5945d042-f986-583d-b382-bf932bb5a4c0",
     "slug": "thomas-county-ks-so",
-    "flock_active_slug": "thomas-county-ks-so",
-    "flock_slugs": [
-      "thomas-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thomas County KS SO"
     ],
@@ -30034,10 +28188,8 @@
   {
     "agency_id": "ce179be7-fd78-5fd3-b518-ee3a04645a5d",
     "slug": "thomaston-ga-pd",
-    "flock_active_slug": "thomaston-ga-pd",
-    "flock_slugs": [
-      "thomaston-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thomaston GA PD"
     ],
@@ -30061,10 +28213,8 @@
   {
     "agency_id": "e390a6c1-54cf-5479-9033-14fd8116dfef",
     "slug": "thomasville-al-pd",
-    "flock_active_slug": "thomasville-al-pd",
-    "flock_slugs": [
-      "thomasville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thomasville AL PD"
     ],
@@ -30088,10 +28238,8 @@
   {
     "agency_id": "576c3c84-781b-58a9-91cf-cc380a304709",
     "slug": "tipp-city-oh-pd",
-    "flock_active_slug": "tipp-city-oh-pd",
-    "flock_slugs": [
-      "tipp-city-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tipp City OH PD"
     ],
@@ -30115,10 +28263,8 @@
   {
     "agency_id": "8fc5db50-d440-5236-9db2-50c9345c00b5",
     "slug": "tipton-county-tn-so",
-    "flock_active_slug": "tipton-county-tn-so",
-    "flock_slugs": [
-      "tipton-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tipton County TN SO"
     ],
@@ -30142,10 +28288,8 @@
   {
     "agency_id": "c745e651-a0bd-543e-a69c-2a9741b766de",
     "slug": "tn-rocic",
-    "flock_active_slug": "tn-rocic",
-    "flock_slugs": [
-      "tn-rocic"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TN ROCIC"
     ],
@@ -30168,10 +28312,8 @@
   {
     "agency_id": "a9edb45d-8dd9-51ed-bb2c-ea6f84b13956",
     "slug": "tonganoxie-ks-pd",
-    "flock_active_slug": "tonganoxie-ks-pd",
-    "flock_slugs": [
-      "tonganoxie-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tonganoxie KS PD"
     ],
@@ -30195,10 +28337,8 @@
   {
     "agency_id": "fe2b7113-c699-52ea-a931-332a78eeafa9",
     "slug": "tontitown-ar-pd",
-    "flock_active_slug": "tontitown-ar-pd",
-    "flock_slugs": [
-      "tontitown-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tontitown AR PD"
     ],
@@ -30222,10 +28362,8 @@
   {
     "agency_id": "805a9ae9-46bf-5ae2-9569-8b164818446d",
     "slug": "town-of-bean-station-pd-tn",
-    "flock_active_slug": "town-of-bean-station-pd-tn",
-    "flock_slugs": [
-      "town-of-bean-station-pd-tn"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Bean Station PD TN"
     ],
@@ -30249,10 +28387,8 @@
   {
     "agency_id": "6cccaaf4-5ab0-5d58-8738-3e9be352ff48",
     "slug": "town-of-hochatown-ok",
-    "flock_active_slug": "town-of-hochatown-ok",
-    "flock_slugs": [
-      "town-of-hochatown-ok"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Hochatown OK"
     ],
@@ -30277,10 +28413,8 @@
   {
     "agency_id": "344aaa5c-c184-5ce6-95ff-e5da42b5d05f",
     "slug": "town-of-jonesboro-la-pd",
-    "flock_active_slug": "town-of-jonesboro-la-pd",
-    "flock_slugs": [
-      "town-of-jonesboro-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Jonesboro LA PD"
     ],
@@ -30304,10 +28438,8 @@
   {
     "agency_id": "d55130b6-dfb4-56fb-a0da-b414dc4c3a0b",
     "slug": "town-of-newburgh-ny-pd",
-    "flock_active_slug": "town-of-newburgh-ny-pd",
-    "flock_slugs": [
-      "town-of-newburgh-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Newburgh NY PD"
     ],
@@ -30331,10 +28463,8 @@
   {
     "agency_id": "1284931e-5fad-5bf5-acd4-d2915e646a90",
     "slug": "town-of-west-blocton-al-pd",
-    "flock_active_slug": "town-of-west-blocton-al-pd",
-    "flock_slugs": [
-      "town-of-west-blocton-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of West Blocton AL PD"
     ],
@@ -30358,10 +28488,8 @@
   {
     "agency_id": "b2f13833-c7b7-543c-99ec-49b4bdacb44c",
     "slug": "towns-county-ga-so",
-    "flock_active_slug": "towns-county-ga-so",
-    "flock_slugs": [
-      "towns-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Towns County GA SO"
     ],
@@ -30385,10 +28513,8 @@
   {
     "agency_id": "9830c3e5-2d83-5bab-a8c2-9b599543b136",
     "slug": "trousdale-county-tn-so",
-    "flock_active_slug": "trousdale-county-tn-so",
-    "flock_slugs": [
-      "trousdale-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Trousdale County TN SO"
     ],
@@ -30412,10 +28538,8 @@
   {
     "agency_id": "f8cd944a-06a2-5184-86c2-86cd8be64ac8",
     "slug": "troy-al-pd",
-    "flock_active_slug": "troy-al-pd",
-    "flock_slugs": [
-      "troy-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Troy AL PD"
     ],
@@ -30439,10 +28563,8 @@
   {
     "agency_id": "ba6fa602-d318-5701-8995-48c2fb9ce83f",
     "slug": "trumann-ar-pd",
-    "flock_active_slug": "trumann-ar-pd",
-    "flock_slugs": [
-      "trumann-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Trumann AR PD"
     ],
@@ -30466,10 +28588,8 @@
   {
     "agency_id": "55ac05cf-0eb2-55d0-a4c4-69e64fb8304b",
     "slug": "trussville-al-pd",
-    "flock_active_slug": "trussville-al-pd",
-    "flock_slugs": [
-      "trussville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Trussville AL PD"
     ],
@@ -30493,10 +28613,8 @@
   {
     "agency_id": "e4108734-2357-576b-a507-f9e621cbccc8",
     "slug": "tunica-county-ms-so-inactive",
-    "flock_active_slug": "tunica-county-ms-so-inactive",
-    "flock_slugs": [
-      "tunica-county-ms-so-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tunica County MS SO [Inactive]"
     ],
@@ -30522,10 +28640,8 @@
   {
     "agency_id": "7f61e9db-1e28-5e9c-9711-242abc424607",
     "slug": "tupelo-ms-pd",
-    "flock_active_slug": "tupelo-ms-pd",
-    "flock_slugs": [
-      "tupelo-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tupelo MS PD"
     ],
@@ -30549,10 +28665,8 @@
   {
     "agency_id": "e0905266-5997-5468-a68a-55abc5e49065",
     "slug": "tupelo-regional-airport",
-    "flock_active_slug": "tupelo-regional-airport",
-    "flock_slugs": [
-      "tupelo-regional-airport"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tupelo Regional Airport"
     ],
@@ -30575,10 +28689,8 @@
   {
     "agency_id": "e2450821-909e-5413-badb-4736e9ce1c21",
     "slug": "tuscaloosa-al-pd",
-    "flock_active_slug": "tuscaloosa-al-pd",
-    "flock_slugs": [
-      "tuscaloosa-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tuscaloosa AL PD"
     ],
@@ -30602,10 +28714,8 @@
   {
     "agency_id": "3c4a3154-fe27-5999-b597-5038c842fd1b",
     "slug": "tuscaloosa-county-al-so",
-    "flock_active_slug": "tuscaloosa-county-al-so",
-    "flock_slugs": [
-      "tuscaloosa-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tuscaloosa County AL SO"
     ],
@@ -30629,10 +28739,8 @@
   {
     "agency_id": "62127fd9-a8e0-5dc1-84bf-53f43e04871a",
     "slug": "tx-brookshire-pd",
-    "flock_active_slug": "tx-brookshire-pd",
-    "flock_slugs": [
-      "tx-brookshire-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Brookshire PD"
     ],
@@ -30656,10 +28764,8 @@
   {
     "agency_id": "c7119d6e-4723-5726-a653-29c15e201d09",
     "slug": "tx-collinsville-pd",
-    "flock_active_slug": "tx-collinsville-pd",
-    "flock_slugs": [
-      "tx-collinsville-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Collinsville PD"
     ],
@@ -30683,10 +28789,8 @@
   {
     "agency_id": "54d9a871-939f-51f6-ac86-476544b30a8c",
     "slug": "tx-commerce-pd",
-    "flock_active_slug": "tx-commerce-pd",
-    "flock_slugs": [
-      "tx-commerce-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Commerce PD"
     ],
@@ -30710,10 +28814,8 @@
   {
     "agency_id": "23770310-7f06-50aa-8f4f-e853024ac42f",
     "slug": "tx-gatesville-pd",
-    "flock_active_slug": "tx-gatesville-pd",
-    "flock_slugs": [
-      "tx-gatesville-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Gatesville PD"
     ],
@@ -30737,10 +28839,8 @@
   {
     "agency_id": "ea76cb09-b645-5bd5-953e-8cce516956cd",
     "slug": "tx-groves-pd",
-    "flock_active_slug": "tx-groves-pd",
-    "flock_slugs": [
-      "tx-groves-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Groves PD"
     ],
@@ -30764,10 +28864,8 @@
   {
     "agency_id": "31394df1-dc2d-5176-83a7-f8878b101f71",
     "slug": "tx-gunter-pd",
-    "flock_active_slug": "tx-gunter-pd",
-    "flock_slugs": [
-      "tx-gunter-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Gunter PD"
     ],
@@ -30791,10 +28889,8 @@
   {
     "agency_id": "c9dde8c2-5175-5e10-8c6e-952e67aaaf60",
     "slug": "tx-joshua-pd",
-    "flock_active_slug": "tx-joshua-pd",
-    "flock_slugs": [
-      "tx-joshua-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Joshua PD"
     ],
@@ -30818,10 +28914,8 @@
   {
     "agency_id": "674a2aec-b989-5082-bcb8-9053765d48a3",
     "slug": "tx-krugerville-pd",
-    "flock_active_slug": "tx-krugerville-pd",
-    "flock_slugs": [
-      "tx-krugerville-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Krugerville PD"
     ],
@@ -30845,10 +28939,8 @@
   {
     "agency_id": "241e9caf-53fc-58a0-bd2c-09b9a90fdd8a",
     "slug": "tx-liberty-county-so",
-    "flock_active_slug": "tx-liberty-county-so",
-    "flock_slugs": [
-      "tx-liberty-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Liberty County SO"
     ],
@@ -30872,10 +28964,8 @@
   {
     "agency_id": "2437d11a-5c2a-53d5-9066-598778e76925",
     "slug": "tx-liberty-pd",
-    "flock_active_slug": "tx-liberty-pd",
-    "flock_slugs": [
-      "tx-liberty-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Liberty PD"
     ],
@@ -30899,10 +28989,8 @@
   {
     "agency_id": "42f71ccb-dfe3-5c22-85fc-4b992e144b19",
     "slug": "tx-milford-pd",
-    "flock_active_slug": "tx-milford-pd",
-    "flock_slugs": [
-      "tx-milford-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Milford PD"
     ],
@@ -30926,10 +29014,8 @@
   {
     "agency_id": "14470704-6aa8-5321-8ace-c321ac517b95",
     "slug": "tx-mustang-ridge-pd",
-    "flock_active_slug": "tx-mustang-ridge-pd",
-    "flock_slugs": [
-      "tx-mustang-ridge-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Mustang Ridge PD"
     ],
@@ -30953,10 +29039,8 @@
   {
     "agency_id": "ab435d9b-d350-5242-8729-5c35f279641a",
     "slug": "tx-prairie-view-a-m-university-campus-pd",
-    "flock_active_slug": "tx-prairie-view-a-m-university-campus-pd",
-    "flock_slugs": [
-      "tx-prairie-view-a-m-university-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Prairie View A & M University Campus PD"
     ],
@@ -30981,10 +29065,8 @@
   {
     "agency_id": "aff6c606-1218-53cb-8b71-45eda13e22de",
     "slug": "tx-san-saba-county-so",
-    "flock_active_slug": "tx-san-saba-county-so",
-    "flock_slugs": [
-      "tx-san-saba-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - San Saba County SO"
     ],
@@ -31008,10 +29090,8 @@
   {
     "agency_id": "27ebe2b4-d831-579b-a3dc-756c9c5ef722",
     "slug": "tx-silsbee-pd",
-    "flock_active_slug": "tx-silsbee-pd",
-    "flock_slugs": [
-      "tx-silsbee-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Silsbee PD"
     ],
@@ -31035,10 +29115,8 @@
   {
     "agency_id": "c6c48a20-ed9a-5bae-bca8-46d8f9823329",
     "slug": "tx-somervell-county-so",
-    "flock_active_slug": "tx-somervell-county-so",
-    "flock_slugs": [
-      "tx-somervell-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Somervell County SO"
     ],
@@ -31062,10 +29140,8 @@
   {
     "agency_id": "0a35fa69-e260-575b-8a13-19e69ee12c6e",
     "slug": "tx-vidor-pd",
-    "flock_active_slug": "tx-vidor-pd",
-    "flock_slugs": [
-      "tx-vidor-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Vidor PD"
     ],
@@ -31089,10 +29165,8 @@
   {
     "agency_id": "851892f4-ef7d-5527-ac82-14408fd07772",
     "slug": "tx-young-county-so",
-    "flock_active_slug": "tx-young-county-so",
-    "flock_slugs": [
-      "tx-young-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "TX - Young County SO"
     ],
@@ -31116,10 +29190,8 @@
   {
     "agency_id": "ccb2d165-85bb-56f5-9e67-3e47f4d999c1",
     "slug": "tyler-tx-pd",
-    "flock_active_slug": "tyler-tx-pd",
-    "flock_slugs": [
-      "tyler-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tyler TX PD"
     ],
@@ -31143,10 +29215,8 @@
   {
     "agency_id": "34de0aaa-196a-5a32-96f4-945f04194922",
     "slug": "tyrone-ga-pd",
-    "flock_active_slug": "tyrone-ga-pd",
-    "flock_slugs": [
-      "tyrone-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tyrone GA PD"
     ],
@@ -31170,10 +29240,8 @@
   {
     "agency_id": "de190cd9-abf6-542a-94c1-eea708ddd05e",
     "slug": "ucpao-ar",
-    "flock_active_slug": "ucpao-ar",
-    "flock_slugs": [
-      "ucpao-ar"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UCPAO AR"
     ],
@@ -31193,10 +29261,8 @@
   {
     "agency_id": "3852b2ef-9c61-53f0-b6b2-cb1f2b3cfff2",
     "slug": "ummc-university-of-mississippi-medical-center-ms-pd",
-    "flock_active_slug": "ummc-university-of-mississippi-medical-center-ms-pd",
-    "flock_slugs": [
-      "ummc-university-of-mississippi-medical-center-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UMMC (University of Mississippi Medical Center) MS PD"
     ],
@@ -31221,10 +29287,8 @@
   {
     "agency_id": "8ad6e06a-9253-5c49-905a-edaf657581ee",
     "slug": "unc-asheville-nc-pd",
-    "flock_active_slug": "unc-asheville-nc-pd",
-    "flock_slugs": [
-      "unc-asheville-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UNC Asheville NC PD"
     ],
@@ -31248,10 +29312,8 @@
   {
     "agency_id": "2b9d6ff2-b44e-5902-b22e-f9582bb8c8db",
     "slug": "union-city-ga-pd",
-    "flock_active_slug": "union-city-ga-pd",
-    "flock_slugs": [
-      "union-city-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union City GA PD"
     ],
@@ -31275,10 +29337,8 @@
   {
     "agency_id": "6b5f8a03-c4a1-5032-aa28-ea6d408a9670",
     "slug": "union-county-ar-so",
-    "flock_active_slug": "union-county-ar-so",
-    "flock_slugs": [
-      "union-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union County AR SO"
     ],
@@ -31302,10 +29362,8 @@
   {
     "agency_id": "3e3ed484-a4be-5b13-a8cd-a2ad4134f556",
     "slug": "union-county-ga-so",
-    "flock_active_slug": "union-county-ga-so",
-    "flock_slugs": [
-      "union-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union County GA SO"
     ],
@@ -31329,10 +29387,8 @@
   {
     "agency_id": "c17ea041-5a5c-5e66-89ae-5bacfb67aadd",
     "slug": "union-county-ky-so",
-    "flock_active_slug": "union-county-ky-so",
-    "flock_slugs": [
-      "union-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union County KY SO"
     ],
@@ -31356,10 +29412,8 @@
   {
     "agency_id": "327a9b1b-3cc7-54d2-b161-170a73dcc909",
     "slug": "union-county-ms-so",
-    "flock_active_slug": "union-county-ms-so",
-    "flock_slugs": [
-      "union-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union County MS SO"
     ],
@@ -31383,10 +29437,8 @@
   {
     "agency_id": "d192e1e5-678a-5532-b8a1-3aed3688f1fd",
     "slug": "university-of-central-arkansas-campus-pd",
-    "flock_active_slug": "university-of-central-arkansas-campus-pd",
-    "flock_slugs": [
-      "university-of-central-arkansas-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Central Arkansas Campus PD"
     ],
@@ -31411,10 +29463,8 @@
   {
     "agency_id": "8a47e530-cd76-5c46-b3c4-2a07f5848257",
     "slug": "university-of-georgia-ga-pd",
-    "flock_active_slug": "university-of-georgia-ga-pd",
-    "flock_slugs": [
-      "university-of-georgia-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Georgia GA PD"
     ],
@@ -31439,10 +29489,8 @@
   {
     "agency_id": "2cd59191-646d-5686-952d-dc9ecabffec1",
     "slug": "university-of-kentucky",
-    "flock_active_slug": "university-of-kentucky",
-    "flock_slugs": [
-      "university-of-kentucky"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Kentucky"
     ],
@@ -31467,10 +29515,8 @@
   {
     "agency_id": "6697078b-2e09-5c91-947e-2085bab28fcb",
     "slug": "university-of-louisiana-at-lafayette-pd",
-    "flock_active_slug": "university-of-louisiana-at-lafayette-pd",
-    "flock_slugs": [
-      "university-of-louisiana-at-lafayette-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Louisiana at Lafayette PD"
     ],
@@ -31495,10 +29541,8 @@
   {
     "agency_id": "45d247c2-093d-5e90-8775-9f4d613f68de",
     "slug": "university-of-louisville-ky-pd",
-    "flock_active_slug": "university-of-louisville-ky-pd",
-    "flock_slugs": [
-      "university-of-louisville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Louisville KY PD"
     ],
@@ -31523,10 +29567,8 @@
   {
     "agency_id": "b407514c-a33b-5915-b3f5-546536ad568a",
     "slug": "university-of-memphis-tn-pd",
-    "flock_active_slug": "university-of-memphis-tn-pd",
-    "flock_slugs": [
-      "university-of-memphis-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Memphis TN PD"
     ],
@@ -31551,10 +29593,8 @@
   {
     "agency_id": "d3270252-c0fc-5712-844d-7e40ba104ac1",
     "slug": "university-of-north-georgia-pd-ga",
-    "flock_active_slug": "university-of-north-georgia-pd-ga",
-    "flock_slugs": [
-      "university-of-north-georgia-pd-ga"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of North Georgia PD (GA)"
     ],
@@ -31579,10 +29619,8 @@
   {
     "agency_id": "34a59c2a-180a-51bd-8fa0-d5ef6021ded7",
     "slug": "university-of-south-florida-fl-pd",
-    "flock_active_slug": "university-of-south-florida-fl-pd",
-    "flock_slugs": [
-      "university-of-south-florida-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of South Florida FL PD"
     ],
@@ -31607,10 +29645,8 @@
   {
     "agency_id": "dc4b6205-af21-54b5-9581-9c34ff8ba5b2",
     "slug": "university-of-tennessee-health-science-center-memphis-tn-pd",
-    "flock_active_slug": "university-of-tennessee-health-science-center-memphis-tn-pd",
-    "flock_slugs": [
-      "university-of-tennessee-health-science-center-memphis-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Tennessee Health Science Center Memphis TN PD"
     ],
@@ -31635,10 +29671,8 @@
   {
     "agency_id": "31a2b41a-43cc-5a92-95b9-b67d2d76c186",
     "slug": "university-of-tennessee-tn-pd",
-    "flock_active_slug": "university-of-tennessee-tn-pd",
-    "flock_slugs": [
-      "university-of-tennessee-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Tennessee TN PD"
     ],
@@ -31663,10 +29697,8 @@
   {
     "agency_id": "db910469-5ced-5aa1-a674-5281b9542b3b",
     "slug": "university-of-tx-uta-arlington-pd",
-    "flock_active_slug": "university-of-tx-uta-arlington-pd",
-    "flock_slugs": [
-      "university-of-tx-uta-arlington-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of TX (UTA)- Arlington PD"
     ],
@@ -31691,10 +29723,8 @@
   {
     "agency_id": "79462519-1fa3-5f38-b894-b9da0884b0a1",
     "slug": "university-of-west-georgia-ga-pd",
-    "flock_active_slug": "university-of-west-georgia-ga-pd",
-    "flock_slugs": [
-      "university-of-west-georgia-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of West Georgia GA PD"
     ],
@@ -31719,10 +29749,8 @@
   {
     "agency_id": "eace5162-7de4-55d2-a4be-a0ec75c5aa79",
     "slug": "urbandale-ia-pd",
-    "flock_active_slug": "urbandale-ia-pd",
-    "flock_slugs": [
-      "urbandale-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Urbandale IA PD"
     ],
@@ -31746,10 +29774,8 @@
   {
     "agency_id": "77623ae2-17f0-5aeb-aeea-b1c4b3d765a2",
     "slug": "utah-county-ut-so-vineyard-pd",
-    "flock_active_slug": "utah-county-ut-so-vineyard-pd",
-    "flock_slugs": [
-      "utah-county-ut-so-vineyard-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Utah County UT SO - Vineyard PD"
     ],
@@ -31773,10 +29799,8 @@
   {
     "agency_id": "b3add988-9341-5a01-9db3-4fa1be4288b5",
     "slug": "van-alstyne-tx-pd",
-    "flock_active_slug": "van-alstyne-tx-pd",
-    "flock_slugs": [
-      "van-alstyne-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Van Alstyne TX PD"
     ],
@@ -31800,10 +29824,8 @@
   {
     "agency_id": "73c539ff-9837-5741-9fda-522dcf9e6430",
     "slug": "van-buren-county-tn-so",
-    "flock_active_slug": "van-buren-county-tn-so",
-    "flock_slugs": [
-      "van-buren-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Van Buren County TN SO"
     ],
@@ -31827,10 +29849,8 @@
   {
     "agency_id": "5e6bd30e-564a-5789-b460-0abd9fb10dd4",
     "slug": "vanderburgh-county-in-so",
-    "flock_active_slug": "vanderburgh-county-in-so",
-    "flock_slugs": [
-      "vanderburgh-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vanderburgh County IN SO"
     ],
@@ -31854,10 +29874,8 @@
   {
     "agency_id": "a75f74e2-3e6e-5b45-8412-5205cbeffb5e",
     "slug": "vernon-parish-la-so",
-    "flock_active_slug": "vernon-parish-la-so",
-    "flock_slugs": [
-      "vernon-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vernon Parish LA SO"
     ],
@@ -31881,10 +29899,8 @@
   {
     "agency_id": "d70682e4-a868-5406-ae56-d2e8b8e5d608",
     "slug": "vienna-il-pd",
-    "flock_active_slug": "vienna-il-pd",
-    "flock_slugs": [
-      "vienna-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vienna IL PD"
     ],
@@ -31908,10 +29924,8 @@
   {
     "agency_id": "b845038a-4f65-5e2d-b32a-f0abd267bfb5",
     "slug": "vincennes-in-pd",
-    "flock_active_slug": "vincennes-in-pd",
-    "flock_slugs": [
-      "vincennes-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vincennes IN PD"
     ],
@@ -31935,10 +29949,8 @@
   {
     "agency_id": "5b6d6f26-bc4c-5881-a6d5-c77675bd3140",
     "slug": "vine-grove-ky-pd",
-    "flock_active_slug": "vine-grove-ky-pd",
-    "flock_slugs": [
-      "vine-grove-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vine Grove KY PD"
     ],
@@ -31962,10 +29974,8 @@
   {
     "agency_id": "a6d8f5f3-be6c-5297-bb73-3369ab5d16b4",
     "slug": "wagoner-co-so-ok",
-    "flock_active_slug": "wagoner-co-so-ok",
-    "flock_slugs": [
-      "wagoner-co-so-ok"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wagoner CO SO OK"
     ],
@@ -31989,10 +29999,8 @@
   {
     "agency_id": "11a71fc2-703e-56e1-94b7-16c4ea05d2d8",
     "slug": "walls-ms-pd",
-    "flock_active_slug": "walls-ms-pd",
-    "flock_slugs": [
-      "walls-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walls MS PD"
     ],
@@ -32016,10 +30024,8 @@
   {
     "agency_id": "7e2a973a-4a1c-5caa-bd5f-09930d4290e7",
     "slug": "walters-state-community-college-tn-campus-pd",
-    "flock_active_slug": "walters-state-community-college-tn-campus-pd",
-    "flock_slugs": [
-      "walters-state-community-college-tn-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walters State Community College TN Campus PD"
     ],
@@ -32044,10 +30050,8 @@
   {
     "agency_id": "03a127b6-be63-5ec4-ab3f-a82111d2b3af",
     "slug": "wapato-wa-pd",
-    "flock_active_slug": "wapato-wa-pd",
-    "flock_slugs": [
-      "wapato-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wapato WA PD"
     ],
@@ -32071,10 +30075,8 @@
   {
     "agency_id": "97c37376-ac7e-5fa1-ba14-3a6e3c2f3fdb",
     "slug": "ward-ar-pd",
-    "flock_active_slug": "ward-ar-pd",
-    "flock_slugs": [
-      "ward-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ward AR PD"
     ],
@@ -32098,10 +30100,8 @@
   {
     "agency_id": "7efefc45-74e6-5f54-b0b9-67cb584acb05",
     "slug": "warden-wa-pd",
-    "flock_active_slug": "warden-wa-pd",
-    "flock_slugs": [
-      "warden-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warden WA PD"
     ],
@@ -32125,10 +30125,8 @@
   {
     "agency_id": "37436a38-0744-593d-975b-1429d5325c89",
     "slug": "warner-robins-ga-pd",
-    "flock_active_slug": "warner-robins-ga-pd",
-    "flock_slugs": [
-      "warner-robins-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warner Robins GA PD"
     ],
@@ -32152,10 +30150,8 @@
   {
     "agency_id": "ff1f004f-f649-5707-b499-dae48b600af2",
     "slug": "warren-ar-pd",
-    "flock_active_slug": "warren-ar-pd",
-    "flock_slugs": [
-      "warren-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warren AR PD"
     ],
@@ -32179,10 +30175,8 @@
   {
     "agency_id": "8129e6ed-ab48-5c12-b2e0-1738564937c1",
     "slug": "warren-county-ky-so",
-    "flock_active_slug": "warren-county-ky-so",
-    "flock_slugs": [
-      "warren-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warren County KY SO"
     ],
@@ -32206,10 +30200,8 @@
   {
     "agency_id": "ac38dafd-7279-5148-9b11-3b97e0436c26",
     "slug": "warren-county-tn-so",
-    "flock_active_slug": "warren-county-tn-so",
-    "flock_slugs": [
-      "warren-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warren County TN SO"
     ],
@@ -32233,10 +30225,8 @@
   {
     "agency_id": "e831a41b-9de0-5d47-b004-6b8bb87fd230",
     "slug": "warrick-county-in-so",
-    "flock_active_slug": "warrick-county-in-so",
-    "flock_slugs": [
-      "warrick-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warrick County IN SO"
     ],
@@ -32260,10 +30250,8 @@
   {
     "agency_id": "766bde8c-6444-5e44-b3f9-bc3c3c29b9b5",
     "slug": "wartburg-tn-pd",
-    "flock_active_slug": "wartburg-tn-pd",
-    "flock_slugs": [
-      "wartburg-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wartburg TN PD"
     ],
@@ -32287,10 +30275,8 @@
   {
     "agency_id": "0847bdf0-9571-5d27-a60a-cbc2a1587e06",
     "slug": "washington-county-in-so",
-    "flock_active_slug": "washington-county-in-so",
-    "flock_slugs": [
-      "washington-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington County IN SO"
     ],
@@ -32314,10 +30300,8 @@
   {
     "agency_id": "447e7e43-cd20-5523-905e-c45a072a59fe",
     "slug": "washington-county-mo-so",
-    "flock_active_slug": "washington-county-mo-so",
-    "flock_slugs": [
-      "washington-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington County MO SO"
     ],
@@ -32341,10 +30325,8 @@
   {
     "agency_id": "6da2bc08-4d3e-587e-8cf2-6bd4bca583d8",
     "slug": "washington-county-oh-so",
-    "flock_active_slug": "washington-county-oh-so",
-    "flock_slugs": [
-      "washington-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington County OH SO"
     ],
@@ -32368,10 +30350,8 @@
   {
     "agency_id": "ddb7f5e8-8754-5cc1-8863-a2a67984bab9",
     "slug": "washington-parish-la-so",
-    "flock_active_slug": "washington-parish-la-so",
-    "flock_slugs": [
-      "washington-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington Parish LA SO"
     ],
@@ -32395,10 +30375,8 @@
   {
     "agency_id": "c0fafd96-b313-5149-bb67-6ee30bfaba59",
     "slug": "waxahachie-tx-pd",
-    "flock_active_slug": "waxahachie-tx-pd",
-    "flock_slugs": [
-      "waxahachie-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waxahachie TX PD"
     ],
@@ -32422,10 +30400,8 @@
   {
     "agency_id": "993d7b3e-6845-5171-8ab1-ba7ba6fa37bd",
     "slug": "waynesville-mo-pd",
-    "flock_active_slug": "waynesville-mo-pd",
-    "flock_slugs": [
-      "waynesville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waynesville MO PD"
     ],
@@ -32449,10 +30425,8 @@
   {
     "agency_id": "723995d3-fb0a-5efa-a4f3-6e9eea7c2955",
     "slug": "webster-county-ga-so",
-    "flock_active_slug": "webster-county-ga-so",
-    "flock_slugs": [
-      "webster-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Webster County GA SO"
     ],
@@ -32476,10 +30450,8 @@
   {
     "agency_id": "a07aaba8-9008-57af-a45c-96ac55fc61ff",
     "slug": "wedowee-al-pd",
-    "flock_active_slug": "wedowee-al-pd",
-    "flock_slugs": [
-      "wedowee-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wedowee AL PD"
     ],
@@ -32503,10 +30475,8 @@
   {
     "agency_id": "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd",
     "slug": "wellington-ks-pd",
-    "flock_active_slug": "wellington-ks-pd",
-    "flock_slugs": [
-      "wellington-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wellington KS PD"
     ],
@@ -32530,10 +30500,8 @@
   {
     "agency_id": "49efe422-cba6-5eca-9cdf-f3acca7b5d33",
     "slug": "west-city-il-pd",
-    "flock_active_slug": "west-city-il-pd",
-    "flock_slugs": [
-      "west-city-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West City IL PD"
     ],
@@ -32557,10 +30525,8 @@
   {
     "agency_id": "df49c680-f2c3-555a-8781-cc29dcd8ff6e",
     "slug": "west-feliciana-parish-la-so",
-    "flock_active_slug": "west-feliciana-parish-la-so",
-    "flock_slugs": [
-      "west-feliciana-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Feliciana Parish LA SO"
     ],
@@ -32584,10 +30550,8 @@
   {
     "agency_id": "fd07c537-56c8-5b0a-a8aa-f339128242d2",
     "slug": "west-fork-ar-pd",
-    "flock_active_slug": "west-fork-ar-pd",
-    "flock_slugs": [
-      "west-fork-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Fork AR PD"
     ],
@@ -32611,10 +30575,8 @@
   {
     "agency_id": "814ab822-3fb6-5aa8-9f9a-c7d722e3ebe3",
     "slug": "west-memphis-ar-pd",
-    "flock_active_slug": "west-memphis-ar-pd",
-    "flock_slugs": [
-      "west-memphis-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Memphis AR PD"
     ],
@@ -32638,10 +30600,8 @@
   {
     "agency_id": "9d4150ad-20d5-5471-8fa0-98a34bf564b3",
     "slug": "west-tawakoni-tx-pd",
-    "flock_active_slug": "west-tawakoni-tx-pd",
-    "flock_slugs": [
-      "west-tawakoni-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Tawakoni TX PD"
     ],
@@ -32665,10 +30625,8 @@
   {
     "agency_id": "7d04c771-ae03-5aa6-8733-461d288a4f98",
     "slug": "west-virginia-fusion-center-wv",
-    "flock_active_slug": "west-virginia-fusion-center-wv",
-    "flock_slugs": [
-      "west-virginia-fusion-center-wv"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Virginia Fusion Center (WV)"
     ],
@@ -32692,10 +30650,8 @@
   {
     "agency_id": "dc144401-0aeb-574d-be86-1103a18c3126",
     "slug": "westfield-in-pd",
-    "flock_active_slug": "westfield-in-pd",
-    "flock_slugs": [
-      "westfield-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westfield IN PD"
     ],
@@ -32719,10 +30675,8 @@
   {
     "agency_id": "2f5a580b-c002-57a3-b1c8-1e389998f2fd",
     "slug": "westwego-la-pd",
-    "flock_active_slug": "westwego-la-pd",
-    "flock_slugs": [
-      "westwego-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westwego LA PD"
     ],
@@ -32746,10 +30700,8 @@
   {
     "agency_id": "89d9b44d-42e2-5298-9adb-c81a51454bc1",
     "slug": "wetumpka-al-pd",
-    "flock_active_slug": "wetumpka-al-pd",
-    "flock_slugs": [
-      "wetumpka-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wetumpka AL PD"
     ],
@@ -32773,10 +30725,8 @@
   {
     "agency_id": "75f9e9a2-57ab-5034-a392-6ff06338c6d6",
     "slug": "wheeler-county-tx-so",
-    "flock_active_slug": "wheeler-county-tx-so",
-    "flock_slugs": [
-      "wheeler-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wheeler County TX SO"
     ],
@@ -32800,10 +30750,8 @@
   {
     "agency_id": "f06be9f2-b406-5778-8108-91e108bbe392",
     "slug": "white-county-ar-so",
-    "flock_active_slug": "white-county-ar-so",
-    "flock_slugs": [
-      "white-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White County AR SO"
     ],
@@ -32827,10 +30775,8 @@
   {
     "agency_id": "b209f3c6-6eb4-50e5-9f71-35cd65a432d8",
     "slug": "white-county-ga-so",
-    "flock_active_slug": "white-county-ga-so",
-    "flock_slugs": [
-      "white-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White County GA SO"
     ],
@@ -32854,10 +30800,8 @@
   {
     "agency_id": "3cb4f094-533a-5084-a3dd-f08cf6979149",
     "slug": "white-county-il-so",
-    "flock_active_slug": "white-county-il-so",
-    "flock_slugs": [
-      "white-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White County IL SO"
     ],
@@ -32881,10 +30825,8 @@
   {
     "agency_id": "ba2949aa-c75a-5fb5-85bb-ca2c04db09aa",
     "slug": "white-hall-ar-pd",
-    "flock_active_slug": "white-hall-ar-pd",
-    "flock_slugs": [
-      "white-hall-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White Hall AR PD"
     ],
@@ -32908,10 +30850,8 @@
   {
     "agency_id": "dd69b7d7-31ef-59bb-8b8f-896081cffa1d",
     "slug": "white-house-tn-pd",
-    "flock_active_slug": "white-house-tn-pd",
-    "flock_slugs": [
-      "white-house-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White House TN PD"
     ],
@@ -32935,10 +30875,8 @@
   {
     "agency_id": "b0794ad4-b162-5fde-847e-f8aa5e47f415",
     "slug": "white-pine-tn-pd",
-    "flock_active_slug": "white-pine-tn-pd",
-    "flock_slugs": [
-      "white-pine-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "White Pine TN PD"
     ],
@@ -32962,10 +30900,8 @@
   {
     "agency_id": "aa86af1c-b2ed-579e-b692-3a8d04d095cb",
     "slug": "whiteville-nc-pd",
-    "flock_active_slug": "whiteville-nc-pd",
-    "flock_slugs": [
-      "whiteville-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whiteville NC PD"
     ],
@@ -32989,10 +30925,8 @@
   {
     "agency_id": "7dee42aa-cb4b-57ef-8c8b-f274bad23676",
     "slug": "whitfield-county-ga-so",
-    "flock_active_slug": "whitfield-county-ga-so",
-    "flock_slugs": [
-      "whitfield-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whitfield County GA SO"
     ],
@@ -33016,10 +30950,8 @@
   {
     "agency_id": "ae02419b-1333-5a33-b12b-47e1b69edbc4",
     "slug": "wichita-county-ks-so",
-    "flock_active_slug": "wichita-county-ks-so",
-    "flock_slugs": [
-      "wichita-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wichita County KS SO"
     ],
@@ -33043,10 +30975,8 @@
   {
     "agency_id": "2c878288-e353-5ce0-b230-43b23e6a43dd",
     "slug": "wichita-state-university-ks-pd",
-    "flock_active_slug": "wichita-state-university-ks-pd",
-    "flock_slugs": [
-      "wichita-state-university-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wichita State University KS PD"
     ],
@@ -33071,10 +31001,8 @@
   {
     "agency_id": "74c0eb90-cf96-5de5-a8b4-8d08e328fe02",
     "slug": "wilkes-county-nc-so",
-    "flock_active_slug": "wilkes-county-nc-so",
-    "flock_slugs": [
-      "wilkes-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilkes County NC SO"
     ],
@@ -33098,10 +31026,8 @@
   {
     "agency_id": "5802ba5c-21fb-584d-91f7-bd9045f909cc",
     "slug": "williamson-co-il-so",
-    "flock_active_slug": "williamson-co-il-so",
-    "flock_slugs": [
-      "williamson-co-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Williamson Co. IL SO"
     ],
@@ -33125,10 +31051,8 @@
   {
     "agency_id": "f0d229af-66ac-56b7-a95b-f15052cee024",
     "slug": "williamson-county-tn-so",
-    "flock_active_slug": "williamson-county-tn-so",
-    "flock_slugs": [
-      "williamson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Williamson County TN SO"
     ],
@@ -33152,10 +31076,8 @@
   {
     "agency_id": "6b536926-5758-5d04-bd24-e7897bd7d019",
     "slug": "wilmore-ky-pd",
-    "flock_active_slug": "wilmore-ky-pd",
-    "flock_slugs": [
-      "wilmore-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilmore KY PD"
     ],
@@ -33179,10 +31101,8 @@
   {
     "agency_id": "533c1a24-6ded-5ce4-bae1-63b08b9dc575",
     "slug": "wilson-county-tn-so",
-    "flock_active_slug": "wilson-county-tn-so",
-    "flock_slugs": [
-      "wilson-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilson County TN SO"
     ],
@@ -33206,10 +31126,8 @@
   {
     "agency_id": "3c4842f4-ada8-5f82-8033-fb3b88096054",
     "slug": "wilton-manors-fl-pd",
-    "flock_active_slug": "wilton-manors-fl-pd",
-    "flock_slugs": [
-      "wilton-manors-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilton Manors FL PD"
     ],
@@ -33233,10 +31151,8 @@
   {
     "agency_id": "2598ff19-984a-5531-996a-b16764fc49f8",
     "slug": "winder-ga-pd",
-    "flock_active_slug": "winder-ga-pd",
-    "flock_slugs": [
-      "winder-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winder GA PD"
     ],
@@ -33260,10 +31176,8 @@
   {
     "agency_id": "2befd69e-14f7-5f24-bbb5-5df4e2861f14",
     "slug": "winfield-ks-pd",
-    "flock_active_slug": "winfield-ks-pd",
-    "flock_slugs": [
-      "winfield-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winfield KS PD"
     ],
@@ -33287,10 +31201,8 @@
   {
     "agency_id": "6aea86f1-45aa-5d87-b240-36c2bc60be1c",
     "slug": "winterville-nc-pd",
-    "flock_active_slug": "winterville-nc-pd",
-    "flock_slugs": [
-      "winterville-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winterville NC PD"
     ],
@@ -33314,10 +31226,8 @@
   {
     "agency_id": "42a54cef-3f3d-594a-8c89-4db0c61e531d",
     "slug": "wixom-mi-pd",
-    "flock_active_slug": "wixom-mi-pd",
-    "flock_slugs": [
-      "wixom-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wixom MI PD"
     ],
@@ -33341,10 +31251,8 @@
   {
     "agency_id": "61969207-b43f-5b4d-a80f-4363804e372b",
     "slug": "wyandotte-mi-pd",
-    "flock_active_slug": "wyandotte-mi-pd",
-    "flock_slugs": [
-      "wyandotte-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wyandotte MI PD"
     ],
@@ -33368,10 +31276,8 @@
   {
     "agency_id": "e6047ddd-94d2-5665-a325-402687547434",
     "slug": "wyandotte-nation-ok-pd",
-    "flock_active_slug": "wyandotte-nation-ok-pd",
-    "flock_slugs": [
-      "wyandotte-nation-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wyandotte Nation OK PD"
     ],
@@ -33395,10 +31301,8 @@
   {
     "agency_id": "3461597e-c0e7-530d-a7dd-b9abf83c4c3d",
     "slug": "wylie-tx-pd",
-    "flock_active_slug": "wylie-tx-pd",
-    "flock_slugs": [
-      "wylie-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wylie TX PD"
     ],
@@ -33422,10 +31326,8 @@
   {
     "agency_id": "bbfcb003-91ba-5770-8129-c8dc5d0e7775",
     "slug": "wynne-ar-pd",
-    "flock_active_slug": "wynne-ar-pd",
-    "flock_slugs": [
-      "wynne-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wynne AR PD"
     ],
@@ -33449,10 +31351,8 @@
   {
     "agency_id": "40cfb193-b8f2-53ee-ae2a-6649749edb1e",
     "slug": "wynne-school-district-9-ar-pd",
-    "flock_active_slug": "wynne-school-district-9-ar-pd",
-    "flock_slugs": [
-      "wynne-school-district-9-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wynne School District 9 AR PD"
     ],
@@ -33476,10 +31376,8 @@
   {
     "agency_id": "5bb51458-3c16-56bc-89e6-a48b1597cbc0",
     "slug": "yazoo-county-ms-so",
-    "flock_active_slug": "yazoo-county-ms-so",
-    "flock_slugs": [
-      "yazoo-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yazoo County MS SO"
     ],
@@ -33503,10 +31401,8 @@
   {
     "agency_id": "d9f58fac-673f-5cc9-8dd7-422e6f438dde",
     "slug": "york-me-pd",
-    "flock_active_slug": "york-me-pd",
-    "flock_slugs": [
-      "york-me-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "York ME PD"
     ],
@@ -33530,10 +31426,8 @@
   {
     "agency_id": "d4d46918-4e0d-5dd4-87fe-30ef1a294c13",
     "slug": "zionsville-in-pd",
-    "flock_active_slug": "zionsville-in-pd",
-    "flock_slugs": [
-      "zionsville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Zionsville IN PD"
     ],
@@ -33557,10 +31451,8 @@
   {
     "agency_id": "10a2a498-db9d-56c0-a06d-8f3a667b6632",
     "slug": "aberdeen-wa-pd",
-    "flock_active_slug": "aberdeen-wa-pd",
-    "flock_slugs": [
-      "aberdeen-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aberdeen WA PD"
     ],
@@ -33584,10 +31476,8 @@
   {
     "agency_id": "cdf714bf-7371-5225-aac6-c7f2ec74d8de",
     "slug": "airway-heights-wa-pd",
-    "flock_active_slug": "airway-heights-wa-pd",
-    "flock_slugs": [
-      "airway-heights-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Airway Heights WA PD"
     ],
@@ -33611,10 +31501,8 @@
   {
     "agency_id": "f4dd311d-51d5-57da-a2e1-fa357409abaa",
     "slug": "black-diamond-wa-pd",
-    "flock_active_slug": "black-diamond-wa-pd",
-    "flock_slugs": [
-      "black-diamond-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Black Diamond WA PD"
     ],
@@ -33638,10 +31526,8 @@
   {
     "agency_id": "6a12952c-da98-5ed6-9fd3-ebaa028ae169",
     "slug": "brewster-wa-pd",
-    "flock_active_slug": "brewster-wa-pd",
-    "flock_slugs": [
-      "brewster-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brewster WA PD"
     ],
@@ -33665,10 +31551,8 @@
   {
     "agency_id": "a2c33b5c-16a8-52e3-8c8a-5be75694d3ed",
     "slug": "chehalis-tribe-law-enforcement-wa",
-    "flock_active_slug": "chehalis-tribe-law-enforcement-wa",
-    "flock_slugs": [
-      "chehalis-tribe-law-enforcement-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chehalis Tribe Law Enforcement WA"
     ],
@@ -33691,10 +31575,8 @@
   {
     "agency_id": "624117fb-8cba-5612-8f6f-0ebbfc512ae9",
     "slug": "chehalis-wa-pd",
-    "flock_active_slug": "chehalis-wa-pd",
-    "flock_slugs": [
-      "chehalis-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chehalis WA PD"
     ],
@@ -33718,10 +31600,8 @@
   {
     "agency_id": "a3ab48c9-e55d-5d26-b801-1b3482289307",
     "slug": "cheney-wa-pd",
-    "flock_active_slug": "cheney-wa-pd",
-    "flock_slugs": [
-      "cheney-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cheney WA PD"
     ],
@@ -33745,10 +31625,8 @@
   {
     "agency_id": "26ad3344-9168-5166-b5de-750998baef78",
     "slug": "cle-elum-wa-pd",
-    "flock_active_slug": "cle-elum-wa-pd",
-    "flock_slugs": [
-      "cle-elum-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cle Elum WA PD"
     ],
@@ -33772,10 +31650,8 @@
   {
     "agency_id": "d305b53f-4dfb-5b79-8505-e3177ff379d8",
     "slug": "clyde-hill-wa-pd",
-    "flock_active_slug": "clyde-hill-wa-pd",
-    "flock_slugs": [
-      "clyde-hill-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clyde Hill WA PD"
     ],
@@ -33799,10 +31675,8 @@
   {
     "agency_id": "8661b49d-944f-56c2-924b-decfbca1a0ef",
     "slug": "columbia-river-drug-task-force-wa",
-    "flock_active_slug": "columbia-river-drug-task-force-wa",
-    "flock_slugs": [
-      "columbia-river-drug-task-force-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbia River Drug Task Force WA"
     ],
@@ -33825,10 +31699,8 @@
   {
     "agency_id": "e586c3ed-f59a-5b5b-aaae-0d4fec8e4c33",
     "slug": "covington-wa-pd",
-    "flock_active_slug": "covington-wa-pd",
-    "flock_slugs": [
-      "covington-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covington WA PD"
     ],
@@ -33852,10 +31724,8 @@
   {
     "agency_id": "9dfa4bef-ba27-525a-8ca3-53a115909b43",
     "slug": "des-moines-wa-pd",
-    "flock_active_slug": "des-moines-wa-pd",
-    "flock_slugs": [
-      "des-moines-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Des Moines WA PD"
     ],
@@ -33879,10 +31749,8 @@
   {
     "agency_id": "c54ee9d3-4114-5c33-a53b-927a6fb46ae3",
     "slug": "douglas-county-wa-so",
-    "flock_active_slug": "douglas-county-wa-so",
-    "flock_slugs": [
-      "douglas-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Douglas County WA SO"
     ],
@@ -33906,10 +31774,8 @@
   {
     "agency_id": "bea6fe44-09ae-5bc8-b1c2-0800bdc544f4",
     "slug": "east-wenatchee-wa-pd",
-    "flock_active_slug": "east-wenatchee-wa-pd",
-    "flock_slugs": [
-      "east-wenatchee-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Wenatchee WA PD"
     ],
@@ -33933,10 +31799,8 @@
   {
     "agency_id": "1fa6ae5e-44d1-55f6-aed6-54453b711387",
     "slug": "eatonville-wa-pd-inactive",
-    "flock_active_slug": "eatonville-wa-pd-inactive",
-    "flock_slugs": [
-      "eatonville-wa-pd-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eatonville WA PD [Inactive]"
     ],
@@ -33962,10 +31826,8 @@
   {
     "agency_id": "a1cf1765-8422-5372-8166-020721a41000",
     "slug": "edmonds-wa-pd",
-    "flock_active_slug": "edmonds-wa-pd",
-    "flock_slugs": [
-      "edmonds-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Edmonds WA PD"
     ],
@@ -33989,10 +31851,8 @@
   {
     "agency_id": "174a74f9-dfc5-58f3-84a1-163706b0c140",
     "slug": "ellensburg-wa-pd",
-    "flock_active_slug": "ellensburg-wa-pd",
-    "flock_slugs": [
-      "ellensburg-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ellensburg WA PD"
     ],
@@ -34016,10 +31876,8 @@
   {
     "agency_id": "4cda9acf-d02a-5d86-bc02-2c4b0479613c",
     "slug": "enumclaw-wa-pd",
-    "flock_active_slug": "enumclaw-wa-pd",
-    "flock_slugs": [
-      "enumclaw-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Enumclaw WA PD"
     ],
@@ -34043,10 +31901,8 @@
   {
     "agency_id": "ec50ea66-f6a3-5d04-bba4-141a0dc10e3e",
     "slug": "everett-wa-police-department",
-    "flock_active_slug": "everett-wa-police-department",
-    "flock_slugs": [
-      "everett-wa-police-department"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Everett (WA) Police Department"
     ],
@@ -34067,10 +31923,8 @@
   {
     "agency_id": "ee7747ac-b100-5d32-9a90-5eb463567352",
     "slug": "federal-way-wa-pd",
-    "flock_active_slug": "federal-way-wa-pd",
-    "flock_slugs": [
-      "federal-way-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Federal Way WA PD"
     ],
@@ -34091,10 +31945,8 @@
   {
     "agency_id": "da58fd20-4713-50c8-8101-c961f41adf93",
     "slug": "goldendale-wa-pd",
-    "flock_active_slug": "goldendale-wa-pd",
-    "flock_slugs": [
-      "goldendale-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goldendale WA PD"
     ],
@@ -34118,10 +31970,8 @@
   {
     "agency_id": "6470d9bb-c6fe-5f4c-8066-15552e374652",
     "slug": "grandview-wa-pd",
-    "flock_active_slug": "grandview-wa-pd",
-    "flock_slugs": [
-      "grandview-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grandview WA PD"
     ],
@@ -34145,10 +31995,8 @@
   {
     "agency_id": "9ccf3b63-963d-5896-a45a-9858abd84b45",
     "slug": "granite-falls-wa-pd",
-    "flock_active_slug": "granite-falls-wa-pd",
-    "flock_slugs": [
-      "granite-falls-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Granite Falls WA PD"
     ],
@@ -34172,10 +32020,8 @@
   {
     "agency_id": "cefe260a-54c6-5039-958b-267204545ae3",
     "slug": "grant-county-wa-so",
-    "flock_active_slug": "grant-county-wa-so",
-    "flock_slugs": [
-      "grant-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grant County WA SO"
     ],
@@ -34199,10 +32045,8 @@
   {
     "agency_id": "8a1ab41e-ef9c-59a5-957c-f66c03cf02bf",
     "slug": "grays-harbor-county-so-wa",
-    "flock_active_slug": "grays-harbor-county-so-wa",
-    "flock_slugs": [
-      "grays-harbor-county-so-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grays Harbor County SO (WA)"
     ],
@@ -34226,10 +32070,8 @@
   {
     "agency_id": "485d236f-0919-564f-807f-406dc4e3b6b4",
     "slug": "kennewick-wa-pd",
-    "flock_active_slug": "kennewick-wa-pd",
-    "flock_slugs": [
-      "kennewick-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kennewick WA PD"
     ],
@@ -34253,10 +32095,8 @@
   {
     "agency_id": "0a9f6f92-fc21-5938-80a2-d0abe88afa88",
     "slug": "kent-wa-pd",
-    "flock_active_slug": "kent-wa-pd",
-    "flock_slugs": [
-      "kent-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kent WA PD"
     ],
@@ -34280,10 +32120,8 @@
   {
     "agency_id": "ccebeae6-1d27-5e90-933a-4aaac0fd38df",
     "slug": "king-county-international-airport-wa",
-    "flock_active_slug": "king-county-international-airport-wa",
-    "flock_slugs": [
-      "king-county-international-airport-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "King County International Airport (WA)"
     ],
@@ -34308,10 +32146,8 @@
   {
     "agency_id": "e9c35d20-8ad1-59aa-b0dc-86652a84a88d",
     "slug": "kittitas-county-wa-so",
-    "flock_active_slug": "kittitas-county-wa-so",
-    "flock_slugs": [
-      "kittitas-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kittitas County WA SO"
     ],
@@ -34335,10 +32171,8 @@
   {
     "agency_id": "b8e97fdd-b1c4-5f64-b530-e8546ff5d182",
     "slug": "kittitas-wa-pd",
-    "flock_active_slug": "kittitas-wa-pd",
-    "flock_slugs": [
-      "kittitas-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kittitas WA PD"
     ],
@@ -34362,10 +32196,8 @@
   {
     "agency_id": "cf2c9940-b7a1-5836-9530-eb899a70dee3",
     "slug": "lake-stevens-wa-pd",
-    "flock_active_slug": "lake-stevens-wa-pd",
-    "flock_slugs": [
-      "lake-stevens-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Stevens WA PD"
     ],
@@ -34389,10 +32221,8 @@
   {
     "agency_id": "5ba1be77-4ad5-577f-abda-2273e45fad1f",
     "slug": "liberty-lake-wa-pd",
-    "flock_active_slug": "liberty-lake-wa-pd",
-    "flock_slugs": [
-      "liberty-lake-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Liberty Lake WA PD"
     ],
@@ -34416,10 +32246,8 @@
   {
     "agency_id": "ad59ad1a-4c0d-555f-9f48-641db03db48f",
     "slug": "lincoln-county-wa-so",
-    "flock_active_slug": "lincoln-county-wa-so",
-    "flock_slugs": [
-      "lincoln-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincoln County WA SO"
     ],
@@ -34443,10 +32271,8 @@
   {
     "agency_id": "086ef644-f88c-5566-8b6c-eb6ac915b485",
     "slug": "marysville-wa-pd",
-    "flock_active_slug": "marysville-wa-pd",
-    "flock_slugs": [
-      "marysville-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marysville WA PD"
     ],
@@ -34470,10 +32296,8 @@
   {
     "agency_id": "6befca9a-079c-5bdf-b905-3498cfed9b0d",
     "slug": "mattawa-wa-pd",
-    "flock_active_slug": "mattawa-wa-pd",
-    "flock_slugs": [
-      "mattawa-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mattawa WA PD"
     ],
@@ -34497,10 +32321,8 @@
   {
     "agency_id": "b40dfa56-11bc-55c0-89e9-036f60938ce7",
     "slug": "mill-creek-wa-pd",
-    "flock_active_slug": "mill-creek-wa-pd",
-    "flock_slugs": [
-      "mill-creek-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mill Creek WA PD"
     ],
@@ -34524,10 +32346,8 @@
   {
     "agency_id": "3bb3e2fd-6e63-5920-bec4-502ebbaaaea7",
     "slug": "monroe-wa-pd",
-    "flock_active_slug": "monroe-wa-pd",
-    "flock_slugs": [
-      "monroe-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe WA PD"
     ],
@@ -34551,10 +32371,8 @@
   {
     "agency_id": "03a55f86-1021-5e86-bdd8-057c2831fc4a",
     "slug": "montesano-wa-pd",
-    "flock_active_slug": "montesano-wa-pd",
-    "flock_slugs": [
-      "montesano-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montesano WA PD"
     ],
@@ -34578,10 +32396,8 @@
   {
     "agency_id": "f97fd1f6-6be0-521b-b601-ad7901256367",
     "slug": "moses-lake-wa-pd",
-    "flock_active_slug": "moses-lake-wa-pd",
-    "flock_slugs": [
-      "moses-lake-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moses Lake WA PD"
     ],
@@ -34605,10 +32421,8 @@
   {
     "agency_id": "d791f0a4-e22d-5acd-972a-08ab21020e2e",
     "slug": "mount-vernon-wa-pd",
-    "flock_active_slug": "mount-vernon-wa-pd",
-    "flock_slugs": [
-      "mount-vernon-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Vernon WA PD"
     ],
@@ -34632,10 +32446,8 @@
   {
     "agency_id": "161ac51a-c857-5ec9-9567-addd22bb89b8",
     "slug": "mountlake-terrace-wa-pd",
-    "flock_active_slug": "mountlake-terrace-wa-pd",
-    "flock_slugs": [
-      "mountlake-terrace-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountlake Terrace WA PD"
     ],
@@ -34659,10 +32471,8 @@
   {
     "agency_id": "f53e930e-8a54-53d0-a257-067e8d7a3845",
     "slug": "moxee-wa-pd",
-    "flock_active_slug": "moxee-wa-pd",
-    "flock_slugs": [
-      "moxee-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moxee WA PD"
     ],
@@ -34686,10 +32496,8 @@
   {
     "agency_id": "f346b97b-25e4-52f9-9698-fa285f30cba6",
     "slug": "mukilteo-wa-pd",
-    "flock_active_slug": "mukilteo-wa-pd",
-    "flock_slugs": [
-      "mukilteo-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mukilteo WA PD"
     ],
@@ -34713,10 +32521,8 @@
   {
     "agency_id": "73452f28-e9d3-5cfe-86d1-3e6492530669",
     "slug": "newcastle-wa-pd",
-    "flock_active_slug": "newcastle-wa-pd",
-    "flock_slugs": [
-      "newcastle-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newcastle WA PD"
     ],
@@ -34740,10 +32546,8 @@
   {
     "agency_id": "bfe7d50b-90a0-5675-ba4d-9ba3e203ddf6",
     "slug": "normandy-park-wa-pd",
-    "flock_active_slug": "normandy-park-wa-pd",
-    "flock_slugs": [
-      "normandy-park-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Normandy Park WA PD"
     ],
@@ -34793,10 +32597,8 @@
   {
     "agency_id": "1a628d9b-50e2-5126-b8f1-4c7d4323e22b",
     "slug": "pasco-pd-wa",
-    "flock_active_slug": "pasco-pd-wa",
-    "flock_slugs": [
-      "pasco-pd-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pasco PD - WA"
     ],
@@ -34820,10 +32622,8 @@
   {
     "agency_id": "0be90b3a-6759-53d7-9f92-d6ea9f9740b0",
     "slug": "port-of-seattle-wa-pd",
-    "flock_active_slug": "port-of-seattle-wa-pd",
-    "flock_slugs": [
-      "port-of-seattle-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Port of Seattle WA PD"
     ],
@@ -34847,10 +32647,8 @@
   {
     "agency_id": "f43058df-275f-54d5-8e10-d7fe826cacfd",
     "slug": "prosser-wa-pd",
-    "flock_active_slug": "prosser-wa-pd",
-    "flock_slugs": [
-      "prosser-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prosser WA PD"
     ],
@@ -34874,10 +32672,8 @@
   {
     "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
     "slug": "richland-pd-wa",
-    "flock_active_slug": "richland-pd-wa",
-    "flock_slugs": [
-      "richland-pd-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richland PD WA"
     ],
@@ -34901,10 +32697,8 @@
   {
     "agency_id": "f9528ae9-97e1-555d-8dd3-f842543cb473",
     "slug": "sedro-woolley-wa-pd",
-    "flock_active_slug": "sedro-woolley-wa-pd",
-    "flock_slugs": [
-      "sedro-woolley-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sedro-Woolley WA PD"
     ],
@@ -34928,10 +32722,8 @@
   {
     "agency_id": "0c8f189e-44ad-5b09-a38c-3915f926928f",
     "slug": "selah-wa-pd",
-    "flock_active_slug": "selah-wa-pd",
-    "flock_slugs": [
-      "selah-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Selah WA PD"
     ],
@@ -34955,10 +32747,8 @@
   {
     "agency_id": "f692a69d-1089-5c5a-9b6a-14884accfab7",
     "slug": "shelton-pd-wa",
-    "flock_active_slug": "shelton-pd-wa",
-    "flock_slugs": [
-      "shelton-pd-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelton PD (WA)"
     ],
@@ -34982,10 +32772,8 @@
   {
     "agency_id": "4f00a0e6-1c7b-5620-800e-9579a5fc4fda",
     "slug": "snohomish-county-wa-911",
-    "flock_active_slug": "snohomish-county-wa-911",
-    "flock_slugs": [
-      "snohomish-county-wa-911"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Snohomish County WA 911"
     ],
@@ -35010,10 +32798,8 @@
   {
     "agency_id": "fb691729-841d-53b7-8242-ef59c222b2c0",
     "slug": "snohomish-county-wa-so",
-    "flock_active_slug": "snohomish-county-wa-so",
-    "flock_slugs": [
-      "snohomish-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Snohomish County WA SO"
     ],
@@ -35037,10 +32823,8 @@
   {
     "agency_id": "8f90c371-b3dd-58a8-9be8-c97e5237369b",
     "slug": "snohomish-wa-pd",
-    "flock_active_slug": "snohomish-wa-pd",
-    "flock_slugs": [
-      "snohomish-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Snohomish WA PD"
     ],
@@ -35064,10 +32848,8 @@
   {
     "agency_id": "ae292ffc-510d-5af1-b78d-7c026bfe1754",
     "slug": "spokane-county-wa-so",
-    "flock_active_slug": "spokane-county-wa-so",
-    "flock_slugs": [
-      "spokane-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spokane County WA SO"
     ],
@@ -35091,10 +32873,8 @@
   {
     "agency_id": "3fb2e1f2-434a-5a2b-b79e-64c927bc461e",
     "slug": "spokane-tribal-pd-wa",
-    "flock_active_slug": "spokane-tribal-pd-wa",
-    "flock_slugs": [
-      "spokane-tribal-pd-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spokane Tribal PD WA"
     ],
@@ -35117,10 +32897,8 @@
   {
     "agency_id": "8171a2b1-544d-544d-8a90-31029959bd72",
     "slug": "spokane-wa-pd",
-    "flock_active_slug": "spokane-wa-pd",
-    "flock_slugs": [
-      "spokane-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spokane WA PD"
     ],
@@ -35144,10 +32922,8 @@
   {
     "agency_id": "8deb7b8b-e076-59c1-8790-ee8d2828f137",
     "slug": "sumner-wa-pd",
-    "flock_active_slug": "sumner-wa-pd",
-    "flock_slugs": [
-      "sumner-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sumner WA PD"
     ],
@@ -35171,10 +32947,8 @@
   {
     "agency_id": "96d2eb94-ea06-5bc6-9e06-faff521982f0",
     "slug": "sunnyside-wa-pd",
-    "flock_active_slug": "sunnyside-wa-pd",
-    "flock_slugs": [
-      "sunnyside-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sunnyside WA PD"
     ],
@@ -35198,10 +32972,8 @@
   {
     "agency_id": "59bd493b-5b49-5cb5-a28a-88a04cef53b9",
     "slug": "suquamish-wa-pd",
-    "flock_active_slug": "suquamish-wa-pd",
-    "flock_slugs": [
-      "suquamish-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Suquamish WA PD"
     ],
@@ -35225,10 +32997,8 @@
   {
     "agency_id": "2645a529-e68c-5ea5-b27c-2a72feb3a845",
     "slug": "toppenish-wa-pd",
-    "flock_active_slug": "toppenish-wa-pd",
-    "flock_slugs": [
-      "toppenish-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Toppenish WA PD"
     ],
@@ -35252,10 +33022,8 @@
   {
     "agency_id": "98942a6b-309a-5d4a-b61a-a7f76f6b0eac",
     "slug": "tukwila-wa-pd",
-    "flock_active_slug": "tukwila-wa-pd",
-    "flock_slugs": [
-      "tukwila-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tukwila WA PD"
     ],
@@ -35279,10 +33047,8 @@
   {
     "agency_id": "6649962a-1efe-5111-a64c-c01c7f0c45e5",
     "slug": "tulalip-tribal-police-dept-wa",
-    "flock_active_slug": "tulalip-tribal-police-dept-wa",
-    "flock_slugs": [
-      "tulalip-tribal-police-dept-wa"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tulalip Tribal Police Dept. (WA)"
     ],
@@ -35303,10 +33069,8 @@
   {
     "agency_id": "1a066427-cc86-5416-87d8-82b8bfe39ca9",
     "slug": "union-gap-wa-pd",
-    "flock_active_slug": "union-gap-wa-pd",
-    "flock_slugs": [
-      "union-gap-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union Gap WA PD"
     ],
@@ -35330,10 +33094,8 @@
   {
     "agency_id": "23762327-be94-51e7-b21f-bf75bc9d5123",
     "slug": "wa-chelan-county-so",
-    "flock_active_slug": "wa-chelan-county-so",
-    "flock_slugs": [
-      "wa-chelan-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "WA - Chelan County SO"
     ],
@@ -35357,10 +33119,8 @@
   {
     "agency_id": "b24c55d3-3dd6-55d6-a443-d361be29e6aa",
     "slug": "walla-walla-wa-pd",
-    "flock_active_slug": "walla-walla-wa-pd",
-    "flock_slugs": [
-      "walla-walla-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walla Walla WA PD"
     ],
@@ -35384,10 +33144,8 @@
   {
     "agency_id": "c2fe92ce-a388-5dfb-bce8-7cc80482f298",
     "slug": "wenatchee-wa-pd",
-    "flock_active_slug": "wenatchee-wa-pd",
-    "flock_slugs": [
-      "wenatchee-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wenatchee WA PD"
     ],
@@ -35411,10 +33169,8 @@
   {
     "agency_id": "4b4d97e4-cbf7-50de-8e7f-7f27cee20cc5",
     "slug": "west-richland-wa-pd",
-    "flock_active_slug": "west-richland-wa-pd",
-    "flock_slugs": [
-      "west-richland-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Richland WA PD"
     ],
@@ -35438,10 +33194,8 @@
   {
     "agency_id": "4d1af216-fba1-5f6f-8db2-1643e64b7425",
     "slug": "westport-wa-pd",
-    "flock_active_slug": "westport-wa-pd",
-    "flock_slugs": [
-      "westport-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westport WA PD"
     ],
@@ -35465,10 +33219,8 @@
   {
     "agency_id": "4038141d-df58-5a8d-ab87-6fb0f1753c24",
     "slug": "yelm-wa-pd",
-    "flock_active_slug": "yelm-wa-pd",
-    "flock_slugs": [
-      "yelm-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yelm WA PD"
     ],
@@ -35492,10 +33244,8 @@
   {
     "agency_id": "13d2b7c9-b19d-542b-890a-f8a417f50fab",
     "slug": "city-of-moreno-valley",
-    "flock_active_slug": "city-of-moreno-valley",
-    "flock_slugs": [
-      "city-of-moreno-valley"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Moreno Valley"
     ],
@@ -35520,10 +33270,8 @@
   {
     "agency_id": "7ef569b7-a705-54be-bfa6-7e115991bd53",
     "slug": "uc-riverside-pd-ca",
-    "flock_active_slug": "uc-riverside-pd-ca",
-    "flock_slugs": [
-      "uc-riverside-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UC Riverside PD (CA)"
     ],
@@ -35547,10 +33295,8 @@
   {
     "agency_id": "b3dffa5b-120c-53d2-ab5a-d6c367597b21",
     "slug": "winchester-trails-ca",
-    "flock_active_slug": "winchester-trails-ca",
-    "flock_slugs": [
-      "winchester-trails-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winchester Trails (CA)"
     ],
@@ -35572,10 +33318,8 @@
   {
     "agency_id": "34c63a91-2f6f-5b56-a59d-ebfa94e65552",
     "slug": "abbotsford-wi-pd",
-    "flock_active_slug": "abbotsford-wi-pd",
-    "flock_slugs": [
-      "abbotsford-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Abbotsford WI PD"
     ],
@@ -35599,10 +33343,8 @@
   {
     "agency_id": "8dfd45f3-d57f-57bf-9631-dba24ecfb3e8",
     "slug": "adams-county-il-so",
-    "flock_active_slug": "adams-county-il-so",
-    "flock_slugs": [
-      "adams-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adams County IL SO"
     ],
@@ -35626,10 +33368,8 @@
   {
     "agency_id": "8813e3cb-3451-5dc3-877e-0941e44f6109",
     "slug": "adams-county-wi-so",
-    "flock_active_slug": "adams-county-wi-so",
-    "flock_slugs": [
-      "adams-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adams County WI SO"
     ],
@@ -35653,10 +33393,8 @@
   {
     "agency_id": "a1fc55e7-5da1-5719-abd4-a523af856bb2",
     "slug": "adams-wi-pd",
-    "flock_active_slug": "adams-wi-pd",
-    "flock_slugs": [
-      "adams-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adams WI PD"
     ],
@@ -35680,10 +33418,8 @@
   {
     "agency_id": "1c7b6b81-1c54-588b-9558-5c5a87ce35d4",
     "slug": "addison-il-pd",
-    "flock_active_slug": "addison-il-pd",
-    "flock_slugs": [
-      "addison-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Addison IL PD"
     ],
@@ -35707,10 +33443,8 @@
   {
     "agency_id": "f854eb94-5622-55b8-9b15-3f2d21a0bfdb",
     "slug": "aitkin-county-mn-so",
-    "flock_active_slug": "aitkin-county-mn-so",
-    "flock_slugs": [
-      "aitkin-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aitkin County MN SO"
     ],
@@ -35734,10 +33468,8 @@
   {
     "agency_id": "18097ae0-2933-5dcc-bfb3-3a3af436a28b",
     "slug": "alabama-department-of-corrections",
-    "flock_active_slug": "alabama-department-of-corrections",
-    "flock_slugs": [
-      "alabama-department-of-corrections"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alabama Department of Corrections"
     ],
@@ -35761,10 +33493,8 @@
   {
     "agency_id": "cb017071-39e4-5042-968e-07216ad78bfc",
     "slug": "alexandria-mn-pd",
-    "flock_active_slug": "alexandria-mn-pd",
-    "flock_slugs": [
-      "alexandria-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alexandria MN PD"
     ],
@@ -35788,10 +33518,8 @@
   {
     "agency_id": "2e15b18e-5627-5e8c-80dc-bb1fcf37019a",
     "slug": "allegan-county-so-mi",
-    "flock_active_slug": "allegan-county-so-mi",
-    "flock_slugs": [
-      "allegan-county-so-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Allegan County SO MI"
     ],
@@ -35815,10 +33543,8 @@
   {
     "agency_id": "a2844a64-8686-51e2-89a9-4f3f6d42f8d1",
     "slug": "allen-county-in-so",
-    "flock_active_slug": "allen-county-in-so",
-    "flock_slugs": [
-      "allen-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Allen County IN SO"
     ],
@@ -35842,10 +33568,8 @@
   {
     "agency_id": "5f05b095-dd72-5a12-b964-d63345ddbcc0",
     "slug": "alpena-county-mi-so",
-    "flock_active_slug": "alpena-county-mi-so",
-    "flock_slugs": [
-      "alpena-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alpena County MI SO"
     ],
@@ -35869,10 +33593,8 @@
   {
     "agency_id": "64ee639f-7b06-563e-8045-b16f32332d63",
     "slug": "altoona-wi-pd",
-    "flock_active_slug": "altoona-wi-pd",
-    "flock_slugs": [
-      "altoona-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Altoona WI PD"
     ],
@@ -35896,10 +33618,8 @@
   {
     "agency_id": "4310c9e3-101d-5e1a-b813-03594268a9eb",
     "slug": "amery-wi-pd",
-    "flock_active_slug": "amery-wi-pd",
-    "flock_slugs": [
-      "amery-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Amery WI PD"
     ],
@@ -35923,10 +33643,8 @@
   {
     "agency_id": "3784d08c-1760-542f-a664-df82a50d2614",
     "slug": "anoka-mn-pd",
-    "flock_active_slug": "anoka-mn-pd",
-    "flock_slugs": [
-      "anoka-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anoka MN PD"
     ],
@@ -35950,10 +33668,8 @@
   {
     "agency_id": "3767fa41-aa7d-598f-8dd7-bf208a9fed98",
     "slug": "antioch-il-pd",
-    "flock_active_slug": "antioch-il-pd",
-    "flock_slugs": [
-      "antioch-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Antioch IL PD"
     ],
@@ -35977,10 +33693,8 @@
   {
     "agency_id": "f5ff64c9-367b-545a-87ab-a0a0a477fac2",
     "slug": "antrim-county-so-mi",
-    "flock_active_slug": "antrim-county-so-mi",
-    "flock_slugs": [
-      "antrim-county-so-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Antrim County SO MI"
     ],
@@ -36004,10 +33718,8 @@
   {
     "agency_id": "d561e3c0-2216-56aa-8a7a-b2a1ac12d6ad",
     "slug": "appleton-wi-pd",
-    "flock_active_slug": "appleton-wi-pd",
-    "flock_slugs": [
-      "appleton-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Appleton WI PD"
     ],
@@ -36031,10 +33743,8 @@
   {
     "agency_id": "5d2a3059-5d50-5f67-85a4-6131c307cf45",
     "slug": "ar-alma-pd",
-    "flock_active_slug": "ar-alma-pd",
-    "flock_slugs": [
-      "ar-alma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AR - Alma PD"
     ],
@@ -36058,10 +33768,8 @@
   {
     "agency_id": "0fa9f4ae-67a5-57e0-8fa5-bca51cc74977",
     "slug": "arnold-mo-pd",
-    "flock_active_slug": "arnold-mo-pd",
-    "flock_slugs": [
-      "arnold-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arnold MO PD"
     ],
@@ -36085,10 +33793,8 @@
   {
     "agency_id": "5c64cac2-080c-5792-b2b1-dc627f1529c5",
     "slug": "arthur-il-pd",
-    "flock_active_slug": "arthur-il-pd",
-    "flock_slugs": [
-      "arthur-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arthur IL PD"
     ],
@@ -36112,10 +33818,8 @@
   {
     "agency_id": "c13d6666-0e0d-5a59-86cc-6f08587b5042",
     "slug": "ashland-county-wi-so",
-    "flock_active_slug": "ashland-county-wi-so",
-    "flock_slugs": [
-      "ashland-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ashland County WI SO"
     ],
@@ -36139,10 +33843,8 @@
   {
     "agency_id": "7e778632-cea8-5f22-a0ac-b0e0b604cfba",
     "slug": "ashland-mo-pd",
-    "flock_active_slug": "ashland-mo-pd",
-    "flock_slugs": [
-      "ashland-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ashland MO PD"
     ],
@@ -36166,10 +33868,8 @@
   {
     "agency_id": "7cd5ae28-61aa-5f9a-b0de-59f135eec4c5",
     "slug": "ashland-wi-pd",
-    "flock_active_slug": "ashland-wi-pd",
-    "flock_slugs": [
-      "ashland-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ashland WI PD"
     ],
@@ -36193,10 +33893,8 @@
   {
     "agency_id": "00e249d7-0d9a-5b27-ba9d-64b1a286a081",
     "slug": "atchison-county-ks-so",
-    "flock_active_slug": "atchison-county-ks-so",
-    "flock_slugs": [
-      "atchison-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Atchison County KS SO"
     ],
@@ -36220,10 +33918,8 @@
   {
     "agency_id": "61fc0ce7-9287-5815-bc73-2de55836ecf9",
     "slug": "attorney-general-of-illinois-medicare-fraud-division",
-    "flock_active_slug": "attorney-general-of-illinois-medicare-fraud-division",
-    "flock_slugs": [
-      "attorney-general-of-illinois-medicare-fraud-division"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Attorney General of Illinois - Medicare Fraud Division"
     ],
@@ -36247,10 +33943,8 @@
   {
     "agency_id": "8909ba11-05c9-5abd-870e-5dc7244d36f8",
     "slug": "auburn-in-pd",
-    "flock_active_slug": "auburn-in-pd",
-    "flock_slugs": [
-      "auburn-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Auburn IN PD"
     ],
@@ -36274,10 +33968,8 @@
   {
     "agency_id": "b215079d-cedb-52e8-901a-10d2bba14604",
     "slug": "audrain-county-mo-so",
-    "flock_active_slug": "audrain-county-mo-so",
-    "flock_slugs": [
-      "audrain-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Audrain County MO SO"
     ],
@@ -36301,10 +33993,8 @@
   {
     "agency_id": "0f86376d-b7c4-5b82-a36f-3383a2de4e65",
     "slug": "aurora-il-pd",
-    "flock_active_slug": "aurora-il-pd",
-    "flock_slugs": [
-      "aurora-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aurora IL PD"
     ],
@@ -36328,10 +34018,8 @@
   {
     "agency_id": "e8f061c3-1d6f-57eb-bc3a-88c150458681",
     "slug": "aviston-il-pd",
-    "flock_active_slug": "aviston-il-pd",
-    "flock_slugs": [
-      "aviston-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aviston IL PD"
     ],
@@ -36355,10 +34043,8 @@
   {
     "agency_id": "6c1400dc-29e9-5307-a613-d21f2838979c",
     "slug": "barrington-hills-il-pd",
-    "flock_active_slug": "barrington-hills-il-pd",
-    "flock_slugs": [
-      "barrington-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barrington Hills IL PD"
     ],
@@ -36382,10 +34068,8 @@
   {
     "agency_id": "3ac8e49f-d46d-5fae-80c3-de224c8bd91c",
     "slug": "barron-county-wi-so",
-    "flock_active_slug": "barron-county-wi-so",
-    "flock_slugs": [
-      "barron-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Barron County WI SO"
     ],
@@ -36409,10 +34093,8 @@
   {
     "agency_id": "534de050-8be9-53c9-ad60-6b0fa769fde1",
     "slug": "bartlett-il-pd",
-    "flock_active_slug": "bartlett-il-pd",
-    "flock_slugs": [
-      "bartlett-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bartlett IL PD"
     ],
@@ -36436,10 +34118,8 @@
   {
     "agency_id": "4048be7b-7adc-50ee-9985-f7cf0044b3d7",
     "slug": "bayfield-county-wi-so",
-    "flock_active_slug": "bayfield-county-wi-so",
-    "flock_slugs": [
-      "bayfield-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bayfield County WI SO"
     ],
@@ -36463,10 +34143,8 @@
   {
     "agency_id": "85993d35-2ffb-5430-9b23-40c3d4aa7793",
     "slug": "beaver-dam-wi-pd",
-    "flock_active_slug": "beaver-dam-wi-pd",
-    "flock_slugs": [
-      "beaver-dam-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Beaver Dam WI PD"
     ],
@@ -36490,10 +34168,8 @@
   {
     "agency_id": "e4d1eb59-9384-5319-921f-683be1b253e4",
     "slug": "becker-county-mn-so",
-    "flock_active_slug": "becker-county-mn-so",
-    "flock_slugs": [
-      "becker-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Becker County MN SO"
     ],
@@ -36517,10 +34193,8 @@
   {
     "agency_id": "3a51da07-9d6e-56c3-9793-454457b7f0c9",
     "slug": "belle-plaine-mn-pd",
-    "flock_active_slug": "belle-plaine-mn-pd",
-    "flock_slugs": [
-      "belle-plaine-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Belle Plaine MN PD"
     ],
@@ -36544,10 +34218,8 @@
   {
     "agency_id": "d07469d0-0d56-5584-b0e1-b228a96fc2ff",
     "slug": "belvidere-il-pd",
-    "flock_active_slug": "belvidere-il-pd",
-    "flock_slugs": [
-      "belvidere-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Belvidere IL PD"
     ],
@@ -36571,10 +34243,8 @@
   {
     "agency_id": "2f3fbeff-7d47-5b39-ad48-73f6627ce489",
     "slug": "berkeley-il-pd",
-    "flock_active_slug": "berkeley-il-pd",
-    "flock_slugs": [
-      "berkeley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Berkeley IL PD"
     ],
@@ -36598,10 +34268,8 @@
   {
     "agency_id": "eff170f2-dbbe-5b5d-bccf-1b2f3cf351c0",
     "slug": "berkeley-mo-pd",
-    "flock_active_slug": "berkeley-mo-pd",
-    "flock_slugs": [
-      "berkeley-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Berkeley MO PD"
     ],
@@ -36625,10 +34293,8 @@
   {
     "agency_id": "29760f8b-702d-5c83-b7cc-4ece8e82d4e6",
     "slug": "berrien-county-mi-so",
-    "flock_active_slug": "berrien-county-mi-so",
-    "flock_slugs": [
-      "berrien-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Berrien County MI SO"
     ],
@@ -36652,10 +34318,8 @@
   {
     "agency_id": "86c9d8ee-e806-55f5-8dd9-eab9aaf86017",
     "slug": "big-bend-wi-pd",
-    "flock_active_slug": "big-bend-wi-pd",
-    "flock_slugs": [
-      "big-bend-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Big Bend WI PD"
     ],
@@ -36679,10 +34343,8 @@
   {
     "agency_id": "e644ca4f-9d0e-5291-9ab7-e929837fad3b",
     "slug": "bixby-ok-pd",
-    "flock_active_slug": "bixby-ok-pd",
-    "flock_slugs": [
-      "bixby-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bixby OK PD"
     ],
@@ -36706,10 +34368,8 @@
   {
     "agency_id": "eea18377-6087-5420-9665-2249a2169638",
     "slug": "blaine-mn-pd",
-    "flock_active_slug": "blaine-mn-pd",
-    "flock_slugs": [
-      "blaine-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blaine MN PD"
     ],
@@ -36733,10 +34393,8 @@
   {
     "agency_id": "3401474d-eec9-579d-9681-26303ba6b7f8",
     "slug": "bloomington-il-pd",
-    "flock_active_slug": "bloomington-il-pd",
-    "flock_slugs": [
-      "bloomington-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bloomington IL PD"
     ],
@@ -36760,10 +34418,8 @@
   {
     "agency_id": "289cbb4f-aded-5e18-a762-3bd5cbf57578",
     "slug": "blount-county-tn-so",
-    "flock_active_slug": "blount-county-tn-so",
-    "flock_slugs": [
-      "blount-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blount County TN SO"
     ],
@@ -36787,10 +34443,8 @@
   {
     "agency_id": "36a1b0c9-db91-5c52-8102-d4ad69fc41a8",
     "slug": "blue-springs-mo-pd",
-    "flock_active_slug": "blue-springs-mo-pd",
-    "flock_slugs": [
-      "blue-springs-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blue Springs MO PD"
     ],
@@ -36814,10 +34468,8 @@
   {
     "agency_id": "d9bb15ad-8500-5f7e-8430-bc6d14baff5b",
     "slug": "bolingbrook-il-pd",
-    "flock_active_slug": "bolingbrook-il-pd",
-    "flock_slugs": [
-      "bolingbrook-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bolingbrook IL PD"
     ],
@@ -36841,10 +34493,8 @@
   {
     "agency_id": "007ef75f-a18e-5e5f-8a7d-2791191bdfdf",
     "slug": "boone-county-ar-so",
-    "flock_active_slug": "boone-county-ar-so",
-    "flock_slugs": [
-      "boone-county-ar-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boone County AR SO"
     ],
@@ -36868,10 +34518,8 @@
   {
     "agency_id": "ab4164d2-6e67-55e5-817a-6a21e6c6994a",
     "slug": "boone-county-il-so",
-    "flock_active_slug": "boone-county-il-so",
-    "flock_slugs": [
-      "boone-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Boone County IL SO"
     ],
@@ -36895,10 +34543,8 @@
   {
     "agency_id": "88a3245f-99e6-54d8-b57d-aec81c0dff17",
     "slug": "bourbon-county-ks-so",
-    "flock_active_slug": "bourbon-county-ks-so",
-    "flock_slugs": [
-      "bourbon-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bourbon County KS SO"
     ],
@@ -36922,10 +34568,8 @@
   {
     "agency_id": "e0311579-fa8f-56d7-a962-d71c4b1890be",
     "slug": "bourbonnais-il-pd",
-    "flock_active_slug": "bourbonnais-il-pd",
-    "flock_slugs": [
-      "bourbonnais-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bourbonnais IL PD"
     ],
@@ -36949,10 +34593,8 @@
   {
     "agency_id": "e5999eef-ff84-5cfc-96ea-0542e548bd14",
     "slug": "bowling-green-mo-pd",
-    "flock_active_slug": "bowling-green-mo-pd",
-    "flock_slugs": [
-      "bowling-green-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bowling Green MO PD"
     ],
@@ -36976,10 +34618,8 @@
   {
     "agency_id": "6111117a-712d-5afa-ad6d-caafbba0fb49",
     "slug": "brentwood-mo-pd",
-    "flock_active_slug": "brentwood-mo-pd",
-    "flock_slugs": [
-      "brentwood-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brentwood MO PD"
     ],
@@ -37003,10 +34643,8 @@
   {
     "agency_id": "7daffb79-5d84-5363-8f23-bd4b353f7ba5",
     "slug": "bridgeport-township-mi-pd",
-    "flock_active_slug": "bridgeport-township-mi-pd",
-    "flock_slugs": [
-      "bridgeport-township-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bridgeport Township MI PD"
     ],
@@ -37030,10 +34668,8 @@
   {
     "agency_id": "410b9b7e-7a9b-53c0-b2cb-1e5942bd03f8",
     "slug": "bridgeton-mo-pd",
-    "flock_active_slug": "bridgeton-mo-pd",
-    "flock_slugs": [
-      "bridgeton-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bridgeton MO PD"
     ],
@@ -37057,10 +34693,8 @@
   {
     "agency_id": "d1ec43f7-068d-5fc5-8be2-5a7ec3e0ac8e",
     "slug": "bridgeview-il-pd",
-    "flock_active_slug": "bridgeview-il-pd",
-    "flock_slugs": [
-      "bridgeview-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bridgeview IL PD"
     ],
@@ -37084,10 +34718,8 @@
   {
     "agency_id": "17453cbc-25c2-54d6-a06b-edbebd3c64b2",
     "slug": "bristol-in-pd",
-    "flock_active_slug": "bristol-in-pd",
-    "flock_slugs": [
-      "bristol-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bristol IN PD"
     ],
@@ -37111,10 +34743,8 @@
   {
     "agency_id": "74173fe2-a6a5-51e2-a952-5f41ec39731a",
     "slug": "brookfield-wi-pd",
-    "flock_active_slug": "brookfield-wi-pd",
-    "flock_slugs": [
-      "brookfield-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brookfield WI PD"
     ],
@@ -37138,10 +34768,8 @@
   {
     "agency_id": "7b8a53d9-d8e7-5d0b-bbd5-c80b7e1b4299",
     "slug": "brookings-sd-pd",
-    "flock_active_slug": "brookings-sd-pd",
-    "flock_slugs": [
-      "brookings-sd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brookings SD PD"
     ],
@@ -37165,10 +34793,8 @@
   {
     "agency_id": "1320544c-4c09-5a08-9264-52d844f58fd1",
     "slug": "brooklyn-park-mn-pd-inactive",
-    "flock_active_slug": "brooklyn-park-mn-pd-inactive",
-    "flock_slugs": [
-      "brooklyn-park-mn-pd-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brooklyn Park MN PD [Inactive]"
     ],
@@ -37194,10 +34820,8 @@
   {
     "agency_id": "a53d43e1-06f2-5d2e-9279-224547f8a6ff",
     "slug": "brown-county-il-so",
-    "flock_active_slug": "brown-county-il-so",
-    "flock_slugs": [
-      "brown-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brown County IL SO"
     ],
@@ -37221,10 +34845,8 @@
   {
     "agency_id": "d9ee5f21-8313-55cf-baa9-515fbedb2848",
     "slug": "brown-county-wi-so",
-    "flock_active_slug": "brown-county-wi-so",
-    "flock_slugs": [
-      "brown-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brown County WI SO"
     ],
@@ -37248,10 +34870,8 @@
   {
     "agency_id": "3e83ccf3-b393-549e-92cf-e361ed1fe864",
     "slug": "buchanan-county-mo-so",
-    "flock_active_slug": "buchanan-county-mo-so",
-    "flock_slugs": [
-      "buchanan-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Buchanan County MO SO"
     ],
@@ -37275,10 +34895,8 @@
   {
     "agency_id": "0fbf7af4-aa47-5aec-b85e-5a9fac84e3c7",
     "slug": "buffalo-county-wi-so",
-    "flock_active_slug": "buffalo-county-wi-so",
-    "flock_slugs": [
-      "buffalo-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Buffalo County WI SO"
     ],
@@ -37302,10 +34920,8 @@
   {
     "agency_id": "ad140090-59f9-53c9-8071-9a4b1c6be438",
     "slug": "burlington-ia-pd",
-    "flock_active_slug": "burlington-ia-pd",
-    "flock_slugs": [
-      "burlington-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burlington IA PD"
     ],
@@ -37329,10 +34945,8 @@
   {
     "agency_id": "cc9e39af-f9a3-57a9-8a24-90980d03ca85",
     "slug": "burnett-county-wi-so",
-    "flock_active_slug": "burnett-county-wi-so",
-    "flock_slugs": [
-      "burnett-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burnett County WI SO"
     ],
@@ -37356,10 +34970,8 @@
   {
     "agency_id": "ec9776d2-5fcb-5599-9453-59a4cba9666b",
     "slug": "burnham-il-pd",
-    "flock_active_slug": "burnham-il-pd",
-    "flock_slugs": [
-      "burnham-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burnham IL PD"
     ],
@@ -37383,10 +34995,8 @@
   {
     "agency_id": "ad1f8353-ce87-54b6-bbcc-30d60098a809",
     "slug": "burton-mi-pd",
-    "flock_active_slug": "burton-mi-pd",
-    "flock_slugs": [
-      "burton-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burton MI PD"
     ],
@@ -37410,10 +35020,8 @@
   {
     "agency_id": "8cf3c2ad-6bd2-5ff7-b426-1483352da3a3",
     "slug": "bushnell-il-pd",
-    "flock_active_slug": "bushnell-il-pd",
-    "flock_slugs": [
-      "bushnell-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bushnell IL PD"
     ],
@@ -37437,10 +35045,8 @@
   {
     "agency_id": "666f18d6-fc44-585d-ba7e-4ddadd58c787",
     "slug": "butler-in-pd",
-    "flock_active_slug": "butler-in-pd",
-    "flock_slugs": [
-      "butler-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Butler IN PD"
     ],
@@ -37464,10 +35070,8 @@
   {
     "agency_id": "870a82fc-4bb1-5a6b-a9ab-5c091584a726",
     "slug": "butler-township-pa-pd",
-    "flock_active_slug": "butler-township-pa-pd",
-    "flock_slugs": [
-      "butler-township-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Butler Township PA PD"
     ],
@@ -37492,10 +35096,8 @@
   {
     "agency_id": "46f1735b-02e4-5214-8a37-823e4d0eccae",
     "slug": "byron-il-pd",
-    "flock_active_slug": "byron-il-pd",
-    "flock_slugs": [
-      "byron-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Byron IL PD"
     ],
@@ -37519,10 +35121,8 @@
   {
     "agency_id": "7747c016-b92d-5450-9403-c6bd93dbfdf6",
     "slug": "calhoun-county-mi-so",
-    "flock_active_slug": "calhoun-county-mi-so",
-    "flock_slugs": [
-      "calhoun-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calhoun County MI SO"
     ],
@@ -37546,10 +35146,8 @@
   {
     "agency_id": "b9a83f24-da75-5f59-b238-72d5cbdd07f0",
     "slug": "callaway-county-mo-so",
-    "flock_active_slug": "callaway-county-mo-so",
-    "flock_slugs": [
-      "callaway-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Callaway County MO SO"
     ],
@@ -37573,10 +35171,8 @@
   {
     "agency_id": "bae5aa33-76f1-5824-ba2b-43661b87150b",
     "slug": "calumet-park-il-pd",
-    "flock_active_slug": "calumet-park-il-pd",
-    "flock_slugs": [
-      "calumet-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calumet Park IL PD"
     ],
@@ -37600,10 +35196,8 @@
   {
     "agency_id": "24c6da75-f381-5856-9b4d-f13034601722",
     "slug": "canton-il-pd",
-    "flock_active_slug": "canton-il-pd",
-    "flock_slugs": [
-      "canton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Canton IL PD"
     ],
@@ -37627,10 +35221,8 @@
   {
     "agency_id": "62ba4003-36bf-5c41-b183-a32cd8186aaa",
     "slug": "carol-stream-il-pd",
-    "flock_active_slug": "carol-stream-il-pd",
-    "flock_slugs": [
-      "carol-stream-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carol Stream IL PD"
     ],
@@ -37654,10 +35246,8 @@
   {
     "agency_id": "d62c6fc3-0b4c-5c4d-adda-606f90bb6899",
     "slug": "carpentersville-il-pd",
-    "flock_active_slug": "carpentersville-il-pd",
-    "flock_slugs": [
-      "carpentersville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carpentersville IL PD"
     ],
@@ -37681,10 +35271,8 @@
   {
     "agency_id": "c6aaf3f7-392f-5bed-8286-9188a196411d",
     "slug": "cary-il-pd",
-    "flock_active_slug": "cary-il-pd",
-    "flock_slugs": [
-      "cary-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cary IL PD"
     ],
@@ -37708,10 +35296,8 @@
   {
     "agency_id": "9b8e1fe7-c01d-5214-9554-5970c51b217c",
     "slug": "cass-county-il-so",
-    "flock_active_slug": "cass-county-il-so",
-    "flock_slugs": [
-      "cass-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cass County IL SO"
     ],
@@ -37735,10 +35321,8 @@
   {
     "agency_id": "eef9972e-b29e-5c9e-afc9-1e4647423ec2",
     "slug": "cass-county-in-so",
-    "flock_active_slug": "cass-county-in-so",
-    "flock_slugs": [
-      "cass-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cass County IN SO"
     ],
@@ -37762,10 +35346,8 @@
   {
     "agency_id": "8c93d84e-4f6f-58cd-a9ba-2e816d811a23",
     "slug": "cass-county-mi-so",
-    "flock_active_slug": "cass-county-mi-so",
-    "flock_slugs": [
-      "cass-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cass County MI SO"
     ],
@@ -37789,10 +35371,8 @@
   {
     "agency_id": "03364078-87a9-5220-b896-494e22085479",
     "slug": "cass-county-mo-so",
-    "flock_active_slug": "cass-county-mo-so",
-    "flock_slugs": [
-      "cass-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cass County MO SO"
     ],
@@ -37816,10 +35396,8 @@
   {
     "agency_id": "7a866b8f-7080-5774-99c3-a3986afa145b",
     "slug": "cedar-county-ia-so",
-    "flock_active_slug": "cedar-county-ia-so",
-    "flock_slugs": [
-      "cedar-county-ia-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedar County IA SO"
     ],
@@ -37843,10 +35421,8 @@
   {
     "agency_id": "308e7ece-43c7-53c1-90a6-82f1e7a26d68",
     "slug": "cedar-rapids-ia-pd",
-    "flock_active_slug": "cedar-rapids-ia-pd",
-    "flock_slugs": [
-      "cedar-rapids-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedar Rapids IA PD"
     ],
@@ -37870,10 +35446,8 @@
   {
     "agency_id": "d90f6099-aaf8-5608-b1e9-265d110bd5e2",
     "slug": "cedarburg-wi-pd-inactive",
-    "flock_active_slug": "cedarburg-wi-pd-inactive",
-    "flock_slugs": [
-      "cedarburg-wi-pd-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cedarburg WI PD [Inactive]"
     ],
@@ -37899,10 +35473,8 @@
   {
     "agency_id": "94472133-52fb-5a43-aa44-11d9a349cf40",
     "slug": "champaign-county-il-so",
-    "flock_active_slug": "champaign-county-il-so",
-    "flock_slugs": [
-      "champaign-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Champaign County IL SO"
     ],
@@ -37926,10 +35498,8 @@
   {
     "agency_id": "18de26ee-c7aa-5936-8bd5-9e88b89e48ea",
     "slug": "champaign-il-pd",
-    "flock_active_slug": "champaign-il-pd",
-    "flock_slugs": [
-      "champaign-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Champaign IL PD"
     ],
@@ -37953,10 +35523,8 @@
   {
     "agency_id": "1eab86b8-2de5-5ed5-8742-197dd3c4fb70",
     "slug": "champlin-mn-pd",
-    "flock_active_slug": "champlin-mn-pd",
-    "flock_slugs": [
-      "champlin-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Champlin MN PD"
     ],
@@ -37980,10 +35548,8 @@
   {
     "agency_id": "d63b125c-d38c-5d36-a91b-c0197f745ff3",
     "slug": "channahon-il-pd",
-    "flock_active_slug": "channahon-il-pd",
-    "flock_slugs": [
-      "channahon-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Channahon IL PD"
     ],
@@ -38007,10 +35573,8 @@
   {
     "agency_id": "ea9df760-f207-5f85-9f8e-7f41997737bd",
     "slug": "charleston-il-pd",
-    "flock_active_slug": "charleston-il-pd",
-    "flock_slugs": [
-      "charleston-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Charleston IL PD"
     ],
@@ -38034,10 +35598,8 @@
   {
     "agency_id": "1b0546b7-5530-5083-b11d-497bf38a12e4",
     "slug": "charter-township-of-buena-vista-mi-pd",
-    "flock_active_slug": "charter-township-of-buena-vista-mi-pd",
-    "flock_slugs": [
-      "charter-township-of-buena-vista-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Charter Township of Buena Vista MI PD"
     ],
@@ -38062,10 +35624,8 @@
   {
     "agency_id": "39c1bf32-571a-58c8-a774-2c4d5dbaa876",
     "slug": "chase-county-ks-so",
-    "flock_active_slug": "chase-county-ks-so",
-    "flock_slugs": [
-      "chase-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chase County KS SO"
     ],
@@ -38089,10 +35649,8 @@
   {
     "agency_id": "03c8ec96-8fdd-51fc-ba38-8a3361b6e6e1",
     "slug": "chatham-il-pd",
-    "flock_active_slug": "chatham-il-pd",
-    "flock_slugs": [
-      "chatham-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chatham IL PD"
     ],
@@ -38116,10 +35674,8 @@
   {
     "agency_id": "118dd293-78d4-541e-8d04-47ca11041dd8",
     "slug": "chenoa-il-pd",
-    "flock_active_slug": "chenoa-il-pd",
-    "flock_slugs": [
-      "chenoa-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chenoa IL PD"
     ],
@@ -38143,10 +35699,8 @@
   {
     "agency_id": "7ae8cb40-265b-533b-969b-3079635a640b",
     "slug": "cherry-valley-il-pd",
-    "flock_active_slug": "cherry-valley-il-pd",
-    "flock_slugs": [
-      "cherry-valley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cherry Valley IL PD"
     ],
@@ -38170,10 +35724,8 @@
   {
     "agency_id": "acf4647c-c214-5dbd-bf7d-fe30bdab5190",
     "slug": "chesterfield-mo-pd",
-    "flock_active_slug": "chesterfield-mo-pd",
-    "flock_slugs": [
-      "chesterfield-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chesterfield MO PD"
     ],
@@ -38197,10 +35749,8 @@
   {
     "agency_id": "f52afc21-52fc-543c-a022-ef3be542587c",
     "slug": "chetek-wi-pd",
-    "flock_active_slug": "chetek-wi-pd",
-    "flock_slugs": [
-      "chetek-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chetek WI PD"
     ],
@@ -38224,10 +35774,8 @@
   {
     "agency_id": "09d70d09-1c2d-59cc-a227-a21fe402ac91",
     "slug": "chicago-il-pd",
-    "flock_active_slug": "chicago-il-pd",
-    "flock_slugs": [
-      "chicago-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chicago IL PD"
     ],
@@ -38251,10 +35799,8 @@
   {
     "agency_id": "119a12e3-bd4d-5937-93fd-615d23d1a4af",
     "slug": "chillicothe-il-pd",
-    "flock_active_slug": "chillicothe-il-pd",
-    "flock_slugs": [
-      "chillicothe-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chillicothe IL PD"
     ],
@@ -38278,10 +35824,8 @@
   {
     "agency_id": "38a70756-8b34-5ac8-a597-dc2dc4fb0d54",
     "slug": "chisago-county-mn-so",
-    "flock_active_slug": "chisago-county-mn-so",
-    "flock_slugs": [
-      "chisago-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chisago County MN SO"
     ],
@@ -38305,10 +35849,8 @@
   {
     "agency_id": "07cdc31b-6552-5357-a9d2-395c8aacbc20",
     "slug": "city-of-delavan-wi-pd",
-    "flock_active_slug": "city-of-delavan-wi-pd",
-    "flock_slugs": [
-      "city-of-delavan-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Delavan WI PD"
     ],
@@ -38332,10 +35874,8 @@
   {
     "agency_id": "9546a481-6379-5b80-a336-7ea764558313",
     "slug": "city-of-maryville-mo",
-    "flock_active_slug": "city-of-maryville-mo",
-    "flock_slugs": [
-      "city-of-maryville-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Maryville MO"
     ],
@@ -38360,10 +35900,8 @@
   {
     "agency_id": "96d3a144-2b50-50fc-a7e5-29dbf9d05b46",
     "slug": "clark-county-wi-so",
-    "flock_active_slug": "clark-county-wi-so",
-    "flock_slugs": [
-      "clark-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clark County WI SO"
     ],
@@ -38387,10 +35925,8 @@
   {
     "agency_id": "0d5bcb83-c360-5ad8-a44f-03c1a0253eba",
     "slug": "clayton-mo-pd",
-    "flock_active_slug": "clayton-mo-pd",
-    "flock_slugs": [
-      "clayton-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clayton MO PD"
     ],
@@ -38414,10 +35950,8 @@
   {
     "agency_id": "aca03c4d-ae27-57ce-8fea-45ac41a984ff",
     "slug": "clayton-township-pd-mi",
-    "flock_active_slug": "clayton-township-pd-mi",
-    "flock_slugs": [
-      "clayton-township-pd-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clayton Township PD MI"
     ],
@@ -38442,10 +35976,8 @@
   {
     "agency_id": "f168928f-b50b-5bd7-8c25-6da6521fdb93",
     "slug": "clear-lake-ia-pd",
-    "flock_active_slug": "clear-lake-ia-pd",
-    "flock_slugs": [
-      "clear-lake-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clear Lake IA PD"
     ],
@@ -38469,10 +36001,8 @@
   {
     "agency_id": "d73bce9a-09ed-536f-aacf-ce00f3ff47fc",
     "slug": "clinton-county-mi-so",
-    "flock_active_slug": "clinton-county-mi-so",
-    "flock_slugs": [
-      "clinton-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clinton County MI SO"
     ],
@@ -38496,10 +36026,8 @@
   {
     "agency_id": "c7494f50-7352-5676-a70e-5754c0542aa0",
     "slug": "clinton-mo-pd",
-    "flock_active_slug": "clinton-mo-pd",
-    "flock_slugs": [
-      "clinton-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clinton MO PD"
     ],
@@ -38523,10 +36051,8 @@
   {
     "agency_id": "02d8c315-100e-5666-98f3-002765ccbef1",
     "slug": "clive-ia-pd",
-    "flock_active_slug": "clive-ia-pd",
-    "flock_slugs": [
-      "clive-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clive IA PD"
     ],
@@ -38550,10 +36076,8 @@
   {
     "agency_id": "a7d678bb-9925-5979-9013-573f7afd3980",
     "slug": "clover-sc-pd",
-    "flock_active_slug": "clover-sc-pd",
-    "flock_slugs": [
-      "clover-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clover SC PD"
     ],
@@ -38577,10 +36101,8 @@
   {
     "agency_id": "c70c6649-4e36-5d65-b654-8e46154274fd",
     "slug": "clovis-nm-pd",
-    "flock_active_slug": "clovis-nm-pd",
-    "flock_slugs": [
-      "clovis-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clovis NM PD"
     ],
@@ -38604,10 +36126,8 @@
   {
     "agency_id": "6d9fe2dd-549b-5d2a-9d59-4bc071523d62",
     "slug": "codington-county-sd-so",
-    "flock_active_slug": "codington-county-sd-so",
-    "flock_slugs": [
-      "codington-county-sd-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Codington County SD SO"
     ],
@@ -38631,10 +36151,8 @@
   {
     "agency_id": "17f5380b-7ab9-57df-b230-76b4d06b35c5",
     "slug": "cole-county-mo-so",
-    "flock_active_slug": "cole-county-mo-so",
-    "flock_slugs": [
-      "cole-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cole County MO SO"
     ],
@@ -38658,10 +36176,8 @@
   {
     "agency_id": "b1c8113d-091b-5783-8c21-eeb452dfc48e",
     "slug": "columbia-county-wi-so",
-    "flock_active_slug": "columbia-county-wi-so",
-    "flock_slugs": [
-      "columbia-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbia County WI SO"
     ],
@@ -38685,10 +36201,8 @@
   {
     "agency_id": "69d63c03-6c68-5891-a854-87588ad43163",
     "slug": "columbia-heights-mn-pd",
-    "flock_active_slug": "columbia-heights-mn-pd",
-    "flock_slugs": [
-      "columbia-heights-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Columbia Heights MN PD"
     ],
@@ -38712,10 +36226,8 @@
   {
     "agency_id": "8f99f695-5554-5fd5-9b6c-63a683f21d55",
     "slug": "concordia-ks-pd",
-    "flock_active_slug": "concordia-ks-pd",
-    "flock_slugs": [
-      "concordia-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Concordia KS PD"
     ],
@@ -38739,10 +36251,8 @@
   {
     "agency_id": "741791f6-7960-5fc3-b12d-df63a6e729a3",
     "slug": "concordia-mo-pd",
-    "flock_active_slug": "concordia-mo-pd",
-    "flock_slugs": [
-      "concordia-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Concordia MO PD"
     ],
@@ -38766,10 +36276,8 @@
   {
     "agency_id": "2a9a9475-74c3-55cf-ba2d-a438c010a78c",
     "slug": "coon-rapids-mn-pd",
-    "flock_active_slug": "coon-rapids-mn-pd",
-    "flock_slugs": [
-      "coon-rapids-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coon Rapids MN PD"
     ],
@@ -38793,10 +36301,8 @@
   {
     "agency_id": "d9fee7b2-7f20-50a6-ac77-239d9252568d",
     "slug": "cooper-county-mo-so",
-    "flock_active_slug": "cooper-county-mo-so",
-    "flock_slugs": [
-      "cooper-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cooper County MO SO"
     ],
@@ -38820,10 +36326,8 @@
   {
     "agency_id": "0679177e-00f1-5f8c-bfef-ca792e38dcf9",
     "slug": "corcoran-mn-pd",
-    "flock_active_slug": "corcoran-mn-pd",
-    "flock_slugs": [
-      "corcoran-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Corcoran MN PD"
     ],
@@ -38847,10 +36351,8 @@
   {
     "agency_id": "3da40a33-acd8-5327-b8ba-56b2dcdd2d1a",
     "slug": "cortland-il-pd",
-    "flock_active_slug": "cortland-il-pd",
-    "flock_slugs": [
-      "cortland-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cortland IL PD"
     ],
@@ -38874,10 +36376,8 @@
   {
     "agency_id": "8214a38c-f5a8-517f-9853-4f407b162775",
     "slug": "cottage-grove-public-safety-dept-mn",
-    "flock_active_slug": "cottage-grove-public-safety-dept-mn",
-    "flock_slugs": [
-      "cottage-grove-public-safety-dept-mn"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cottage Grove Public Safety Dept (MN)"
     ],
@@ -38901,10 +36401,8 @@
   {
     "agency_id": "6302190f-62a2-5c68-b0ad-75a5fd02f16d",
     "slug": "cottleville-mo-pd",
-    "flock_active_slug": "cottleville-mo-pd",
-    "flock_slugs": [
-      "cottleville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cottleville MO PD"
     ],
@@ -38928,10 +36426,8 @@
   {
     "agency_id": "1ff68981-e83d-5009-9aa3-4e0f0154a554",
     "slug": "council-bluffs-ia-pd",
-    "flock_active_slug": "council-bluffs-ia-pd",
-    "flock_slugs": [
-      "council-bluffs-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Council Bluffs IA PD"
     ],
@@ -38955,10 +36451,8 @@
   {
     "agency_id": "2b7eb81e-b761-5492-9580-2dcd5ab76593",
     "slug": "country-club-hills-il-pd",
-    "flock_active_slug": "country-club-hills-il-pd",
-    "flock_slugs": [
-      "country-club-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Country Club Hills IL PD"
     ],
@@ -38982,10 +36476,8 @@
   {
     "agency_id": "1157f0a1-9333-5132-aaa0-0398c3792aa4",
     "slug": "crawford-county-wi-so",
-    "flock_active_slug": "crawford-county-wi-so",
-    "flock_slugs": [
-      "crawford-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawford County WI SO"
     ],
@@ -39009,10 +36501,8 @@
   {
     "agency_id": "aad7db30-32cc-5914-9651-329f0de707f3",
     "slug": "crawfordsville-in-pd",
-    "flock_active_slug": "crawfordsville-in-pd",
-    "flock_slugs": [
-      "crawfordsville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crawfordsville IN PD"
     ],
@@ -39036,10 +36526,8 @@
   {
     "agency_id": "0edf3c8d-3550-540d-a7e8-743a6918eac4",
     "slug": "crest-hill-il-pd",
-    "flock_active_slug": "crest-hill-il-pd",
-    "flock_slugs": [
-      "crest-hill-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crest Hill IL PD"
     ],
@@ -39063,10 +36551,8 @@
   {
     "agency_id": "6e38440f-8399-5164-8b86-df171b134d51",
     "slug": "crestwood-mo-pd",
-    "flock_active_slug": "crestwood-mo-pd",
-    "flock_slugs": [
-      "crestwood-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crestwood MO PD"
     ],
@@ -39090,10 +36576,8 @@
   {
     "agency_id": "08c541c2-954a-56b9-a223-b26dda70f57f",
     "slug": "creve-coeur-il-pd",
-    "flock_active_slug": "creve-coeur-il-pd",
-    "flock_slugs": [
-      "creve-coeur-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Creve Coeur IL PD"
     ],
@@ -39117,10 +36601,8 @@
   {
     "agency_id": "bda3ede3-da47-52eb-a40b-f417c7494ba2",
     "slug": "creve-coeur-mo-pd",
-    "flock_active_slug": "creve-coeur-mo-pd",
-    "flock_slugs": [
-      "creve-coeur-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Creve Coeur MO PD"
     ],
@@ -39144,10 +36626,8 @@
   {
     "agency_id": "a7665caa-e72d-5fca-8a55-24a031751a0a",
     "slug": "crow-wing-county-mn-so",
-    "flock_active_slug": "crow-wing-county-mn-so",
-    "flock_slugs": [
-      "crow-wing-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crow Wing County MN SO"
     ],
@@ -39171,10 +36651,8 @@
   {
     "agency_id": "cf6057f1-a97e-527f-b36d-60255d73f589",
     "slug": "crown-point-in-pd",
-    "flock_active_slug": "crown-point-in-pd",
-    "flock_slugs": [
-      "crown-point-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crown Point IN PD"
     ],
@@ -39198,10 +36676,8 @@
   {
     "agency_id": "144e2be5-e887-5767-9358-5613fc4d0e22",
     "slug": "crystal-mn-pd",
-    "flock_active_slug": "crystal-mn-pd",
-    "flock_slugs": [
-      "crystal-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crystal MN PD"
     ],
@@ -39225,10 +36701,8 @@
   {
     "agency_id": "40c9fae0-b541-5831-a4f3-8c04a7c5b664",
     "slug": "cumberland-wi-pd",
-    "flock_active_slug": "cumberland-wi-pd",
-    "flock_slugs": [
-      "cumberland-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cumberland WI PD"
     ],
@@ -39252,10 +36726,8 @@
   {
     "agency_id": "1abbf8a3-7ce4-5b04-a6a8-30264fb8de0f",
     "slug": "dakota-county-mn-so",
-    "flock_active_slug": "dakota-county-mn-so",
-    "flock_slugs": [
-      "dakota-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dakota County MN SO"
     ],
@@ -39279,10 +36751,8 @@
   {
     "agency_id": "48841a6b-f280-54eb-ba5d-cb57962ad687",
     "slug": "dane-county-wi-so",
-    "flock_active_slug": "dane-county-wi-so",
-    "flock_slugs": [
-      "dane-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dane County WI SO"
     ],
@@ -39306,10 +36776,8 @@
   {
     "agency_id": "4a1c911b-5e90-53fd-805e-3b55f344434d",
     "slug": "danville-il-pd",
-    "flock_active_slug": "danville-il-pd",
-    "flock_slugs": [
-      "danville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Danville IL PD"
     ],
@@ -39333,10 +36801,8 @@
   {
     "agency_id": "bf03074d-f0cc-5535-a5ad-acd79a1c773f",
     "slug": "darien-il-pd",
-    "flock_active_slug": "darien-il-pd",
-    "flock_slugs": [
-      "darien-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Darien IL PD"
     ],
@@ -39360,10 +36826,8 @@
   {
     "agency_id": "f06cc8df-2213-5e33-8ffc-b2d27cd83785",
     "slug": "davison-township-mi-pd",
-    "flock_active_slug": "davison-township-mi-pd",
-    "flock_slugs": [
-      "davison-township-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Davison Township MI PD"
     ],
@@ -39387,10 +36851,8 @@
   {
     "agency_id": "73f8bc50-5046-53d3-ae0a-8098aee31daf",
     "slug": "dawson-county-ne-so",
-    "flock_active_slug": "dawson-county-ne-so",
-    "flock_slugs": [
-      "dawson-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dawson County NE SO"
     ],
@@ -39414,10 +36876,8 @@
   {
     "agency_id": "e7bb452e-d57f-5a3b-84ea-b777e69610ad",
     "slug": "dayton-mn-pd",
-    "flock_active_slug": "dayton-mn-pd",
-    "flock_slugs": [
-      "dayton-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dayton MN PD"
     ],
@@ -39441,10 +36901,8 @@
   {
     "agency_id": "f297fe03-8165-5a63-bb57-d5bbd188b5d0",
     "slug": "depue-il-pd",
-    "flock_active_slug": "depue-il-pd",
-    "flock_slugs": [
-      "depue-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Depue IL PD"
     ],
@@ -39468,10 +36926,8 @@
   {
     "agency_id": "8d00525b-08a4-5e51-bad7-3a50ca04029d",
     "slug": "des-moines-ia-pd",
-    "flock_active_slug": "des-moines-ia-pd",
-    "flock_slugs": [
-      "des-moines-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Des Moines IA PD"
     ],
@@ -39495,10 +36951,8 @@
   {
     "agency_id": "d9733593-c879-591b-9a39-b4ae051f3716",
     "slug": "detroit-lakes-mn-pd",
-    "flock_active_slug": "detroit-lakes-mn-pd",
-    "flock_slugs": [
-      "detroit-lakes-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Detroit Lakes MN PD"
     ],
@@ -39522,10 +36976,8 @@
   {
     "agency_id": "da5f90aa-d20d-5b94-b5ea-c5f0fc5a648d",
     "slug": "dickinson-county-mi-so",
-    "flock_active_slug": "dickinson-county-mi-so",
-    "flock_slugs": [
-      "dickinson-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dickinson County MI SO"
     ],
@@ -39549,10 +37001,8 @@
   {
     "agency_id": "6db005e6-690c-5735-a77f-1837ef342c47",
     "slug": "dixmoor-il-pd",
-    "flock_active_slug": "dixmoor-il-pd",
-    "flock_slugs": [
-      "dixmoor-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dixmoor IL PD"
     ],
@@ -39576,10 +37026,8 @@
   {
     "agency_id": "2d0b5504-f05c-5e69-b295-fccccf3a1378",
     "slug": "dolton-il-pd",
-    "flock_active_slug": "dolton-il-pd",
-    "flock_slugs": [
-      "dolton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dolton IL PD"
     ],
@@ -39603,10 +37051,8 @@
   {
     "agency_id": "fb09b25d-a076-533d-9d20-cf98818ab608",
     "slug": "downers-grove-il-pd",
-    "flock_active_slug": "downers-grove-il-pd",
-    "flock_slugs": [
-      "downers-grove-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Downers Grove IL PD"
     ],
@@ -39630,10 +37076,8 @@
   {
     "agency_id": "7f866083-eff9-59e4-92b4-d90a091d147f",
     "slug": "dubuque-ia-pd",
-    "flock_active_slug": "dubuque-ia-pd",
-    "flock_slugs": [
-      "dubuque-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dubuque IA PD"
     ],
@@ -39657,10 +37101,8 @@
   {
     "agency_id": "27d95757-5e1b-509a-8b32-96033e0287e7",
     "slug": "dupage-co-il-prosecutor-office",
-    "flock_active_slug": "dupage-co-il-prosecutor-office",
-    "flock_slugs": [
-      "dupage-co-il-prosecutor-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DuPage Co IL Prosecutor Office"
     ],
@@ -39681,10 +37123,8 @@
   {
     "agency_id": "6ea5ab85-81af-5fad-90cd-cb06d9ae7209",
     "slug": "east-dundee-il-pd",
-    "flock_active_slug": "east-dundee-il-pd",
-    "flock_slugs": [
-      "east-dundee-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Dundee IL PD"
     ],
@@ -39708,10 +37148,8 @@
   {
     "agency_id": "ebd8a154-cc66-599b-916b-96b761cfa99f",
     "slug": "east-lansing-mi-pd",
-    "flock_active_slug": "east-lansing-mi-pd",
-    "flock_slugs": [
-      "east-lansing-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Lansing MI PD"
     ],
@@ -39735,10 +37173,8 @@
   {
     "agency_id": "54404659-745a-593e-9d2f-649a324ee79d",
     "slug": "east-moline-il-pd",
-    "flock_active_slug": "east-moline-il-pd",
-    "flock_slugs": [
-      "east-moline-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Moline IL PD"
     ],
@@ -39762,10 +37198,8 @@
   {
     "agency_id": "777f1aa7-7acc-5247-9da4-68d7767a34e7",
     "slug": "east-peoria-il-pd",
-    "flock_active_slug": "east-peoria-il-pd",
-    "flock_slugs": [
-      "east-peoria-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Peoria IL PD"
     ],
@@ -39789,10 +37223,8 @@
   {
     "agency_id": "3f6a5bc4-4d44-59cc-ae66-518fb87c78c4",
     "slug": "eau-claire-county-wi-so",
-    "flock_active_slug": "eau-claire-county-wi-so",
-    "flock_slugs": [
-      "eau-claire-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eau Claire County WI SO"
     ],
@@ -39816,10 +37248,8 @@
   {
     "agency_id": "b8b402e4-2fa8-5f1c-81cc-48e252e68d3e",
     "slug": "elk-river-mn-pd",
-    "flock_active_slug": "elk-river-mn-pd",
-    "flock_slugs": [
-      "elk-river-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elk River MN PD"
     ],
@@ -39843,10 +37273,8 @@
   {
     "agency_id": "cc2d43b6-5dbb-56d3-9f29-760851f06823",
     "slug": "elkhart-county-in-so",
-    "flock_active_slug": "elkhart-county-in-so",
-    "flock_slugs": [
-      "elkhart-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elkhart County IN SO"
     ],
@@ -39870,10 +37298,8 @@
   {
     "agency_id": "799de733-ef0d-5e12-8c85-bb3fc66f33c2",
     "slug": "elkhorn-wi-pd",
-    "flock_active_slug": "elkhorn-wi-pd",
-    "flock_slugs": [
-      "elkhorn-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elkhorn WI PD"
     ],
@@ -39897,10 +37323,8 @@
   {
     "agency_id": "95e9f49e-54a2-5189-9d12-3de8c1ce824f",
     "slug": "elm-grove-wi-pd",
-    "flock_active_slug": "elm-grove-wi-pd",
-    "flock_slugs": [
-      "elm-grove-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elm Grove WI PD"
     ],
@@ -39924,10 +37348,8 @@
   {
     "agency_id": "d6288828-66b9-59d2-9d1e-978302070932",
     "slug": "elmhurst-il-pd",
-    "flock_active_slug": "elmhurst-il-pd",
-    "flock_slugs": [
-      "elmhurst-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elmhurst IL PD"
     ],
@@ -39951,10 +37373,8 @@
   {
     "agency_id": "f3842ace-bf7f-5480-89eb-03752500b126",
     "slug": "escambia-county-fl-so",
-    "flock_active_slug": "escambia-county-fl-so",
-    "flock_slugs": [
-      "escambia-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Escambia County FL SO"
     ],
@@ -39978,10 +37398,8 @@
   {
     "agency_id": "bd91d366-1958-50af-9a6d-3ddd2b1e0f14",
     "slug": "eureka-mo-pd",
-    "flock_active_slug": "eureka-mo-pd",
-    "flock_slugs": [
-      "eureka-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eureka MO PD"
     ],
@@ -40005,10 +37423,8 @@
   {
     "agency_id": "2e0213d8-b9d8-5a1c-b473-7008e89544fe",
     "slug": "excelsior-springs-mo-pd",
-    "flock_active_slug": "excelsior-springs-mo-pd",
-    "flock_slugs": [
-      "excelsior-springs-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Excelsior Springs MO PD"
     ],
@@ -40032,10 +37448,8 @@
   {
     "agency_id": "a1078504-f18e-54fe-a657-0d1ce4ca5efc",
     "slug": "fairfax-county-va-pd",
-    "flock_active_slug": "fairfax-county-va-pd",
-    "flock_slugs": [
-      "fairfax-county-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairfax County VA PD"
     ],
@@ -40059,10 +37473,8 @@
   {
     "agency_id": "0310288b-0343-51cd-9ae7-3ea06e29f5c9",
     "slug": "faribault-mn-pd",
-    "flock_active_slug": "faribault-mn-pd",
-    "flock_slugs": [
-      "faribault-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Faribault MN PD"
     ],
@@ -40086,10 +37498,8 @@
   {
     "agency_id": "081ce3e5-5a44-50b9-a898-eca30706590d",
     "slug": "farmer-city-il-pd",
-    "flock_active_slug": "farmer-city-il-pd",
-    "flock_slugs": [
-      "farmer-city-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Farmer City IL PD"
     ],
@@ -40113,10 +37523,8 @@
   {
     "agency_id": "3d1390a3-758a-5fd2-9063-5f2c17b972dd",
     "slug": "fayette-county-il-so",
-    "flock_active_slug": "fayette-county-il-so",
-    "flock_slugs": [
-      "fayette-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fayette County IL SO"
     ],
@@ -40140,10 +37548,8 @@
   {
     "agency_id": "d4f7da0f-875e-55b3-8085-7605775ba01a",
     "slug": "ferguson-mo-pd",
-    "flock_active_slug": "ferguson-mo-pd",
-    "flock_slugs": [
-      "ferguson-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ferguson MO PD"
     ],
@@ -40167,10 +37573,8 @@
   {
     "agency_id": "2273a1d4-37fc-51c3-a001-ee792495bc3b",
     "slug": "fishkill-town-ny-pd",
-    "flock_active_slug": "fishkill-town-ny-pd",
-    "flock_slugs": [
-      "fishkill-town-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fishkill Town NY PD"
     ],
@@ -40194,10 +37598,8 @@
   {
     "agency_id": "96d343f2-2c43-51b2-9772-933f09cee6b4",
     "slug": "flint-mi-pd",
-    "flock_active_slug": "flint-mi-pd",
-    "flock_slugs": [
-      "flint-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flint MI PD"
     ],
@@ -40221,10 +37623,8 @@
   {
     "agency_id": "a7835f61-1bc5-547e-8486-3bf49142bf36",
     "slug": "florence-co-wi-so",
-    "flock_active_slug": "florence-co-wi-so",
-    "flock_slugs": [
-      "florence-co-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Florence Co. WI SO"
     ],
@@ -40248,10 +37648,8 @@
   {
     "agency_id": "39dc1699-cfa2-5d78-b0e3-fa723b7295ba",
     "slug": "florissant-mo-pd",
-    "flock_active_slug": "florissant-mo-pd",
-    "flock_slugs": [
-      "florissant-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Florissant MO PD"
     ],
@@ -40275,10 +37673,8 @@
   {
     "agency_id": "1329f462-f1a3-541b-91b7-de7e1b9d0106",
     "slug": "flossmoor-il-pd",
-    "flock_active_slug": "flossmoor-il-pd",
-    "flock_slugs": [
-      "flossmoor-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flossmoor IL PD"
     ],
@@ -40302,10 +37698,8 @@
   {
     "agency_id": "fa5a5d7e-1a82-5e49-8bab-2f0973802f57",
     "slug": "flushing-city-mi-pd",
-    "flock_active_slug": "flushing-city-mi-pd",
-    "flock_slugs": [
-      "flushing-city-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flushing City MI PD"
     ],
@@ -40329,10 +37723,8 @@
   {
     "agency_id": "d4b720f0-ff77-5d7b-b5b3-7d7ba1b8d224",
     "slug": "forest-county-wi-so",
-    "flock_active_slug": "forest-county-wi-so",
-    "flock_slugs": [
-      "forest-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Forest County WI SO"
     ],
@@ -40356,10 +37748,8 @@
   {
     "agency_id": "b6e6af57-fc3f-534c-b6d9-80eca71775b8",
     "slug": "forest-preserve-district-will-county-pd-il",
-    "flock_active_slug": "forest-preserve-district-will-county-pd-il",
-    "flock_slugs": [
-      "forest-preserve-district-will-county-pd-il"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Forest Preserve District Will County PD (IL)"
     ],
@@ -40383,10 +37773,8 @@
   {
     "agency_id": "d2085fad-ad5f-542d-a4b2-a94527ad5aa5",
     "slug": "fox-valley-il-parks-district",
-    "flock_active_slug": "fox-valley-il-parks-district",
-    "flock_slugs": [
-      "fox-valley-il-parks-district"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fox Valley IL Parks District"
     ],
@@ -40408,10 +37796,8 @@
   {
     "agency_id": "5bb78d28-c522-5130-b2bb-69533f355b9d",
     "slug": "franklin-county-mo-so",
-    "flock_active_slug": "franklin-county-mo-so",
-    "flock_slugs": [
-      "franklin-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin County MO SO"
     ],
@@ -40435,10 +37821,8 @@
   {
     "agency_id": "4339d929-cc3d-55d8-955f-b28e15787d75",
     "slug": "franklin-in-pd",
-    "flock_active_slug": "franklin-in-pd",
-    "flock_slugs": [
-      "franklin-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin IN PD"
     ],
@@ -40462,10 +37846,8 @@
   {
     "agency_id": "2f32ead8-5bef-5eef-be7e-45798fb2214c",
     "slug": "franklin-ma-pd",
-    "flock_active_slug": "franklin-ma-pd",
-    "flock_slugs": [
-      "franklin-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin MA PD"
     ],
@@ -40489,10 +37871,8 @@
   {
     "agency_id": "a9467d63-b933-50cf-94b5-eccae5a6e858",
     "slug": "franklin-park-il-pd",
-    "flock_active_slug": "franklin-park-il-pd",
-    "flock_slugs": [
-      "franklin-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin Park IL PD"
     ],
@@ -40516,10 +37896,8 @@
   {
     "agency_id": "f9f8454b-eca1-5f08-b499-24091a85c25b",
     "slug": "freeport-il-pd",
-    "flock_active_slug": "freeport-il-pd",
-    "flock_slugs": [
-      "freeport-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Freeport IL PD"
     ],
@@ -40543,10 +37921,8 @@
   {
     "agency_id": "0b72463c-fc95-5667-b109-aa1268c4663d",
     "slug": "fremont-county-ia-so",
-    "flock_active_slug": "fremont-county-ia-so",
-    "flock_slugs": [
-      "fremont-county-ia-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fremont County IA SO"
     ],
@@ -40570,10 +37946,8 @@
   {
     "agency_id": "a7a9ed9d-e639-541b-9b65-9828e03ac984",
     "slug": "fridley-mn-pd",
-    "flock_active_slug": "fridley-mn-pd",
-    "flock_slugs": [
-      "fridley-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fridley MN PD"
     ],
@@ -40597,10 +37971,8 @@
   {
     "agency_id": "6cd22850-c866-5ab9-ac2c-995959fe44db",
     "slug": "fulton-county-il-so",
-    "flock_active_slug": "fulton-county-il-so",
-    "flock_slugs": [
-      "fulton-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulton County IL SO"
     ],
@@ -40624,10 +37996,8 @@
   {
     "agency_id": "26d65c25-0c20-5c9f-9d9e-a4393b6591a8",
     "slug": "fulton-il-pd",
-    "flock_active_slug": "fulton-il-pd",
-    "flock_slugs": [
-      "fulton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulton IL PD"
     ],
@@ -40651,10 +38021,8 @@
   {
     "agency_id": "a89c4964-202a-5ade-ae92-1d396caea94b",
     "slug": "fulton-mo-pd",
-    "flock_active_slug": "fulton-mo-pd",
-    "flock_slugs": [
-      "fulton-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulton MO PD"
     ],
@@ -40678,10 +38046,8 @@
   {
     "agency_id": "08289966-3b3c-5b3c-9bfd-929c869f4382",
     "slug": "galesburg-il-pd",
-    "flock_active_slug": "galesburg-il-pd",
-    "flock_slugs": [
-      "galesburg-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Galesburg IL PD"
     ],
@@ -40705,10 +38071,8 @@
   {
     "agency_id": "ef844c90-4f5b-5d46-a100-f0b98f79be22",
     "slug": "galva-il-pd",
-    "flock_active_slug": "galva-il-pd",
-    "flock_slugs": [
-      "galva-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Galva IL PD"
     ],
@@ -40732,10 +38096,8 @@
   {
     "agency_id": "1588b191-6b6c-5f96-965f-8b8acf93b643",
     "slug": "gary-in-pd",
-    "flock_active_slug": "gary-in-pd",
-    "flock_slugs": [
-      "gary-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gary IN PD"
     ],
@@ -40759,10 +38121,8 @@
   {
     "agency_id": "34c997ed-7b1a-5b3c-91ab-c78a14c248fc",
     "slug": "gas-city-in-pd",
-    "flock_active_slug": "gas-city-in-pd",
-    "flock_slugs": [
-      "gas-city-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gas City IN PD"
     ],
@@ -40786,10 +38146,8 @@
   {
     "agency_id": "3518dc27-3457-5561-92b8-1d29fcc38f33",
     "slug": "gasconade-co-mo-so",
-    "flock_active_slug": "gasconade-co-mo-so",
-    "flock_slugs": [
-      "gasconade-co-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gasconade Co MO SO"
     ],
@@ -40813,10 +38171,8 @@
   {
     "agency_id": "bf710db3-5a03-5049-93bf-114cd58530a8",
     "slug": "gaylord-mi-pd",
-    "flock_active_slug": "gaylord-mi-pd",
-    "flock_slugs": [
-      "gaylord-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gaylord MI PD"
     ],
@@ -40840,10 +38196,8 @@
   {
     "agency_id": "74c4c0e8-5ae4-5177-98d0-843020271963",
     "slug": "genesee-county-mi-so",
-    "flock_active_slug": "genesee-county-mi-so",
-    "flock_slugs": [
-      "genesee-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Genesee County MI SO"
     ],
@@ -40867,10 +38221,8 @@
   {
     "agency_id": "3169d20b-c390-54d7-8b7a-6376d4997b83",
     "slug": "gentry-county-mo-so",
-    "flock_active_slug": "gentry-county-mo-so",
-    "flock_slugs": [
-      "gentry-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gentry County MO SO"
     ],
@@ -40894,10 +38246,8 @@
   {
     "agency_id": "b1ecb767-0326-5d4c-9937-1a3981a4883e",
     "slug": "georgetown-il-pd",
-    "flock_active_slug": "georgetown-il-pd",
-    "flock_slugs": [
-      "georgetown-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgetown IL PD"
     ],
@@ -40921,10 +38271,8 @@
   {
     "agency_id": "427889a7-fa49-5813-87a4-ddbc3dc296b8",
     "slug": "germantown-tn-pd",
-    "flock_active_slug": "germantown-tn-pd",
-    "flock_slugs": [
-      "germantown-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Germantown TN PD"
     ],
@@ -40948,10 +38296,8 @@
   {
     "agency_id": "f982a410-a911-5e23-9335-a04fe856c198",
     "slug": "glasgow-ky-pd",
-    "flock_active_slug": "glasgow-ky-pd",
-    "flock_slugs": [
-      "glasgow-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glasgow KY PD"
     ],
@@ -40975,10 +38321,8 @@
   {
     "agency_id": "59817ea9-1aa5-5e91-885f-c7599645dde8",
     "slug": "glen-carbon-il-pd",
-    "flock_active_slug": "glen-carbon-il-pd",
-    "flock_slugs": [
-      "glen-carbon-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glen Carbon IL PD"
     ],
@@ -41002,10 +38346,8 @@
   {
     "agency_id": "7f6a5dc4-e26a-5875-939f-f69492ba7e04",
     "slug": "glen-ellyn-il-pd",
-    "flock_active_slug": "glen-ellyn-il-pd",
-    "flock_slugs": [
-      "glen-ellyn-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glen Ellyn IL PD"
     ],
@@ -41029,10 +38371,8 @@
   {
     "agency_id": "f9fd1f9f-def5-59df-b436-15d1d8af5d24",
     "slug": "glencoe-il-pd",
-    "flock_active_slug": "glencoe-il-pd",
-    "flock_slugs": [
-      "glencoe-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glencoe IL PD"
     ],
@@ -41056,10 +38396,8 @@
   {
     "agency_id": "a167c86d-4226-5291-ad16-aa7cd3605133",
     "slug": "glendale-oh-pd",
-    "flock_active_slug": "glendale-oh-pd",
-    "flock_slugs": [
-      "glendale-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glendale OH PD"
     ],
@@ -41083,10 +38421,8 @@
   {
     "agency_id": "74568caf-00b2-5ddb-8615-7635f560c40a",
     "slug": "glenview-il-pd",
-    "flock_active_slug": "glenview-il-pd",
-    "flock_slugs": [
-      "glenview-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glenview IL PD"
     ],
@@ -41110,10 +38446,8 @@
   {
     "agency_id": "ad47eff1-a840-5f91-91fa-91b1bb587b09",
     "slug": "gogebic-county-mi-so",
-    "flock_active_slug": "gogebic-county-mi-so",
-    "flock_slugs": [
-      "gogebic-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gogebic County MI SO"
     ],
@@ -41137,10 +38471,8 @@
   {
     "agency_id": "66c6e22d-8d9f-5ef0-9a37-d51eb0bc3e4c",
     "slug": "gosper-county-ne-so",
-    "flock_active_slug": "gosper-county-ne-so",
-    "flock_slugs": [
-      "gosper-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gosper County NE SO"
     ],
@@ -41164,10 +38496,8 @@
   {
     "agency_id": "84c17f77-e9b6-5ff2-9145-f4643c923279",
     "slug": "grafton-wi-pd",
-    "flock_active_slug": "grafton-wi-pd",
-    "flock_slugs": [
-      "grafton-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grafton WI PD"
     ],
@@ -41191,10 +38521,8 @@
   {
     "agency_id": "0e520272-c4db-5ab6-b613-fed5be5101b0",
     "slug": "grain-valley-mo-pd",
-    "flock_active_slug": "grain-valley-mo-pd",
-    "flock_slugs": [
-      "grain-valley-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grain Valley MO PD"
     ],
@@ -41218,10 +38546,8 @@
   {
     "agency_id": "d4cd2087-1540-5ea9-8eee-a1cb65f78478",
     "slug": "grand-beachmichiana-mi-pd",
-    "flock_active_slug": "grand-beachmichiana-mi-pd",
-    "flock_slugs": [
-      "grand-beachmichiana-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Beach/Michiana MI PD"
     ],
@@ -41243,10 +38569,8 @@
   {
     "agency_id": "511cd55b-d0cf-5b9c-98e4-29e75fac7595",
     "slug": "grand-blanc-twp-mi-pd",
-    "flock_active_slug": "grand-blanc-twp-mi-pd",
-    "flock_slugs": [
-      "grand-blanc-twp-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Blanc Twp MI PD"
     ],
@@ -41270,10 +38594,8 @@
   {
     "agency_id": "78519532-ed37-5fec-a860-715d57272394",
     "slug": "grand-chute-wi-pd",
-    "flock_active_slug": "grand-chute-wi-pd",
-    "flock_slugs": [
-      "grand-chute-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Chute WI PD"
     ],
@@ -41297,10 +38619,8 @@
   {
     "agency_id": "22e90ef0-84b4-5f14-b976-c00dc15a7e0c",
     "slug": "grand-rapids-mi-pd",
-    "flock_active_slug": "grand-rapids-mi-pd",
-    "flock_slugs": [
-      "grand-rapids-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Rapids MI PD"
     ],
@@ -41324,10 +38644,8 @@
   {
     "agency_id": "1b92219c-fc5a-5ca5-b3c9-9286c5a67e6b",
     "slug": "grand-rapids-mn-pd",
-    "flock_active_slug": "grand-rapids-mn-pd",
-    "flock_slugs": [
-      "grand-rapids-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Rapids MN PD"
     ],
@@ -41351,10 +38669,8 @@
   {
     "agency_id": "a3a12563-d011-5a02-a1af-09053f94616f",
     "slug": "grand-traverse-county-mi-so",
-    "flock_active_slug": "grand-traverse-county-mi-so",
-    "flock_slugs": [
-      "grand-traverse-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Traverse County MI SO"
     ],
@@ -41378,10 +38694,8 @@
   {
     "agency_id": "34c44229-46fa-58e0-a546-fceae0dc71dc",
     "slug": "grand-valley-state-university-mi",
-    "flock_active_slug": "grand-valley-state-university-mi",
-    "flock_slugs": [
-      "grand-valley-state-university-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Valley State University MI"
     ],
@@ -41404,10 +38718,8 @@
   {
     "agency_id": "e47ab3fb-9aad-53fc-a6e5-bb8134556e78",
     "slug": "grandview-mo-pd",
-    "flock_active_slug": "grandview-mo-pd",
-    "flock_slugs": [
-      "grandview-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grandview MO PD"
     ],
@@ -41431,10 +38743,8 @@
   {
     "agency_id": "ae021650-23f1-5fa5-90ab-0caaa5cd652e",
     "slug": "grant-county-wi-so",
-    "flock_active_slug": "grant-county-wi-so",
-    "flock_slugs": [
-      "grant-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grant County WI SO"
     ],
@@ -41458,10 +38768,8 @@
   {
     "agency_id": "9151e9b4-505a-59f0-b4e8-839a4a0d5e44",
     "slug": "gratiot-county-mi-so",
-    "flock_active_slug": "gratiot-county-mi-so",
-    "flock_slugs": [
-      "gratiot-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gratiot County MI SO"
     ],
@@ -41485,10 +38793,8 @@
   {
     "agency_id": "431236ca-a7f1-5077-a168-8440912ef197",
     "slug": "green-lake-county-wi-so",
-    "flock_active_slug": "green-lake-county-wi-so",
-    "flock_slugs": [
-      "green-lake-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Green Lake County WI SO"
     ],
@@ -41512,10 +38818,8 @@
   {
     "agency_id": "5202aca8-787f-59c3-b5cb-0cdf00956ee2",
     "slug": "greenfield-wi-pd",
-    "flock_active_slug": "greenfield-wi-pd",
-    "flock_slugs": [
-      "greenfield-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenfield WI PD"
     ],
@@ -41539,10 +38843,8 @@
   {
     "agency_id": "81723f08-c083-524e-8bcc-ae49b6eea307",
     "slug": "griffith-in-pd",
-    "flock_active_slug": "griffith-in-pd",
-    "flock_slugs": [
-      "griffith-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Griffith IN PD"
     ],
@@ -41566,10 +38868,8 @@
   {
     "agency_id": "1cd5b5d2-5949-57cf-b719-d37d316ae88b",
     "slug": "grundy-county-il-911",
-    "flock_active_slug": "grundy-county-il-911",
-    "flock_slugs": [
-      "grundy-county-il-911"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grundy County IL 911"
     ],
@@ -41594,10 +38894,8 @@
   {
     "agency_id": "439b73b5-4c09-5c34-9fb8-388f9be01140",
     "slug": "grundy-county-il-so",
-    "flock_active_slug": "grundy-county-il-so",
-    "flock_slugs": [
-      "grundy-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grundy County IL SO"
     ],
@@ -41621,10 +38919,8 @@
   {
     "agency_id": "e0abf545-15a9-58c1-9a94-ba32d085dc83",
     "slug": "gun-lake-tribal-pd-mi",
-    "flock_active_slug": "gun-lake-tribal-pd-mi",
-    "flock_slugs": [
-      "gun-lake-tribal-pd-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gun Lake Tribal PD MI"
     ],
@@ -41646,10 +38942,8 @@
   {
     "agency_id": "68631c83-43b6-5a95-9075-c20305c30c2b",
     "slug": "gurnee-il-pd",
-    "flock_active_slug": "gurnee-il-pd",
-    "flock_slugs": [
-      "gurnee-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gurnee IL PD"
     ],
@@ -41673,10 +38967,8 @@
   {
     "agency_id": "7d89d9bb-992a-54e3-8518-a79f00600371",
     "slug": "hall-county-ne-so",
-    "flock_active_slug": "hall-county-ne-so",
-    "flock_slugs": [
-      "hall-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hall County NE SO"
     ],
@@ -41700,10 +38992,8 @@
   {
     "agency_id": "a05ba7fe-e641-5414-8691-7218747fca05",
     "slug": "hamburg-township-mi-pd-livingston-county",
-    "flock_active_slug": "hamburg-township-mi-pd-livingston-county",
-    "flock_slugs": [
-      "hamburg-township-mi-pd-livingston-county"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamburg Township MI PD (Livingston County)"
     ],
@@ -41727,10 +39017,8 @@
   {
     "agency_id": "9dc1f76c-5959-5408-a1fe-c08116042150",
     "slug": "hannibal-mo-pd",
-    "flock_active_slug": "hannibal-mo-pd",
-    "flock_slugs": [
-      "hannibal-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hannibal MO PD"
     ],
@@ -41754,10 +39042,8 @@
   {
     "agency_id": "6896cdda-a821-5bee-92e4-480a647935f9",
     "slug": "harlan-county-ne-so",
-    "flock_active_slug": "harlan-county-ne-so",
-    "flock_slugs": [
-      "harlan-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harlan County NE SO"
     ],
@@ -41781,10 +39067,8 @@
   {
     "agency_id": "aac83bd6-19d3-57a1-8466-ce78ca095d67",
     "slug": "harper-community-college-il-pd",
-    "flock_active_slug": "harper-community-college-il-pd",
-    "flock_slugs": [
-      "harper-community-college-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harper Community College IL PD"
     ],
@@ -41807,10 +39091,8 @@
   {
     "agency_id": "22213367-467f-5990-a5b7-cf4d2fd8ed16",
     "slug": "harrison-county-in-so",
-    "flock_active_slug": "harrison-county-in-so",
-    "flock_slugs": [
-      "harrison-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrison County IN SO"
     ],
@@ -41834,10 +39116,8 @@
   {
     "agency_id": "2866ca1d-ac90-5b92-a50c-e61581927de0",
     "slug": "harrisonville-mo-pd",
-    "flock_active_slug": "harrisonville-mo-pd",
-    "flock_slugs": [
-      "harrisonville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrisonville MO PD"
     ],
@@ -41861,10 +39141,8 @@
   {
     "agency_id": "c77a64f4-d119-5ef2-87ff-a6e9f561059b",
     "slug": "harvey-il-pd",
-    "flock_active_slug": "harvey-il-pd",
-    "flock_slugs": [
-      "harvey-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harvey IL PD"
     ],
@@ -41888,10 +39166,8 @@
   {
     "agency_id": "9ea628b5-3837-54db-a7f3-450c6d9b58f5",
     "slug": "harwood-heights-il-pd",
-    "flock_active_slug": "harwood-heights-il-pd",
-    "flock_slugs": [
-      "harwood-heights-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harwood Heights IL PD"
     ],
@@ -41915,10 +39191,8 @@
   {
     "agency_id": "831cc3ff-8aba-53c7-9e84-9563ebfc3986",
     "slug": "hazel-crest-il-pd",
-    "flock_active_slug": "hazel-crest-il-pd",
-    "flock_slugs": [
-      "hazel-crest-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hazel Crest IL PD"
     ],
@@ -41942,10 +39216,8 @@
   {
     "agency_id": "963535c0-0dec-5c86-8d5b-74c8198f2803",
     "slug": "hazelwood-mo-pd",
-    "flock_active_slug": "hazelwood-mo-pd",
-    "flock_slugs": [
-      "hazelwood-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hazelwood MO PD"
     ],
@@ -41969,10 +39241,8 @@
   {
     "agency_id": "f4f203a6-fc83-5bfd-8f1f-7af6aba18a26",
     "slug": "hennepin-county-mn-so",
-    "flock_active_slug": "hennepin-county-mn-so",
-    "flock_slugs": [
-      "hennepin-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hennepin County MN SO"
     ],
@@ -41996,10 +39266,8 @@
   {
     "agency_id": "00722523-e762-5e6b-b385-126719c10535",
     "slug": "henry-county-il-so",
-    "flock_active_slug": "henry-county-il-so",
-    "flock_slugs": [
-      "henry-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Henry County IL SO"
     ],
@@ -42023,10 +39291,8 @@
   {
     "agency_id": "91e65027-9037-5b5d-8b9a-4619c9afee86",
     "slug": "hickory-hills-il-pd",
-    "flock_active_slug": "hickory-hills-il-pd",
-    "flock_slugs": [
-      "hickory-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hickory Hills IL PD"
     ],
@@ -42050,10 +39316,8 @@
   {
     "agency_id": "01b26356-3781-56ad-a111-488ec0ac5afc",
     "slug": "highland-in-pd",
-    "flock_active_slug": "highland-in-pd",
-    "flock_slugs": [
-      "highland-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Highland IN PD"
     ],
@@ -42077,10 +39341,8 @@
   {
     "agency_id": "9e7aee38-a6e0-5012-8508-e0782418a8f5",
     "slug": "highland-park-il-pd",
-    "flock_active_slug": "highland-park-il-pd",
-    "flock_slugs": [
-      "highland-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Highland Park IL PD"
     ],
@@ -42104,10 +39366,8 @@
   {
     "agency_id": "40be66c5-0c12-5d7d-af04-9b7f57f1b13e",
     "slug": "hill-city-mn-pd",
-    "flock_active_slug": "hill-city-mn-pd",
-    "flock_slugs": [
-      "hill-city-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hill City MN PD"
     ],
@@ -42131,10 +39391,8 @@
   {
     "agency_id": "895c1145-f10c-5754-b9ae-ebe81b105239",
     "slug": "hinckley-il-pd",
-    "flock_active_slug": "hinckley-il-pd",
-    "flock_slugs": [
-      "hinckley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hinckley IL PD"
     ],
@@ -42158,10 +39416,8 @@
   {
     "agency_id": "ec053d1e-1d82-5762-a943-5e13c0240462",
     "slug": "hinsdale-il-pd",
-    "flock_active_slug": "hinsdale-il-pd",
-    "flock_slugs": [
-      "hinsdale-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hinsdale IL PD"
     ],
@@ -42185,10 +39441,8 @@
   {
     "agency_id": "74f50fc4-758e-52b5-bfb8-31a4d6dd1b88",
     "slug": "hobart-in-pd",
-    "flock_active_slug": "hobart-in-pd",
-    "flock_slugs": [
-      "hobart-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hobart IN PD"
     ],
@@ -42212,10 +39466,8 @@
   {
     "agency_id": "3085695b-3dbf-5f6c-949f-cb02b97df49d",
     "slug": "hoffman-estates-il-pd",
-    "flock_active_slug": "hoffman-estates-il-pd",
-    "flock_slugs": [
-      "hoffman-estates-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hoffman Estates IL PD"
     ],
@@ -42239,10 +39491,8 @@
   {
     "agency_id": "cf983014-53dd-5c18-a7aa-6d1ba5c1e175",
     "slug": "holland-mi-pd",
-    "flock_active_slug": "holland-mi-pd",
-    "flock_slugs": [
-      "holland-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Holland MI PD"
     ],
@@ -42266,10 +39516,8 @@
   {
     "agency_id": "f49894b3-b144-5811-bd60-7b5d2b90ba9e",
     "slug": "holmen-wi-pd",
-    "flock_active_slug": "holmen-wi-pd",
-    "flock_slugs": [
-      "holmen-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Holmen WI PD"
     ],
@@ -42293,10 +39541,8 @@
   {
     "agency_id": "a4833358-aef1-5ef2-bbf5-3a6edeb47799",
     "slug": "hoopeston-il-pd",
-    "flock_active_slug": "hoopeston-il-pd",
-    "flock_slugs": [
-      "hoopeston-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hoopeston IL PD"
     ],
@@ -42320,10 +39566,8 @@
   {
     "agency_id": "3c253ddc-1b4c-5a5c-9b51-f64a62db205a",
     "slug": "howard-county-in-so",
-    "flock_active_slug": "howard-county-in-so",
-    "flock_slugs": [
-      "howard-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Howard County IN SO"
     ],
@@ -42347,10 +39591,8 @@
   {
     "agency_id": "69dc886d-6480-525a-ac42-05134bbb4a64",
     "slug": "hudson-wi-pd",
-    "flock_active_slug": "hudson-wi-pd",
-    "flock_slugs": [
-      "hudson-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hudson WI PD"
     ],
@@ -42374,10 +39616,8 @@
   {
     "agency_id": "eb75e60e-3249-5a82-8fe1-9e35ba934818",
     "slug": "huntington-in-pd",
-    "flock_active_slug": "huntington-in-pd",
-    "flock_slugs": [
-      "huntington-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntington IN PD"
     ],
@@ -42401,10 +39641,8 @@
   {
     "agency_id": "cfad8227-46b3-54f8-b657-8dc2f35cf043",
     "slug": "huntley-il-pd",
-    "flock_active_slug": "huntley-il-pd",
-    "flock_slugs": [
-      "huntley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntley IL PD"
     ],
@@ -42428,10 +39666,8 @@
   {
     "agency_id": "06eba63e-686c-57f6-adc4-fef090463891",
     "slug": "ia-eldridge-pd",
-    "flock_active_slug": "ia-eldridge-pd",
-    "flock_slugs": [
-      "ia-eldridge-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IA - Eldridge PD"
     ],
@@ -42455,10 +39691,8 @@
   {
     "agency_id": "e678476c-5cc6-535e-8a2b-ba0008b416d6",
     "slug": "ia-storm-lake-pd",
-    "flock_active_slug": "ia-storm-lake-pd",
-    "flock_slugs": [
-      "ia-storm-lake-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IA - Storm Lake PD"
     ],
@@ -42482,10 +39716,8 @@
   {
     "agency_id": "c4b8ebca-7a77-5b26-9aed-86aa52e19450",
     "slug": "iberia-mo-pd-deactivated",
-    "flock_active_slug": "iberia-mo-pd-deactivated",
-    "flock_slugs": [
-      "iberia-mo-pd-deactivated"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iberia MO PD (deactivated)"
     ],
@@ -42509,10 +39741,8 @@
   {
     "agency_id": "a936dc4d-21fb-5228-afe8-c027b3bd8e34",
     "slug": "illinois-attorney-general",
-    "flock_active_slug": "illinois-attorney-general",
-    "flock_slugs": [
-      "illinois-attorney-general"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Illinois Attorney General"
     ],
@@ -42536,10 +39766,8 @@
   {
     "agency_id": "6c14bcb5-4490-5d6d-93fd-c80cbc3517ee",
     "slug": "in-angola-pd",
-    "flock_active_slug": "in-angola-pd",
-    "flock_slugs": [
-      "in-angola-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IN - Angola PD"
     ],
@@ -42563,10 +39791,8 @@
   {
     "agency_id": "d4612d0a-2312-5650-92ea-c42517b1e227",
     "slug": "in-noble-county-so",
-    "flock_active_slug": "in-noble-county-so",
-    "flock_slugs": [
-      "in-noble-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IN- Noble County SO"
     ],
@@ -42590,10 +39816,8 @@
   {
     "agency_id": "d4fb01e9-f8ad-5896-9a8b-83383f08886d",
     "slug": "in-rensselaer-pd",
-    "flock_active_slug": "in-rensselaer-pd",
-    "flock_slugs": [
-      "in-rensselaer-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IN - Rensselaer PD"
     ],
@@ -42617,10 +39841,8 @@
   {
     "agency_id": "23d18d22-2969-5d7a-a4ff-b3bdc7e2efb8",
     "slug": "in-tipton-county-so",
-    "flock_active_slug": "in-tipton-county-so",
-    "flock_slugs": [
-      "in-tipton-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IN - Tipton County SO"
     ],
@@ -42644,10 +39866,8 @@
   {
     "agency_id": "0f8e9173-ccc4-57f1-a0fd-a20ba6500b10",
     "slug": "independence-mo-pd",
-    "flock_active_slug": "independence-mo-pd",
-    "flock_slugs": [
-      "independence-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Independence MO PD"
     ],
@@ -42671,10 +39891,8 @@
   {
     "agency_id": "f62243ca-8646-5807-ba33-82f678b0849b",
     "slug": "indiana-hidta",
-    "flock_active_slug": "indiana-hidta",
-    "flock_slugs": [
-      "indiana-hidta"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indiana HIDTA"
     ],
@@ -42696,10 +39914,8 @@
   {
     "agency_id": "01e1c9a1-edc3-5c32-9d00-21aa1c14b296",
     "slug": "inverness-il-pd",
-    "flock_active_slug": "inverness-il-pd",
-    "flock_slugs": [
-      "inverness-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Inverness IL PD"
     ],
@@ -42723,10 +39939,8 @@
   {
     "agency_id": "9eee170a-40ac-57fc-a29d-84167f1f73f1",
     "slug": "iowa-county-wi-so",
-    "flock_active_slug": "iowa-county-wi-so",
-    "flock_slugs": [
-      "iowa-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iowa County WI SO"
     ],
@@ -42750,10 +39964,8 @@
   {
     "agency_id": "4929af51-29cb-50f2-9874-dd623cdb5738",
     "slug": "iowa-department-of-corrections",
-    "flock_active_slug": "iowa-department-of-corrections",
-    "flock_slugs": [
-      "iowa-department-of-corrections"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iowa Department of Corrections"
     ],
@@ -42777,10 +39989,8 @@
   {
     "agency_id": "0c8a1c92-24bd-52fb-9892-5225730c62d0",
     "slug": "itasca-county-mn-so",
-    "flock_active_slug": "itasca-county-mn-so",
-    "flock_slugs": [
-      "itasca-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Itasca County MN SO"
     ],
@@ -42804,10 +40014,8 @@
   {
     "agency_id": "8fd5e75d-ca68-57b6-b38a-2328f0671f69",
     "slug": "jackson-county-mi-so",
-    "flock_active_slug": "jackson-county-mi-so",
-    "flock_slugs": [
-      "jackson-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County MI SO"
     ],
@@ -42831,10 +40039,8 @@
   {
     "agency_id": "bfc86657-7599-5aa8-8b22-f261ed3ce68f",
     "slug": "jackson-county-mo-so",
-    "flock_active_slug": "jackson-county-mo-so",
-    "flock_slugs": [
-      "jackson-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County MO SO"
     ],
@@ -42858,10 +40064,8 @@
   {
     "agency_id": "4680db1d-bff7-5564-a32b-1c9975d13fa4",
     "slug": "jackson-mi-pd",
-    "flock_active_slug": "jackson-mi-pd",
-    "flock_slugs": [
-      "jackson-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson MI PD"
     ],
@@ -42885,10 +40089,8 @@
   {
     "agency_id": "4a8611b7-772b-5264-b85c-c74f5adf79b7",
     "slug": "jacksonville-il-pd",
-    "flock_active_slug": "jacksonville-il-pd",
-    "flock_slugs": [
-      "jacksonville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jacksonville IL PD"
     ],
@@ -42912,10 +40114,8 @@
   {
     "agency_id": "01f1fee2-0a74-52d4-9691-e8e77305e251",
     "slug": "janesville-wi-pd",
-    "flock_active_slug": "janesville-wi-pd",
-    "flock_slugs": [
-      "janesville-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Janesville WI PD"
     ],
@@ -42939,10 +40139,8 @@
   {
     "agency_id": "601c8ef8-320f-5d30-9d8f-4233570b74cd",
     "slug": "jasper-county-sheriff-ia",
-    "flock_active_slug": "jasper-county-sheriff-ia",
-    "flock_slugs": [
-      "jasper-county-sheriff-ia"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jasper County Sheriff IA"
     ],
@@ -42966,10 +40164,8 @@
   {
     "agency_id": "a43979bd-48aa-5be0-8016-31d30bcb1d7e",
     "slug": "jefferson-city-mo-pd",
-    "flock_active_slug": "jefferson-city-mo-pd",
-    "flock_slugs": [
-      "jefferson-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson City MO PD"
     ],
@@ -42993,10 +40189,8 @@
   {
     "agency_id": "199fbd09-f525-5295-9516-4d35ddd828da",
     "slug": "johnson-county-ks-so",
-    "flock_active_slug": "johnson-county-ks-so",
-    "flock_slugs": [
-      "johnson-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnson County KS SO"
     ],
@@ -43020,10 +40214,8 @@
   {
     "agency_id": "410c43eb-92df-5183-bc30-02ee9b4eb7b9",
     "slug": "johnson-county-mo-so",
-    "flock_active_slug": "johnson-county-mo-so",
-    "flock_slugs": [
-      "johnson-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnson County MO SO"
     ],
@@ -43047,10 +40239,8 @@
   {
     "agency_id": "b817b521-bf9b-58d2-8b52-3deba1919cf4",
     "slug": "johnston-ia-pd",
-    "flock_active_slug": "johnston-ia-pd",
-    "flock_slugs": [
-      "johnston-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnston IA PD"
     ],
@@ -43074,10 +40264,8 @@
   {
     "agency_id": "e5684bf2-ee06-5fbf-881b-a3d0627cf9a7",
     "slug": "joliet-il-pd",
-    "flock_active_slug": "joliet-il-pd",
-    "flock_slugs": [
-      "joliet-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Joliet IL PD"
     ],
@@ -43101,10 +40289,8 @@
   {
     "agency_id": "3c68b323-63da-56c9-ac32-b578ab0269f4",
     "slug": "joliet-junior-college-il-pd",
-    "flock_active_slug": "joliet-junior-college-il-pd",
-    "flock_slugs": [
-      "joliet-junior-college-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Joliet Junior College IL PD"
     ],
@@ -43129,10 +40315,8 @@
   {
     "agency_id": "42f6f981-3dba-554f-bf85-4a5aaba9a361",
     "slug": "kalamazoo-mi-pd",
-    "flock_active_slug": "kalamazoo-mi-pd",
-    "flock_slugs": [
-      "kalamazoo-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kalamazoo MI PD"
     ],
@@ -43156,10 +40340,8 @@
   {
     "agency_id": "4b9e675b-39b7-5ad2-b836-8d0fc50cc3fc",
     "slug": "kalamazoo-township-mi-pd",
-    "flock_active_slug": "kalamazoo-township-mi-pd",
-    "flock_slugs": [
-      "kalamazoo-township-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kalamazoo Township MI PD"
     ],
@@ -43183,10 +40365,8 @@
   {
     "agency_id": "339503d1-9389-51a0-a491-4d895d33e6be",
     "slug": "kanabec-county-mn-so",
-    "flock_active_slug": "kanabec-county-mn-so",
-    "flock_slugs": [
-      "kanabec-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kanabec County MN SO"
     ],
@@ -43210,10 +40390,8 @@
   {
     "agency_id": "bb65471d-8a0b-524f-b1aa-9a3c90a7adb1",
     "slug": "kandiyohi-mn-so",
-    "flock_active_slug": "kandiyohi-mn-so",
-    "flock_slugs": [
-      "kandiyohi-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kandiyohi MN SO"
     ],
@@ -43237,10 +40415,8 @@
   {
     "agency_id": "2c626217-0f47-51a0-95e2-9648ba9b24ae",
     "slug": "kane-county-il-so",
-    "flock_active_slug": "kane-county-il-so",
-    "flock_slugs": [
-      "kane-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kane County IL SO"
     ],
@@ -43264,10 +40440,8 @@
   {
     "agency_id": "ab8a0ec4-4f32-5cfd-8b55-349891317914",
     "slug": "kankakee-county-il-so",
-    "flock_active_slug": "kankakee-county-il-so",
-    "flock_slugs": [
-      "kankakee-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kankakee County IL SO"
     ],
@@ -43291,10 +40465,8 @@
   {
     "agency_id": "a412d6c4-4e2e-5b6a-8e8d-3afd820a935d",
     "slug": "kankakee-il-pd",
-    "flock_active_slug": "kankakee-il-pd",
-    "flock_slugs": [
-      "kankakee-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kankakee IL PD"
     ],
@@ -43318,10 +40490,8 @@
   {
     "agency_id": "2650fcae-462e-5914-a5ec-cd336222ecd6",
     "slug": "kansas-city-ks-pd",
-    "flock_active_slug": "kansas-city-ks-pd",
-    "flock_slugs": [
-      "kansas-city-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kansas City KS PD"
     ],
@@ -43345,10 +40515,8 @@
   {
     "agency_id": "1575e160-5ccc-5940-817e-14a0cc4ea440",
     "slug": "kansas-city-mo-pd",
-    "flock_active_slug": "kansas-city-mo-pd",
-    "flock_slugs": [
-      "kansas-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kansas City MO PD"
     ],
@@ -43372,10 +40540,8 @@
   {
     "agency_id": "20247b33-7848-5bba-9b07-3babeedf346b",
     "slug": "kansas-kbi",
-    "flock_active_slug": "kansas-kbi",
-    "flock_slugs": [
-      "kansas-kbi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kansas KBI"
     ],
@@ -43399,10 +40565,8 @@
   {
     "agency_id": "48b1c67e-d8ea-5e18-96fd-6fab506a4ac9",
     "slug": "kaukauna-wi-pd",
-    "flock_active_slug": "kaukauna-wi-pd",
-    "flock_slugs": [
-      "kaukauna-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kaukauna WI PD"
     ],
@@ -43426,10 +40590,8 @@
   {
     "agency_id": "1b626fde-9bd4-5ac1-8b67-9ee507f6abd2",
     "slug": "kearney-ne-pd",
-    "flock_active_slug": "kearney-ne-pd",
-    "flock_slugs": [
-      "kearney-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kearney NE PD"
     ],
@@ -43453,10 +40615,8 @@
   {
     "agency_id": "e801f979-a3d4-5d4f-b5fa-2c77ddb16f7d",
     "slug": "kencom-public-safety-dispatch",
-    "flock_active_slug": "kencom-public-safety-dispatch",
-    "flock_slugs": [
-      "kencom-public-safety-dispatch"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KenCom Public Safety Dispatch"
     ],
@@ -43478,10 +40638,8 @@
   {
     "agency_id": "97944767-063d-512c-9002-ac050873a225",
     "slug": "kendall-county-il-so",
-    "flock_active_slug": "kendall-county-il-so",
-    "flock_slugs": [
-      "kendall-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kendall County IL SO"
     ],
@@ -43505,10 +40663,8 @@
   {
     "agency_id": "532a93d4-706b-57f9-a098-44c0c3ee6f52",
     "slug": "kenosha-wi-pd",
-    "flock_active_slug": "kenosha-wi-pd",
-    "flock_slugs": [
-      "kenosha-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kenosha WI PD"
     ],
@@ -43532,10 +40688,8 @@
   {
     "agency_id": "deac339f-a7b4-544a-b843-797cb866f6d5",
     "slug": "kentwood-mi-pd",
-    "flock_active_slug": "kentwood-mi-pd",
-    "flock_slugs": [
-      "kentwood-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kentwood MI PD"
     ],
@@ -43559,10 +40713,8 @@
   {
     "agency_id": "a455dabe-1d2a-5ff0-931e-7073f74b2485",
     "slug": "kewanee-il-pd",
-    "flock_active_slug": "kewanee-il-pd",
-    "flock_slugs": [
-      "kewanee-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kewanee IL PD"
     ],
@@ -43586,10 +40738,8 @@
   {
     "agency_id": "b46460cb-6557-5c64-ac35-17affc02e9aa",
     "slug": "knox-county-il-so",
-    "flock_active_slug": "knox-county-il-so",
-    "flock_slugs": [
-      "knox-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Knox County IL SO"
     ],
@@ -43613,10 +40763,8 @@
   {
     "agency_id": "2fbf6a2c-207d-51be-b49f-ff9881378e95",
     "slug": "knox-county-so-ne",
-    "flock_active_slug": "knox-county-so-ne",
-    "flock_slugs": [
-      "knox-county-so-ne"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Knox County SO NE"
     ],
@@ -43640,10 +40788,8 @@
   {
     "agency_id": "2063ac62-08e5-5bb2-b745-7d12edbeb82a",
     "slug": "ku-medical-center-ks-pd",
-    "flock_active_slug": "ku-medical-center-ks-pd",
-    "flock_slugs": [
-      "ku-medical-center-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KU Medical Center KS PD"
     ],
@@ -43665,10 +40811,8 @@
   {
     "agency_id": "975d1487-d81b-5a81-ba5d-14a0cff1963a",
     "slug": "la-crosse-wi-pd",
-    "flock_active_slug": "la-crosse-wi-pd",
-    "flock_slugs": [
-      "la-crosse-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Crosse WI PD"
     ],
@@ -43692,10 +40836,8 @@
   {
     "agency_id": "a9cb23c0-ba98-529e-b18c-70d38c389301",
     "slug": "la-grange-il-pd",
-    "flock_active_slug": "la-grange-il-pd",
-    "flock_slugs": [
-      "la-grange-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Grange IL PD"
     ],
@@ -43719,10 +40861,8 @@
   {
     "agency_id": "ee9c732f-9567-5e73-a5e4-7fd6b2e43cae",
     "slug": "la-grange-mo-pd",
-    "flock_active_slug": "la-grange-mo-pd",
-    "flock_slugs": [
-      "la-grange-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Grange MO PD"
     ],
@@ -43746,10 +40886,8 @@
   {
     "agency_id": "1777b0fa-59d6-5a16-99a4-2612385d4832",
     "slug": "la-grange-park-il-pd",
-    "flock_active_slug": "la-grange-park-il-pd",
-    "flock_slugs": [
-      "la-grange-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Grange Park IL PD"
     ],
@@ -43773,10 +40911,8 @@
   {
     "agency_id": "a5fe1ce1-350c-5c34-93d9-45cd85e7dcb0",
     "slug": "lac-courte-oreilles-tribal-police-wi",
-    "flock_active_slug": "lac-courte-oreilles-tribal-police-wi",
-    "flock_slugs": [
-      "lac-courte-oreilles-tribal-police-wi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lac Courte Oreilles Tribal Police WI"
     ],
@@ -43797,10 +40933,8 @@
   {
     "agency_id": "86f28a4f-a73d-5b26-af26-cd45976dc4b6",
     "slug": "ladd-il-pd",
-    "flock_active_slug": "ladd-il-pd",
-    "flock_slugs": [
-      "ladd-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ladd IL PD"
     ],
@@ -43824,10 +40958,8 @@
   {
     "agency_id": "f0d122d8-dc02-5a9b-9e31-bec9d49de498",
     "slug": "ladue-mo-pd",
-    "flock_active_slug": "ladue-mo-pd",
-    "flock_slugs": [
-      "ladue-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ladue MO PD"
     ],
@@ -43851,10 +40983,8 @@
   {
     "agency_id": "4848d30a-d896-5019-9690-d4a229c60c9d",
     "slug": "lady-lake-fl-pd",
-    "flock_active_slug": "lady-lake-fl-pd",
-    "flock_slugs": [
-      "lady-lake-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lady Lake FL PD"
     ],
@@ -43878,10 +41008,8 @@
   {
     "agency_id": "af9ca9ad-22f2-5472-bbdd-f195383212bf",
     "slug": "lafayette-in-pd",
-    "flock_active_slug": "lafayette-in-pd",
-    "flock_slugs": [
-      "lafayette-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lafayette IN PD"
     ],
@@ -43905,10 +41033,8 @@
   {
     "agency_id": "4b0bb1c3-0f9a-552a-84c3-ded25575b6a5",
     "slug": "lake-city-mn-pd",
-    "flock_active_slug": "lake-city-mn-pd",
-    "flock_slugs": [
-      "lake-city-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake City MN PD"
     ],
@@ -43932,10 +41058,8 @@
   {
     "agency_id": "8a0d58ca-2aeb-5aee-b03c-c7d487a231f9",
     "slug": "lake-county-forest-preserves-il-pd",
-    "flock_active_slug": "lake-county-forest-preserves-il-pd",
-    "flock_slugs": [
-      "lake-county-forest-preserves-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake County Forest Preserves IL PD"
     ],
@@ -43959,10 +41083,8 @@
   {
     "agency_id": "5c78d06e-2459-521e-9c8e-e7fb09368ec1",
     "slug": "lake-county-il-so",
-    "flock_active_slug": "lake-county-il-so",
-    "flock_slugs": [
-      "lake-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake County IL SO"
     ],
@@ -43986,10 +41108,8 @@
   {
     "agency_id": "84d92c0e-9f73-5d54-9f1a-167345415e37",
     "slug": "lake-county-in-so",
-    "flock_active_slug": "lake-county-in-so",
-    "flock_slugs": [
-      "lake-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake County IN SO"
     ],
@@ -44013,10 +41133,8 @@
   {
     "agency_id": "fbde4082-81d1-5a01-96f8-61e0f05331aa",
     "slug": "lake-delton-wi-pd",
-    "flock_active_slug": "lake-delton-wi-pd",
-    "flock_slugs": [
-      "lake-delton-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Delton WI PD"
     ],
@@ -44040,10 +41158,8 @@
   {
     "agency_id": "4e17b936-1c81-5979-837e-949a00e99ed8",
     "slug": "lake-forest-il-pd",
-    "flock_active_slug": "lake-forest-il-pd",
-    "flock_slugs": [
-      "lake-forest-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Forest IL PD"
     ],
@@ -44067,10 +41183,8 @@
   {
     "agency_id": "86d5f17a-1c68-586b-9906-cb5e5bcbbffa",
     "slug": "lake-geneva-wi-pd",
-    "flock_active_slug": "lake-geneva-wi-pd",
-    "flock_slugs": [
-      "lake-geneva-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Geneva WI PD"
     ],
@@ -44094,10 +41208,8 @@
   {
     "agency_id": "ca1155b3-0644-5933-962f-bea4152578fa",
     "slug": "lake-in-the-hills-il-pd",
-    "flock_active_slug": "lake-in-the-hills-il-pd",
-    "flock_slugs": [
-      "lake-in-the-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake In The Hills IL PD"
     ],
@@ -44121,10 +41233,8 @@
   {
     "agency_id": "70e7b525-fb35-53b2-81bc-3d2278ff37cc",
     "slug": "lake-st-louis-mo-pd",
-    "flock_active_slug": "lake-st-louis-mo-pd",
-    "flock_slugs": [
-      "lake-st-louis-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake St. Louis MO PD"
     ],
@@ -44148,10 +41258,8 @@
   {
     "agency_id": "08608b27-b22d-560d-ad08-3036292f5726",
     "slug": "lake-villa-il-pd",
-    "flock_active_slug": "lake-villa-il-pd",
-    "flock_slugs": [
-      "lake-villa-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Villa IL PD"
     ],
@@ -44175,10 +41283,8 @@
   {
     "agency_id": "d0a632b9-80e3-5176-9d23-b1ed349cbf33",
     "slug": "lake-zurich-il-pd",
-    "flock_active_slug": "lake-zurich-il-pd",
-    "flock_slugs": [
-      "lake-zurich-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Zurich IL PD"
     ],
@@ -44202,10 +41308,8 @@
   {
     "agency_id": "80a5a34c-1e20-5952-a76a-39f5cf03f60f",
     "slug": "lakes-area-mn-pd",
-    "flock_active_slug": "lakes-area-mn-pd",
-    "flock_slugs": [
-      "lakes-area-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakes Area MN PD"
     ],
@@ -44227,10 +41331,8 @@
   {
     "agency_id": "031ff71a-d1a6-5408-8c61-3da99e901eaf",
     "slug": "lakeville-mn-pd",
-    "flock_active_slug": "lakeville-mn-pd",
-    "flock_slugs": [
-      "lakeville-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakeville MN PD"
     ],
@@ -44254,10 +41356,8 @@
   {
     "agency_id": "a7a557ab-7c5a-5931-8de1-ffb3ad3f8ed7",
     "slug": "lansing-mi-pd",
-    "flock_active_slug": "lansing-mi-pd",
-    "flock_slugs": [
-      "lansing-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lansing MI PD"
     ],
@@ -44281,10 +41381,8 @@
   {
     "agency_id": "e984082a-7484-5f89-8035-70140e6bc9e1",
     "slug": "lasalle-co-il-so-new",
-    "flock_active_slug": "lasalle-co-il-so-new",
-    "flock_slugs": [
-      "lasalle-co-il-so-new"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "LaSalle Co. IL SO - New"
     ],
@@ -44308,10 +41406,8 @@
   {
     "agency_id": "6a7272f6-c1f7-569a-9965-a53bf898cb4c",
     "slug": "lasalle-il-pd",
-    "flock_active_slug": "lasalle-il-pd",
-    "flock_slugs": [
-      "lasalle-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lasalle IL PD"
     ],
@@ -44335,10 +41431,8 @@
   {
     "agency_id": "b370c992-4136-576f-9257-384c57485f84",
     "slug": "le-mars-ia-pd",
-    "flock_active_slug": "le-mars-ia-pd",
-    "flock_slugs": [
-      "le-mars-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Le Mars IA PD"
     ],
@@ -44362,10 +41456,8 @@
   {
     "agency_id": "7d6dd5df-5631-5d6a-9a5c-9901165698cf",
     "slug": "leake-county-ms-so",
-    "flock_active_slug": "leake-county-ms-so",
-    "flock_slugs": [
-      "leake-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Leake County MS SO"
     ],
@@ -44389,10 +41481,8 @@
   {
     "agency_id": "69027c30-6549-5ae1-8b98-91a187ad6837",
     "slug": "lebanon-in-pd",
-    "flock_active_slug": "lebanon-in-pd",
-    "flock_slugs": [
-      "lebanon-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lebanon IN PD"
     ],
@@ -44416,10 +41506,8 @@
   {
     "agency_id": "5477a9c3-b2ed-56f7-8edf-9a8ab9dbe7bd",
     "slug": "lee-county-il-so",
-    "flock_active_slug": "lee-county-il-so",
-    "flock_slugs": [
-      "lee-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lee County IL SO"
     ],
@@ -44443,10 +41531,8 @@
   {
     "agency_id": "acf768de-49e9-5669-b304-9ce466cc8567",
     "slug": "lees-summit-mo-pd",
-    "flock_active_slug": "lees-summit-mo-pd",
-    "flock_slugs": [
-      "lees-summit-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lee's Summit MO PD"
     ],
@@ -44470,10 +41556,8 @@
   {
     "agency_id": "9712f779-9579-5b89-8632-b42a237b4264",
     "slug": "lena-il-pd",
-    "flock_active_slug": "lena-il-pd",
-    "flock_slugs": [
-      "lena-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lena IL PD"
     ],
@@ -44497,10 +41581,8 @@
   {
     "agency_id": "10563a60-3447-5202-adf7-e64f4830555b",
     "slug": "lexington-ky-pd",
-    "flock_active_slug": "lexington-ky-pd",
-    "flock_slugs": [
-      "lexington-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lexington KY PD"
     ],
@@ -44524,10 +41606,8 @@
   {
     "agency_id": "b07067f6-feea-5216-9df7-02c559d1433e",
     "slug": "liberty-mo-pd",
-    "flock_active_slug": "liberty-mo-pd",
-    "flock_slugs": [
-      "liberty-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Liberty MO PD"
     ],
@@ -44551,10 +41631,8 @@
   {
     "agency_id": "9fb147ec-3eb4-5222-a508-f87227b2dd80",
     "slug": "lincoln-county-tn-so",
-    "flock_active_slug": "lincoln-county-tn-so",
-    "flock_slugs": [
-      "lincoln-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincoln County TN SO"
     ],
@@ -44578,10 +41656,8 @@
   {
     "agency_id": "934736dd-26af-5d3a-9c48-317b892cc0df",
     "slug": "lincolnshire-il-pd",
-    "flock_active_slug": "lincolnshire-il-pd",
-    "flock_slugs": [
-      "lincolnshire-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincolnshire IL PD"
     ],
@@ -44605,10 +41681,8 @@
   {
     "agency_id": "c33c872f-5b52-5d69-9f66-cc775d4e6de6",
     "slug": "lisle-il-pd",
-    "flock_active_slug": "lisle-il-pd",
-    "flock_slugs": [
-      "lisle-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lisle IL PD"
     ],
@@ -44632,10 +41706,8 @@
   {
     "agency_id": "3e1f3a21-7013-5065-9e5e-c69c56c844c2",
     "slug": "little-falls-mn-pd",
-    "flock_active_slug": "little-falls-mn-pd",
-    "flock_slugs": [
-      "little-falls-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Little Falls MN PD"
     ],
@@ -44659,10 +41731,8 @@
   {
     "agency_id": "acc34541-076e-5352-8772-a2adc01b3664",
     "slug": "livingston-county-il-so",
-    "flock_active_slug": "livingston-county-il-so",
-    "flock_slugs": [
-      "livingston-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Livingston County IL SO"
     ],
@@ -44686,10 +41756,8 @@
   {
     "agency_id": "093afd07-89c3-5bb0-b7c2-cb619403b706",
     "slug": "locust-grove-ok-pd",
-    "flock_active_slug": "locust-grove-ok-pd",
-    "flock_slugs": [
-      "locust-grove-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Locust Grove OK PD"
     ],
@@ -44713,10 +41781,8 @@
   {
     "agency_id": "82355cfa-6fbf-5d7d-b37e-da698f4c8fbf",
     "slug": "logansport-in-pd",
-    "flock_active_slug": "logansport-in-pd",
-    "flock_slugs": [
-      "logansport-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Logansport IN PD"
     ],
@@ -44740,10 +41806,8 @@
   {
     "agency_id": "32511bff-0fa2-56b6-8501-a80d36263de0",
     "slug": "lombard-il-pd",
-    "flock_active_slug": "lombard-il-pd",
-    "flock_slugs": [
-      "lombard-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lombard IL PD"
     ],
@@ -44767,10 +41831,8 @@
   {
     "agency_id": "c097eede-0812-50a6-9434-2e14c9ba80d4",
     "slug": "loup-county-ne-so",
-    "flock_active_slug": "loup-county-ne-so",
-    "flock_slugs": [
-      "loup-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loup County NE SO"
     ],
@@ -44794,10 +41856,8 @@
   {
     "agency_id": "41b39531-c263-563b-9eea-dfb9e4c21e62",
     "slug": "loves-park-il-pd",
-    "flock_active_slug": "loves-park-il-pd",
-    "flock_slugs": [
-      "loves-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loves Park IL PD"
     ],
@@ -44821,10 +41881,8 @@
   {
     "agency_id": "0c89f10d-2bc1-5e11-91de-0d60564c05b1",
     "slug": "lyons-il-pd",
-    "flock_active_slug": "lyons-il-pd",
-    "flock_slugs": [
-      "lyons-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lyons IL PD"
     ],
@@ -44848,10 +41906,8 @@
   {
     "agency_id": "bcea7227-fcb3-5144-9458-0c7831cb6a7f",
     "slug": "macomb-il-pd",
-    "flock_active_slug": "macomb-il-pd",
-    "flock_slugs": [
-      "macomb-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Macomb IL PD"
     ],
@@ -44875,10 +41931,8 @@
   {
     "agency_id": "9a965e25-550c-5cad-ab72-823639a987bc",
     "slug": "macon-county-il-so",
-    "flock_active_slug": "macon-county-il-so",
-    "flock_slugs": [
-      "macon-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Macon County IL SO"
     ],
@@ -44902,10 +41956,8 @@
   {
     "agency_id": "a478ce83-b3da-5a3a-87f0-0f182c6de433",
     "slug": "macon-county-mo-so",
-    "flock_active_slug": "macon-county-mo-so",
-    "flock_slugs": [
-      "macon-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Macon County MO SO"
     ],
@@ -44929,10 +41981,8 @@
   {
     "agency_id": "06d10421-5ef5-548c-99cc-e07097c1eee6",
     "slug": "macon-county-nc-so",
-    "flock_active_slug": "macon-county-nc-so",
-    "flock_slugs": [
-      "macon-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Macon County NC SO"
     ],
@@ -44956,10 +42006,8 @@
   {
     "agency_id": "f44673b6-c2d4-5a79-a4d0-f0be468aa056",
     "slug": "manchester-mo-pd",
-    "flock_active_slug": "manchester-mo-pd",
-    "flock_slugs": [
-      "manchester-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Manchester MO PD"
     ],
@@ -44983,10 +42031,8 @@
   {
     "agency_id": "77d238c6-d42e-520a-81ef-39ae06cea555",
     "slug": "maple-bluff-wi-pd",
-    "flock_active_slug": "maple-bluff-wi-pd",
-    "flock_slugs": [
-      "maple-bluff-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maple Bluff WI PD"
     ],
@@ -45010,10 +42056,8 @@
   {
     "agency_id": "d6eff37e-41de-50e7-ad6e-acb09ccca03a",
     "slug": "maple-grove-mn-pd",
-    "flock_active_slug": "maple-grove-mn-pd",
-    "flock_slugs": [
-      "maple-grove-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maple Grove MN PD"
     ],
@@ -45037,10 +42081,8 @@
   {
     "agency_id": "48627306-a82b-56a3-8061-1cfa7f788c8c",
     "slug": "maplewood-mn-pd",
-    "flock_active_slug": "maplewood-mn-pd",
-    "flock_slugs": [
-      "maplewood-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maplewood MN PD"
     ],
@@ -45064,10 +42106,8 @@
   {
     "agency_id": "1c9a7b40-d081-5c1e-bb5c-1612eba7c04c",
     "slug": "maplewood-mo-pd",
-    "flock_active_slug": "maplewood-mo-pd",
-    "flock_slugs": [
-      "maplewood-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maplewood MO PD"
     ],
@@ -45091,10 +42131,8 @@
   {
     "agency_id": "49a2ced6-b7ff-551b-967d-dbe9a563ba1f",
     "slug": "mar-mac-ia-pd",
-    "flock_active_slug": "mar-mac-ia-pd",
-    "flock_slugs": [
-      "mar-mac-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mar Mac IA PD"
     ],
@@ -45116,10 +42154,8 @@
   {
     "agency_id": "de703379-164b-540f-9ed9-6bda74764a33",
     "slug": "marathon-county-wi-so",
-    "flock_active_slug": "marathon-county-wi-so",
-    "flock_slugs": [
-      "marathon-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marathon County WI SO"
     ],
@@ -45143,10 +42179,8 @@
   {
     "agency_id": "2ea4284a-9d5a-5e9f-96a4-70b012905f4b",
     "slug": "maries-county-mo-so",
-    "flock_active_slug": "maries-county-mo-so",
-    "flock_slugs": [
-      "maries-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maries County MO SO"
     ],
@@ -45170,10 +42204,8 @@
   {
     "agency_id": "fcfca14c-4056-5acc-9b67-199efd4c35e6",
     "slug": "marinette-county-so-wi",
-    "flock_active_slug": "marinette-county-so-wi",
-    "flock_slugs": [
-      "marinette-county-so-wi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marinette County SO (WI)"
     ],
@@ -45197,10 +42229,8 @@
   {
     "agency_id": "9ae91570-4ef8-574a-a780-bb83d6445010",
     "slug": "marinette-wi-pd",
-    "flock_active_slug": "marinette-wi-pd",
-    "flock_slugs": [
-      "marinette-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marinette WI PD"
     ],
@@ -45224,10 +42254,8 @@
   {
     "agency_id": "69525ae8-173f-5986-a121-bfe2f6a7c75e",
     "slug": "marion-county-mo-so",
-    "flock_active_slug": "marion-county-mo-so",
-    "flock_slugs": [
-      "marion-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion County MO SO"
     ],
@@ -45251,10 +42279,8 @@
   {
     "agency_id": "51a2e9a0-a307-5c1b-802c-5dff83987abb",
     "slug": "marion-in-pd",
-    "flock_active_slug": "marion-in-pd",
-    "flock_slugs": [
-      "marion-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion IN PD"
     ],
@@ -45278,10 +42304,8 @@
   {
     "agency_id": "bb5faf65-b11b-5b91-99a0-4e3f4fc441c0",
     "slug": "markle-in-pd",
-    "flock_active_slug": "markle-in-pd",
-    "flock_slugs": [
-      "markle-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Markle IN PD"
     ],
@@ -45305,10 +42329,8 @@
   {
     "agency_id": "ecce1ab4-ff8b-5820-b394-3cf3a95c4aa9",
     "slug": "marquette-county-wi-so",
-    "flock_active_slug": "marquette-county-wi-so",
-    "flock_slugs": [
-      "marquette-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marquette County WI SO"
     ],
@@ -45332,10 +42354,8 @@
   {
     "agency_id": "bd7df9f4-2314-5deb-8842-737880b6e12a",
     "slug": "marseilles-il-pd",
-    "flock_active_slug": "marseilles-il-pd",
-    "flock_slugs": [
-      "marseilles-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marseilles IL PD"
     ],
@@ -45359,10 +42379,8 @@
   {
     "agency_id": "1dcdab89-7f4f-5f52-9b08-1c81d79875da",
     "slug": "marshall-wi-pd",
-    "flock_active_slug": "marshall-wi-pd",
-    "flock_slugs": [
-      "marshall-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall WI PD"
     ],
@@ -45386,10 +42404,8 @@
   {
     "agency_id": "2b67edac-fb7c-556c-a54d-dbaea32ff979",
     "slug": "mason-county-il-so",
-    "flock_active_slug": "mason-county-il-so",
-    "flock_slugs": [
-      "mason-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mason County IL SO"
     ],
@@ -45413,10 +42429,8 @@
   {
     "agency_id": "ee034a0a-e3aa-5f9a-b1cb-6ef3aab3ab30",
     "slug": "mattoon-il-pd",
-    "flock_active_slug": "mattoon-il-pd",
-    "flock_slugs": [
-      "mattoon-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mattoon IL PD"
     ],
@@ -45440,10 +42454,8 @@
   {
     "agency_id": "91ffefb1-b950-596d-bf82-a14898869db8",
     "slug": "mauston-wi-pd",
-    "flock_active_slug": "mauston-wi-pd",
-    "flock_slugs": [
-      "mauston-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mauston WI PD"
     ],
@@ -45467,10 +42479,8 @@
   {
     "agency_id": "ac66c3f7-6512-50e4-a827-e72ee74e1ec3",
     "slug": "mcdonough-county-il-so",
-    "flock_active_slug": "mcdonough-county-il-so",
-    "flock_slugs": [
-      "mcdonough-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McDonough County IL SO"
     ],
@@ -45494,10 +42504,8 @@
   {
     "agency_id": "6e35ebef-a2b4-5481-a20e-fe8f337c5604",
     "slug": "mclean-county-il-so",
-    "flock_active_slug": "mclean-county-il-so",
-    "flock_slugs": [
-      "mclean-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mclean County IL SO"
     ],
@@ -45521,10 +42529,8 @@
   {
     "agency_id": "1957d6ec-9e46-5573-8006-a1747ce5e405",
     "slug": "medina-mn-pd",
-    "flock_active_slug": "medina-mn-pd",
-    "flock_slugs": [
-      "medina-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Medina MN PD"
     ],
@@ -45548,10 +42554,8 @@
   {
     "agency_id": "c9bbd8db-a564-5012-a804-7da61cee4b7f",
     "slug": "melrose-park-il-pd",
-    "flock_active_slug": "melrose-park-il-pd",
-    "flock_slugs": [
-      "melrose-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Melrose Park IL PD"
     ],
@@ -45575,10 +42579,8 @@
   {
     "agency_id": "debe73f3-deb7-579f-b7fd-23cf08b4571d",
     "slug": "menard-county-il-so",
-    "flock_active_slug": "menard-county-il-so",
-    "flock_slugs": [
-      "menard-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Menard County IL SO"
     ],
@@ -45602,10 +42604,8 @@
   {
     "agency_id": "e32564b7-f694-551f-854b-82bc1a8d8689",
     "slug": "menasha-wi-pd",
-    "flock_active_slug": "menasha-wi-pd",
-    "flock_slugs": [
-      "menasha-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Menasha WI PD"
     ],
@@ -45629,10 +42629,8 @@
   {
     "agency_id": "9fc91181-14c4-539c-b0c3-dc1439d7a633",
     "slug": "mendota-il-pd",
-    "flock_active_slug": "mendota-il-pd",
-    "flock_slugs": [
-      "mendota-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mendota IL PD"
     ],
@@ -45656,10 +42654,8 @@
   {
     "agency_id": "d8ef6f92-49dd-5bd5-90f6-eb9c9a5e4989",
     "slug": "menominee-tribal-wi-pd",
-    "flock_active_slug": "menominee-tribal-wi-pd",
-    "flock_slugs": [
-      "menominee-tribal-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Menominee Tribal WI PD"
     ],
@@ -45681,10 +42677,8 @@
   {
     "agency_id": "ce21e05d-ff66-5c62-bb76-564fb5847c49",
     "slug": "menomonie-wi-pd",
-    "flock_active_slug": "menomonie-wi-pd",
-    "flock_slugs": [
-      "menomonie-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Menomonie WI PD"
     ],
@@ -45708,10 +42702,8 @@
   {
     "agency_id": "c970eee9-dfa4-572f-b6a1-d277e58b1ea3",
     "slug": "mercer-county-mo-so",
-    "flock_active_slug": "mercer-county-mo-so",
-    "flock_slugs": [
-      "mercer-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mercer County MO SO"
     ],
@@ -45735,10 +42727,8 @@
   {
     "agency_id": "9b980d42-c065-5810-9c74-981e34f7d5db",
     "slug": "metra-il-pd",
-    "flock_active_slug": "metra-il-pd",
-    "flock_slugs": [
-      "metra-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Metra IL PD"
     ],
@@ -45760,10 +42750,8 @@
   {
     "agency_id": "5517e7ce-5275-5836-b842-60291059583a",
     "slug": "metro-east-auto-theft-il",
-    "flock_active_slug": "metro-east-auto-theft-il",
-    "flock_slugs": [
-      "metro-east-auto-theft-il"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Metro East Auto Theft (IL)"
     ],
@@ -45785,10 +42773,8 @@
   {
     "agency_id": "4c50e1f8-00f6-55e3-b7cf-5903b88d10f0",
     "slug": "metro-police-authority-of-genesee-county-mi",
-    "flock_active_slug": "metro-police-authority-of-genesee-county-mi",
-    "flock_slugs": [
-      "metro-police-authority-of-genesee-county-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Metro Police Authority of Genesee County MI"
     ],
@@ -45809,10 +42795,8 @@
   {
     "agency_id": "3b78d3ac-8681-5883-bdbc-97b96ee98f92",
     "slug": "metropolitan-washington-dc-pd",
-    "flock_active_slug": "metropolitan-washington-dc-pd",
-    "flock_slugs": [
-      "metropolitan-washington-dc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Metropolitan Washington DC PD"
     ],
@@ -45836,10 +42820,8 @@
   {
     "agency_id": "8411dcd5-2554-5c12-bd29-3011416295f3",
     "slug": "mi-saginaw-county-so",
-    "flock_active_slug": "mi-saginaw-county-so",
-    "flock_slugs": [
-      "mi-saginaw-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MI - Saginaw County SO"
     ],
@@ -45863,10 +42845,8 @@
   {
     "agency_id": "f5e0c86e-e04c-59e4-a375-2d750514b2e9",
     "slug": "mi-village-of-middleville",
-    "flock_active_slug": "mi-village-of-middleville",
-    "flock_slugs": [
-      "mi-village-of-middleville"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MI - Village of Middleville"
     ],
@@ -45890,10 +42870,8 @@
   {
     "agency_id": "82ead99d-795e-5031-b192-9453d936d13f",
     "slug": "michigan-state-police",
-    "flock_active_slug": "michigan-state-police",
-    "flock_slugs": [
-      "michigan-state-police"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Michigan State Police"
     ],
@@ -45911,10 +42889,8 @@
   {
     "agency_id": "46a289b8-e8c9-533f-b591-f181324feece",
     "slug": "mid-missouri-drug-task-force-mo",
-    "flock_active_slug": "mid-missouri-drug-task-force-mo",
-    "flock_slugs": [
-      "mid-missouri-drug-task-force-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mid Missouri Drug Task Force MO"
     ],
@@ -45936,10 +42912,8 @@
   {
     "agency_id": "d7485eb7-89be-5d04-b5aa-f89802eabe00",
     "slug": "middleton-wi-pd",
-    "flock_active_slug": "middleton-wi-pd",
-    "flock_slugs": [
-      "middleton-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middleton WI PD"
     ],
@@ -45963,10 +42937,8 @@
   {
     "agency_id": "af5f46b3-cbd2-53b5-81d6-9841c72cee3a",
     "slug": "midlothian-il-pd",
-    "flock_active_slug": "midlothian-il-pd",
-    "flock_slugs": [
-      "midlothian-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midlothian IL PD"
     ],
@@ -45990,10 +42962,8 @@
   {
     "agency_id": "575a341d-41da-525f-86a1-ed001be05134",
     "slug": "midwest-hidta",
-    "flock_active_slug": "midwest-hidta",
-    "flock_slugs": [
-      "midwest-hidta"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midwest HIDTA"
     ],
@@ -46015,10 +42985,8 @@
   {
     "agency_id": "ca02cebe-ea6d-55d5-8a9f-b54efeb6e816",
     "slug": "milan-il-pd",
-    "flock_active_slug": "milan-il-pd",
-    "flock_slugs": [
-      "milan-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milan IL PD"
     ],
@@ -46042,10 +43010,8 @@
   {
     "agency_id": "866e5e2f-2560-52b5-b537-ede05bfa5bf0",
     "slug": "mille-lacs-county-mn-so",
-    "flock_active_slug": "mille-lacs-county-mn-so",
-    "flock_slugs": [
-      "mille-lacs-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mille Lacs County MN SO"
     ],
@@ -46069,10 +43035,8 @@
   {
     "agency_id": "dd3b5ac5-8f74-5f7c-a8e7-74f43aab90cf",
     "slug": "milwaukee-county-wi-so",
-    "flock_active_slug": "milwaukee-county-wi-so",
-    "flock_slugs": [
-      "milwaukee-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milwaukee County WI SO"
     ],
@@ -46096,10 +43060,8 @@
   {
     "agency_id": "47624845-fd5d-5cb9-bb18-22d138c82a2f",
     "slug": "milwaukee-wi-pd",
-    "flock_active_slug": "milwaukee-wi-pd",
-    "flock_slugs": [
-      "milwaukee-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milwaukee WI PD"
     ],
@@ -46123,10 +43085,8 @@
   {
     "agency_id": "d915f08b-c777-594c-8d03-e7aa18faa224",
     "slug": "minnehaha-county-sd-so",
-    "flock_active_slug": "minnehaha-county-sd-so",
-    "flock_slugs": [
-      "minnehaha-county-sd-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Minnehaha County SD SO"
     ],
@@ -46150,10 +43110,8 @@
   {
     "agency_id": "ed14dd1e-7cd3-564e-bcda-f0fa8000279b",
     "slug": "minnetonka-mn-pd",
-    "flock_active_slug": "minnetonka-mn-pd",
-    "flock_slugs": [
-      "minnetonka-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Minnetonka MN PD"
     ],
@@ -46177,10 +43135,8 @@
   {
     "agency_id": "91b36939-a36f-5344-a742-fdf4d921cfc7",
     "slug": "missouri-information-analysis-center",
-    "flock_active_slug": "missouri-information-analysis-center",
-    "flock_slugs": [
-      "missouri-information-analysis-center"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Missouri Information Analysis Center"
     ],
@@ -46204,10 +43160,8 @@
   {
     "agency_id": "a91b1817-a8b3-5f5d-b919-97ebd40ed049",
     "slug": "mn-isanti-co-so",
-    "flock_active_slug": "mn-isanti-co-so",
-    "flock_slugs": [
-      "mn-isanti-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MN - Isanti CO SO"
     ],
@@ -46231,10 +43185,8 @@
   {
     "agency_id": "c8ab6c28-596d-53c6-b407-4dea827f1875",
     "slug": "mn-renville-county-so",
-    "flock_active_slug": "mn-renville-county-so",
-    "flock_slugs": [
-      "mn-renville-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MN - Renville County SO"
     ],
@@ -46258,10 +43210,8 @@
   {
     "agency_id": "c288a954-6b73-59fd-8be8-5e9ceb1ce35b",
     "slug": "mocic",
-    "flock_active_slug": "mocic",
-    "flock_slugs": [
-      "mocic"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MOCIC"
     ],
@@ -46283,10 +43233,8 @@
   {
     "agency_id": "4c41fb01-ce59-5e0c-b7cd-27a0d430a135",
     "slug": "mokena-il-pd",
-    "flock_active_slug": "mokena-il-pd",
-    "flock_slugs": [
-      "mokena-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mokena IL PD"
     ],
@@ -46310,10 +43258,8 @@
   {
     "agency_id": "3622b748-4354-514d-999e-085900e2788f",
     "slug": "moline-il-pd",
-    "flock_active_slug": "moline-il-pd",
-    "flock_slugs": [
-      "moline-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moline IL PD"
     ],
@@ -46337,10 +43283,8 @@
   {
     "agency_id": "adae9d74-efdb-55d5-97d3-c36e5bdf2901",
     "slug": "monon-in-pd",
-    "flock_active_slug": "monon-in-pd",
-    "flock_slugs": [
-      "monon-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monon IN PD"
     ],
@@ -46364,10 +43308,8 @@
   {
     "agency_id": "ee951b26-f4f7-5998-9926-07dad383c19c",
     "slug": "monona-wi-pd",
-    "flock_active_slug": "monona-wi-pd",
-    "flock_slugs": [
-      "monona-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monona WI PD"
     ],
@@ -46391,10 +43333,8 @@
   {
     "agency_id": "446fc431-037a-58fc-b933-e74fcbbe0589",
     "slug": "montgomery-county-in-so",
-    "flock_active_slug": "montgomery-county-in-so",
-    "flock_slugs": [
-      "montgomery-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County IN SO"
     ],
@@ -46418,10 +43358,8 @@
   {
     "agency_id": "9ac14bba-7c72-59f1-85df-3455307865bb",
     "slug": "montgomery-county-mo-so",
-    "flock_active_slug": "montgomery-county-mo-so",
-    "flock_slugs": [
-      "montgomery-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County MO SO"
     ],
@@ -46445,10 +43383,8 @@
   {
     "agency_id": "0cda5eb2-0835-5d04-a75c-c87ffc78b259",
     "slug": "morgan-co-mo-so",
-    "flock_active_slug": "morgan-co-mo-so",
-    "flock_slugs": [
-      "morgan-co-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morgan Co MO SO"
     ],
@@ -46472,10 +43408,8 @@
   {
     "agency_id": "bcaea2fc-2f24-500b-aa04-2e9a48714470",
     "slug": "morgan-county-al-so",
-    "flock_active_slug": "morgan-county-al-so",
-    "flock_slugs": [
-      "morgan-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morgan County AL SO"
     ],
@@ -46499,10 +43433,8 @@
   {
     "agency_id": "c57c612b-30e6-57fd-a677-ab1b3f1ea095",
     "slug": "morgan-county-il-so",
-    "flock_active_slug": "morgan-county-il-so",
-    "flock_slugs": [
-      "morgan-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morgan County IL SO"
     ],
@@ -46526,10 +43458,8 @@
   {
     "agency_id": "3866d3dd-0947-53a2-bc9f-176663194d41",
     "slug": "morris-il-pd",
-    "flock_active_slug": "morris-il-pd",
-    "flock_slugs": [
-      "morris-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morris IL PD"
     ],
@@ -46553,10 +43483,8 @@
   {
     "agency_id": "bf8ea3d6-3328-5aae-b893-89b65ae9778b",
     "slug": "morton-grove-il-pd",
-    "flock_active_slug": "morton-grove-il-pd",
-    "flock_slugs": [
-      "morton-grove-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morton Grove IL PD"
     ],
@@ -46580,10 +43508,8 @@
   {
     "agency_id": "4b263c34-8305-54be-ba2c-d372af5d8cb9",
     "slug": "morton-il-pd",
-    "flock_active_slug": "morton-il-pd",
-    "flock_slugs": [
-      "morton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Morton IL PD"
     ],
@@ -46607,10 +43533,8 @@
   {
     "agency_id": "942ecaeb-d4e6-5e70-93f7-a1b5de310e59",
     "slug": "mounds-view-mn-pd",
-    "flock_active_slug": "mounds-view-mn-pd",
-    "flock_slugs": [
-      "mounds-view-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mounds View MN PD"
     ],
@@ -46634,10 +43558,8 @@
   {
     "agency_id": "ab728c4f-75ab-5426-a128-347510fd59ae",
     "slug": "mount-morris-township-pd-mi",
-    "flock_active_slug": "mount-morris-township-pd-mi",
-    "flock_slugs": [
-      "mount-morris-township-pd-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Morris Township PD MI"
     ],
@@ -46661,10 +43583,8 @@
   {
     "agency_id": "a9dfc933-4764-50f2-b8af-a9d83f716bcc",
     "slug": "mount-pleasant-wi-pd",
-    "flock_active_slug": "mount-pleasant-wi-pd",
-    "flock_slugs": [
-      "mount-pleasant-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Pleasant WI PD"
     ],
@@ -46688,10 +43608,8 @@
   {
     "agency_id": "f9d0e316-2a82-5430-83ac-b575bbbd3b30",
     "slug": "mount-prospect-il-pd",
-    "flock_active_slug": "mount-prospect-il-pd",
-    "flock_slugs": [
-      "mount-prospect-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Prospect IL PD"
     ],
@@ -46715,10 +43633,8 @@
   {
     "agency_id": "8d50a8e8-88c9-5543-9626-6b52b5ec8aa9",
     "slug": "mountain-bay-metro-wi-pd",
-    "flock_active_slug": "mountain-bay-metro-wi-pd",
-    "flock_slugs": [
-      "mountain-bay-metro-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain Bay Metro WI PD"
     ],
@@ -46740,10 +43656,8 @@
   {
     "agency_id": "722d3888-33e0-5402-81bc-ba850f4d2138",
     "slug": "mt-zion-il-pd",
-    "flock_active_slug": "mt-zion-il-pd",
-    "flock_slugs": [
-      "mt-zion-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mt. Zion IL PD"
     ],
@@ -46767,10 +43681,8 @@
   {
     "agency_id": "231f4813-4f34-50ad-8f9f-50ff22f19f58",
     "slug": "mundelein-il-pd",
-    "flock_active_slug": "mundelein-il-pd",
-    "flock_slugs": [
-      "mundelein-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mundelein IL PD"
     ],
@@ -46794,10 +43706,8 @@
   {
     "agency_id": "3f81bdf2-d1cd-56ec-82ed-d206b8bce10c",
     "slug": "murfreesboro-tn-pd",
-    "flock_active_slug": "murfreesboro-tn-pd",
-    "flock_slugs": [
-      "murfreesboro-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Murfreesboro TN PD"
     ],
@@ -46821,10 +43731,8 @@
   {
     "agency_id": "ba25eaa1-d9d6-56e0-af0b-19f216a20973",
     "slug": "muscoda-wi-pd",
-    "flock_active_slug": "muscoda-wi-pd",
-    "flock_slugs": [
-      "muscoda-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muscoda WI PD"
     ],
@@ -46848,10 +43756,8 @@
   {
     "agency_id": "4d5ec8f7-96b3-5c2b-8987-909e8c95be73",
     "slug": "muskego-wi-pd",
-    "flock_active_slug": "muskego-wi-pd",
-    "flock_slugs": [
-      "muskego-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muskego WI PD"
     ],
@@ -46875,10 +43781,8 @@
   {
     "agency_id": "e22180ab-8aa2-5f16-871d-67b35a2f5df5",
     "slug": "muskegon-county-mi-so",
-    "flock_active_slug": "muskegon-county-mi-so",
-    "flock_slugs": [
-      "muskegon-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muskegon County MI SO"
     ],
@@ -46902,10 +43806,8 @@
   {
     "agency_id": "2511076a-5a0c-5581-8e67-bcea492b116b",
     "slug": "muskegon-mi-pd",
-    "flock_active_slug": "muskegon-mi-pd",
-    "flock_slugs": [
-      "muskegon-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Muskegon MI PD"
     ],
@@ -46929,10 +43831,8 @@
   {
     "agency_id": "5636b999-c848-5c54-aee4-9af56260b80a",
     "slug": "napoleon-twp-mi-pd",
-    "flock_active_slug": "napoleon-twp-mi-pd",
-    "flock_slugs": [
-      "napoleon-twp-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Napoleon Twp MI PD"
     ],
@@ -46956,10 +43856,8 @@
   {
     "agency_id": "8f552811-dba7-5474-b67e-c64a8449b1d5",
     "slug": "nassau-county-ny-pd",
-    "flock_active_slug": "nassau-county-ny-pd",
-    "flock_slugs": [
-      "nassau-county-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nassau County NY PD"
     ],
@@ -46983,10 +43881,8 @@
   {
     "agency_id": "ebd8c966-defb-5756-ab02-9f0503238ddc",
     "slug": "national-center-for-missing-exploited-children-ncmec",
-    "flock_active_slug": "national-center-for-missing-exploited-children-ncmec",
-    "flock_slugs": [
-      "national-center-for-missing-exploited-children-ncmec"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "National Center for Missing & Exploited Children [NCMEC]"
     ],
@@ -47008,10 +43904,8 @@
   {
     "agency_id": "16d11768-19bb-5329-beea-53bba5831199",
     "slug": "ne-colfax-co-so",
-    "flock_active_slug": "ne-colfax-co-so",
-    "flock_slugs": [
-      "ne-colfax-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "NE - Colfax Co SO"
     ],
@@ -47035,10 +43929,8 @@
   {
     "agency_id": "1c877550-3d76-5d6b-82dd-dd8303812e55",
     "slug": "ne-cozad-pd",
-    "flock_active_slug": "ne-cozad-pd",
-    "flock_slugs": [
-      "ne-cozad-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "NE - Cozad PD"
     ],
@@ -47062,10 +43954,8 @@
   {
     "agency_id": "b15c1511-b3b6-5e99-b290-b0df7f6f21fc",
     "slug": "neshkoro-wi-pd",
-    "flock_active_slug": "neshkoro-wi-pd",
-    "flock_slugs": [
-      "neshkoro-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Neshkoro WI PD"
     ],
@@ -47089,10 +43979,8 @@
   {
     "agency_id": "c0e59394-2725-5b22-9572-b7ec5efeb6ad",
     "slug": "new-berlin-wi-pd",
-    "flock_active_slug": "new-berlin-wi-pd",
-    "flock_slugs": [
-      "new-berlin-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Berlin WI PD"
     ],
@@ -47116,10 +44004,8 @@
   {
     "agency_id": "753953bc-cbcf-528e-8992-c420831bd3af",
     "slug": "new-brighton-dept-of-pub-safety-mn",
-    "flock_active_slug": "new-brighton-dept-of-pub-safety-mn",
-    "flock_slugs": [
-      "new-brighton-dept-of-pub-safety-mn"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Brighton Dept of Pub Safety (MN)"
     ],
@@ -47143,10 +44029,8 @@
   {
     "agency_id": "d7c3bf5a-86e3-5f11-a31b-959021e5c157",
     "slug": "new-canaan-ct-pd",
-    "flock_active_slug": "new-canaan-ct-pd",
-    "flock_slugs": [
-      "new-canaan-ct-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Canaan CT PD"
     ],
@@ -47170,10 +44054,8 @@
   {
     "agency_id": "76e9bc59-ddb5-5b73-9e56-b719f515b21f",
     "slug": "new-haven-in-pd",
-    "flock_active_slug": "new-haven-in-pd",
-    "flock_slugs": [
-      "new-haven-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Haven IN PD"
     ],
@@ -47197,10 +44079,8 @@
   {
     "agency_id": "05522c43-0b06-5eb2-bbbe-3cf0a0a1bcad",
     "slug": "new-hope-mn-pd",
-    "flock_active_slug": "new-hope-mn-pd",
-    "flock_slugs": [
-      "new-hope-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Hope MN PD"
     ],
@@ -47224,10 +44104,8 @@
   {
     "agency_id": "f4ea6d84-1df1-5fbb-b36c-f15890de25a8",
     "slug": "new-london-wi-pd",
-    "flock_active_slug": "new-london-wi-pd",
-    "flock_slugs": [
-      "new-london-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New London WI PD"
     ],
@@ -47251,10 +44129,8 @@
   {
     "agency_id": "e1b4e110-8de0-5c16-a946-cd609a278f23",
     "slug": "new-richmond-wi-pd",
-    "flock_active_slug": "new-richmond-wi-pd",
-    "flock_slugs": [
-      "new-richmond-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Richmond WI PD"
     ],
@@ -47278,10 +44154,8 @@
   {
     "agency_id": "8e415549-1c7c-5dee-8737-65faeb5b76cb",
     "slug": "nictd-in-pd",
-    "flock_active_slug": "nictd-in-pd",
-    "flock_slugs": [
-      "nictd-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "NICTD - IN PD"
     ],
@@ -47303,10 +44177,8 @@
   {
     "agency_id": "1ed248b5-54d4-5605-a715-029ce4d1202c",
     "slug": "norfolk-southern-rr-il-pd",
-    "flock_active_slug": "norfolk-southern-rr-il-pd",
-    "flock_slugs": [
-      "norfolk-southern-rr-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Norfolk Southern RR IL PD"
     ],
@@ -47328,10 +44200,8 @@
   {
     "agency_id": "f4f0fe27-4eb0-5a5b-8272-7ceb08d293f0",
     "slug": "normal-il-pd",
-    "flock_active_slug": "normal-il-pd",
-    "flock_slugs": [
-      "normal-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Normal IL PD"
     ],
@@ -47355,10 +44225,8 @@
   {
     "agency_id": "0269cdec-8cc4-5990-a48b-8632e46923d0",
     "slug": "normandy-mo-pd",
-    "flock_active_slug": "normandy-mo-pd",
-    "flock_slugs": [
-      "normandy-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Normandy MO PD"
     ],
@@ -47382,10 +44250,8 @@
   {
     "agency_id": "3d732688-1d7b-5994-9b68-c40f4420d52e",
     "slug": "north-aurora-il-pd",
-    "flock_active_slug": "north-aurora-il-pd",
-    "flock_slugs": [
-      "north-aurora-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Aurora IL PD"
     ],
@@ -47409,10 +44275,8 @@
   {
     "agency_id": "5f435921-aed1-5fea-8696-68796f3e590b",
     "slug": "north-chicago-il-pd",
-    "flock_active_slug": "north-chicago-il-pd",
-    "flock_slugs": [
-      "north-chicago-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Chicago IL PD"
     ],
@@ -47436,10 +44300,8 @@
   {
     "agency_id": "ebdd67bc-4b76-56fc-927d-f9855fabb506",
     "slug": "north-county-cooperative-mo-pd",
-    "flock_active_slug": "north-county-cooperative-mo-pd",
-    "flock_slugs": [
-      "north-county-cooperative-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North County Cooperative MO PD"
     ],
@@ -47461,10 +44323,8 @@
   {
     "agency_id": "7dfe18e8-7be7-5ee4-97ab-9f23c75008e4",
     "slug": "north-liberty-ia-pd",
-    "flock_active_slug": "north-liberty-ia-pd",
-    "flock_slugs": [
-      "north-liberty-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Liberty IA PD"
     ],
@@ -47488,10 +44348,8 @@
   {
     "agency_id": "195276c5-49f3-5ee7-a515-21e65d7bbd3e",
     "slug": "north-manchester-in-pd",
-    "flock_active_slug": "north-manchester-in-pd",
-    "flock_slugs": [
-      "north-manchester-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Manchester IN PD"
     ],
@@ -47515,10 +44373,8 @@
   {
     "agency_id": "2a67ecc7-c654-517c-ab50-890cb95183cd",
     "slug": "north-missouri-drug-task-force-mo",
-    "flock_active_slug": "north-missouri-drug-task-force-mo",
-    "flock_slugs": [
-      "north-missouri-drug-task-force-mo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Missouri Drug Task Force MO"
     ],
@@ -47540,10 +44396,8 @@
   {
     "agency_id": "ca2563e5-08eb-530e-9915-8b42398f82d6",
     "slug": "north-mo-dtf-brookfield-mo-pd",
-    "flock_active_slug": "north-mo-dtf-brookfield-mo-pd",
-    "flock_slugs": [
-      "north-mo-dtf-brookfield-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North MO DTF Brookfield MO PD"
     ],
@@ -47565,10 +44419,8 @@
   {
     "agency_id": "eed93202-1ef4-5e63-9602-bf0a3c831e37",
     "slug": "northbrook-il-pd",
-    "flock_active_slug": "northbrook-il-pd",
-    "flock_slugs": [
-      "northbrook-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Northbrook IL PD"
     ],
@@ -47592,10 +44444,8 @@
   {
     "agency_id": "7e2cc3cd-efb3-5308-9bbf-68cb37d7f207",
     "slug": "norton-ks-pd",
-    "flock_active_slug": "norton-ks-pd",
-    "flock_slugs": [
-      "norton-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Norton KS PD"
     ],
@@ -47619,10 +44469,8 @@
   {
     "agency_id": "9f117bfe-8ea7-5b65-9455-5c9aca039a77",
     "slug": "norton-shores-mi-pd",
-    "flock_active_slug": "norton-shores-mi-pd",
-    "flock_slugs": [
-      "norton-shores-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Norton Shores MI PD"
     ],
@@ -47646,10 +44494,8 @@
   {
     "agency_id": "7c84ef24-4ecc-5f49-8efa-7ef6881915eb",
     "slug": "oak-brook-il-pd",
-    "flock_active_slug": "oak-brook-il-pd",
-    "flock_slugs": [
-      "oak-brook-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oak Brook IL PD"
     ],
@@ -47673,10 +44519,8 @@
   {
     "agency_id": "8afd4743-6131-5f9d-bc40-18060db09d8b",
     "slug": "oak-creek-wi-pd",
-    "flock_active_slug": "oak-creek-wi-pd",
-    "flock_slugs": [
-      "oak-creek-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oak Creek WI PD"
     ],
@@ -47700,10 +44544,8 @@
   {
     "agency_id": "2c3c98d6-b071-5ff0-8de7-bc2d930bd4eb",
     "slug": "oconomowoc-wi-pd",
-    "flock_active_slug": "oconomowoc-wi-pd",
-    "flock_slugs": [
-      "oconomowoc-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oconomowoc WI PD"
     ],
@@ -47727,10 +44569,8 @@
   {
     "agency_id": "12c18352-88fe-5f2d-8f05-d051ad80a54e",
     "slug": "odessa-mo-pd",
-    "flock_active_slug": "odessa-mo-pd",
-    "flock_slugs": [
-      "odessa-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Odessa MO PD"
     ],
@@ -47754,10 +44594,8 @@
   {
     "agency_id": "e78434bc-ddb8-5079-8278-482c9560f1cf",
     "slug": "oelwein-ia-pd",
-    "flock_active_slug": "oelwein-ia-pd",
-    "flock_slugs": [
-      "oelwein-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oelwein IA PD"
     ],
@@ -47781,10 +44619,8 @@
   {
     "agency_id": "20b80787-056d-5a99-9031-63813d783928",
     "slug": "ofallon-il-pd",
-    "flock_active_slug": "ofallon-il-pd",
-    "flock_slugs": [
-      "ofallon-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "O'Fallon IL PD"
     ],
@@ -47808,10 +44644,8 @@
   {
     "agency_id": "d47372fd-fca6-5e87-b07e-fe9557358c8e",
     "slug": "ogle-county-il-so",
-    "flock_active_slug": "ogle-county-il-so",
-    "flock_slugs": [
-      "ogle-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ogle County IL SO"
     ],
@@ -47835,10 +44669,8 @@
   {
     "agency_id": "2e3a2b92-92fb-5af6-85ce-3ca1cdcd437b",
     "slug": "ohio-county-so-wv",
-    "flock_active_slug": "ohio-county-so-wv",
-    "flock_slugs": [
-      "ohio-county-so-wv"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ohio County SO WV"
     ],
@@ -47862,10 +44694,8 @@
   {
     "agency_id": "53eac6bb-9671-56ec-945c-59a5422f1e9f",
     "slug": "onalaska-wi-pd",
-    "flock_active_slug": "onalaska-wi-pd",
-    "flock_slugs": [
-      "onalaska-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Onalaska WI PD"
     ],
@@ -47889,10 +44719,8 @@
   {
     "agency_id": "1c5a67b1-138c-55c5-a049-51bed74fe31e",
     "slug": "oneida-wi-pd",
-    "flock_active_slug": "oneida-wi-pd",
-    "flock_slugs": [
-      "oneida-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oneida WI PD"
     ],
@@ -47916,10 +44744,8 @@
   {
     "agency_id": "1a58b468-aed9-5156-9cac-081f677aa915",
     "slug": "orland-hills-il-pd",
-    "flock_active_slug": "orland-hills-il-pd",
-    "flock_slugs": [
-      "orland-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orland Hills IL PD"
     ],
@@ -47943,10 +44769,8 @@
   {
     "agency_id": "b137d7a0-0ff0-5b63-8ff0-d3bf0da6fac4",
     "slug": "orono-mn-pd",
-    "flock_active_slug": "orono-mn-pd",
-    "flock_slugs": [
-      "orono-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orono MN PD"
     ],
@@ -47970,10 +44794,8 @@
   {
     "agency_id": "b3e0658b-046f-5d25-89ad-9427ba5895c8",
     "slug": "osage-beach-mo-pd",
-    "flock_active_slug": "osage-beach-mo-pd",
-    "flock_slugs": [
-      "osage-beach-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Osage Beach MO PD"
     ],
@@ -47997,10 +44819,8 @@
   {
     "agency_id": "13df0cd6-aa4b-5f74-9b11-7ca790a450c4",
     "slug": "osceola-wi-pd",
-    "flock_active_slug": "osceola-wi-pd",
-    "flock_slugs": [
-      "osceola-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Osceola WI PD"
     ],
@@ -48024,10 +44844,8 @@
   {
     "agency_id": "889be286-5b75-5049-aab7-2305ed29c84f",
     "slug": "osseo-mn-pd",
-    "flock_active_slug": "osseo-mn-pd",
-    "flock_slugs": [
-      "osseo-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Osseo MN PD"
     ],
@@ -48051,10 +44869,8 @@
   {
     "agency_id": "e1b85173-786b-5ed4-b93f-60e671197312",
     "slug": "oswego-il-pd",
-    "flock_active_slug": "oswego-il-pd",
-    "flock_slugs": [
-      "oswego-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oswego IL PD"
     ],
@@ -48078,10 +44894,8 @@
   {
     "agency_id": "8257dbad-a094-5048-b94c-a74e00ce6186",
     "slug": "ouachita-parish-la-so",
-    "flock_active_slug": "ouachita-parish-la-so",
-    "flock_slugs": [
-      "ouachita-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ouachita Parish LA SO"
     ],
@@ -48105,10 +44919,8 @@
   {
     "agency_id": "6e0bb4bb-b95f-504b-abaa-cf2cf04f1c54",
     "slug": "overland-mo-pd",
-    "flock_active_slug": "overland-mo-pd",
-    "flock_slugs": [
-      "overland-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Overland MO PD"
     ],
@@ -48132,10 +44944,8 @@
   {
     "agency_id": "42811e97-66b2-569c-9eb5-71791f5549f6",
     "slug": "owatonna-mn-pd",
-    "flock_active_slug": "owatonna-mn-pd",
-    "flock_slugs": [
-      "owatonna-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Owatonna MN PD"
     ],
@@ -48159,10 +44969,8 @@
   {
     "agency_id": "b303518b-2142-54e3-bf25-c50b77109ea0",
     "slug": "ozaukee-county-wi-so",
-    "flock_active_slug": "ozaukee-county-wi-so",
-    "flock_slugs": [
-      "ozaukee-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ozaukee County WI SO"
     ],
@@ -48186,10 +44994,8 @@
   {
     "agency_id": "62aae0da-4b76-5f88-848b-f5a68768795f",
     "slug": "palatine-il-pd",
-    "flock_active_slug": "palatine-il-pd",
-    "flock_slugs": [
-      "palatine-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palatine IL PD"
     ],
@@ -48213,10 +45019,8 @@
   {
     "agency_id": "f36159e7-6b68-5f8b-9288-da3dd26c0376",
     "slug": "palmyra-mo-pd",
-    "flock_active_slug": "palmyra-mo-pd",
-    "flock_slugs": [
-      "palmyra-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palmyra MO PD"
     ],
@@ -48240,10 +45044,8 @@
   {
     "agency_id": "f453f0f0-f6ae-5f5b-9c49-d890e836b697",
     "slug": "palos-heights-il-pd",
-    "flock_active_slug": "palos-heights-il-pd",
-    "flock_slugs": [
-      "palos-heights-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palos Heights IL PD"
     ],
@@ -48267,10 +45069,8 @@
   {
     "agency_id": "6f26d866-3a6d-5c1e-83c3-cdb4690e4792",
     "slug": "palos-hills-il-pd",
-    "flock_active_slug": "palos-hills-il-pd",
-    "flock_slugs": [
-      "palos-hills-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palos Hills IL PD"
     ],
@@ -48294,10 +45094,8 @@
   {
     "agency_id": "ef136a32-88f5-5722-b762-6d3a67673899",
     "slug": "palos-park-il-pd",
-    "flock_active_slug": "palos-park-il-pd",
-    "flock_slugs": [
-      "palos-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palos Park IL PD"
     ],
@@ -48321,10 +45119,8 @@
   {
     "agency_id": "cb58a460-c326-51ed-b8fe-023d549e8387",
     "slug": "parke-county-in-so",
-    "flock_active_slug": "parke-county-in-so",
-    "flock_slugs": [
-      "parke-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Parke County IN SO"
     ],
@@ -48348,10 +45144,8 @@
   {
     "agency_id": "dde8b2dc-b829-5d9f-a1a6-ee7d143568f6",
     "slug": "parkville-mo-pd",
-    "flock_active_slug": "parkville-mo-pd",
-    "flock_slugs": [
-      "parkville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Parkville MO PD"
     ],
@@ -48375,10 +45169,8 @@
   {
     "agency_id": "f1ef4c25-6d06-5b69-a81a-7459511ded6e",
     "slug": "paul-bunyan-task-force-mn",
-    "flock_active_slug": "paul-bunyan-task-force-mn",
-    "flock_slugs": [
-      "paul-bunyan-task-force-mn"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paul Bunyan Task Force MN"
     ],
@@ -48400,10 +45192,8 @@
   {
     "agency_id": "b21e4bcb-4a1e-5ac4-9850-be288d26211f",
     "slug": "pecatonica-il-pd",
-    "flock_active_slug": "pecatonica-il-pd",
-    "flock_slugs": [
-      "pecatonica-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pecatonica IL PD"
     ],
@@ -48427,10 +45217,8 @@
   {
     "agency_id": "c3dbf848-024a-5eef-b9c0-43d43cc22797",
     "slug": "peoria-county-il-so",
-    "flock_active_slug": "peoria-county-il-so",
-    "flock_slugs": [
-      "peoria-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peoria County IL SO"
     ],
@@ -48454,10 +45242,8 @@
   {
     "agency_id": "321740e2-fa4f-5cf0-8b41-946c8940fb8c",
     "slug": "pepin-county-wi-so",
-    "flock_active_slug": "pepin-county-wi-so",
-    "flock_slugs": [
-      "pepin-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pepin County WI SO"
     ],
@@ -48481,10 +45267,8 @@
   {
     "agency_id": "f6819d49-710f-58a8-a579-dcade52945a2",
     "slug": "perkins-township-oh-pd",
-    "flock_active_slug": "perkins-township-oh-pd",
-    "flock_slugs": [
-      "perkins-township-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Perkins Township OH PD"
     ],
@@ -48508,10 +45292,8 @@
   {
     "agency_id": "34034d82-8744-59d3-8910-ce3f386487c0",
     "slug": "peru-in-pd",
-    "flock_active_slug": "peru-in-pd",
-    "flock_slugs": [
-      "peru-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peru IN PD"
     ],
@@ -48535,10 +45317,8 @@
   {
     "agency_id": "be1ce994-e9ea-5d5b-a514-60aa119b7e63",
     "slug": "phelps-county-ne-so",
-    "flock_active_slug": "phelps-county-ne-so",
-    "flock_slugs": [
-      "phelps-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Phelps County NE SO"
     ],
@@ -48562,10 +45342,8 @@
   {
     "agency_id": "9d81abe1-f3cb-506c-8952-d7e0d24bd7af",
     "slug": "pierz-mn-pd",
-    "flock_active_slug": "pierz-mn-pd",
-    "flock_slugs": [
-      "pierz-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pierz MN PD"
     ],
@@ -48589,10 +45367,8 @@
   {
     "agency_id": "cd0e9ea4-4494-59cc-ac74-04f1c3103113",
     "slug": "pike-county-il-so",
-    "flock_active_slug": "pike-county-il-so",
-    "flock_slugs": [
-      "pike-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pike County IL SO"
     ],
@@ -48616,10 +45392,8 @@
   {
     "agency_id": "16c18acc-739b-548f-b666-ef2d98b4e977",
     "slug": "pine-county-mn-so",
-    "flock_active_slug": "pine-county-mn-so",
-    "flock_slugs": [
-      "pine-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pine County MN SO"
     ],
@@ -48643,10 +45417,8 @@
   {
     "agency_id": "99ba33b0-9d8d-5a56-a2a8-b609bc3ba50a",
     "slug": "pittsburg-ks-pd",
-    "flock_active_slug": "pittsburg-ks-pd",
-    "flock_slugs": [
-      "pittsburg-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pittsburg KS PD"
     ],
@@ -48670,10 +45442,8 @@
   {
     "agency_id": "4ec4bbea-82e9-5dba-9fe6-3d9f8607c371",
     "slug": "plainview-mn-pd",
-    "flock_active_slug": "plainview-mn-pd",
-    "flock_slugs": [
-      "plainview-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plainview MN PD"
     ],
@@ -48697,10 +45467,8 @@
   {
     "agency_id": "aa66f189-e19a-5599-991f-b41c16a90e2d",
     "slug": "platte-city-mo-pd",
-    "flock_active_slug": "platte-city-mo-pd",
-    "flock_slugs": [
-      "platte-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Platte City MO PD"
     ],
@@ -48724,10 +45492,8 @@
   {
     "agency_id": "67bcdf5b-0686-5610-9dd3-f17cbe1323a6",
     "slug": "platte-county-mo-so",
-    "flock_active_slug": "platte-county-mo-so",
-    "flock_slugs": [
-      "platte-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Platte County MO SO"
     ],
@@ -48751,10 +45517,8 @@
   {
     "agency_id": "c8c956b2-eee0-528b-bef5-fccf51eeb1c0",
     "slug": "pleasant-hill-ia-pd",
-    "flock_active_slug": "pleasant-hill-ia-pd",
-    "flock_slugs": [
-      "pleasant-hill-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pleasant Hill IA PD"
     ],
@@ -48778,10 +45542,8 @@
   {
     "agency_id": "ca11e654-7b16-5113-8924-9803cf3f8f18",
     "slug": "pleasant-hill-mo-pd",
-    "flock_active_slug": "pleasant-hill-mo-pd",
-    "flock_slugs": [
-      "pleasant-hill-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pleasant Hill MO PD"
     ],
@@ -48805,10 +45567,8 @@
   {
     "agency_id": "5895ac51-f788-58f3-99a1-a1c717981220",
     "slug": "pleasant-valley-mo-pd",
-    "flock_active_slug": "pleasant-valley-mo-pd",
-    "flock_slugs": [
-      "pleasant-valley-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pleasant Valley MO PD"
     ],
@@ -48832,10 +45592,8 @@
   {
     "agency_id": "2eeb0add-97b2-5aac-9427-7df7ddc57e21",
     "slug": "plover-wi-pd",
-    "flock_active_slug": "plover-wi-pd",
-    "flock_slugs": [
-      "plover-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plover WI PD"
     ],
@@ -48859,10 +45617,8 @@
   {
     "agency_id": "e567f15f-d2c4-52ec-ad9e-d9f162ec8d5f",
     "slug": "plymouth-mn-pd",
-    "flock_active_slug": "plymouth-mn-pd",
-    "flock_slugs": [
-      "plymouth-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plymouth MN PD"
     ],
@@ -48886,10 +45642,8 @@
   {
     "agency_id": "08d1f49a-7a6c-5310-9e6a-62e7fcac4180",
     "slug": "plymouth-pd-in",
-    "flock_active_slug": "plymouth-pd-in",
-    "flock_slugs": [
-      "plymouth-pd-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Plymouth PD IN"
     ],
@@ -48913,10 +45667,8 @@
   {
     "agency_id": "f281211f-b834-5a11-b94e-93a0b31398ce",
     "slug": "pokagon-tribal-mi-pd",
-    "flock_active_slug": "pokagon-tribal-mi-pd",
-    "flock_slugs": [
-      "pokagon-tribal-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pokagon Tribal MI PD"
     ],
@@ -48938,10 +45690,8 @@
   {
     "agency_id": "b65d1d9f-6e69-558a-9d9c-2aa58dfb4da1",
     "slug": "port-edwards-wi-pd",
-    "flock_active_slug": "port-edwards-wi-pd",
-    "flock_slugs": [
-      "port-edwards-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Port Edwards WI PD"
     ],
@@ -48965,10 +45715,8 @@
   {
     "agency_id": "95283e6c-d7c2-5135-a10e-d06c36d39412",
     "slug": "portage-county-wi-so",
-    "flock_active_slug": "portage-county-wi-so",
-    "flock_slugs": [
-      "portage-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Portage County WI SO"
     ],
@@ -48992,10 +45740,8 @@
   {
     "agency_id": "43c1eb5e-475c-5627-a594-25e50c5383d5",
     "slug": "portage-in-pd",
-    "flock_active_slug": "portage-in-pd",
-    "flock_slugs": [
-      "portage-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Portage IN PD"
     ],
@@ -49019,10 +45765,8 @@
   {
     "agency_id": "041d0ab6-4b0c-5ca4-a0a1-7dfb333e060c",
     "slug": "portage-mi-pd",
-    "flock_active_slug": "portage-mi-pd",
-    "flock_slugs": [
-      "portage-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Portage MI PD"
     ],
@@ -49046,10 +45790,8 @@
   {
     "agency_id": "22977a7d-ae27-56ce-9f61-cae55cd61f09",
     "slug": "porter-county-in-so",
-    "flock_active_slug": "porter-county-in-so",
-    "flock_slugs": [
-      "porter-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Porter County IN SO"
     ],
@@ -49073,10 +45815,8 @@
   {
     "agency_id": "c61708ed-50c2-5859-bd2e-e99edf0049dc",
     "slug": "porter-in-pd",
-    "flock_active_slug": "porter-in-pd",
-    "flock_slugs": [
-      "porter-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Porter IN PD"
     ],
@@ -49100,10 +45840,8 @@
   {
     "agency_id": "1ab0235f-3c4d-5d30-9fbd-8224c614fe26",
     "slug": "posen-il-pd",
-    "flock_active_slug": "posen-il-pd",
-    "flock_slugs": [
-      "posen-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Posen IL PD"
     ],
@@ -49127,10 +45865,8 @@
   {
     "agency_id": "f5e061f0-084e-567b-a4bb-6b576db5bf22",
     "slug": "pottawatomie-county-ks-so",
-    "flock_active_slug": "pottawatomie-county-ks-so",
-    "flock_slugs": [
-      "pottawatomie-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pottawatomie County KS SO"
     ],
@@ -49154,10 +45890,8 @@
   {
     "agency_id": "c51f3d82-f258-5f09-b3c2-294f239d6675",
     "slug": "pottawattamie-county-ia-so",
-    "flock_active_slug": "pottawattamie-county-ia-so",
-    "flock_slugs": [
-      "pottawattamie-county-ia-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pottawattamie County IA SO"
     ],
@@ -49181,10 +45915,8 @@
   {
     "agency_id": "30bdbd92-705e-56c7-abd2-1a3474c2dfc8",
     "slug": "prairie-du-chien-wi-pd",
-    "flock_active_slug": "prairie-du-chien-wi-pd",
-    "flock_slugs": [
-      "prairie-du-chien-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prairie Du Chien WI PD"
     ],
@@ -49208,10 +45940,8 @@
   {
     "agency_id": "564d1f83-adce-5e59-92b4-710365f510f9",
     "slug": "prescott-wi-pd",
-    "flock_active_slug": "prescott-wi-pd",
-    "flock_slugs": [
-      "prescott-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prescott WI PD"
     ],
@@ -49235,10 +45965,8 @@
   {
     "agency_id": "f49b20d2-8cce-5037-8de0-a5051274be89",
     "slug": "prince-william-county-va-pd",
-    "flock_active_slug": "prince-william-county-va-pd",
-    "flock_slugs": [
-      "prince-william-county-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prince William County VA PD"
     ],
@@ -49262,10 +45990,8 @@
   {
     "agency_id": "ddd117ec-d675-5d14-8026-8a52cf1ea73e",
     "slug": "prior-lake-mn-pd",
-    "flock_active_slug": "prior-lake-mn-pd",
-    "flock_slugs": [
-      "prior-lake-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prior Lake MN PD"
     ],
@@ -49289,10 +46015,8 @@
   {
     "agency_id": "804cc446-6f65-5737-8d8a-4d0b1cd59ed8",
     "slug": "quincy-il-pd",
-    "flock_active_slug": "quincy-il-pd",
-    "flock_slugs": [
-      "quincy-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Quincy IL PD"
     ],
@@ -49316,10 +46040,8 @@
   {
     "agency_id": "8f2b08ca-1d21-5e61-86ad-42d3a0a1a4bc",
     "slug": "racine-county-wi-communications-center",
-    "flock_active_slug": "racine-county-wi-communications-center",
-    "flock_slugs": [
-      "racine-county-wi-communications-center"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Racine County WI Communications Center"
     ],
@@ -49344,10 +46066,8 @@
   {
     "agency_id": "ec5c59e1-4010-5462-9296-242c04774b6b",
     "slug": "racine-wi-pd",
-    "flock_active_slug": "racine-wi-pd",
-    "flock_slugs": [
-      "racine-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Racine WI PD"
     ],
@@ -49371,10 +46091,8 @@
   {
     "agency_id": "a903ded2-e510-57aa-9328-ccb0a1866838",
     "slug": "raeford-nc-pd",
-    "flock_active_slug": "raeford-nc-pd",
-    "flock_slugs": [
-      "raeford-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Raeford NC PD"
     ],
@@ -49398,10 +46116,8 @@
   {
     "agency_id": "f8b0b63f-6efd-5887-94b7-a840057a5bdf",
     "slug": "ralls-county-mo-so",
-    "flock_active_slug": "ralls-county-mo-so",
-    "flock_slugs": [
-      "ralls-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ralls County MO SO"
     ],
@@ -49425,10 +46141,8 @@
   {
     "agency_id": "4297e879-f07f-50de-ba17-78f390a32d7d",
     "slug": "ramsey-county-mn-so",
-    "flock_active_slug": "ramsey-county-mn-so",
-    "flock_slugs": [
-      "ramsey-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ramsey County MN SO"
     ],
@@ -49452,10 +46166,8 @@
   {
     "agency_id": "01348243-1e18-5ec0-9d83-14a2f005cb4a",
     "slug": "ramsey-mn-pd",
-    "flock_active_slug": "ramsey-mn-pd",
-    "flock_slugs": [
-      "ramsey-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ramsey MN PD"
     ],
@@ -49479,10 +46191,8 @@
   {
     "agency_id": "c300f5cb-8a3d-5493-812c-67cb08f43d83",
     "slug": "rantoul-il-pd",
-    "flock_active_slug": "rantoul-il-pd",
-    "flock_slugs": [
-      "rantoul-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rantoul IL PD"
     ],
@@ -49506,10 +46216,8 @@
   {
     "agency_id": "8d93a953-7021-5188-b879-0f59c3b59504",
     "slug": "raymore-mo-pd",
-    "flock_active_slug": "raymore-mo-pd",
-    "flock_slugs": [
-      "raymore-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Raymore MO PD"
     ],
@@ -49533,10 +46241,8 @@
   {
     "agency_id": "8a0c1670-2eeb-5847-8092-3b69c6ec858b",
     "slug": "raytown-mo-pd",
-    "flock_active_slug": "raytown-mo-pd",
-    "flock_slugs": [
-      "raytown-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Raytown MO PD"
     ],
@@ -49560,10 +46266,8 @@
   {
     "agency_id": "ce63e193-e4df-59fc-8d75-fc7c67813415",
     "slug": "rice-lake-wi-pd",
-    "flock_active_slug": "rice-lake-wi-pd",
-    "flock_slugs": [
-      "rice-lake-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rice Lake WI PD"
     ],
@@ -49584,10 +46288,8 @@
   {
     "agency_id": "bff633df-1498-5115-9f91-7fb558325387",
     "slug": "rice-steele-county-mn-911-center",
-    "flock_active_slug": "rice-steele-county-mn-911-center",
-    "flock_slugs": [
-      "rice-steele-county-mn-911-center"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rice & Steele County MN 911 Center"
     ],
@@ -49608,10 +46310,8 @@
   {
     "agency_id": "a57bb4d5-e6c8-5187-9907-1287e385d699",
     "slug": "richland-county-wi-so",
-    "flock_active_slug": "richland-county-wi-so",
-    "flock_slugs": [
-      "richland-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richland County WI SO"
     ],
@@ -49635,10 +46335,8 @@
   {
     "agency_id": "350de331-f2b0-5127-ad65-02106d7c94e9",
     "slug": "richmond-heights-mo-pd",
-    "flock_active_slug": "richmond-heights-mo-pd",
-    "flock_slugs": [
-      "richmond-heights-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richmond Heights MO PD"
     ],
@@ -49662,10 +46360,8 @@
   {
     "agency_id": "4e76fb63-864b-51af-a1a4-a33298c17445",
     "slug": "richmond-mo-pd",
-    "flock_active_slug": "richmond-mo-pd",
-    "flock_slugs": [
-      "richmond-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richmond MO PD"
     ],
@@ -49689,10 +46385,8 @@
   {
     "agency_id": "530e38df-f3ed-59f5-ab3a-db68ba1c629f",
     "slug": "ridgeland-ms-pd",
-    "flock_active_slug": "ridgeland-ms-pd",
-    "flock_slugs": [
-      "ridgeland-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ridgeland MS PD"
     ],
@@ -49716,10 +46410,8 @@
   {
     "agency_id": "5da90a55-4122-569c-b889-aafaa79f06b0",
     "slug": "rig-wi-dtf",
-    "flock_active_slug": "rig-wi-dtf",
-    "flock_slugs": [
-      "rig-wi-dtf"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "RIG WI DTF"
     ],
@@ -49741,10 +46433,8 @@
   {
     "agency_id": "a35696b8-5204-55f3-9b11-48e356413cff",
     "slug": "river-falls-wi-pd",
-    "flock_active_slug": "river-falls-wi-pd",
-    "flock_slugs": [
-      "river-falls-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "River Falls WI PD"
     ],
@@ -49768,10 +46458,8 @@
   {
     "agency_id": "fdb7ad74-3fc2-5483-9036-89d3f9f44156",
     "slug": "river-grove-il-pd",
-    "flock_active_slug": "river-grove-il-pd",
-    "flock_slugs": [
-      "river-grove-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "River Grove IL PD"
     ],
@@ -49795,10 +46483,8 @@
   {
     "agency_id": "f4514611-e49b-56a7-befc-e0c7e8625c1d",
     "slug": "riverdale-il-pd",
-    "flock_active_slug": "riverdale-il-pd",
-    "flock_slugs": [
-      "riverdale-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Riverdale IL PD"
     ],
@@ -49822,10 +46508,8 @@
   {
     "agency_id": "6fdecc13-9fc3-5173-a756-28b490f0671b",
     "slug": "riverton-il-pd",
-    "flock_active_slug": "riverton-il-pd",
-    "flock_slugs": [
-      "riverton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Riverton IL PD"
     ],
@@ -49849,10 +46533,8 @@
   {
     "agency_id": "9e45839a-67c1-5aec-9653-b178bce3a78f",
     "slug": "robbinsdale-mn-pd",
-    "flock_active_slug": "robbinsdale-mn-pd",
-    "flock_slugs": [
-      "robbinsdale-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Robbinsdale MN PD"
     ],
@@ -49876,10 +46558,8 @@
   {
     "agency_id": "7628cad1-2be8-5b72-8acb-c44e5336dcd0",
     "slug": "rock-county-ne-so",
-    "flock_active_slug": "rock-county-ne-so",
-    "flock_slugs": [
-      "rock-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock County NE SO"
     ],
@@ -49903,10 +46583,8 @@
   {
     "agency_id": "e2fd1cf8-7935-5554-8f12-a769f67d1317",
     "slug": "rock-falls-il-pd",
-    "flock_active_slug": "rock-falls-il-pd",
-    "flock_slugs": [
-      "rock-falls-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock Falls IL PD"
     ],
@@ -49930,10 +46608,8 @@
   {
     "agency_id": "b814ec12-37a4-5506-9fd1-59581418d2e2",
     "slug": "rock-island-county-il-so",
-    "flock_active_slug": "rock-island-county-il-so",
-    "flock_slugs": [
-      "rock-island-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock Island County IL SO"
     ],
@@ -49957,10 +46633,8 @@
   {
     "agency_id": "9e465cf6-7c91-5e2b-be77-9bec891549d9",
     "slug": "rock-island-il-pd",
-    "flock_active_slug": "rock-island-il-pd",
-    "flock_slugs": [
-      "rock-island-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock Island IL PD"
     ],
@@ -49984,10 +46658,8 @@
   {
     "agency_id": "b1825c07-df4b-5a0d-a336-64ec93729058",
     "slug": "rockdale-il-pd",
-    "flock_active_slug": "rockdale-il-pd",
-    "flock_slugs": [
-      "rockdale-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockdale IL PD"
     ],
@@ -50011,10 +46683,8 @@
   {
     "agency_id": "7d67f242-bcaa-5656-8559-573497180345",
     "slug": "rockford-il-pd",
-    "flock_active_slug": "rockford-il-pd",
-    "flock_slugs": [
-      "rockford-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockford IL PD"
     ],
@@ -50038,10 +46708,8 @@
   {
     "agency_id": "2a46ab39-31ab-5cca-b2bb-de9c6af1fc2d",
     "slug": "rogers-mn-pd",
-    "flock_active_slug": "rogers-mn-pd",
-    "flock_slugs": [
-      "rogers-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rogers MN PD"
     ],
@@ -50065,10 +46733,8 @@
   {
     "agency_id": "c3ea3e79-4842-5ea2-afe8-a847dabf3960",
     "slug": "rolling-meadows-il-pd",
-    "flock_active_slug": "rolling-meadows-il-pd",
-    "flock_slugs": [
-      "rolling-meadows-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rolling Meadows IL PD"
     ],
@@ -50092,10 +46758,8 @@
   {
     "agency_id": "dc19b6cd-4292-59bf-be41-13d6acbf86a3",
     "slug": "romeoville-il-pd",
-    "flock_active_slug": "romeoville-il-pd",
-    "flock_slugs": [
-      "romeoville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Romeoville IL PD"
     ],
@@ -50119,10 +46783,8 @@
   {
     "agency_id": "e8069aca-6075-52c2-a664-ddbdfc28c8bd",
     "slug": "roselle-il-pd",
-    "flock_active_slug": "roselle-il-pd",
-    "flock_slugs": [
-      "roselle-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roselle IL PD"
     ],
@@ -50146,10 +46808,8 @@
   {
     "agency_id": "e86599c9-3b79-5370-9b2d-d5062f23115d",
     "slug": "rosemont-il-pd",
-    "flock_active_slug": "rosemont-il-pd",
-    "flock_slugs": [
-      "rosemont-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rosemont IL PD"
     ],
@@ -50173,10 +46833,8 @@
   {
     "agency_id": "e159df06-c6d3-566d-bfb2-6c9abe31d855",
     "slug": "roseville-mn-pd",
-    "flock_active_slug": "roseville-mn-pd",
-    "flock_slugs": [
-      "roseville-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roseville MN PD"
     ],
@@ -50200,10 +46858,8 @@
   {
     "agency_id": "5939f596-b524-531e-982b-10580d3e2317",
     "slug": "rossville-il-pd",
-    "flock_active_slug": "rossville-il-pd",
-    "flock_slugs": [
-      "rossville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rossville IL PD"
     ],
@@ -50227,10 +46883,8 @@
   {
     "agency_id": "2bbc46f1-ebe2-5bd3-aafe-f1956a3ecc52",
     "slug": "round-lake-park-il-pd",
-    "flock_active_slug": "round-lake-park-il-pd",
-    "flock_slugs": [
-      "round-lake-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Round Lake Park IL PD"
     ],
@@ -50254,10 +46908,8 @@
   {
     "agency_id": "ee9741c4-1528-5eac-92a9-7025341e7bdc",
     "slug": "saginaw-mi-pd",
-    "flock_active_slug": "saginaw-mi-pd",
-    "flock_slugs": [
-      "saginaw-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saginaw MI PD"
     ],
@@ -50281,10 +46933,8 @@
   {
     "agency_id": "07fbb118-e8c8-580c-9734-4573d634560c",
     "slug": "saint-croix-falls-wi-pd",
-    "flock_active_slug": "saint-croix-falls-wi-pd",
-    "flock_slugs": [
-      "saint-croix-falls-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saint Croix Falls WI PD"
     ],
@@ -50308,10 +46958,8 @@
   {
     "agency_id": "c5d7b908-dcb3-51aa-a185-6640aca6408d",
     "slug": "saint-francis-wi-pd",
-    "flock_active_slug": "saint-francis-wi-pd",
-    "flock_slugs": [
-      "saint-francis-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saint Francis WI PD"
     ],
@@ -50335,10 +46983,8 @@
   {
     "agency_id": "4ec54275-baff-59d8-8b65-ab55b6ab864b",
     "slug": "saline-county-ks-so",
-    "flock_active_slug": "saline-county-ks-so",
-    "flock_slugs": [
-      "saline-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saline County KS SO"
     ],
@@ -50362,10 +47008,8 @@
   {
     "agency_id": "c59579e1-7048-5e48-8d5b-19dce65ffacf",
     "slug": "sangamon-county-il-so",
-    "flock_active_slug": "sangamon-county-il-so",
-    "flock_slugs": [
-      "sangamon-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sangamon County IL SO"
     ],
@@ -50389,10 +47033,8 @@
   {
     "agency_id": "efefcc6b-e5e5-52c4-a280-4fc9542d251e",
     "slug": "sauk-county-wi-so",
-    "flock_active_slug": "sauk-county-wi-so",
-    "flock_slugs": [
-      "sauk-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sauk County WI SO"
     ],
@@ -50416,10 +47058,8 @@
   {
     "agency_id": "39706823-e774-547e-892f-16240b88fa57",
     "slug": "sawyer-county-wi-so",
-    "flock_active_slug": "sawyer-county-wi-so",
-    "flock_slugs": [
-      "sawyer-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sawyer County WI SO"
     ],
@@ -50443,10 +47083,8 @@
   {
     "agency_id": "1e49a436-a64e-52de-ba8e-02d6faa67b3c",
     "slug": "schuyler-county-mo-so",
-    "flock_active_slug": "schuyler-county-mo-so",
-    "flock_slugs": [
-      "schuyler-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Schuyler County MO SO"
     ],
@@ -50470,10 +47108,8 @@
   {
     "agency_id": "211ce17e-3fb3-5f2d-b980-b2fe9a3d105b",
     "slug": "sedalia-mo-pd",
-    "flock_active_slug": "sedalia-mo-pd",
-    "flock_slugs": [
-      "sedalia-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sedalia MO PD"
     ],
@@ -50497,10 +47133,8 @@
   {
     "agency_id": "9715bce5-a0e0-5554-b8c1-d9b9d07038ac",
     "slug": "sergeant-bluff-ia-pd",
-    "flock_active_slug": "sergeant-bluff-ia-pd",
-    "flock_slugs": [
-      "sergeant-bluff-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sergeant Bluff IA PD"
     ],
@@ -50524,10 +47158,8 @@
   {
     "agency_id": "5a55d9f3-432f-5dea-88cf-160641701bfa",
     "slug": "seward-county-ne-so",
-    "flock_active_slug": "seward-county-ne-so",
-    "flock_slugs": [
-      "seward-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seward County NE SO"
     ],
@@ -50551,10 +47183,8 @@
   {
     "agency_id": "b3306dbe-b893-5bf6-94ef-7a2bb9040ea7",
     "slug": "shawnee-county-ks-so",
-    "flock_active_slug": "shawnee-county-ks-so",
-    "flock_slugs": [
-      "shawnee-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shawnee County KS SO"
     ],
@@ -50578,10 +47208,8 @@
   {
     "agency_id": "3965613f-2f35-575b-9b74-9b642f718a69",
     "slug": "sheboygan-wi-pd",
-    "flock_active_slug": "sheboygan-wi-pd",
-    "flock_slugs": [
-      "sheboygan-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sheboygan WI PD"
     ],
@@ -50605,10 +47233,8 @@
   {
     "agency_id": "9d3a9bdf-95b2-5a7e-bb38-7c1df7b2ccbc",
     "slug": "shelby-county-il-so",
-    "flock_active_slug": "shelby-county-il-so",
-    "flock_slugs": [
-      "shelby-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelby County IL SO"
     ],
@@ -50632,10 +47258,8 @@
   {
     "agency_id": "f4913582-ef63-5178-b143-14b549e4e0d3",
     "slug": "sherman-il-pd",
-    "flock_active_slug": "sherman-il-pd",
-    "flock_slugs": [
-      "sherman-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sherman IL PD"
     ],
@@ -50659,10 +47283,8 @@
   {
     "agency_id": "4025af52-9657-5a91-8d91-5e7b16129898",
     "slug": "shorewood-il-pd",
-    "flock_active_slug": "shorewood-il-pd",
-    "flock_slugs": [
-      "shorewood-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shorewood IL PD"
     ],
@@ -50686,10 +47308,8 @@
   {
     "agency_id": "6555b67d-ab5d-5ee9-87b6-73d8c967d4de",
     "slug": "silver-lake-pd-in",
-    "flock_active_slug": "silver-lake-pd-in",
-    "flock_slugs": [
-      "silver-lake-pd-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Silver Lake PD IN"
     ],
@@ -50713,10 +47333,8 @@
   {
     "agency_id": "cc8485e2-c7c2-5a86-a257-9753d6628468",
     "slug": "sioux-falls-sd-pd",
-    "flock_active_slug": "sioux-falls-sd-pd",
-    "flock_slugs": [
-      "sioux-falls-sd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sioux Falls SD PD"
     ],
@@ -50740,10 +47358,8 @@
   {
     "agency_id": "33bca86f-d1f5-5851-97ed-98d8839f5865",
     "slug": "sisseton-sd-pd",
-    "flock_active_slug": "sisseton-sd-pd",
-    "flock_slugs": [
-      "sisseton-sd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sisseton SD PD"
     ],
@@ -50767,10 +47383,8 @@
   {
     "agency_id": "04c23f38-97ef-5dc6-ab3b-09397b2d826b",
     "slug": "somerset-wi-pd",
-    "flock_active_slug": "somerset-wi-pd",
-    "flock_slugs": [
-      "somerset-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Somerset WI PD"
     ],
@@ -50794,10 +47408,8 @@
   {
     "agency_id": "a55b47b4-b779-5e0f-b259-0fdab51dc0d9",
     "slug": "south-barrington-il-pd",
-    "flock_active_slug": "south-barrington-il-pd",
-    "flock_slugs": [
-      "south-barrington-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Barrington IL PD"
     ],
@@ -50821,10 +47433,8 @@
   {
     "agency_id": "8b2d65ea-dddd-54c2-9511-48d32bddc18e",
     "slug": "south-bend-in-airport-transit-pd",
-    "flock_active_slug": "south-bend-in-airport-transit-pd",
-    "flock_slugs": [
-      "south-bend-in-airport-transit-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Bend IN Airport Transit PD"
     ],
@@ -50846,10 +47456,8 @@
   {
     "agency_id": "f8eac578-4a87-5452-9648-3b5c3e9d442b",
     "slug": "south-bend-in-pd",
-    "flock_active_slug": "south-bend-in-pd",
-    "flock_slugs": [
-      "south-bend-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Bend IN PD"
     ],
@@ -50873,10 +47481,8 @@
   {
     "agency_id": "e7840385-23e5-558b-80ae-ed36447baaad",
     "slug": "south-dakota-division-of-criminal-investigation-sd",
-    "flock_active_slug": "south-dakota-division-of-criminal-investigation-sd",
-    "flock_slugs": [
-      "south-dakota-division-of-criminal-investigation-sd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Dakota Division of Criminal Investigation SD"
     ],
@@ -50900,10 +47506,8 @@
   {
     "agency_id": "8b99c10c-ad9d-5bcc-b8f6-85127a38a68f",
     "slug": "south-elgin-il-pd",
-    "flock_active_slug": "south-elgin-il-pd",
-    "flock_slugs": [
-      "south-elgin-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Elgin IL PD"
     ],
@@ -50927,10 +47531,8 @@
   {
     "agency_id": "bb9acb6e-d045-5a0d-949d-d07dd385ce54",
     "slug": "south-lake-minnetonka-mn-pd",
-    "flock_active_slug": "south-lake-minnetonka-mn-pd",
-    "flock_slugs": [
-      "south-lake-minnetonka-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Lake Minnetonka MN PD"
     ],
@@ -50952,10 +47554,8 @@
   {
     "agency_id": "ec4581eb-409c-5dac-9db1-ec29b83b1dde",
     "slug": "south-saint-paul-mn-pd",
-    "flock_active_slug": "south-saint-paul-mn-pd",
-    "flock_slugs": [
-      "south-saint-paul-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Saint Paul MN PD"
     ],
@@ -50979,10 +47579,8 @@
   {
     "agency_id": "a7f3876b-fb42-5fe0-bf2b-227307e9ce0c",
     "slug": "southern-view-il-pd",
-    "flock_active_slug": "southern-view-il-pd",
-    "flock_slugs": [
-      "southern-view-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southern View IL PD"
     ],
@@ -51006,10 +47604,8 @@
   {
     "agency_id": "6318e935-4c02-5b9a-822e-7a5a10f531e7",
     "slug": "spring-arbor-mi-pd",
-    "flock_active_slug": "spring-arbor-mi-pd",
-    "flock_slugs": [
-      "spring-arbor-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spring Arbor MI PD"
     ],
@@ -51033,10 +47629,8 @@
   {
     "agency_id": "e53b6d70-b1e4-57eb-bfba-fc863dcdcf48",
     "slug": "spring-lake-park-mn-pd",
-    "flock_active_slug": "spring-lake-park-mn-pd",
-    "flock_slugs": [
-      "spring-lake-park-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spring Lake Park MN PD"
     ],
@@ -51060,10 +47654,8 @@
   {
     "agency_id": "2b5acb8c-7c6c-59d8-b9ca-35dbc89ce2f9",
     "slug": "spring-valley-il-pd",
-    "flock_active_slug": "spring-valley-il-pd",
-    "flock_slugs": [
-      "spring-valley-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Spring Valley IL PD"
     ],
@@ -51087,10 +47679,8 @@
   {
     "agency_id": "066189c0-92fe-5fb0-b4df-1479e2a9c37b",
     "slug": "st-ann-mo-pd",
-    "flock_active_slug": "st-ann-mo-pd",
-    "flock_slugs": [
-      "st-ann-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Ann MO PD"
     ],
@@ -51114,10 +47704,8 @@
   {
     "agency_id": "1499135c-d526-5315-b668-d4842e3de5b4",
     "slug": "st-charles-il-pd",
-    "flock_active_slug": "st-charles-il-pd",
-    "flock_slugs": [
-      "st-charles-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Charles IL PD"
     ],
@@ -51141,10 +47729,8 @@
   {
     "agency_id": "f66cee82-3994-5aba-aefd-424338fadb5c",
     "slug": "st-croix-tribal-wi-pd",
-    "flock_active_slug": "st-croix-tribal-wi-pd",
-    "flock_slugs": [
-      "st-croix-tribal-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Croix Tribal WI PD"
     ],
@@ -51166,10 +47752,8 @@
   {
     "agency_id": "cb8c2625-58be-51e4-ba04-180ba6f43939",
     "slug": "st-joseph-county-so-in",
-    "flock_active_slug": "st-joseph-county-so-in",
-    "flock_slugs": [
-      "st-joseph-county-so-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Joseph County SO IN"
     ],
@@ -51193,10 +47777,8 @@
   {
     "agency_id": "a8616b01-179f-5ba0-86fa-4766e1e83001",
     "slug": "st-joseph-department-of-public-safety-mi",
-    "flock_active_slug": "st-joseph-department-of-public-safety-mi",
-    "flock_slugs": [
-      "st-joseph-department-of-public-safety-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Joseph Department of Public Safety MI"
     ],
@@ -51220,10 +47802,8 @@
   {
     "agency_id": "a5ca185f-518e-583a-9a6c-844d29c5e4e4",
     "slug": "st-joseph-mo-pd",
-    "flock_active_slug": "st-joseph-mo-pd",
-    "flock_slugs": [
-      "st-joseph-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Joseph MO PD"
     ],
@@ -51247,10 +47827,8 @@
   {
     "agency_id": "0c6df986-bc2b-51d1-a34e-c961fd0cd01b",
     "slug": "st-louis-county-mn-so",
-    "flock_active_slug": "st-louis-county-mn-so",
-    "flock_slugs": [
-      "st-louis-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Louis County MN SO"
     ],
@@ -51274,10 +47852,8 @@
   {
     "agency_id": "5f1e151b-6464-5c79-aaa0-739f3049c505",
     "slug": "st-louis-county-mo-pd",
-    "flock_active_slug": "st-louis-county-mo-pd",
-    "flock_slugs": [
-      "st-louis-county-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Louis County MO PD"
     ],
@@ -51301,10 +47877,8 @@
   {
     "agency_id": "1c8d9b52-2963-5081-8848-dcad04034507",
     "slug": "st-paul-mn-pd",
-    "flock_active_slug": "st-paul-mn-pd",
-    "flock_slugs": [
-      "st-paul-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St Paul MN PD"
     ],
@@ -51328,10 +47902,8 @@
   {
     "agency_id": "cdca8b33-c442-503f-af8c-540666db6a6e",
     "slug": "st-peters-mo-pd",
-    "flock_active_slug": "st-peters-mo-pd",
-    "flock_slugs": [
-      "st-peters-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Peters MO PD"
     ],
@@ -51355,10 +47927,8 @@
   {
     "agency_id": "20e01b81-c6bb-5434-b035-1c0609537b4e",
     "slug": "starke-county-in-so",
-    "flock_active_slug": "starke-county-in-so",
-    "flock_slugs": [
-      "starke-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Starke County IN SO"
     ],
@@ -51382,10 +47952,8 @@
   {
     "agency_id": "231e883f-3c80-5de4-82f6-0066f96599de",
     "slug": "steger-il-pd",
-    "flock_active_slug": "steger-il-pd",
-    "flock_slugs": [
-      "steger-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Steger IL PD"
     ],
@@ -51409,10 +47977,8 @@
   {
     "agency_id": "7bbfe78f-2fc3-5ff0-bed8-3672b78fa6f5",
     "slug": "stephenson-county-il-so",
-    "flock_active_slug": "stephenson-county-il-so",
-    "flock_slugs": [
-      "stephenson-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stephenson County IL SO"
     ],
@@ -51436,10 +48002,8 @@
   {
     "agency_id": "ac892bb2-7ab9-514c-a749-cb991177898a",
     "slug": "sterling-il-pd",
-    "flock_active_slug": "sterling-il-pd",
-    "flock_slugs": [
-      "sterling-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sterling IL PD"
     ],
@@ -51463,10 +48027,8 @@
   {
     "agency_id": "87ee399c-32d8-56f7-b425-e946cc187512",
     "slug": "stillwater-mn-pd",
-    "flock_active_slug": "stillwater-mn-pd",
-    "flock_slugs": [
-      "stillwater-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stillwater MN PD"
     ],
@@ -51490,10 +48052,8 @@
   {
     "agency_id": "2c800b21-021b-525a-9c12-09fd22b47cff",
     "slug": "streator-il-pd",
-    "flock_active_slug": "streator-il-pd",
-    "flock_slugs": [
-      "streator-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Streator IL PD"
     ],
@@ -51517,10 +48077,8 @@
   {
     "agency_id": "c2f1b832-61bb-5b3e-b691-b90bcbb41a73",
     "slug": "sturgis-mi-pd",
-    "flock_active_slug": "sturgis-mi-pd",
-    "flock_slugs": [
-      "sturgis-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sturgis MI PD"
     ],
@@ -51544,10 +48102,8 @@
   {
     "agency_id": "8ac6ec3b-234a-59cd-9a1f-05b3ee4a0994",
     "slug": "suffolk-county-ny-so",
-    "flock_active_slug": "suffolk-county-ny-so",
-    "flock_slugs": [
-      "suffolk-county-ny-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Suffolk County NY SO"
     ],
@@ -51571,10 +48127,8 @@
   {
     "agency_id": "26b55e2a-20a3-5b84-8b69-f27930a9ffbf",
     "slug": "sullivan-il-pd",
-    "flock_active_slug": "sullivan-il-pd",
-    "flock_slugs": [
-      "sullivan-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sullivan IL PD"
     ],
@@ -51598,10 +48152,8 @@
   {
     "agency_id": "e6b481d8-b552-51d3-9605-665358b5db6f",
     "slug": "summit-il-pd",
-    "flock_active_slug": "summit-il-pd",
-    "flock_slugs": [
-      "summit-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Summit IL PD"
     ],
@@ -51625,10 +48177,8 @@
   {
     "agency_id": "6c1b404e-0861-5f9b-90df-407447ce91d0",
     "slug": "sun-valley-pd-id",
-    "flock_active_slug": "sun-valley-pd-id",
-    "flock_slugs": [
-      "sun-valley-pd-id"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sun Valley PD ID"
     ],
@@ -51652,10 +48202,8 @@
   {
     "agency_id": "2ee8be9c-36be-5b04-8276-8a23b5017ec7",
     "slug": "sunset-hills-mo-pd",
-    "flock_active_slug": "sunset-hills-mo-pd",
-    "flock_slugs": [
-      "sunset-hills-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sunset Hills MO PD"
     ],
@@ -51679,10 +48227,8 @@
   {
     "agency_id": "73fb593c-5e61-51ab-b98e-b3bcd8f115b2",
     "slug": "superior-wi-pd",
-    "flock_active_slug": "superior-wi-pd",
-    "flock_slugs": [
-      "superior-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Superior WI PD"
     ],
@@ -51706,10 +48252,8 @@
   {
     "agency_id": "5860ab70-9d74-5729-9d22-6e49f430d8dd",
     "slug": "sweet-springs-mo-pd",
-    "flock_active_slug": "sweet-springs-mo-pd",
-    "flock_slugs": [
-      "sweet-springs-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sweet Springs MO PD"
     ],
@@ -51733,10 +48277,8 @@
   {
     "agency_id": "8314a5f8-4e07-55f5-89d4-38fe638acac3",
     "slug": "sycamore-il-pd",
-    "flock_active_slug": "sycamore-il-pd",
-    "flock_slugs": [
-      "sycamore-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sycamore IL PD"
     ],
@@ -51760,10 +48302,8 @@
   {
     "agency_id": "41a7dce4-9c9c-5b95-956b-b63ccdfde94d",
     "slug": "taylor-mi-pd",
-    "flock_active_slug": "taylor-mi-pd",
-    "flock_slugs": [
-      "taylor-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Taylor MI PD"
     ],
@@ -51787,10 +48327,8 @@
   {
     "agency_id": "d4a77610-12e7-5668-9d4e-35c89ccf88a9",
     "slug": "tazewell-county-il-so",
-    "flock_active_slug": "tazewell-county-il-so",
-    "flock_slugs": [
-      "tazewell-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tazewell County IL SO"
     ],
@@ -51814,10 +48352,8 @@
   {
     "agency_id": "d82b3167-0a4c-50c2-9e76-1fbeb0f8cadb",
     "slug": "texas-financial-crimes-intelligence-center",
-    "flock_active_slug": "texas-financial-crimes-intelligence-center",
-    "flock_slugs": [
-      "texas-financial-crimes-intelligence-center"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Texas Financial Crimes Intelligence Center"
     ],
@@ -51841,10 +48377,8 @@
   {
     "agency_id": "0eadee12-f285-5750-a555-20e83e01cd3d",
     "slug": "the-tribal-police-of-the-grand-traverse-band-of-ottawa-chippewa-indians-mi",
-    "flock_active_slug": "the-tribal-police-of-the-grand-traverse-band-of-ottawa-chippewa-indians-mi",
-    "flock_slugs": [
-      "the-tribal-police-of-the-grand-traverse-band-of-ottawa-chippewa-indians-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "The Tribal Police of the Grand Traverse Band of Ottawa & Chippewa Indians MI"
     ],
@@ -51865,10 +48399,8 @@
   {
     "agency_id": "4d619007-18ee-5b52-ad91-556926040aa6",
     "slug": "three-rivers-mi-pd",
-    "flock_active_slug": "three-rivers-mi-pd",
-    "flock_slugs": [
-      "three-rivers-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Three Rivers MI PD"
     ],
@@ -51892,10 +48424,8 @@
   {
     "agency_id": "568309c8-1579-5089-9d48-ce4b50d01305",
     "slug": "tinley-park-il-pd",
-    "flock_active_slug": "tinley-park-il-pd",
-    "flock_slugs": [
-      "tinley-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tinley Park IL PD"
     ],
@@ -51919,10 +48449,8 @@
   {
     "agency_id": "96fe9fc2-f3e4-5122-8f76-f6d9ffb644dd",
     "slug": "tippecanoe-county-in-so",
-    "flock_active_slug": "tippecanoe-county-in-so",
-    "flock_slugs": [
-      "tippecanoe-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tippecanoe County IN SO"
     ],
@@ -51946,10 +48474,8 @@
   {
     "agency_id": "f1943f89-bab9-55ed-a5cc-3281e5495acd",
     "slug": "tipton-ia-pd",
-    "flock_active_slug": "tipton-ia-pd",
-    "flock_slugs": [
-      "tipton-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tipton IA PD"
     ],
@@ -51973,10 +48499,8 @@
   {
     "agency_id": "e8f98da2-2b5c-5f7e-bd7b-e77840a06d0a",
     "slug": "todd-county-mn-so",
-    "flock_active_slug": "todd-county-mn-so",
-    "flock_slugs": [
-      "todd-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Todd County MN SO"
     ],
@@ -52000,10 +48524,8 @@
   {
     "agency_id": "77c8121f-6676-5114-98c1-b86ba26922db",
     "slug": "tomah-wi-pd",
-    "flock_active_slug": "tomah-wi-pd",
-    "flock_slugs": [
-      "tomah-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tomah WI PD"
     ],
@@ -52027,10 +48549,8 @@
   {
     "agency_id": "1c167116-8652-5527-9732-ef7f57295c4b",
     "slug": "town-of-campbell-wi-pd",
-    "flock_active_slug": "town-of-campbell-wi-pd",
-    "flock_slugs": [
-      "town-of-campbell-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Campbell WI PD"
     ],
@@ -52054,10 +48574,8 @@
   {
     "agency_id": "2de60e84-3f17-5fcd-866f-e64f3c3678cd",
     "slug": "town-of-delavan-wi-pd",
-    "flock_active_slug": "town-of-delavan-wi-pd",
-    "flock_slugs": [
-      "town-of-delavan-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town Of Delavan WI PD"
     ],
@@ -52081,10 +48599,8 @@
   {
     "agency_id": "bc6adc33-31de-5fa2-9158-abb3363c7556",
     "slug": "traverse-city-mi-pd",
-    "flock_active_slug": "traverse-city-mi-pd",
-    "flock_slugs": [
-      "traverse-city-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Traverse City MI PD"
     ],
@@ -52108,10 +48624,8 @@
   {
     "agency_id": "42a59299-75a2-5ea9-980a-00b0d9227e06",
     "slug": "tulsa-county-ok-so",
-    "flock_active_slug": "tulsa-county-ok-so",
-    "flock_slugs": [
-      "tulsa-county-ok-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tulsa County OK SO"
     ],
@@ -52135,10 +48649,8 @@
   {
     "agency_id": "7cdfb206-6df4-5a34-95de-148485eacad8",
     "slug": "two-rivers-wi-pd",
-    "flock_active_slug": "two-rivers-wi-pd",
-    "flock_slugs": [
-      "two-rivers-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Two Rivers WI PD"
     ],
@@ -52162,10 +48674,8 @@
   {
     "agency_id": "9546c9a9-fb6d-5944-9dd9-d2ce6143edfd",
     "slug": "union-county-sd-so",
-    "flock_active_slug": "union-county-sd-so",
-    "flock_slugs": [
-      "union-county-sd-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union County SD SO"
     ],
@@ -52189,10 +48699,8 @@
   {
     "agency_id": "5a70c4ea-c534-5ab3-8728-aa992933aca4",
     "slug": "university-city-mo-pd",
-    "flock_active_slug": "university-city-mo-pd",
-    "flock_slugs": [
-      "university-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University City MO PD"
     ],
@@ -52217,10 +48725,8 @@
   {
     "agency_id": "345c0f28-678d-593f-986a-5f60b09471fd",
     "slug": "university-of-central-missouri-pd",
-    "flock_active_slug": "university-of-central-missouri-pd",
-    "flock_slugs": [
-      "university-of-central-missouri-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Central Missouri PD"
     ],
@@ -52243,10 +48749,8 @@
   {
     "agency_id": "bf524189-2ba8-53a6-a3d3-9336e0c5d876",
     "slug": "university-of-illinois-at-urbana-champaign-il-pd",
-    "flock_active_slug": "university-of-illinois-at-urbana-champaign-il-pd",
-    "flock_slugs": [
-      "university-of-illinois-at-urbana-champaign-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Illinois at Urbana-Champaign IL PD"
     ],
@@ -52271,10 +48775,8 @@
   {
     "agency_id": "0e8fdf8c-1752-5528-9a84-b98041c02002",
     "slug": "university-of-illinois-chicago-il-pd",
-    "flock_active_slug": "university-of-illinois-chicago-il-pd",
-    "flock_slugs": [
-      "university-of-illinois-chicago-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Illinois - Chicago IL PD"
     ],
@@ -52299,10 +48801,8 @@
   {
     "agency_id": "e09c298d-cb78-5f17-9273-91f0d9b5c82f",
     "slug": "university-of-illinois-springfield",
-    "flock_active_slug": "university-of-illinois-springfield",
-    "flock_slugs": [
-      "university-of-illinois-springfield"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Illinois- Springfield"
     ],
@@ -52327,10 +48827,8 @@
   {
     "agency_id": "f8511920-caf4-5fed-ae0c-9d91e3678cb5",
     "slug": "university-of-minnesota-mn-pd-twin-cities",
-    "flock_active_slug": "university-of-minnesota-mn-pd-twin-cities",
-    "flock_slugs": [
-      "university-of-minnesota-mn-pd-twin-cities"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Minnesota MN PD (Twin Cities)"
     ],
@@ -52353,10 +48851,8 @@
   {
     "agency_id": "506efefe-608f-5fbb-896c-c7747df5287f",
     "slug": "university-of-wisconsin-green-bay-wi-pd",
-    "flock_active_slug": "university-of-wisconsin-green-bay-wi-pd",
-    "flock_slugs": [
-      "university-of-wisconsin-green-bay-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Wisconsin - Green Bay WI PD"
     ],
@@ -52381,10 +48877,8 @@
   {
     "agency_id": "cf9fc9ff-bc24-5955-9f1a-9359e47eef29",
     "slug": "university-of-wisconsin-madison-wi-pd",
-    "flock_active_slug": "university-of-wisconsin-madison-wi-pd",
-    "flock_slugs": [
-      "university-of-wisconsin-madison-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Wisconsin - Madison WI PD"
     ],
@@ -52409,10 +48903,8 @@
   {
     "agency_id": "35f3d1d3-2f2d-5a9a-8e7f-9844358bc7a9",
     "slug": "valley-county-so-ne",
-    "flock_active_slug": "valley-county-so-ne",
-    "flock_slugs": [
-      "valley-county-so-ne"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Valley County SO NE"
     ],
@@ -52436,10 +48928,8 @@
   {
     "agency_id": "700a58bc-34f2-5462-a020-13e248ce0fe2",
     "slug": "valparaiso-in-pd",
-    "flock_active_slug": "valparaiso-in-pd",
-    "flock_slugs": [
-      "valparaiso-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Valparaiso IN PD"
     ],
@@ -52463,10 +48953,8 @@
   {
     "agency_id": "b68b4e86-ed10-52c5-915e-c44a17924c21",
     "slug": "vandalia-il-pd",
-    "flock_active_slug": "vandalia-il-pd",
-    "flock_slugs": [
-      "vandalia-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vandalia IL PD"
     ],
@@ -52490,10 +48978,8 @@
   {
     "agency_id": "a30c6a46-d5a5-5f29-bd08-3f2a641ae52c",
     "slug": "vermillion-county-in-so",
-    "flock_active_slug": "vermillion-county-in-so",
-    "flock_slugs": [
-      "vermillion-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vermillion County IN SO"
     ],
@@ -52517,10 +49003,8 @@
   {
     "agency_id": "a74b6a24-0527-55cc-bb81-9391801dac63",
     "slug": "vigo-county-in-so",
-    "flock_active_slug": "vigo-county-in-so",
-    "flock_slugs": [
-      "vigo-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vigo County IN SO"
     ],
@@ -52544,10 +49028,8 @@
   {
     "agency_id": "85b59b7f-fa8d-5d5a-a89a-73b89f75bb5e",
     "slug": "village-of-manhattan-il-pd",
-    "flock_active_slug": "village-of-manhattan-il-pd",
-    "flock_slugs": [
-      "village-of-manhattan-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village of Manhattan IL PD"
     ],
@@ -52571,10 +49053,8 @@
   {
     "agency_id": "86c693eb-88d7-5b3c-b902-8f120593ee5a",
     "slug": "village-of-pingree-grove-il-pd",
-    "flock_active_slug": "village-of-pingree-grove-il-pd",
-    "flock_slugs": [
-      "village-of-pingree-grove-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village of Pingree Grove IL PD"
     ],
@@ -52598,10 +49078,8 @@
   {
     "agency_id": "fd9f0670-f188-5b45-921f-a9bc73803f1b",
     "slug": "village-of-turtle-lake-wi-pd",
-    "flock_active_slug": "village-of-turtle-lake-wi-pd",
-    "flock_slugs": [
-      "village-of-turtle-lake-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village of Turtle Lake WI PD"
     ],
@@ -52625,10 +49103,8 @@
   {
     "agency_id": "7ed0b3ee-87cf-5051-bae4-0121f8169770",
     "slug": "virden-il-pd",
-    "flock_active_slug": "virden-il-pd",
-    "flock_slugs": [
-      "virden-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Virden IL PD"
     ],
@@ -52652,10 +49128,8 @@
   {
     "agency_id": "29813d09-79a6-59e0-b490-b5895cef48d5",
     "slug": "wabash-county-in-so",
-    "flock_active_slug": "wabash-county-in-so",
-    "flock_slugs": [
-      "wabash-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wabash County IN SO"
     ],
@@ -52679,10 +49153,8 @@
   {
     "agency_id": "15e9f564-abe1-59cc-898f-c4f2d5d7969d",
     "slug": "wabash-in-pd",
-    "flock_active_slug": "wabash-in-pd",
-    "flock_slugs": [
-      "wabash-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wabash IN PD"
     ],
@@ -52706,10 +49178,8 @@
   {
     "agency_id": "7d9948c0-b0b5-5f18-b985-7fb63b8716fd",
     "slug": "wabaunsee-county-so-ks",
-    "flock_active_slug": "wabaunsee-county-so-ks",
-    "flock_slugs": [
-      "wabaunsee-county-so-ks"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wabaunsee County SO (KS)"
     ],
@@ -52733,10 +49203,8 @@
   {
     "agency_id": "7fbf892f-5e02-5391-8dc3-6d3663dc6f1f",
     "slug": "walworth-county-wi-so",
-    "flock_active_slug": "walworth-county-wi-so",
-    "flock_slugs": [
-      "walworth-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walworth County WI SO"
     ],
@@ -52760,10 +49228,8 @@
   {
     "agency_id": "25ccb34b-932d-520e-b8e1-afca60943421",
     "slug": "wamego-ks-pd",
-    "flock_active_slug": "wamego-ks-pd",
-    "flock_slugs": [
-      "wamego-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wamego KS PD"
     ],
@@ -52787,10 +49253,8 @@
   {
     "agency_id": "421644c1-ff97-54fc-8f5e-eab9e8965dd8",
     "slug": "warrenville-il-pd",
-    "flock_active_slug": "warrenville-il-pd",
-    "flock_slugs": [
-      "warrenville-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warrenville IL PD"
     ],
@@ -52814,10 +49278,8 @@
   {
     "agency_id": "395ba856-68c2-5406-b878-51c55b4af97f",
     "slug": "warson-woods-mo-pd",
-    "flock_active_slug": "warson-woods-mo-pd",
-    "flock_slugs": [
-      "warson-woods-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warson Woods MO PD"
     ],
@@ -52841,10 +49303,8 @@
   {
     "agency_id": "4d0d5aac-359d-5e6d-8c2e-fdb090a87cab",
     "slug": "washburn-county-wi-so",
-    "flock_active_slug": "washburn-county-wi-so",
-    "flock_slugs": [
-      "washburn-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washburn County WI SO"
     ],
@@ -52868,10 +49328,8 @@
   {
     "agency_id": "5cad947e-67e9-5010-99f7-57d1ecc1bfc5",
     "slug": "washington-ia-pd",
-    "flock_active_slug": "washington-ia-pd",
-    "flock_slugs": [
-      "washington-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington IA PD"
     ],
@@ -52895,10 +49353,8 @@
   {
     "agency_id": "f273ff02-5719-532a-9ea7-cfa32bd2b4fb",
     "slug": "washington-mo-pd",
-    "flock_active_slug": "washington-mo-pd",
-    "flock_slugs": [
-      "washington-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington MO PD"
     ],
@@ -52922,10 +49378,8 @@
   {
     "agency_id": "474fc0b7-93e2-5116-ad45-00f5305afb81",
     "slug": "waterville-oh-pd",
-    "flock_active_slug": "waterville-oh-pd",
-    "flock_slugs": [
-      "waterville-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waterville OH PD"
     ],
@@ -52949,10 +49403,8 @@
   {
     "agency_id": "226ce58a-5835-54d4-b49a-925f504a06bc",
     "slug": "wauconda-il-pd",
-    "flock_active_slug": "wauconda-il-pd",
-    "flock_slugs": [
-      "wauconda-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wauconda IL PD"
     ],
@@ -52976,10 +49428,8 @@
   {
     "agency_id": "1db8b953-86cd-564d-9320-34a8260a2896",
     "slug": "waukee-ia-pd",
-    "flock_active_slug": "waukee-ia-pd",
-    "flock_slugs": [
-      "waukee-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waukee IA PD"
     ],
@@ -53003,10 +49453,8 @@
   {
     "agency_id": "0c72e083-2336-584f-9f06-2e18706fe114",
     "slug": "waukegan-il-pd",
-    "flock_active_slug": "waukegan-il-pd",
-    "flock_slugs": [
-      "waukegan-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waukegan IL PD"
     ],
@@ -53030,10 +49478,8 @@
   {
     "agency_id": "01846502-13e6-529e-81da-4122f0df2e67",
     "slug": "waukesha-wi-pd",
-    "flock_active_slug": "waukesha-wi-pd",
-    "flock_slugs": [
-      "waukesha-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waukesha WI PD"
     ],
@@ -53057,10 +49503,8 @@
   {
     "agency_id": "5bd453b8-5842-5c9d-8d8e-75036e86bab1",
     "slug": "waukon-ia-pd",
-    "flock_active_slug": "waukon-ia-pd",
-    "flock_slugs": [
-      "waukon-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waukon IA PD"
     ],
@@ -53084,10 +49528,8 @@
   {
     "agency_id": "37077425-5f27-5d96-ad7d-951553cb1a40",
     "slug": "waupaca-county-wi-so",
-    "flock_active_slug": "waupaca-county-wi-so",
-    "flock_slugs": [
-      "waupaca-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waupaca County WI SO"
     ],
@@ -53111,10 +49553,8 @@
   {
     "agency_id": "4bad037e-e0b6-5c9a-ac05-71e0428df8b6",
     "slug": "wayland-mi-pd",
-    "flock_active_slug": "wayland-mi-pd",
-    "flock_slugs": [
-      "wayland-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wayland MI PD"
     ],
@@ -53138,10 +49578,8 @@
   {
     "agency_id": "58e40696-3cf5-5b28-90bc-077850322e23",
     "slug": "wayne-county-tn-so",
-    "flock_active_slug": "wayne-county-tn-so",
-    "flock_slugs": [
-      "wayne-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wayne County TN SO"
     ],
@@ -53165,10 +49603,8 @@
   {
     "agency_id": "eb41eb0f-ab16-5b79-98b1-fabd32de88cc",
     "slug": "wayzata-mn-pd",
-    "flock_active_slug": "wayzata-mn-pd",
-    "flock_slugs": [
-      "wayzata-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wayzata MN PD"
     ],
@@ -53192,10 +49628,8 @@
   {
     "agency_id": "79304dc7-17d0-5c18-8ea3-c1bebd5be181",
     "slug": "webster-groves-mo-pd",
-    "flock_active_slug": "webster-groves-mo-pd",
-    "flock_slugs": [
-      "webster-groves-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Webster Groves MO PD"
     ],
@@ -53219,10 +49653,8 @@
   {
     "agency_id": "24674433-f057-5ed8-86b7-842da4a6d7d9",
     "slug": "wentzville-mo-pd",
-    "flock_active_slug": "wentzville-mo-pd",
-    "flock_slugs": [
-      "wentzville-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wentzville MO PD"
     ],
@@ -53246,10 +49678,8 @@
   {
     "agency_id": "9088f009-135c-5bd3-b848-3b33d838fbca",
     "slug": "west-bend-wi-pd",
-    "flock_active_slug": "west-bend-wi-pd",
-    "flock_slugs": [
-      "west-bend-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Bend WI PD"
     ],
@@ -53273,10 +49703,8 @@
   {
     "agency_id": "3dc0746e-fde2-5827-aa77-870ed0eb0d38",
     "slug": "west-chicago-il-pd",
-    "flock_active_slug": "west-chicago-il-pd",
-    "flock_slugs": [
-      "west-chicago-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Chicago IL PD"
     ],
@@ -53300,10 +49728,8 @@
   {
     "agency_id": "f310219f-9ab8-511e-a2d1-5d60e83c7ae6",
     "slug": "west-fargo-nd-pd",
-    "flock_active_slug": "west-fargo-nd-pd",
-    "flock_slugs": [
-      "west-fargo-nd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Fargo ND PD"
     ],
@@ -53327,10 +49753,8 @@
   {
     "agency_id": "cb0d1872-49f5-542a-8e9b-d26659316e51",
     "slug": "west-hennepin-mn-public-safety-department",
-    "flock_active_slug": "west-hennepin-mn-public-safety-department",
-    "flock_slugs": [
-      "west-hennepin-mn-public-safety-department"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Hennepin MN Public Safety Department"
     ],
@@ -53352,10 +49776,8 @@
   {
     "agency_id": "eac4231d-23d7-537a-b116-3df89c703145",
     "slug": "west-lafayette-in-pd",
-    "flock_active_slug": "west-lafayette-in-pd",
-    "flock_slugs": [
-      "west-lafayette-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Lafayette IN PD"
     ],
@@ -53379,10 +49801,8 @@
   {
     "agency_id": "87147070-af8c-5f25-a680-a2ef1b6a42bd",
     "slug": "west-saint-paul-mn-pd",
-    "flock_active_slug": "west-saint-paul-mn-pd",
-    "flock_slugs": [
-      "west-saint-paul-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Saint Paul MN PD"
     ],
@@ -53406,10 +49826,8 @@
   {
     "agency_id": "e13f7b50-5ebb-5775-9f34-08dfaedfc6f8",
     "slug": "westchester-il-pd",
-    "flock_active_slug": "westchester-il-pd",
-    "flock_slugs": [
-      "westchester-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westchester IL PD"
     ],
@@ -53433,10 +49851,8 @@
   {
     "agency_id": "cc7dd76c-11e6-514f-864b-355cd0364c12",
     "slug": "westmont-il-pd",
-    "flock_active_slug": "westmont-il-pd",
-    "flock_slugs": [
-      "westmont-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westmont IL PD"
     ],
@@ -53460,10 +49876,8 @@
   {
     "agency_id": "f2a01a15-43da-56c7-a67a-b55c18b052e1",
     "slug": "wheaton-il-pd",
-    "flock_active_slug": "wheaton-il-pd",
-    "flock_slugs": [
-      "wheaton-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wheaton IL PD"
     ],
@@ -53487,10 +49901,8 @@
   {
     "agency_id": "9fad61fa-a492-507f-af9c-b574ff2ef51a",
     "slug": "wheeler-county-ne-so",
-    "flock_active_slug": "wheeler-county-ne-so",
-    "flock_slugs": [
-      "wheeler-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wheeler County NE SO"
     ],
@@ -53514,10 +49926,8 @@
   {
     "agency_id": "680c0426-ed1f-5845-991d-6bf4bc195893",
     "slug": "wheeling-il-pd",
-    "flock_active_slug": "wheeling-il-pd",
-    "flock_slugs": [
-      "wheeling-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wheeling IL PD"
     ],
@@ -53541,10 +49951,8 @@
   {
     "agency_id": "dcca3a09-a725-5131-ac8f-6509e5ae86c6",
     "slug": "whitestown-in-pd",
-    "flock_active_slug": "whitestown-in-pd",
-    "flock_slugs": [
-      "whitestown-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whitestown IN PD"
     ],
@@ -53568,10 +49976,8 @@
   {
     "agency_id": "dfb470a8-0bd8-5dff-93ef-09cb48a3b8d9",
     "slug": "whitewater-wi-pd",
-    "flock_active_slug": "whitewater-wi-pd",
-    "flock_slugs": [
-      "whitewater-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whitewater WI PD"
     ],
@@ -53595,10 +50001,8 @@
   {
     "agency_id": "46026e17-2773-557b-8c77-9bb821008f55",
     "slug": "whitley-county-in-prosector",
-    "flock_active_slug": "whitley-county-in-prosector",
-    "flock_slugs": [
-      "whitley-county-in-prosector"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whitley County IN Prosector"
     ],
@@ -53623,10 +50027,8 @@
   {
     "agency_id": "559314dc-3c03-5481-8e99-44dd450f4832",
     "slug": "wi-department-of-justice",
-    "flock_active_slug": "wi-department-of-justice",
-    "flock_slugs": [
-      "wi-department-of-justice"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "WI Department of Justice"
     ],
@@ -53647,10 +50049,8 @@
   {
     "agency_id": "10a5ec58-c356-56bd-b744-dcd96516bf45",
     "slug": "will-county-il-so",
-    "flock_active_slug": "will-county-il-so",
-    "flock_slugs": [
-      "will-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Will County IL SO"
     ],
@@ -53674,10 +50074,8 @@
   {
     "agency_id": "ecc6f576-1c66-5aec-a7f6-52a8dc465359",
     "slug": "willmar-mn-pd",
-    "flock_active_slug": "willmar-mn-pd",
-    "flock_slugs": [
-      "willmar-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Willmar MN PD"
     ],
@@ -53701,10 +50099,8 @@
   {
     "agency_id": "39c1a42a-84e7-5f72-9517-bddd4c12ed69",
     "slug": "willowbrook-il-pd",
-    "flock_active_slug": "willowbrook-il-pd",
-    "flock_slugs": [
-      "willowbrook-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Willowbrook IL PD"
     ],
@@ -53728,10 +50124,8 @@
   {
     "agency_id": "75e59165-e3af-5313-a216-3becda364128",
     "slug": "wilmette-il-pd",
-    "flock_active_slug": "wilmette-il-pd",
-    "flock_slugs": [
-      "wilmette-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilmette IL PD"
     ],
@@ -53755,10 +50149,8 @@
   {
     "agency_id": "96461e90-2ae1-5486-97c9-3c6786a77268",
     "slug": "windsor-il-pd",
-    "flock_active_slug": "windsor-il-pd",
-    "flock_slugs": [
-      "windsor-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Windsor- IL- PD"
     ],
@@ -53782,10 +50174,8 @@
   {
     "agency_id": "7f7dbaf5-786c-5a9d-adb5-a4b1cfd3a9f5",
     "slug": "winnebago-county-il-so",
-    "flock_active_slug": "winnebago-county-il-so",
-    "flock_slugs": [
-      "winnebago-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winnebago County IL SO"
     ],
@@ -53809,10 +50199,8 @@
   {
     "agency_id": "cc6f4673-1f25-50dd-a0c8-66e11dcf5dd5",
     "slug": "winona-mn-pd",
-    "flock_active_slug": "winona-mn-pd",
-    "flock_slugs": [
-      "winona-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winona MN PD"
     ],
@@ -53836,10 +50224,8 @@
   {
     "agency_id": "eb5865cb-bc96-5012-9bc1-f3a0f3a1aa29",
     "slug": "wisconsin-state-capitol-police-wi",
-    "flock_active_slug": "wisconsin-state-capitol-police-wi",
-    "flock_slugs": [
-      "wisconsin-state-capitol-police-wi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wisconsin State Capitol Police (WI)"
     ],
@@ -53860,10 +50246,8 @@
   {
     "agency_id": "8706dd16-9417-56e0-9a5c-c7c8facb8a4a",
     "slug": "wonder-lake-il-pd",
-    "flock_active_slug": "wonder-lake-il-pd",
-    "flock_slugs": [
-      "wonder-lake-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wonder Lake IL PD"
     ],
@@ -53887,10 +50271,8 @@
   {
     "agency_id": "cc2956ca-f5e2-5d1d-a339-bce2ed7509c7",
     "slug": "wood-dale-il-pd",
-    "flock_active_slug": "wood-dale-il-pd",
-    "flock_slugs": [
-      "wood-dale-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wood Dale IL PD"
     ],
@@ -53914,10 +50296,8 @@
   {
     "agency_id": "f2c31c3d-455d-5e50-bdb3-704546e06d5d",
     "slug": "woodbury-mn-dps",
-    "flock_active_slug": "woodbury-mn-dps",
-    "flock_slugs": [
-      "woodbury-mn-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodbury MN DPS"
     ],
@@ -53941,10 +50321,8 @@
   {
     "agency_id": "96e8f723-e16d-57dd-8a37-90838394a5c8",
     "slug": "woodford-county-il-so",
-    "flock_active_slug": "woodford-county-il-so",
-    "flock_slugs": [
-      "woodford-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodford County IL SO"
     ],
@@ -53968,10 +50346,8 @@
   {
     "agency_id": "dcbc4540-1649-57ee-b38a-5b54407c7a2d",
     "slug": "woodlawn-oh-pd",
-    "flock_active_slug": "woodlawn-oh-pd",
-    "flock_slugs": [
-      "woodlawn-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodlawn OH PD"
     ],
@@ -53995,10 +50371,8 @@
   {
     "agency_id": "bd3acd96-c968-5d4b-b2c3-31c6e891cdeb",
     "slug": "woodridge-il-pd",
-    "flock_active_slug": "woodridge-il-pd",
-    "flock_slugs": [
-      "woodridge-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodridge IL PD"
     ],
@@ -54022,10 +50396,8 @@
   {
     "agency_id": "1ab26067-d9cb-58f6-8299-4a16e079eda3",
     "slug": "woodstock-al-pd",
-    "flock_active_slug": "woodstock-al-pd",
-    "flock_slugs": [
-      "woodstock-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodstock AL PD"
     ],
@@ -54049,10 +50421,8 @@
   {
     "agency_id": "169e3125-f04a-596b-a1cd-689d05563b53",
     "slug": "woodstock-il-pd",
-    "flock_active_slug": "woodstock-il-pd",
-    "flock_slugs": [
-      "woodstock-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodstock IL PD"
     ],
@@ -54076,10 +50446,8 @@
   {
     "agency_id": "b491b526-42ce-5464-b5fe-35ec6822faaf",
     "slug": "wright-county-mn-so",
-    "flock_active_slug": "wright-county-mn-so",
-    "flock_slugs": [
-      "wright-county-mn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wright County MN SO"
     ],
@@ -54103,10 +50471,8 @@
   {
     "agency_id": "78022a7a-840b-52a8-90fc-26bc940af47c",
     "slug": "wyoming-mi-pd",
-    "flock_active_slug": "wyoming-mi-pd",
-    "flock_slugs": [
-      "wyoming-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wyoming MI PD"
     ],
@@ -54130,10 +50496,8 @@
   {
     "agency_id": "89787a43-38fc-541d-a5bb-f873abe39909",
     "slug": "wyoming-mn-pd",
-    "flock_active_slug": "wyoming-mn-pd",
-    "flock_slugs": [
-      "wyoming-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wyoming MN PD"
     ],
@@ -54157,10 +50521,8 @@
   {
     "agency_id": "8dc55817-9a25-5b39-87f6-cb45dfea288d",
     "slug": "zion-il-pd",
-    "flock_active_slug": "zion-il-pd",
-    "flock_slugs": [
-      "zion-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Zion IL PD"
     ],
@@ -54184,10 +50546,8 @@
   {
     "agency_id": "05c2b9c0-aceb-5390-a6dc-2bb64d316ddb",
     "slug": "las-vegas-metro-police-department-nv",
-    "flock_active_slug": "las-vegas-metro-police-department-nv",
-    "flock_slugs": [
-      "las-vegas-metro-police-department-nv"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Las Vegas Metro Police Department - NV"
     ],
@@ -54208,10 +50568,8 @@
   {
     "agency_id": "b7db96e1-1b22-5872-a7c9-879294ff68dd",
     "slug": "do-not-use",
-    "flock_active_slug": "do-not-use",
-    "flock_slugs": [
-      "do-not-use"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DO NOT USE"
     ],
@@ -54228,10 +50586,8 @@
   {
     "agency_id": "dd6717e0-c038-5486-a363-149f53fcb71f",
     "slug": "courtyard-vallejo-napa-valley-ca",
-    "flock_active_slug": "courtyard-vallejo-napa-valley-ca",
-    "flock_slugs": [
-      "courtyard-vallejo-napa-valley-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Courtyard Vallejo Napa Valley (CA)"
     ],
@@ -54251,10 +50607,8 @@
   {
     "agency_id": "e027c461-1535-5a50-a802-7c301aae3ef5",
     "slug": "arturos-street-encinitas-ca",
-    "flock_active_slug": "arturos-street-encinitas-ca",
-    "flock_slugs": [
-      "arturos-street-encinitas-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arturo's Street - Encinitas (CA)"
     ],
@@ -54274,10 +50628,8 @@
   {
     "agency_id": "ca247e71-d26b-503d-b12e-9a0d17120d19",
     "slug": "avocado-farm",
-    "flock_active_slug": "avocado-farm",
-    "flock_slugs": [
-      "avocado-farm"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avocado Farm"
     ],
@@ -54294,10 +50646,8 @@
   {
     "agency_id": "9d905b35-df88-5650-98e3-04932f4c4e4c",
     "slug": "bella-vista-ca",
-    "flock_active_slug": "bella-vista-ca",
-    "flock_slugs": [
-      "bella-vista-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bella Vista (CA)"
     ],
@@ -54321,10 +50671,8 @@
   {
     "agency_id": "af321126-761c-5a9d-8407-c2903555cea2",
     "slug": "brookside-lane-ca",
-    "flock_active_slug": "brookside-lane-ca",
-    "flock_slugs": [
-      "brookside-lane-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brookside Lane (CA)"
     ],
@@ -54344,10 +50692,8 @@
   {
     "agency_id": "0278cb18-fa05-5e70-bd89-fa4ee6293679",
     "slug": "cape-concord-ca",
-    "flock_active_slug": "cape-concord-ca",
-    "flock_slugs": [
-      "cape-concord-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cape Concord (CA)"
     ],
@@ -54367,10 +50713,8 @@
   {
     "agency_id": "2d857199-5bc0-5332-b306-57ffbccffedf",
     "slug": "coromandel-park-ca",
-    "flock_active_slug": "coromandel-park-ca",
-    "flock_slugs": [
-      "coromandel-park-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coromandel Park (CA)"
     ],
@@ -54390,10 +50734,8 @@
   {
     "agency_id": "01d3b3e4-1267-5fa5-88e8-74ae670a5de3",
     "slug": "double-ll-ranch-ca",
-    "flock_active_slug": "double-ll-ranch-ca",
-    "flock_slugs": [
-      "double-ll-ranch-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Double LL Ranch (CA)"
     ],
@@ -54413,10 +50755,8 @@
   {
     "agency_id": "7433bae9-95a2-5c99-ae90-2b413cf72ade",
     "slug": "extended-stay-america-esa-management",
-    "flock_active_slug": "extended-stay-america-esa-management",
-    "flock_slugs": [
-      "extended-stay-america-esa-management"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Extended Stay America (ESA) Management"
     ],
@@ -54433,10 +50773,8 @@
   {
     "agency_id": "12b27181-a026-5768-831e-5080d0e8f7db",
     "slug": "flock-safety-customer",
-    "flock_active_slug": "flock-safety-customer",
-    "flock_slugs": [
-      "flock-safety-customer"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flock Safety - Customer"
     ],
@@ -54453,10 +50791,8 @@
   {
     "agency_id": "bff0452b-0682-5103-9dec-657f11133177",
     "slug": "four-s-ranch-master-association-ivy-gate-ca",
-    "flock_active_slug": "four-s-ranch-master-association-ivy-gate-ca",
-    "flock_slugs": [
-      "four-s-ranch-master-association-ivy-gate-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Four S Ranch Master Association @ Ivy Gate (CA)"
     ],
@@ -54476,10 +50812,8 @@
   {
     "agency_id": "b19c3690-ca47-5de5-b017-45ddb7e841db",
     "slug": "indian-head-park-il-pd",
-    "flock_active_slug": "indian-head-park-il-pd",
-    "flock_slugs": [
-      "indian-head-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indian Head Park IL PD"
     ],
@@ -54503,10 +50837,8 @@
   {
     "agency_id": "76f3e707-b2fd-56b2-88a2-b4ec9bc1c32b",
     "slug": "la-jolla-village-tennis-club-ca",
-    "flock_active_slug": "la-jolla-village-tennis-club-ca",
-    "flock_slugs": [
-      "la-jolla-village-tennis-club-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Jolla Village Tennis Club (CA)"
     ],
@@ -54526,10 +50858,8 @@
   {
     "agency_id": "cf1041d0-897a-5e93-b2dd-f4b921c17387",
     "slug": "laurel-pointe",
-    "flock_active_slug": "laurel-pointe",
-    "flock_slugs": [
-      "laurel-pointe"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Laurel Pointe"
     ],
@@ -54546,10 +50876,8 @@
   {
     "agency_id": "36569ecd-2f5d-5f7f-b245-8ee2d7ad141d",
     "slug": "malabar-ranch",
-    "flock_active_slug": "malabar-ranch",
-    "flock_slugs": [
-      "malabar-ranch"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Malabar Ranch"
     ],
@@ -54566,10 +50894,8 @@
   {
     "agency_id": "fad52ea9-518d-5b5f-9319-523d524a4951",
     "slug": "rainbow-hills-ca",
-    "flock_active_slug": "rainbow-hills-ca",
-    "flock_slugs": [
-      "rainbow-hills-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rainbow Hills (CA)"
     ],
@@ -54589,10 +50915,8 @@
   {
     "agency_id": "abe43773-8c60-5ac0-a85e-beb81581495c",
     "slug": "shadow-mountain-ca",
-    "flock_active_slug": "shadow-mountain-ca",
-    "flock_slugs": [
-      "shadow-mountain-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shadow Mountain (CA)"
     ],
@@ -54612,10 +50936,8 @@
   {
     "agency_id": "3fd7724e-3b41-5bb2-9299-2822165ad9e5",
     "slug": "silverado-community-association-ca",
-    "flock_active_slug": "silverado-community-association-ca",
-    "flock_slugs": [
-      "silverado-community-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Silverado Community Association (CA)"
     ],
@@ -54635,10 +50957,8 @@
   {
     "agency_id": "95298932-ab8e-53b6-a217-9829c5b23003",
     "slug": "sky-ranch-ca",
-    "flock_active_slug": "sky-ranch-ca",
-    "flock_slugs": [
-      "sky-ranch-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sky Ranch (CA)"
     ],
@@ -54658,10 +50978,8 @@
   {
     "agency_id": "84139469-d3e8-5acb-a7d9-167031a68f89",
     "slug": "skylark-ca",
-    "flock_active_slug": "skylark-ca",
-    "flock_slugs": [
-      "skylark-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Skylark (CA)"
     ],
@@ -54681,10 +50999,8 @@
   {
     "agency_id": "cd7a6b5d-a0d2-568f-8425-b71a379a3813",
     "slug": "southwestern-yacht-club-ca",
-    "flock_active_slug": "southwestern-yacht-club-ca",
-    "flock_slugs": [
-      "southwestern-yacht-club-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Southwestern Yacht Club (CA)"
     ],
@@ -54704,10 +51020,8 @@
   {
     "agency_id": "90f18f56-acf8-50be-907b-b9f4c5c8ea40",
     "slug": "upper-el-nido-hoa-ca",
-    "flock_active_slug": "upper-el-nido-hoa-ca",
-    "flock_slugs": [
-      "upper-el-nido-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Upper El Nido HOA (CA)"
     ],
@@ -54727,10 +51041,8 @@
   {
     "agency_id": "9cfc1add-eec3-577c-a9d5-60a46eee57a6",
     "slug": "vista-brighton-place",
-    "flock_active_slug": "vista-brighton-place",
-    "flock_slugs": [
-      "vista-brighton-place"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vista Brighton Place"
     ],
@@ -54747,10 +51059,8 @@
   {
     "agency_id": "de6842af-5222-54e3-8b5b-696493c72bb2",
     "slug": "westwood-financial-tx",
-    "flock_active_slug": "westwood-financial-tx",
-    "flock_slugs": [
-      "westwood-financial-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westwood Financial (TX)"
     ],
@@ -54770,10 +51080,8 @@
   {
     "agency_id": "6aa367a3-5fbd-5af4-85f2-16bc3cf21bd7",
     "slug": "whispering-palms",
-    "flock_active_slug": "whispering-palms",
-    "flock_slugs": [
-      "whispering-palms"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whispering Palms"
     ],
@@ -54790,10 +51098,8 @@
   {
     "agency_id": "b35f77d1-5ba2-55f4-837e-ceed9a0e2d44",
     "slug": "wynola-water-district-ca",
-    "flock_active_slug": "wynola-water-district-ca",
-    "flock_slugs": [
-      "wynola-water-district-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wynola Water District (CA)"
     ],
@@ -54813,10 +51119,8 @@
   {
     "agency_id": "ccfcb8c7-bf3b-56de-9182-cfaadfe01336",
     "slug": "san-bernardino-county-ca-fd",
-    "flock_active_slug": "san-bernardino-county-ca-fd",
-    "flock_slugs": [
-      "san-bernardino-county-ca-fd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Bernardino County CA FD"
     ],
@@ -54840,10 +51144,8 @@
   {
     "agency_id": "4df8ea7d-7b9b-5ece-9184-0e1dbf236060",
     "slug": "city-of-menifee-ca-pd",
-    "flock_active_slug": "city-of-menifee-ca-pd",
-    "flock_slugs": [
-      "city-of-menifee-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Menifee CA PD"
     ],
@@ -54867,10 +51169,8 @@
   {
     "agency_id": "d542f966-5b6d-5af2-9487-b56dcceff9bc",
     "slug": "acworth-ga-pd",
-    "flock_active_slug": "acworth-ga-pd",
-    "flock_slugs": [
-      "acworth-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Acworth GA PD"
     ],
@@ -54894,10 +51194,8 @@
   {
     "agency_id": "fa6baf9a-f0ea-59f7-8930-ec7619987935",
     "slug": "ada-county-id-so",
-    "flock_active_slug": "ada-county-id-so",
-    "flock_slugs": [
-      "ada-county-id-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ada County ID SO"
     ],
@@ -54921,10 +51219,8 @@
   {
     "agency_id": "5fdadbce-d7e7-5ad9-9aa2-39df17274168",
     "slug": "adams-county-wa-so",
-    "flock_active_slug": "adams-county-wa-so",
-    "flock_slugs": [
-      "adams-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adams County WA SO"
     ],
@@ -54948,10 +51244,8 @@
   {
     "agency_id": "e688e697-f3a1-5473-8634-7220b1c29827",
     "slug": "alabaster-al-pd",
-    "flock_active_slug": "alabaster-al-pd",
-    "flock_slugs": [
-      "alabaster-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alabaster AL PD"
     ],
@@ -54975,10 +51269,8 @@
   {
     "agency_id": "0adf7971-e3c3-5e9c-bed6-d320de19fa16",
     "slug": "alamogordo-nm-pd",
-    "flock_active_slug": "alamogordo-nm-pd",
-    "flock_slugs": [
-      "alamogordo-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alamogordo NM PD"
     ],
@@ -55002,10 +51294,8 @@
   {
     "agency_id": "33845531-5686-56e0-a3ff-371fae83d26b",
     "slug": "albion-mi-dps",
-    "flock_active_slug": "albion-mi-dps",
-    "flock_slugs": [
-      "albion-mi-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Albion MI DPS"
     ],
@@ -55029,10 +51319,8 @@
   {
     "agency_id": "7b176a82-055c-505b-b86f-055f1e8dadb1",
     "slug": "amarillo-tx-pd",
-    "flock_active_slug": "amarillo-tx-pd",
-    "flock_slugs": [
-      "amarillo-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Amarillo TX PD"
     ],
@@ -55056,10 +51344,8 @@
   {
     "agency_id": "bb67ce71-a1d3-5c7f-8616-228e675343d2",
     "slug": "angleton-pd-tx",
-    "flock_active_slug": "angleton-pd-tx",
-    "flock_slugs": [
-      "angleton-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Angleton PD TX"
     ],
@@ -55083,10 +51369,8 @@
   {
     "agency_id": "7129ba09-8579-5b73-b23e-bc18bec8a1f0",
     "slug": "anna-tx-pd",
-    "flock_active_slug": "anna-tx-pd",
-    "flock_slugs": [
-      "anna-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anna TX PD"
     ],
@@ -55110,10 +51394,8 @@
   {
     "agency_id": "c941fbc9-bbcd-5357-8b4c-09d32ef8057d",
     "slug": "aransas-pass-tx-pd",
-    "flock_active_slug": "aransas-pass-tx-pd",
-    "flock_slugs": [
-      "aransas-pass-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aransas Pass TX PD"
     ],
@@ -55137,10 +51419,8 @@
   {
     "agency_id": "edfed5af-e1b0-5f02-9296-74a3f3d3cd27",
     "slug": "arizona-department-of-public-safety",
-    "flock_active_slug": "arizona-department-of-public-safety",
-    "flock_slugs": [
-      "arizona-department-of-public-safety"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arizona Department of Public Safety",
       "Arizona Department of Public Safety [Inactive]"
@@ -55167,10 +51447,8 @@
   {
     "agency_id": "8eecf7c2-1efa-5c96-9386-beb802c1407b",
     "slug": "arlington-tx-pd",
-    "flock_active_slug": "arlington-tx-pd",
-    "flock_slugs": [
-      "arlington-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arlington TX PD"
     ],
@@ -55194,10 +51472,8 @@
   {
     "agency_id": "44e7f6fb-a51c-5366-9941-cd0c9a06280e",
     "slug": "aubrey-tx-pd",
-    "flock_active_slug": "aubrey-tx-pd",
-    "flock_slugs": [
-      "aubrey-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aubrey TX PD"
     ],
@@ -55221,10 +51497,8 @@
   {
     "agency_id": "a752d5bb-a9d8-575f-a5fd-b9c605074330",
     "slug": "aurora-oh-pd",
-    "flock_active_slug": "aurora-oh-pd",
-    "flock_slugs": [
-      "aurora-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Aurora OH PD"
     ],
@@ -55248,10 +51522,8 @@
   {
     "agency_id": "d89a7347-b229-5e28-8897-0d12974e6970",
     "slug": "avoca-pa-pd",
-    "flock_active_slug": "avoca-pa-pd",
-    "flock_slugs": [
-      "avoca-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avoca PA PD"
     ],
@@ -55275,10 +51547,8 @@
   {
     "agency_id": "2340ee9a-43bf-51c6-87a7-5b8d495f22ea",
     "slug": "avon-co-pd",
-    "flock_active_slug": "avon-co-pd",
-    "flock_slugs": [
-      "avon-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avon CO PD"
     ],
@@ -55302,10 +51572,8 @@
   {
     "agency_id": "4ca9d7dc-3cc5-50b2-99b3-712320a8213f",
     "slug": "bardstown-pd-ky",
-    "flock_active_slug": "bardstown-pd-ky",
-    "flock_slugs": [
-      "bardstown-pd-ky"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bardstown PD KY"
     ],
@@ -55329,10 +51597,8 @@
   {
     "agency_id": "df9c2eba-7efa-58ca-acc7-c6efc127c253",
     "slug": "bay-st-louis-ms-pd",
-    "flock_active_slug": "bay-st-louis-ms-pd",
-    "flock_slugs": [
-      "bay-st-louis-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bay St. Louis MS PD"
     ],
@@ -55356,10 +51622,8 @@
   {
     "agency_id": "c499c65e-f208-5f0b-beb1-8b8a45b850f8",
     "slug": "beaumont-tx-pd",
-    "flock_active_slug": "beaumont-tx-pd",
-    "flock_slugs": [
-      "beaumont-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Beaumont TX PD"
     ],
@@ -55383,10 +51647,8 @@
   {
     "agency_id": "c393770f-0606-5998-b112-df8ddbb5ed6e",
     "slug": "belpre-oh-pd",
-    "flock_active_slug": "belpre-oh-pd",
-    "flock_slugs": [
-      "belpre-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Belpre OH PD"
     ],
@@ -55410,10 +51672,8 @@
   {
     "agency_id": "e8d2706e-5bb2-56b2-94d1-f7234d6f97f0",
     "slug": "benton-county-wa-so",
-    "flock_active_slug": "benton-county-wa-so",
-    "flock_slugs": [
-      "benton-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Benton County WA SO"
     ],
@@ -55437,10 +51697,8 @@
   {
     "agency_id": "ae5f8f5a-3153-554d-95cc-23af8fb3d4c7",
     "slug": "bienville-parish-la-so",
-    "flock_active_slug": "bienville-parish-la-so",
-    "flock_slugs": [
-      "bienville-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bienville Parish LA SO"
     ],
@@ -55464,10 +51722,8 @@
   {
     "agency_id": "78943dad-4180-53c4-88cf-f901d0898282",
     "slug": "braintree-ma-pd",
-    "flock_active_slug": "braintree-ma-pd",
-    "flock_slugs": [
-      "braintree-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Braintree MA PD"
     ],
@@ -55491,10 +51747,8 @@
   {
     "agency_id": "8850cc76-6d6f-5a25-8e97-8af1c309e550",
     "slug": "branson-mo-pd",
-    "flock_active_slug": "branson-mo-pd",
-    "flock_slugs": [
-      "branson-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Branson MO PD"
     ],
@@ -55518,10 +51772,8 @@
   {
     "agency_id": "5f1f387f-0658-59c6-87c7-8164864b1d8a",
     "slug": "brevard-county-fl-so",
-    "flock_active_slug": "brevard-county-fl-so",
-    "flock_slugs": [
-      "brevard-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brevard County FL SO"
     ],
@@ -55545,10 +51797,8 @@
   {
     "agency_id": "168541a4-8c85-5c18-9552-8634c1be8aff",
     "slug": "brighton-co-pd",
-    "flock_active_slug": "brighton-co-pd",
-    "flock_slugs": [
-      "brighton-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brighton CO PD"
     ],
@@ -55572,10 +51822,8 @@
   {
     "agency_id": "ace2fd72-18e2-5321-93d9-c646e1b54dfb",
     "slug": "buncombe-county-nc-so",
-    "flock_active_slug": "buncombe-county-nc-so",
-    "flock_slugs": [
-      "buncombe-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Buncombe County NC SO"
     ],
@@ -55599,10 +51847,8 @@
   {
     "agency_id": "58da8dfd-9230-5ec7-901b-28f74b2a185e",
     "slug": "burr-ridge-il-pd",
-    "flock_active_slug": "burr-ridge-il-pd",
-    "flock_slugs": [
-      "burr-ridge-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burr Ridge IL PD"
     ],
@@ -55626,10 +51872,8 @@
   {
     "agency_id": "c11a14ff-0bc7-5a6d-9876-c5932d05c38e",
     "slug": "butler-township-oh-pd",
-    "flock_active_slug": "butler-township-oh-pd",
-    "flock_slugs": [
-      "butler-township-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Butler Township OH PD"
     ],
@@ -55654,10 +51898,8 @@
   {
     "agency_id": "c66af22c-6fde-53a0-8836-8fafcae67abe",
     "slug": "byron-ga-pd",
-    "flock_active_slug": "byron-ga-pd",
-    "flock_slugs": [
-      "byron-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Byron GA PD"
     ],
@@ -55681,10 +51923,8 @@
   {
     "agency_id": "a755d105-7422-566c-a37b-160bc3ad62aa",
     "slug": "calhoun-county-sc-so",
-    "flock_active_slug": "calhoun-county-sc-so",
-    "flock_slugs": [
-      "calhoun-county-sc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calhoun County SC SO"
     ],
@@ -55708,10 +51948,8 @@
   {
     "agency_id": "5492a305-c8f7-58a7-b9b7-8673f6db55ee",
     "slug": "canon-city-co-pd",
-    "flock_active_slug": "canon-city-co-pd",
-    "flock_slugs": [
-      "canon-city-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Canon City CO PD"
     ],
@@ -55735,10 +51973,8 @@
   {
     "agency_id": "f05c2fb1-cbf7-5bc7-8621-b6e9bc41f7ca",
     "slug": "cape-girardeau-mo-pd",
-    "flock_active_slug": "cape-girardeau-mo-pd",
-    "flock_slugs": [
-      "cape-girardeau-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cape Girardeau MO PD"
     ],
@@ -55762,10 +51998,8 @@
   {
     "agency_id": "1dba43e2-697d-5e61-9735-064449270334",
     "slug": "capitan-nm-pd",
-    "flock_active_slug": "capitan-nm-pd",
-    "flock_slugs": [
-      "capitan-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Capitan NM PD"
     ],
@@ -55789,10 +52023,8 @@
   {
     "agency_id": "9dc845ac-23af-554b-a04b-cdcda0f2cf0a",
     "slug": "carlsbad-nm-pd",
-    "flock_active_slug": "carlsbad-nm-pd",
-    "flock_slugs": [
-      "carlsbad-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carlsbad NM PD"
     ],
@@ -55816,10 +52048,8 @@
   {
     "agency_id": "25b5736d-ca58-5b4c-8338-ba3dbedf97a2",
     "slug": "carmel-in-pd",
-    "flock_active_slug": "carmel-in-pd",
-    "flock_slugs": [
-      "carmel-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carmel IN PD"
     ],
@@ -55843,10 +52073,8 @@
   {
     "agency_id": "3be8eb08-59e0-52cc-ae43-8ae880a39155",
     "slug": "carroll-county-ga-so",
-    "flock_active_slug": "carroll-county-ga-so",
-    "flock_slugs": [
-      "carroll-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carroll County GA SO"
     ],
@@ -55870,10 +52098,8 @@
   {
     "agency_id": "ab79617d-0e54-5bb1-9f27-09b8ac3ca329",
     "slug": "cartersville-ga-pd",
-    "flock_active_slug": "cartersville-ga-pd",
-    "flock_slugs": [
-      "cartersville-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cartersville GA PD"
     ],
@@ -55897,10 +52123,8 @@
   {
     "agency_id": "42a52453-1e95-57ff-9ff5-6a94e751c1d1",
     "slug": "castle-hills-tx-pd",
-    "flock_active_slug": "castle-hills-tx-pd",
-    "flock_slugs": [
-      "castle-hills-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Castle Hills TX PD"
     ],
@@ -55924,10 +52148,8 @@
   {
     "agency_id": "1abcc311-ecfb-5a53-b3eb-0e816f8600ad",
     "slug": "chaffee-county-co-so",
-    "flock_active_slug": "chaffee-county-co-so",
-    "flock_slugs": [
-      "chaffee-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chaffee County CO SO"
     ],
@@ -55951,10 +52173,8 @@
   {
     "agency_id": "6e310e38-c509-536a-9353-6d5cc18d000d",
     "slug": "chanute-ks-pd",
-    "flock_active_slug": "chanute-ks-pd",
-    "flock_slugs": [
-      "chanute-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chanute KS PD"
     ],
@@ -55978,10 +52198,8 @@
   {
     "agency_id": "a8aeeab9-3273-5315-a006-1eb8c5c9a837",
     "slug": "cherokee-county-ga-da",
-    "flock_active_slug": "cherokee-county-ga-da",
-    "flock_slugs": [
-      "cherokee-county-ga-da"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cherokee County GA DA"
     ],
@@ -56005,10 +52223,8 @@
   {
     "agency_id": "48a65226-c77c-557d-ac4a-fa2f396f2672",
     "slug": "chesterfield-county-va-pd",
-    "flock_active_slug": "chesterfield-county-va-pd",
-    "flock_slugs": [
-      "chesterfield-county-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chesterfield County VA PD"
     ],
@@ -56032,10 +52248,8 @@
   {
     "agency_id": "0459e086-a9f0-55d4-98b3-40a4c71bd422",
     "slug": "chesterton-in-pd",
-    "flock_active_slug": "chesterton-in-pd",
-    "flock_slugs": [
-      "chesterton-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chesterton IN PD"
     ],
@@ -56059,10 +52273,8 @@
   {
     "agency_id": "f355bd44-e7f0-59d9-9912-a214591b1176",
     "slug": "cheyenne-wy-pd",
-    "flock_active_slug": "cheyenne-wy-pd",
-    "flock_slugs": [
-      "cheyenne-wy-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cheyenne WY PD"
     ],
@@ -56086,10 +52298,8 @@
   {
     "agency_id": "2a81180b-9741-5727-b1fa-43e818c48eee",
     "slug": "chippewa-pa-pd",
-    "flock_active_slug": "chippewa-pa-pd",
-    "flock_slugs": [
-      "chippewa-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chippewa PA PD"
     ],
@@ -56113,10 +52323,8 @@
   {
     "agency_id": "88e8f181-cb40-571c-a9ef-2016786d23d3",
     "slug": "cibolo-tx-pd",
-    "flock_active_slug": "cibolo-tx-pd",
-    "flock_slugs": [
-      "cibolo-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cibolo TX PD"
     ],
@@ -56140,10 +52348,8 @@
   {
     "agency_id": "620a7fd7-54fb-527a-a0a0-db0391ec3d32",
     "slug": "city-of-peoria-pd-az",
-    "flock_active_slug": "city-of-peoria-pd-az",
-    "flock_slugs": [
-      "city-of-peoria-pd-az"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Peoria PD AZ"
     ],
@@ -56167,10 +52373,8 @@
   {
     "agency_id": "665867f8-b8cf-5e20-8d53-84fe87ef17e8",
     "slug": "city-of-west-tx-pd",
-    "flock_active_slug": "city-of-west-tx-pd",
-    "flock_slugs": [
-      "city-of-west-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of West TX PD"
     ],
@@ -56194,10 +52398,8 @@
   {
     "agency_id": "e7b1e508-e1f5-533a-9768-0bd3b1b7e4e7",
     "slug": "clarksville-in-pd",
-    "flock_active_slug": "clarksville-in-pd",
-    "flock_slugs": [
-      "clarksville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clarksville IN PD"
     ],
@@ -56221,10 +52423,8 @@
   {
     "agency_id": "e5b539ef-5cf4-5ca8-aa25-4974940d7338",
     "slug": "clarksville-va-pd",
-    "flock_active_slug": "clarksville-va-pd",
-    "flock_slugs": [
-      "clarksville-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clarksville VA PD"
     ],
@@ -56248,10 +52448,8 @@
   {
     "agency_id": "fa38518d-176e-5618-8803-fec5379eddcc",
     "slug": "cleveland-oh-division-of-police",
-    "flock_active_slug": "cleveland-oh-division-of-police",
-    "flock_slugs": [
-      "cleveland-oh-division-of-police"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cleveland OH Division of Police"
     ],
@@ -56272,10 +52470,8 @@
   {
     "agency_id": "ba14bc3d-110f-5809-93e3-998bb6dd1647",
     "slug": "clinton-township-nj-pd",
-    "flock_active_slug": "clinton-township-nj-pd",
-    "flock_slugs": [
-      "clinton-township-nj-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clinton Township NJ PD"
     ],
@@ -56300,10 +52496,8 @@
   {
     "agency_id": "a73737a6-9dc7-5cd5-9902-0cb22d57cbef",
     "slug": "cloud-county-ks-so",
-    "flock_active_slug": "cloud-county-ks-so",
-    "flock_slugs": [
-      "cloud-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cloud County KS SO"
     ],
@@ -56327,10 +52521,8 @@
   {
     "agency_id": "fb1b3ad0-6321-5316-8995-1309ed1f2e3d",
     "slug": "coastal-bend-college-campus-pd",
-    "flock_active_slug": "coastal-bend-college-campus-pd",
-    "flock_slugs": [
-      "coastal-bend-college-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coastal Bend College Campus PD"
     ],
@@ -56347,10 +52539,8 @@
   {
     "agency_id": "67cf5190-2ae6-577a-9cba-8a23246426a2",
     "slug": "cocoa-beach-fl-pd",
-    "flock_active_slug": "cocoa-beach-fl-pd",
-    "flock_slugs": [
-      "cocoa-beach-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cocoa Beach FL PD"
     ],
@@ -56374,10 +52564,8 @@
   {
     "agency_id": "e8a7b51c-a9f3-500a-afd9-ef442a4d65de",
     "slug": "coeur-dalene-id-pd",
-    "flock_active_slug": "coeur-dalene-id-pd",
-    "flock_slugs": [
-      "coeur-dalene-id-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coeur d'Alene ID PD"
     ],
@@ -56401,10 +52589,8 @@
   {
     "agency_id": "82cf2048-a3fa-5d48-9aa1-432f1b812031",
     "slug": "coffeyville-ks-pd",
-    "flock_active_slug": "coffeyville-ks-pd",
-    "flock_slugs": [
-      "coffeyville-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coffeyville KS PD"
     ],
@@ -56428,10 +52614,8 @@
   {
     "agency_id": "d1b20e27-981c-5161-b77b-1ca1374b9d58",
     "slug": "college-place-wa-pd",
-    "flock_active_slug": "college-place-wa-pd",
-    "flock_slugs": [
-      "college-place-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "College Place WA PD"
     ],
@@ -56456,10 +52640,8 @@
   {
     "agency_id": "08514a25-077d-52d1-a7e3-5bcc3ef1be56",
     "slug": "colorado-state-parks",
-    "flock_active_slug": "colorado-state-parks",
-    "flock_slugs": [
-      "colorado-state-parks"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colorado State Parks"
     ],
@@ -56483,10 +52665,8 @@
   {
     "agency_id": "1dfc1565-66fb-5bcb-aca3-73a8080a4883",
     "slug": "colorado-state-patrol",
-    "flock_active_slug": "colorado-state-patrol",
-    "flock_slugs": [
-      "colorado-state-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colorado State Patrol"
     ],
@@ -56510,10 +52690,8 @@
   {
     "agency_id": "76abf391-67a8-5834-8293-9985b7dd0b28",
     "slug": "colquitt-county-ga-so",
-    "flock_active_slug": "colquitt-county-ga-so",
-    "flock_slugs": [
-      "colquitt-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colquitt County GA SO"
     ],
@@ -56537,10 +52715,8 @@
   {
     "agency_id": "9c60d40d-5c2a-5d50-98df-ef9207ad246e",
     "slug": "colville-wa-tribal-police",
-    "flock_active_slug": "colville-wa-tribal-police",
-    "flock_slugs": [
-      "colville-wa-tribal-police"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colville WA Tribal Police"
     ],
@@ -56561,10 +52737,8 @@
   {
     "agency_id": "ea319c7e-2b15-5a8f-a44e-e01c7f15fb91",
     "slug": "concord-nc-pd",
-    "flock_active_slug": "concord-nc-pd",
-    "flock_slugs": [
-      "concord-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Concord NC PD"
     ],
@@ -56588,10 +52762,8 @@
   {
     "agency_id": "dbc98894-0e11-5f49-9c7e-60ad63665372",
     "slug": "cookeville-tn-pd",
-    "flock_active_slug": "cookeville-tn-pd",
-    "flock_slugs": [
-      "cookeville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cookeville TN PD"
     ],
@@ -56615,10 +52787,8 @@
   {
     "agency_id": "cf935e78-cf30-5b28-8280-e16fc3ffffcb",
     "slug": "coolidge-az-pd",
-    "flock_active_slug": "coolidge-az-pd",
-    "flock_slugs": [
-      "coolidge-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coolidge AZ PD"
     ],
@@ -56642,10 +52812,8 @@
   {
     "agency_id": "10e8e190-ea44-5c7d-8f65-833f633dafe5",
     "slug": "cottonwood-az-pd",
-    "flock_active_slug": "cottonwood-az-pd",
-    "flock_slugs": [
-      "cottonwood-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cottonwood AZ PD"
     ],
@@ -56669,10 +52837,8 @@
   {
     "agency_id": "03f134fe-242c-5bcc-966b-00ef1107d549",
     "slug": "covington-la-pd",
-    "flock_active_slug": "covington-la-pd",
-    "flock_slugs": [
-      "covington-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covington LA PD"
     ],
@@ -56696,10 +52862,8 @@
   {
     "agency_id": "b39579e5-a3da-5be9-8d85-1809248eb2d2",
     "slug": "crowley-tx-pd",
-    "flock_active_slug": "crowley-tx-pd",
-    "flock_slugs": [
-      "crowley-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Crowley TX PD"
     ],
@@ -56723,10 +52887,8 @@
   {
     "agency_id": "1c04d8ba-fb0a-5860-be04-ccaff3b5a458",
     "slug": "cullman-county-al-so",
-    "flock_active_slug": "cullman-county-al-so",
-    "flock_slugs": [
-      "cullman-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cullman County AL SO"
     ],
@@ -56750,10 +52912,8 @@
   {
     "agency_id": "670079f3-1c59-571d-ae29-8b23fd1d6936",
     "slug": "cumberland-metro-in-pd",
-    "flock_active_slug": "cumberland-metro-in-pd",
-    "flock_slugs": [
-      "cumberland-metro-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cumberland Metro IN PD"
     ],
@@ -56777,10 +52937,8 @@
   {
     "agency_id": "59146eea-4e86-53a4-914f-350fc4c572ad",
     "slug": "curry-co-nm-so",
-    "flock_active_slug": "curry-co-nm-so",
-    "flock_slugs": [
-      "curry-co-nm-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Curry Co NM SO"
     ],
@@ -56804,10 +52962,8 @@
   {
     "agency_id": "fda93fd6-504f-5a2d-8e38-b24446527b7b",
     "slug": "custer-county-co-so",
-    "flock_active_slug": "custer-county-co-so",
-    "flock_slugs": [
-      "custer-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Custer County CO SO"
     ],
@@ -56831,10 +52987,8 @@
   {
     "agency_id": "6ad471ab-ccf5-510a-a32e-7a75abb44f16",
     "slug": "cvg-airport-ky-pd",
-    "flock_active_slug": "cvg-airport-ky-pd",
-    "flock_slugs": [
-      "cvg-airport-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CVG Airport KY PD"
     ],
@@ -56857,10 +53011,8 @@
   {
     "agency_id": "ff35f6c5-112e-5970-b59f-47dcef6947e5",
     "slug": "cypress-fairbanks-isd-tx-pd",
-    "flock_active_slug": "cypress-fairbanks-isd-tx-pd",
-    "flock_slugs": [
-      "cypress-fairbanks-isd-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cypress Fairbanks ISD (TX) PD"
     ],
@@ -56883,10 +53035,8 @@
   {
     "agency_id": "4236130a-8a86-56ca-99d2-3df76a83785e",
     "slug": "dallas-tx-pd",
-    "flock_active_slug": "dallas-tx-pd",
-    "flock_slugs": [
-      "dallas-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dallas TX PD"
     ],
@@ -56910,10 +53060,8 @@
   {
     "agency_id": "af4d01cc-9961-5565-84cd-743047b5d6d8",
     "slug": "dalworthington-gardens-tx-pd",
-    "flock_active_slug": "dalworthington-gardens-tx-pd",
-    "flock_slugs": [
-      "dalworthington-gardens-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dalworthington Gardens TX PD"
     ],
@@ -56937,10 +53085,8 @@
   {
     "agency_id": "b8c85dfd-939e-57be-990b-33e4391c8c43",
     "slug": "davenport-ia-pd",
-    "flock_active_slug": "davenport-ia-pd",
-    "flock_slugs": [
-      "davenport-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Davenport IA PD"
     ],
@@ -56964,10 +53110,8 @@
   {
     "agency_id": "73cf9251-fae2-5f5c-80c4-11d3facfb08b",
     "slug": "davidson-county-nc-so",
-    "flock_active_slug": "davidson-county-nc-so",
-    "flock_slugs": [
-      "davidson-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Davidson County NC SO"
     ],
@@ -56991,10 +53135,8 @@
   {
     "agency_id": "6256d3d4-6ba6-5351-affc-f3082a291183",
     "slug": "daytona-beach-fl-pd",
-    "flock_active_slug": "daytona-beach-fl-pd",
-    "flock_slugs": [
-      "daytona-beach-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Daytona Beach FL PD"
     ],
@@ -57018,10 +53160,8 @@
   {
     "agency_id": "7440bb36-9b8f-568c-92d0-868e94cd9119",
     "slug": "de-pere-wi-pd",
-    "flock_active_slug": "de-pere-wi-pd",
-    "flock_slugs": [
-      "de-pere-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "De Pere WI PD"
     ],
@@ -57045,10 +53185,8 @@
   {
     "agency_id": "afb91a39-c8bf-553a-9253-3743c1217a58",
     "slug": "deactivated-demo",
-    "flock_active_slug": "deactivated-demo",
-    "flock_slugs": [
-      "deactivated-demo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[DEACTIVATED] - demo"
     ],
@@ -57066,10 +53204,8 @@
   {
     "agency_id": "a64727cf-9798-595e-9bf4-72f177cdd221",
     "slug": "dearborn-mi-pd",
-    "flock_active_slug": "dearborn-mi-pd",
-    "flock_slugs": [
-      "dearborn-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dearborn MI PD"
     ],
@@ -57093,10 +53229,8 @@
   {
     "agency_id": "6d5c11fe-8430-59c2-baaa-f58768de0676",
     "slug": "denison-university-campus-oh-pd",
-    "flock_active_slug": "denison-university-campus-oh-pd",
-    "flock_slugs": [
-      "denison-university-campus-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Denison University Campus OH PD"
     ],
@@ -57120,10 +53254,8 @@
   {
     "agency_id": "1d005a2a-4695-5eab-9bee-7f4695e85d67",
     "slug": "derby-ks-pd",
-    "flock_active_slug": "derby-ks-pd",
-    "flock_slugs": [
-      "derby-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Derby KS PD"
     ],
@@ -57147,10 +53279,8 @@
   {
     "agency_id": "b5b0ea88-f581-5f95-8b99-49aee51bf008",
     "slug": "douglas-county-ne-so",
-    "flock_active_slug": "douglas-county-ne-so",
-    "flock_slugs": [
-      "douglas-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Douglas County NE SO"
     ],
@@ -57174,10 +53304,8 @@
   {
     "agency_id": "5a1a33e6-f884-5e84-9ba1-4f6537aa4ee9",
     "slug": "dupage-county-il-so",
-    "flock_active_slug": "dupage-county-il-so",
-    "flock_slugs": [
-      "dupage-county-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DuPage County IL SO"
     ],
@@ -57201,10 +53329,8 @@
   {
     "agency_id": "f82c7448-abbf-57f7-8f5e-14724f3246d8",
     "slug": "durango-co-pd",
-    "flock_active_slug": "durango-co-pd",
-    "flock_slugs": [
-      "durango-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Durango CO PD"
     ],
@@ -57228,10 +53354,8 @@
   {
     "agency_id": "214d51be-8684-5997-b06d-192f73bfda10",
     "slug": "east-hampton-village-ny-pd",
-    "flock_active_slug": "east-hampton-village-ny-pd",
-    "flock_slugs": [
-      "east-hampton-village-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Hampton Village NY PD"
     ],
@@ -57255,10 +53379,8 @@
   {
     "agency_id": "8ab5f889-89ad-5ee4-a976-723e0eefc958",
     "slug": "east-tawakoni-tx-pd",
-    "flock_active_slug": "east-tawakoni-tx-pd",
-    "flock_slugs": [
-      "east-tawakoni-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Tawakoni TX PD"
     ],
@@ -57282,10 +53404,8 @@
   {
     "agency_id": "37fe0831-74e0-50aa-9fda-bcdddba2f334",
     "slug": "eastborough-ks-pd",
-    "flock_active_slug": "eastborough-ks-pd",
-    "flock_slugs": [
-      "eastborough-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eastborough KS PD"
     ],
@@ -57309,10 +53429,8 @@
   {
     "agency_id": "e632b056-447a-53e8-8925-f244082558d5",
     "slug": "eaton-oh-pd",
-    "flock_active_slug": "eaton-oh-pd",
-    "flock_slugs": [
-      "eaton-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eaton OH PD"
     ],
@@ -57336,10 +53454,8 @@
   {
     "agency_id": "7568882a-e195-54e8-9c2a-3c1e58504ff4",
     "slug": "ector-county-tx-so",
-    "flock_active_slug": "ector-county-tx-so",
-    "flock_slugs": [
-      "ector-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ector County TX SO"
     ],
@@ -57363,10 +53479,8 @@
   {
     "agency_id": "2da579b3-00f2-5cb0-b94e-46ebce100b8c",
     "slug": "edinburg-tx-pd",
-    "flock_active_slug": "edinburg-tx-pd",
-    "flock_slugs": [
-      "edinburg-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Edinburg TX PD"
     ],
@@ -57390,10 +53504,8 @@
   {
     "agency_id": "1d113153-e73b-5352-a0fb-436a31bc6ac0",
     "slug": "edmond-ok-pd",
-    "flock_active_slug": "edmond-ok-pd",
-    "flock_slugs": [
-      "edmond-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Edmond OK PD"
     ],
@@ -57417,10 +53529,8 @@
   {
     "agency_id": "2fd6cbd4-7238-5034-9a16-ed38ac4550ef",
     "slug": "el-macero-hoa-ca",
-    "flock_active_slug": "el-macero-hoa-ca",
-    "flock_slugs": [
-      "el-macero-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Macero HOA (CA)"
     ],
@@ -57440,10 +53550,8 @@
   {
     "agency_id": "7d1f365f-6b58-503b-ab4a-5c929f72ec2d",
     "slug": "el-mirage-az-pd",
-    "flock_active_slug": "el-mirage-az-pd",
-    "flock_slugs": [
-      "el-mirage-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Mirage AZ PD"
     ],
@@ -57467,10 +53575,8 @@
   {
     "agency_id": "59970831-4f53-57f5-876c-78db7e83bfac",
     "slug": "elizabeth-co-pd",
-    "flock_active_slug": "elizabeth-co-pd",
-    "flock_slugs": [
-      "elizabeth-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elizabeth CO PD"
     ],
@@ -57494,10 +53600,8 @@
   {
     "agency_id": "ec51f84f-781f-5de9-92d6-c40b6903e095",
     "slug": "elizabethtown-ky-pd",
-    "flock_active_slug": "elizabethtown-ky-pd",
-    "flock_slugs": [
-      "elizabethtown-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elizabethtown KY PD"
     ],
@@ -57521,10 +53625,8 @@
   {
     "agency_id": "9551326d-4a81-5941-bbea-1e1fdd635378",
     "slug": "eloy-az-pd",
-    "flock_active_slug": "eloy-az-pd",
-    "flock_slugs": [
-      "eloy-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eloy AZ PD"
     ],
@@ -57548,10 +53650,8 @@
   {
     "agency_id": "c9dacd3f-79dc-593d-8c1e-11c91d429a2b",
     "slug": "erwin-nc-pd",
-    "flock_active_slug": "erwin-nc-pd",
-    "flock_slugs": [
-      "erwin-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Erwin NC PD"
     ],
@@ -57575,10 +53675,8 @@
   {
     "agency_id": "ebd986fe-777e-5598-8ea4-4ce967b5fe6a",
     "slug": "evansville-in-pd",
-    "flock_active_slug": "evansville-in-pd",
-    "flock_slugs": [
-      "evansville-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Evansville IN PD"
     ],
@@ -57602,10 +53700,8 @@
   {
     "agency_id": "15280ed4-cf41-5c09-be94-934a382b100e",
     "slug": "fairmount-in-pd",
-    "flock_active_slug": "fairmount-in-pd",
-    "flock_slugs": [
-      "fairmount-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairmount IN PD"
     ],
@@ -57629,10 +53725,8 @@
   {
     "agency_id": "34742246-1bed-5515-8ae8-9d58ae703d8b",
     "slug": "fargo-nd-pd",
-    "flock_active_slug": "fargo-nd-pd",
-    "flock_slugs": [
-      "fargo-nd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fargo ND PD"
     ],
@@ -57656,10 +53750,8 @@
   {
     "agency_id": "b2602fed-a7a7-5d56-bda7-5d561d159a88",
     "slug": "fishers-in-pd",
-    "flock_active_slug": "fishers-in-pd",
-    "flock_slugs": [
-      "fishers-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fishers IN PD"
     ],
@@ -57683,10 +53775,8 @@
   {
     "agency_id": "5757726e-ad41-55a6-8505-d14c1d0b7155",
     "slug": "flagstaff-az-pd-inactive",
-    "flock_active_slug": "flagstaff-az-pd-inactive",
-    "flock_slugs": [
-      "flagstaff-az-pd-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flagstaff AZ PD [Inactive]"
     ],
@@ -57712,10 +53802,8 @@
   {
     "agency_id": "52c7fd41-280f-5ea4-9c8b-dc6bda2cd265",
     "slug": "florida-highway-patrol",
-    "flock_active_slug": "florida-highway-patrol",
-    "flock_slugs": [
-      "florida-highway-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Florida Highway Patrol"
     ],
@@ -57739,10 +53827,8 @@
   {
     "agency_id": "91fa4c27-6472-5af3-9376-dfd2f3506902",
     "slug": "floyd-county-in-so",
-    "flock_active_slug": "floyd-county-in-so",
-    "flock_slugs": [
-      "floyd-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Floyd County IN SO"
     ],
@@ -57766,10 +53852,8 @@
   {
     "agency_id": "07c4ae1a-d62b-59a2-90e0-5c660623f5bc",
     "slug": "fort-collins-police-services-fcps",
-    "flock_active_slug": "fort-collins-police-services-fcps",
-    "flock_slugs": [
-      "fort-collins-police-services-fcps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Collins Police Services (FCPS)"
     ],
@@ -57786,10 +53870,8 @@
   {
     "agency_id": "6e8b5384-5568-5425-873a-3b938ef50bdd",
     "slug": "fort-pierce-fl-pd",
-    "flock_active_slug": "fort-pierce-fl-pd",
-    "flock_slugs": [
-      "fort-pierce-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Pierce FL PD"
     ],
@@ -57813,10 +53895,8 @@
   {
     "agency_id": "0947bd83-8736-5e8b-9026-3453bfe18eab",
     "slug": "fort-wayne-in-pd",
-    "flock_active_slug": "fort-wayne-in-pd",
-    "flock_slugs": [
-      "fort-wayne-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Wayne IN PD"
     ],
@@ -57840,10 +53920,8 @@
   {
     "agency_id": "98a718df-b7f1-579e-980b-f15455712ea8",
     "slug": "fountain-co-pd",
-    "flock_active_slug": "fountain-co-pd",
-    "flock_slugs": [
-      "fountain-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fountain CO PD"
     ],
@@ -57867,10 +53945,8 @@
   {
     "agency_id": "600546b1-48fb-5c91-b3ea-bfb4b344ea45",
     "slug": "franklin-county-al-so",
-    "flock_active_slug": "franklin-county-al-so",
-    "flock_slugs": [
-      "franklin-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin County AL SO"
     ],
@@ -57894,10 +53970,8 @@
   {
     "agency_id": "cf7ccb03-2dd9-595e-9e66-61aaf61446e4",
     "slug": "franklin-township-pa-pd",
-    "flock_active_slug": "franklin-township-pa-pd",
-    "flock_slugs": [
-      "franklin-township-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Franklin Township PA PD"
     ],
@@ -57922,10 +53996,8 @@
   {
     "agency_id": "b87b8efa-56ea-51a9-94b2-af4629ccb399",
     "slug": "frederick-co-pd",
-    "flock_active_slug": "frederick-co-pd",
-    "flock_slugs": [
-      "frederick-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Frederick CO PD"
     ],
@@ -57949,10 +54021,8 @@
   {
     "agency_id": "46f33130-f146-5894-a43c-6dbc13acb84c",
     "slug": "fulshear-tx-pd",
-    "flock_active_slug": "fulshear-tx-pd",
-    "flock_slugs": [
-      "fulshear-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fulshear TX PD"
     ],
@@ -57976,10 +54046,8 @@
   {
     "agency_id": "c143bee8-890e-5886-a99f-af7065a63fde",
     "slug": "galena-park-isd-tx-pd",
-    "flock_active_slug": "galena-park-isd-tx-pd",
-    "flock_slugs": [
-      "galena-park-isd-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Galena Park ISD TX PD"
     ],
@@ -58003,10 +54071,8 @@
   {
     "agency_id": "215171e7-de36-55fd-a9ae-c30aa2b510d2",
     "slug": "gallia-county-oh-so",
-    "flock_active_slug": "gallia-county-oh-so",
-    "flock_slugs": [
-      "gallia-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gallia County OH SO"
     ],
@@ -58030,10 +54096,8 @@
   {
     "agency_id": "8ee23bec-a1f8-5a2e-997b-5d074dd5306e",
     "slug": "garden-city-mi-pd",
-    "flock_active_slug": "garden-city-mi-pd",
-    "flock_slugs": [
-      "garden-city-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Garden City MI PD"
     ],
@@ -58057,10 +54121,8 @@
   {
     "agency_id": "112cf5e1-4f1e-5a5f-a2e2-cf5d6494391e",
     "slug": "gardner-ks-pd",
-    "flock_active_slug": "gardner-ks-pd",
-    "flock_slugs": [
-      "gardner-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gardner KS PD"
     ],
@@ -58084,10 +54146,8 @@
   {
     "agency_id": "6c6bb653-cb86-5aa7-9020-e7f855f21136",
     "slug": "garfield-county-co-so",
-    "flock_active_slug": "garfield-county-co-so",
-    "flock_slugs": [
-      "garfield-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Garfield County CO SO"
     ],
@@ -58111,10 +54171,8 @@
   {
     "agency_id": "72337b1e-ca68-5771-9afd-f10a5878bf48",
     "slug": "geauga-county-oh-so",
-    "flock_active_slug": "geauga-county-oh-so",
-    "flock_slugs": [
-      "geauga-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Geauga County OH SO"
     ],
@@ -58138,10 +54196,8 @@
   {
     "agency_id": "d8ac1516-3b1c-55b7-9e1d-c8a764f78b93",
     "slug": "georgetown-sc-pd",
-    "flock_active_slug": "georgetown-sc-pd",
-    "flock_slugs": [
-      "georgetown-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgetown SC PD"
     ],
@@ -58165,10 +54221,8 @@
   {
     "agency_id": "23f8ef51-8ed2-5b97-9597-571dd35e93f4",
     "slug": "georgia-state-patrol-ga-pd",
-    "flock_active_slug": "georgia-state-patrol-ga-pd",
-    "flock_slugs": [
-      "georgia-state-patrol-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Georgia State Patrol GA PD"
     ],
@@ -58192,10 +54246,8 @@
   {
     "agency_id": "77e04206-2f50-5e78-96a9-63fda0cc1c1a",
     "slug": "gilbert-az-pd",
-    "flock_active_slug": "gilbert-az-pd",
-    "flock_slugs": [
-      "gilbert-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gilbert AZ PD"
     ],
@@ -58219,10 +54271,8 @@
   {
     "agency_id": "b788e288-0eb5-5d1e-b01a-b581210e6288",
     "slug": "glen-cove-ny-pd",
-    "flock_active_slug": "glen-cove-ny-pd",
-    "flock_slugs": [
-      "glen-cove-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glen Cove NY PD"
     ],
@@ -58246,10 +54296,8 @@
   {
     "agency_id": "29015316-5682-5f60-81cc-7db0922e00ca",
     "slug": "glendale-az-pd",
-    "flock_active_slug": "glendale-az-pd",
-    "flock_slugs": [
-      "glendale-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glendale AZ PD"
     ],
@@ -58273,10 +54321,8 @@
   {
     "agency_id": "742d8d2b-c183-529f-ba34-dc74241e16f1",
     "slug": "gluckstadt-ms-pd",
-    "flock_active_slug": "gluckstadt-ms-pd",
-    "flock_slugs": [
-      "gluckstadt-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gluckstadt MS PD"
     ],
@@ -58300,10 +54346,8 @@
   {
     "agency_id": "5e30615e-c370-500c-8197-508b27b0f86d",
     "slug": "goddard-ks-pd",
-    "flock_active_slug": "goddard-ks-pd",
-    "flock_slugs": [
-      "goddard-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goddard KS PD"
     ],
@@ -58327,10 +54371,8 @@
   {
     "agency_id": "da926183-f9a1-5dc8-8dc3-5e0946eaac0d",
     "slug": "grand-county-co-so",
-    "flock_active_slug": "grand-county-co-so",
-    "flock_slugs": [
-      "grand-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand County CO SO"
     ],
@@ -58354,10 +54396,8 @@
   {
     "agency_id": "14ee7f76-e8dd-536d-a1ff-06bbe199ecb8",
     "slug": "grand-haven-mi-dps",
-    "flock_active_slug": "grand-haven-mi-dps",
-    "flock_slugs": [
-      "grand-haven-mi-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Haven MI DPS"
     ],
@@ -58381,10 +54421,8 @@
   {
     "agency_id": "013d6dc7-e6f4-5636-a71c-4bc0f469cfbd",
     "slug": "grand-island-ne-pd",
-    "flock_active_slug": "grand-island-ne-pd",
-    "flock_slugs": [
-      "grand-island-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grand Island NE PD"
     ],
@@ -58408,10 +54446,8 @@
   {
     "agency_id": "ae9b0e51-d96d-54e5-96d7-7afc70c2f729",
     "slug": "grant-county-in-so",
-    "flock_active_slug": "grant-county-in-so",
-    "flock_slugs": [
-      "grant-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grant County IN SO"
     ],
@@ -58435,10 +54471,8 @@
   {
     "agency_id": "fd114abb-7fce-5343-b7bf-3f50e9467168",
     "slug": "gray-county-tx-so",
-    "flock_active_slug": "gray-county-tx-so",
-    "flock_slugs": [
-      "gray-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gray County TX SO"
     ],
@@ -58462,10 +54496,8 @@
   {
     "agency_id": "8c74ef44-ffef-58c4-a3d3-5e119f5b32d1",
     "slug": "grayslake-il-pd",
-    "flock_active_slug": "grayslake-il-pd",
-    "flock_slugs": [
-      "grayslake-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grayslake IL PD"
     ],
@@ -58489,10 +54521,8 @@
   {
     "agency_id": "6f0c28f7-e520-5be0-bea6-d56c1348a42d",
     "slug": "greene-county-in-so",
-    "flock_active_slug": "greene-county-in-so",
-    "flock_slugs": [
-      "greene-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greene County IN SO"
     ],
@@ -58516,10 +54546,8 @@
   {
     "agency_id": "ec1a9b4a-be29-5f6a-90a8-6ccc7998602d",
     "slug": "greene-county-mo-so",
-    "flock_active_slug": "greene-county-mo-so",
-    "flock_slugs": [
-      "greene-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greene County MO SO"
     ],
@@ -58543,10 +54571,8 @@
   {
     "agency_id": "9f140f52-8485-5c46-b2ff-989ada88a173",
     "slug": "greene-county-oh-so",
-    "flock_active_slug": "greene-county-oh-so",
-    "flock_slugs": [
-      "greene-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greene County OH SO"
     ],
@@ -58570,10 +54596,8 @@
   {
     "agency_id": "eac84c33-9b72-571b-96c9-37412d8d9afe",
     "slug": "guadalupe-county-tx-so",
-    "flock_active_slug": "guadalupe-county-tx-so",
-    "flock_slugs": [
-      "guadalupe-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Guadalupe County TX SO"
     ],
@@ -58597,10 +54621,8 @@
   {
     "agency_id": "b2c965b0-2911-5f89-bcb4-3e4a64b59e28",
     "slug": "gulf-breeze-fl-pd",
-    "flock_active_slug": "gulf-breeze-fl-pd",
-    "flock_slugs": [
-      "gulf-breeze-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gulf Breeze FL PD"
     ],
@@ -58624,10 +54646,8 @@
   {
     "agency_id": "7dab4c99-6c9b-53ad-9a95-b45d03e93651",
     "slug": "hamilton-county-oh-so",
-    "flock_active_slug": "hamilton-county-oh-so",
-    "flock_slugs": [
-      "hamilton-county-oh-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hamilton County OH SO"
     ],
@@ -58651,10 +54671,8 @@
   {
     "agency_id": "ae9b92a9-3245-59d0-b327-e9cebfcd4802",
     "slug": "hanover-park-il-pd",
-    "flock_active_slug": "hanover-park-il-pd",
-    "flock_slugs": [
-      "hanover-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hanover Park IL PD"
     ],
@@ -58678,10 +54696,8 @@
   {
     "agency_id": "c06f848e-9555-5b50-aafb-ad82dba1e4b0",
     "slug": "harper-county-ks-so",
-    "flock_active_slug": "harper-county-ks-so",
-    "flock_slugs": [
-      "harper-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harper County KS SO"
     ],
@@ -58705,10 +54721,8 @@
   {
     "agency_id": "ee3ed021-142c-5e15-9389-6cb9ef374f14",
     "slug": "harrah-ok-pd-original",
-    "flock_active_slug": "harrah-ok-pd-original",
-    "flock_slugs": [
-      "harrah-ok-pd-original"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harrah OK PD - original"
     ],
@@ -58732,10 +54746,8 @@
   {
     "agency_id": "fc6001b2-b458-595f-81ca-39eea2f38702",
     "slug": "harris-county-const-tx-pct-1",
-    "flock_active_slug": "harris-county-const-tx-pct-1",
-    "flock_slugs": [
-      "harris-county-const-tx-pct-1"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County Const TX Pct 1"
     ],
@@ -58760,10 +54772,8 @@
   {
     "agency_id": "29c78d37-fab1-5f19-82e9-eb0f8f1f6ed4",
     "slug": "harris-county-const-tx-pct-4",
-    "flock_active_slug": "harris-county-const-tx-pct-4",
-    "flock_slugs": [
-      "harris-county-const-tx-pct-4"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County Const TX Pct 4"
     ],
@@ -58788,10 +54798,8 @@
   {
     "agency_id": "86bb7d0d-8c22-5ebc-b3f1-c48bba71a3fc",
     "slug": "harris-county-const-tx-pct-5",
-    "flock_active_slug": "harris-county-const-tx-pct-5",
-    "flock_slugs": [
-      "harris-county-const-tx-pct-5"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County Const TX Pct 5"
     ],
@@ -58816,10 +54824,8 @@
   {
     "agency_id": "7b0525fb-a2de-517b-8d62-0e66d83a5f8a",
     "slug": "harris-county-tx-so",
-    "flock_active_slug": "harris-county-tx-so",
-    "flock_slugs": [
-      "harris-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harris County TX SO"
     ],
@@ -58843,10 +54849,8 @@
   {
     "agency_id": "55c91b7c-b22b-50c3-8163-54a1cd31eb2d",
     "slug": "harvey-county-ks-so",
-    "flock_active_slug": "harvey-county-ks-so",
-    "flock_slugs": [
-      "harvey-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Harvey County KS SO"
     ],
@@ -58870,10 +54874,8 @@
   {
     "agency_id": "5beab980-d0ca-5fcd-9465-126e42183cb9",
     "slug": "hays-county-tx-so",
-    "flock_active_slug": "hays-county-tx-so",
-    "flock_slugs": [
-      "hays-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hays County TX SO"
     ],
@@ -58897,10 +54899,8 @@
   {
     "agency_id": "6ba0e995-becb-5fb3-9cf0-551629559119",
     "slug": "haywood-county-tn-so",
-    "flock_active_slug": "haywood-county-tn-so",
-    "flock_slugs": [
-      "haywood-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Haywood County TN SO"
     ],
@@ -58924,10 +54924,8 @@
   {
     "agency_id": "154abc24-20fe-5b59-a9f7-6894b04fbe7f",
     "slug": "hazel-park-mi-pd",
-    "flock_active_slug": "hazel-park-mi-pd",
-    "flock_slugs": [
-      "hazel-park-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hazel Park MI PD"
     ],
@@ -58951,10 +54949,8 @@
   {
     "agency_id": "1c6f2f0e-2bc6-5a88-9b08-c0d0b6e5aabc",
     "slug": "hazleton-pa-pd",
-    "flock_active_slug": "hazleton-pa-pd",
-    "flock_slugs": [
-      "hazleton-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hazleton PA PD"
     ],
@@ -58978,10 +54974,8 @@
   {
     "agency_id": "f61031e0-f718-5ff8-8864-4758113a1ab0",
     "slug": "highland-heights-ky-pd",
-    "flock_active_slug": "highland-heights-ky-pd",
-    "flock_slugs": [
-      "highland-heights-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Highland Heights KY PD"
     ],
@@ -59005,10 +54999,8 @@
   {
     "agency_id": "925ee626-f5b9-5fa4-b079-55cb545544e8",
     "slug": "hillsborough-county-fl-so",
-    "flock_active_slug": "hillsborough-county-fl-so",
-    "flock_slugs": [
-      "hillsborough-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hillsborough County FL SO"
     ],
@@ -59032,10 +55024,8 @@
   {
     "agency_id": "7668abc0-518f-54d3-ba9c-f26b5f589a6e",
     "slug": "holmes-county-fl-so",
-    "flock_active_slug": "holmes-county-fl-so",
-    "flock_slugs": [
-      "holmes-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Holmes County FL SO"
     ],
@@ -59059,10 +55049,8 @@
   {
     "agency_id": "f4dc6f84-bde0-5cae-9559-c0176c93f434",
     "slug": "hope-mills-nc-pd",
-    "flock_active_slug": "hope-mills-nc-pd",
-    "flock_slugs": [
-      "hope-mills-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hope Mills NC PD"
     ],
@@ -59086,10 +55074,8 @@
   {
     "agency_id": "bb0febe1-224f-577e-bb17-67a25f020cae",
     "slug": "hopkins-mn-pd",
-    "flock_active_slug": "hopkins-mn-pd",
-    "flock_slugs": [
-      "hopkins-mn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hopkins MN PD"
     ],
@@ -59113,10 +55099,8 @@
   {
     "agency_id": "6f6b79ba-3a13-58cf-ba47-a480cfc20d1c",
     "slug": "hopkinsville-ky-pd",
-    "flock_active_slug": "hopkinsville-ky-pd",
-    "flock_slugs": [
-      "hopkinsville-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hopkinsville KY PD"
     ],
@@ -59140,10 +55124,8 @@
   {
     "agency_id": "e2f7cd4f-6164-50e6-a70c-cc7ee108e7db",
     "slug": "horizon-tx-pd",
-    "flock_active_slug": "horizon-tx-pd",
-    "flock_slugs": [
-      "horizon-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Horizon TX PD"
     ],
@@ -59163,10 +55145,8 @@
   {
     "agency_id": "00925cc1-e5f8-5aad-a52d-3af6c6a86167",
     "slug": "hotchkiss-co-pd",
-    "flock_active_slug": "hotchkiss-co-pd",
-    "flock_slugs": [
-      "hotchkiss-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hotchkiss CO PD"
     ],
@@ -59190,10 +55170,8 @@
   {
     "agency_id": "bac4e6fd-2c35-5b01-8682-e44194710efe",
     "slug": "houston-arson-bureau-tx",
-    "flock_active_slug": "houston-arson-bureau-tx",
-    "flock_slugs": [
-      "houston-arson-bureau-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Houston Arson Bureau TX"
     ],
@@ -59216,10 +55194,8 @@
   {
     "agency_id": "706e9041-d58e-56f1-9a89-b86c5a1383c2",
     "slug": "houston-housing-authority-tx",
-    "flock_active_slug": "houston-housing-authority-tx",
-    "flock_slugs": [
-      "houston-housing-authority-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Houston Housing Authority TX"
     ],
@@ -59239,10 +55215,8 @@
   {
     "agency_id": "fe2ade2a-15d6-5074-8593-c2f5c8f2c590",
     "slug": "huffman-isd-tx-pd",
-    "flock_active_slug": "huffman-isd-tx-pd",
-    "flock_slugs": [
-      "huffman-isd-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huffman ISD TX PD"
     ],
@@ -59265,10 +55239,8 @@
   {
     "agency_id": "fd05682d-3987-58cc-8d6c-29be3b9c8d01",
     "slug": "humble-tx-pd",
-    "flock_active_slug": "humble-tx-pd",
-    "flock_slugs": [
-      "humble-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Humble TX PD"
     ],
@@ -59292,10 +55264,8 @@
   {
     "agency_id": "d03317b0-030a-58d4-a90a-755fb3f0e9b2",
     "slug": "hutto-tx-pd",
-    "flock_active_slug": "hutto-tx-pd",
-    "flock_slugs": [
-      "hutto-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hutto TX PD"
     ],
@@ -59319,10 +55289,8 @@
   {
     "agency_id": "87edb18c-d52a-58e1-8b2e-49610dd28420",
     "slug": "idaho-falls-id-pd",
-    "flock_active_slug": "idaho-falls-id-pd",
-    "flock_slugs": [
-      "idaho-falls-id-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Idaho Falls ID PD"
     ],
@@ -59346,10 +55314,8 @@
   {
     "agency_id": "35b4a697-51fc-562f-8343-8cf646e56921",
     "slug": "independence-ks-pd",
-    "flock_active_slug": "independence-ks-pd",
-    "flock_slugs": [
-      "independence-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Independence KS PD"
     ],
@@ -59373,10 +55339,8 @@
   {
     "agency_id": "1823dc9c-f3d2-56c8-a704-ad70f4004478",
     "slug": "indian-hill-oh-pd",
-    "flock_active_slug": "indian-hill-oh-pd",
-    "flock_slugs": [
-      "indian-hill-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indian Hill OH PD"
     ],
@@ -59399,10 +55363,8 @@
   {
     "agency_id": "11cea26c-b53b-516d-a77b-8c9c84eaa954",
     "slug": "indiana-state-police-in-pd",
-    "flock_active_slug": "indiana-state-police-in-pd",
-    "flock_slugs": [
-      "indiana-state-police-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indiana State Police IN PD"
     ],
@@ -59423,10 +55385,8 @@
   {
     "agency_id": "01f6b457-7376-5798-9ee7-c961ce20cc8f",
     "slug": "ingalls-in-pd",
-    "flock_active_slug": "ingalls-in-pd",
-    "flock_slugs": [
-      "ingalls-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ingalls IN PD"
     ],
@@ -59450,10 +55410,8 @@
   {
     "agency_id": "0e77546c-f42d-5397-9d1d-3ab0f0444bc5",
     "slug": "iowa-state-university-ia-pd",
-    "flock_active_slug": "iowa-state-university-ia-pd",
-    "flock_slugs": [
-      "iowa-state-university-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iowa State University IA PD"
     ],
@@ -59477,10 +55435,8 @@
   {
     "agency_id": "7b9c9e32-280e-5ec1-8161-8fd56c8af6eb",
     "slug": "iredell-county-nc-so",
-    "flock_active_slug": "iredell-county-nc-so",
-    "flock_slugs": [
-      "iredell-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Iredell County NC SO"
     ],
@@ -59504,10 +55460,8 @@
   {
     "agency_id": "71190b91-66b8-51ee-968b-3790ede2697d",
     "slug": "irving-tx-pd",
-    "flock_active_slug": "irving-tx-pd",
-    "flock_slugs": [
-      "irving-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Irving TX PD"
     ],
@@ -59531,10 +55485,8 @@
   {
     "agency_id": "ee6c220e-0891-588d-b5d4-0fcdc861549b",
     "slug": "jackson-county-or-so",
-    "flock_active_slug": "jackson-county-or-so",
-    "flock_slugs": [
-      "jackson-county-or-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson County OR SO"
     ],
@@ -59558,10 +55510,8 @@
   {
     "agency_id": "435c6b9c-86df-50a1-a582-2b96a1d7bb50",
     "slug": "jackson-township-oh-pd-stark-county",
-    "flock_active_slug": "jackson-township-oh-pd-stark-county",
-    "flock_slugs": [
-      "jackson-township-oh-pd-stark-county"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson Township OH PD (Stark County)"
     ],
@@ -59585,10 +55535,8 @@
   {
     "agency_id": "6184b16e-aefb-5c87-9eac-ff7428124cf2",
     "slug": "jackson-wi-pd",
-    "flock_active_slug": "jackson-wi-pd",
-    "flock_slugs": [
-      "jackson-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jackson WI PD"
     ],
@@ -59612,10 +55560,8 @@
   {
     "agency_id": "e6d03602-bbe7-50c4-8f03-6b4c8c87e13c",
     "slug": "jefferson-county-co-so",
-    "flock_active_slug": "jefferson-county-co-so",
-    "flock_slugs": [
-      "jefferson-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County CO SO"
     ],
@@ -59639,10 +55585,8 @@
   {
     "agency_id": "dd4a7e3d-91aa-5348-8062-144c55cf896a",
     "slug": "jefferson-county-mo-so",
-    "flock_active_slug": "jefferson-county-mo-so",
-    "flock_slugs": [
-      "jefferson-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jefferson County MO SO"
     ],
@@ -59666,10 +55610,8 @@
   {
     "agency_id": "3274b2ce-a479-5c49-8d40-40674ff526df",
     "slug": "jerome-county-id-so",
-    "flock_active_slug": "jerome-county-id-so",
-    "flock_slugs": [
-      "jerome-county-id-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jerome County ID SO"
     ],
@@ -59693,10 +55635,8 @@
   {
     "agency_id": "0e1537ca-6548-53ec-842e-3dd38ca7783a",
     "slug": "jesup-ga-pd",
-    "flock_active_slug": "jesup-ga-pd",
-    "flock_slugs": [
-      "jesup-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jesup GA PD"
     ],
@@ -59720,10 +55660,8 @@
   {
     "agency_id": "ba107933-2f9d-5af5-836f-72a35dd288ba",
     "slug": "johnson-county-tx-so",
-    "flock_active_slug": "johnson-county-tx-so",
-    "flock_slugs": [
-      "johnson-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Johnson County TX SO"
     ],
@@ -59747,10 +55685,8 @@
   {
     "agency_id": "d4632c9c-5651-525d-9b47-ef8fddcfd570",
     "slug": "juab-county-ut-so",
-    "flock_active_slug": "juab-county-ut-so",
-    "flock_slugs": [
-      "juab-county-ut-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Juab County UT SO"
     ],
@@ -59774,10 +55710,8 @@
   {
     "agency_id": "2f650a42-04b2-5a80-b515-6e633d95f562",
     "slug": "junction-city-ks-pd",
-    "flock_active_slug": "junction-city-ks-pd",
-    "flock_slugs": [
-      "junction-city-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Junction City KS PD"
     ],
@@ -59801,10 +55735,8 @@
   {
     "agency_id": "7cabcca1-9a07-54d1-9983-fb34e7384b0e",
     "slug": "justice-il-pd",
-    "flock_active_slug": "justice-il-pd",
-    "flock_slugs": [
-      "justice-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Justice IL PD"
     ],
@@ -59825,10 +55757,8 @@
   {
     "agency_id": "f2f4ed6f-9c17-5114-b5fb-9ac1758b0e91",
     "slug": "kaysville-ut-pd",
-    "flock_active_slug": "kaysville-ut-pd",
-    "flock_slugs": [
-      "kaysville-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kaysville UT PD"
     ],
@@ -59852,10 +55782,8 @@
   {
     "agency_id": "64aa09f6-ae60-5ac3-bd67-4123f65c0837",
     "slug": "keller-tx-pd",
-    "flock_active_slug": "keller-tx-pd",
-    "flock_slugs": [
-      "keller-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Keller TX PD"
     ],
@@ -59879,10 +55807,8 @@
   {
     "agency_id": "ef8ce1d9-daaa-5651-844c-6d677d938479",
     "slug": "kenosha-county-wi-so",
-    "flock_active_slug": "kenosha-county-wi-so",
-    "flock_slugs": [
-      "kenosha-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kenosha County WI SO"
     ],
@@ -59906,10 +55832,8 @@
   {
     "agency_id": "720434b9-9ea0-53bd-8dbf-d270972ba0b4",
     "slug": "kill-devil-hills-nc-pd",
-    "flock_active_slug": "kill-devil-hills-nc-pd",
-    "flock_slugs": [
-      "kill-devil-hills-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kill Devil Hills NC PD"
     ],
@@ -59933,10 +55857,8 @@
   {
     "agency_id": "fdea17cf-bc23-5719-9476-2baf8e95eda4",
     "slug": "kokomo-in-pd",
-    "flock_active_slug": "kokomo-in-pd",
-    "flock_slugs": [
-      "kokomo-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kokomo IN PD"
     ],
@@ -59960,10 +55882,8 @@
   {
     "agency_id": "bf6a86c1-4843-58ca-99e4-9746308139ff",
     "slug": "kosciusko-ms-pd",
-    "flock_active_slug": "kosciusko-ms-pd",
-    "flock_slugs": [
-      "kosciusko-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kosciusko MS PD"
     ],
@@ -59987,10 +55907,8 @@
   {
     "agency_id": "a8e8b0db-9fc4-5dea-a99a-ad0d59f5b721",
     "slug": "ks-meade-county-so",
-    "flock_active_slug": "ks-meade-county-so",
-    "flock_slugs": [
-      "ks-meade-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "KS - Meade County SO"
     ],
@@ -60014,10 +55932,8 @@
   {
     "agency_id": "43557976-7af7-5201-b3d4-84d8bfd04496",
     "slug": "la-vernia-tx-pd",
-    "flock_active_slug": "la-vernia-tx-pd",
-    "flock_slugs": [
-      "la-vernia-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Vernia TX PD"
     ],
@@ -60041,10 +55957,8 @@
   {
     "agency_id": "bc86cd23-c81b-5ac0-ab43-b39314452c78",
     "slug": "lake-jackson-tx-pd",
-    "flock_active_slug": "lake-jackson-tx-pd",
-    "flock_slugs": [
-      "lake-jackson-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Jackson TX PD"
     ],
@@ -60068,10 +55982,8 @@
   {
     "agency_id": "8a4e5ccd-6777-53fd-8b71-f003043ad23d",
     "slug": "lake-wales-fl-pd",
-    "flock_active_slug": "lake-wales-fl-pd",
-    "flock_slugs": [
-      "lake-wales-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Wales FL PD"
     ],
@@ -60095,10 +56007,8 @@
   {
     "agency_id": "cdfd2ca3-f75b-52a9-ba8a-a37162349117",
     "slug": "lakeland-fl-pd",
-    "flock_active_slug": "lakeland-fl-pd",
-    "flock_slugs": [
-      "lakeland-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakeland FL PD"
     ],
@@ -60122,10 +56032,8 @@
   {
     "agency_id": "5a1588da-969e-5a60-be2e-5fe547c2716d",
     "slug": "lakewood-wa-pd",
-    "flock_active_slug": "lakewood-wa-pd",
-    "flock_slugs": [
-      "lakewood-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakewood WA PD"
     ],
@@ -60149,10 +56057,8 @@
   {
     "agency_id": "ac8630d9-9449-5933-8d24-c7c2fb3fc297",
     "slug": "lamar-co-pd",
-    "flock_active_slug": "lamar-co-pd",
-    "flock_slugs": [
-      "lamar-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lamar CO PD"
     ],
@@ -60176,10 +56082,8 @@
   {
     "agency_id": "6c8f70e1-61a4-5034-8be8-7fbfeb80cfaf",
     "slug": "lansing-il-pd",
-    "flock_active_slug": "lansing-il-pd",
-    "flock_slugs": [
-      "lansing-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lansing IL PD"
     ],
@@ -60203,10 +56107,8 @@
   {
     "agency_id": "2b7299f2-42fe-5bde-a636-27045a1cede2",
     "slug": "laporte-county-in-so",
-    "flock_active_slug": "laporte-county-in-so",
-    "flock_slugs": [
-      "laporte-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Laporte County IN SO"
     ],
@@ -60230,10 +56132,8 @@
   {
     "agency_id": "b7c7e65a-3dc6-59da-9302-9c91abf653d9",
     "slug": "larimer-county-co-so",
-    "flock_active_slug": "larimer-county-co-so",
-    "flock_slugs": [
-      "larimer-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Larimer County CO SO"
     ],
@@ -60257,10 +56157,8 @@
   {
     "agency_id": "4f241c0e-e0e9-56fe-acb8-531d82bc7f0c",
     "slug": "las-vegas-nm-pd",
-    "flock_active_slug": "las-vegas-nm-pd",
-    "flock_slugs": [
-      "las-vegas-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Las Vegas NM PD"
     ],
@@ -60284,10 +56182,8 @@
   {
     "agency_id": "84fb42a7-dcc9-573d-9fac-886f426aa172",
     "slug": "lea-county-nm-so",
-    "flock_active_slug": "lea-county-nm-so",
-    "flock_slugs": [
-      "lea-county-nm-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lea County NM SO"
     ],
@@ -60311,10 +56207,8 @@
   {
     "agency_id": "4bd9591a-0e56-5370-a6a0-49133f75f44d",
     "slug": "lebanon-tn-pd",
-    "flock_active_slug": "lebanon-tn-pd",
-    "flock_slugs": [
-      "lebanon-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lebanon TN PD"
     ],
@@ -60338,10 +56232,8 @@
   {
     "agency_id": "fa76668b-f6e2-5703-850a-724a856e27e8",
     "slug": "lee-county-ga-so",
-    "flock_active_slug": "lee-county-ga-so",
-    "flock_slugs": [
-      "lee-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lee County GA SO"
     ],
@@ -60365,10 +56257,8 @@
   {
     "agency_id": "280f533e-bfda-55cc-bb4e-afc52d38809c",
     "slug": "lexington-ne-pd",
-    "flock_active_slug": "lexington-ne-pd",
-    "flock_slugs": [
-      "lexington-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lexington NE PD"
     ],
@@ -60392,10 +56282,8 @@
   {
     "agency_id": "27ddc09e-b891-5da1-b3d4-ff6e5e5c1255",
     "slug": "liberty-hill-tx-pd",
-    "flock_active_slug": "liberty-hill-tx-pd",
-    "flock_slugs": [
-      "liberty-hill-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Liberty Hill TX PD"
     ],
@@ -60419,10 +56307,8 @@
   {
     "agency_id": "ef416bb6-70c6-5a73-837b-5369b01f7688",
     "slug": "ligonier-in-pd",
-    "flock_active_slug": "ligonier-in-pd",
-    "flock_slugs": [
-      "ligonier-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ligonier IN PD"
     ],
@@ -60446,10 +56332,8 @@
   {
     "agency_id": "41a6955d-343c-53b7-8137-0abe038746af",
     "slug": "lincoln-county-so-ne",
-    "flock_active_slug": "lincoln-county-so-ne",
-    "flock_slugs": [
-      "lincoln-county-so-ne"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lincoln County SO NE"
     ],
@@ -60473,10 +56357,8 @@
   {
     "agency_id": "7564e858-e67f-55a7-a65b-b747bcdce37a",
     "slug": "lindale-tx-pd",
-    "flock_active_slug": "lindale-tx-pd",
-    "flock_slugs": [
-      "lindale-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lindale TX PD"
     ],
@@ -60500,10 +56382,8 @@
   {
     "agency_id": "712ff333-a22a-5e58-b99d-852b357bc527",
     "slug": "little-rock-ar-pd",
-    "flock_active_slug": "little-rock-ar-pd",
-    "flock_slugs": [
-      "little-rock-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Little Rock AR PD"
     ],
@@ -60527,10 +56407,8 @@
   {
     "agency_id": "c271c9db-1f2d-5f5d-ae31-dcf7e0604730",
     "slug": "live-oak-tx-pd",
-    "flock_active_slug": "live-oak-tx-pd",
-    "flock_slugs": [
-      "live-oak-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Live Oak TX PD"
     ],
@@ -60554,10 +56432,8 @@
   {
     "agency_id": "56fc0bed-e741-5104-8b26-2e99d95164ed",
     "slug": "livingston-tx-pd",
-    "flock_active_slug": "livingston-tx-pd",
-    "flock_slugs": [
-      "livingston-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Livingston TX PD"
     ],
@@ -60581,10 +56457,8 @@
   {
     "agency_id": "2ea04594-73c6-5b31-9376-040b40227203",
     "slug": "lodi-oh-pd",
-    "flock_active_slug": "lodi-oh-pd",
-    "flock_slugs": [
-      "lodi-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lodi OH PD"
     ],
@@ -60608,10 +56482,8 @@
   {
     "agency_id": "5c8bc31d-a96e-58bc-9985-83cf09bc55c4",
     "slug": "lodi-wi-pd",
-    "flock_active_slug": "lodi-wi-pd",
-    "flock_slugs": [
-      "lodi-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lodi WI PD"
     ],
@@ -60635,10 +56507,8 @@
   {
     "agency_id": "b90f3085-f640-5300-a97a-9f3d334e2300",
     "slug": "logan-county-ne-so",
-    "flock_active_slug": "logan-county-ne-so",
-    "flock_slugs": [
-      "logan-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Logan County NE SO"
     ],
@@ -60662,10 +56532,8 @@
   {
     "agency_id": "406483e3-05e6-51be-bfaa-3aaa5f443898",
     "slug": "lone-peak-ut-pd",
-    "flock_active_slug": "lone-peak-ut-pd",
-    "flock_slugs": [
-      "lone-peak-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lone Peak UT PD"
     ],
@@ -60685,10 +56553,8 @@
   {
     "agency_id": "83cf8f49-4381-5526-be5f-545a5348c0aa",
     "slug": "lone-tree-co-pd",
-    "flock_active_slug": "lone-tree-co-pd",
-    "flock_slugs": [
-      "lone-tree-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lone Tree CO PD"
     ],
@@ -60712,10 +56578,8 @@
   {
     "agency_id": "83c40e6d-6341-5751-8701-9fce636cacfe",
     "slug": "louisiana-state-police-la",
-    "flock_active_slug": "louisiana-state-police-la",
-    "flock_slugs": [
-      "louisiana-state-police-la"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Louisiana State Police (LA)"
     ],
@@ -60736,10 +56600,8 @@
   {
     "agency_id": "13738db8-64a8-5933-9e8f-0cb14d4fc06e",
     "slug": "louisville-metro-ky-pd",
-    "flock_active_slug": "louisville-metro-ky-pd",
-    "flock_slugs": [
-      "louisville-metro-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Louisville Metro KY PD"
     ],
@@ -60763,10 +56625,8 @@
   {
     "agency_id": "4671f34c-d1a6-5eca-9d02-1d62c10e8844",
     "slug": "loveland-co-pd",
-    "flock_active_slug": "loveland-co-pd",
-    "flock_slugs": [
-      "loveland-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Loveland CO PD"
     ],
@@ -60790,10 +56650,8 @@
   {
     "agency_id": "0ea248e4-2cb4-59b9-813e-c02d6cc28980",
     "slug": "lubbock-county-tx-so",
-    "flock_active_slug": "lubbock-county-tx-so",
-    "flock_slugs": [
-      "lubbock-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lubbock County TX SO"
     ],
@@ -60817,10 +56675,8 @@
   {
     "agency_id": "6bb4cde3-7276-536e-9fd1-5460da14a861",
     "slug": "lubbock-tx-pd",
-    "flock_active_slug": "lubbock-tx-pd",
-    "flock_slugs": [
-      "lubbock-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lubbock TX PD"
     ],
@@ -60844,10 +56700,8 @@
   {
     "agency_id": "fd75a365-8094-56a9-9f09-521bae6ed96c",
     "slug": "lufkin-tx-pd",
-    "flock_active_slug": "lufkin-tx-pd",
-    "flock_slugs": [
-      "lufkin-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lufkin TX PD"
     ],
@@ -60871,10 +56725,8 @@
   {
     "agency_id": "3d5e478f-0c0b-5954-a283-8698c605ec6e",
     "slug": "lumberton-nc-pd",
-    "flock_active_slug": "lumberton-nc-pd",
-    "flock_slugs": [
-      "lumberton-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lumberton NC PD"
     ],
@@ -60898,10 +56750,8 @@
   {
     "agency_id": "8715915b-9217-59d1-a24d-6bf625664c38",
     "slug": "madison-ms-pd",
-    "flock_active_slug": "madison-ms-pd",
-    "flock_slugs": [
-      "madison-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madison MS PD"
     ],
@@ -60925,10 +56775,8 @@
   {
     "agency_id": "26471680-9023-5832-9fe0-65cbf190f8fb",
     "slug": "manor-tx-pd",
-    "flock_active_slug": "manor-tx-pd",
-    "flock_slugs": [
-      "manor-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Manor TX PD"
     ],
@@ -60952,10 +56800,8 @@
   {
     "agency_id": "877eba0c-c597-5eaa-8736-8bde89e0c8de",
     "slug": "maricopa-az-pd",
-    "flock_active_slug": "maricopa-az-pd",
-    "flock_slugs": [
-      "maricopa-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maricopa AZ PD"
     ],
@@ -60979,10 +56825,8 @@
   {
     "agency_id": "291d7a66-7b0d-5dfa-9da0-2ead16939318",
     "slug": "maricopa-county-az-so",
-    "flock_active_slug": "maricopa-county-az-so",
-    "flock_slugs": [
-      "maricopa-county-az-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maricopa County AZ SO"
     ],
@@ -61006,10 +56850,8 @@
   {
     "agency_id": "1ea93740-5c3f-5af5-ad51-deb343ddd7c3",
     "slug": "marion-ar-pd",
-    "flock_active_slug": "marion-ar-pd",
-    "flock_slugs": [
-      "marion-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion AR PD"
     ],
@@ -61033,10 +56875,8 @@
   {
     "agency_id": "7c6cf141-a181-5dae-9b97-ec0dbc02ad31",
     "slug": "marion-health-pd-in",
-    "flock_active_slug": "marion-health-pd-in",
-    "flock_slugs": [
-      "marion-health-pd-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marion Health PD (IN)"
     ],
@@ -61059,10 +56899,8 @@
   {
     "agency_id": "abb515ad-5db0-5e8c-b545-f294d6c18d26",
     "slug": "marshall-tx-pd",
-    "flock_active_slug": "marshall-tx-pd",
-    "flock_slugs": [
-      "marshall-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall TX PD"
     ],
@@ -61086,10 +56924,8 @@
   {
     "agency_id": "3cb17d7c-b4ee-5981-baf5-e4f328b85c47",
     "slug": "marshalltown-ia-pd",
-    "flock_active_slug": "marshalltown-ia-pd",
-    "flock_slugs": [
-      "marshalltown-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshalltown IA PD"
     ],
@@ -61113,10 +56949,8 @@
   {
     "agency_id": "74723ca8-4d17-5001-b331-b624b1f17682",
     "slug": "martin-county-tx-so",
-    "flock_active_slug": "martin-county-tx-so",
-    "flock_slugs": [
-      "martin-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Martin County TX SO"
     ],
@@ -61140,10 +56974,8 @@
   {
     "agency_id": "81092291-2b17-5b46-9265-bee747d29aeb",
     "slug": "maryland-heights-mo-pd",
-    "flock_active_slug": "maryland-heights-mo-pd",
-    "flock_slugs": [
-      "maryland-heights-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Maryland Heights MO PD"
     ],
@@ -61167,10 +56999,8 @@
   {
     "agency_id": "a518b060-c955-551d-9a50-74cac642dbb2",
     "slug": "marysville-oh-pd",
-    "flock_active_slug": "marysville-oh-pd",
-    "flock_slugs": [
-      "marysville-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marysville OH PD"
     ],
@@ -61194,10 +57024,8 @@
   {
     "agency_id": "39ad8707-b234-5389-9801-072b5698d00c",
     "slug": "mauldin-sc-pd",
-    "flock_active_slug": "mauldin-sc-pd",
-    "flock_slugs": [
-      "mauldin-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mauldin SC PD"
     ],
@@ -61221,10 +57049,8 @@
   {
     "agency_id": "cefe2b77-668a-5d07-96bc-36b5163340c5",
     "slug": "medford-or-pd",
-    "flock_active_slug": "medford-or-pd",
-    "flock_slugs": [
-      "medford-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Medford OR PD"
     ],
@@ -61248,10 +57074,8 @@
   {
     "agency_id": "b6515b89-55f8-5e15-b351-4658d7c0709a",
     "slug": "medina-township-oh-pd",
-    "flock_active_slug": "medina-township-oh-pd",
-    "flock_slugs": [
-      "medina-township-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Medina Township OH PD"
     ],
@@ -61275,10 +57099,8 @@
   {
     "agency_id": "985ecb07-5eb6-50f7-94f5-a56a20a68409",
     "slug": "menomonee-falls-wi-pd",
-    "flock_active_slug": "menomonee-falls-wi-pd",
-    "flock_slugs": [
-      "menomonee-falls-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Menomonee Falls WI PD"
     ],
@@ -61302,10 +57124,8 @@
   {
     "agency_id": "b39950d7-7cad-575d-9d99-abb922972fcc",
     "slug": "mesquite-tx-pd",
-    "flock_active_slug": "mesquite-tx-pd",
-    "flock_slugs": [
-      "mesquite-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mesquite TX PD"
     ],
@@ -61329,10 +57149,8 @@
   {
     "agency_id": "bc4868bf-96d2-5911-8921-faae7415deeb",
     "slug": "michigan-city-in-pd",
-    "flock_active_slug": "michigan-city-in-pd",
-    "flock_slugs": [
-      "michigan-city-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Michigan City IN PD"
     ],
@@ -61356,10 +57174,8 @@
   {
     "agency_id": "c214c5b9-8c55-5112-9921-fcd18d33382c",
     "slug": "middle-tennessee-state-tn-pd",
-    "flock_active_slug": "middle-tennessee-state-tn-pd",
-    "flock_slugs": [
-      "middle-tennessee-state-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middle Tennessee State TN PD"
     ],
@@ -61382,10 +57198,8 @@
   {
     "agency_id": "52f076ef-306b-55b7-aa07-2476e59007dd",
     "slug": "middleburg-heights-oh-pd",
-    "flock_active_slug": "middleburg-heights-oh-pd",
-    "flock_slugs": [
-      "middleburg-heights-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middleburg Heights OH PD"
     ],
@@ -61409,10 +57223,8 @@
   {
     "agency_id": "63f8962b-cb22-5476-88db-e8beb26383b3",
     "slug": "midland-county-tx-so",
-    "flock_active_slug": "midland-county-tx-so",
-    "flock_slugs": [
-      "midland-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midland County TX SO"
     ],
@@ -61436,10 +57248,8 @@
   {
     "agency_id": "3053d876-ce3a-5d22-97ec-47bb64bea8aa",
     "slug": "milam-county-tx-so",
-    "flock_active_slug": "milam-county-tx-so",
-    "flock_slugs": [
-      "milam-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milam County TX SO"
     ],
@@ -61463,10 +57273,8 @@
   {
     "agency_id": "8f1a53de-df59-5dcb-b388-aa85d834016d",
     "slug": "milford-mi-pd",
-    "flock_active_slug": "milford-mi-pd",
-    "flock_slugs": [
-      "milford-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milford MI PD"
     ],
@@ -61490,10 +57298,8 @@
   {
     "agency_id": "50b1ae41-9796-5012-861b-a7571e8b7beb",
     "slug": "mineral-county-nv-so",
-    "flock_active_slug": "mineral-county-nv-so",
-    "flock_slugs": [
-      "mineral-county-nv-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mineral County NV SO"
     ],
@@ -61517,10 +57323,8 @@
   {
     "agency_id": "2bb0c048-144c-5d68-99dd-3e9d4a40b0cd",
     "slug": "missouri-department-of-conservation",
-    "flock_active_slug": "missouri-department-of-conservation",
-    "flock_slugs": [
-      "missouri-department-of-conservation"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Missouri Department of Conservation"
     ],
@@ -61544,10 +57348,8 @@
   {
     "agency_id": "97932d9c-048f-5407-a368-3e46fdabbab3",
     "slug": "missouri-state-highway-patrol",
-    "flock_active_slug": "missouri-state-highway-patrol",
-    "flock_slugs": [
-      "missouri-state-highway-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Missouri State Highway Patrol"
     ],
@@ -61571,10 +57373,8 @@
   {
     "agency_id": "37798954-c4b3-54b6-a8c9-c8b72f97cc32",
     "slug": "moffat-county-so-co",
-    "flock_active_slug": "moffat-county-so-co",
-    "flock_slugs": [
-      "moffat-county-so-co"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moffat County SO CO"
     ],
@@ -61598,10 +57398,8 @@
   {
     "agency_id": "b695fbb5-19cb-5e64-ad0b-33423e89f1b6",
     "slug": "monahans-tx-pd",
-    "flock_active_slug": "monahans-tx-pd",
-    "flock_slugs": [
-      "monahans-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monahans TX PD"
     ],
@@ -61625,10 +57423,8 @@
   {
     "agency_id": "efa8f484-8939-534a-909e-2e759243886f",
     "slug": "monroe-county-wi-so",
-    "flock_active_slug": "monroe-county-wi-so",
-    "flock_slugs": [
-      "monroe-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe County WI SO"
     ],
@@ -61652,10 +57448,8 @@
   {
     "agency_id": "a876b7c8-45b2-53a9-a8a6-460d19bdfc51",
     "slug": "montgomery-county-constable",
-    "flock_active_slug": "montgomery-county-constable",
-    "flock_slugs": [
-      "montgomery-county-constable"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County Constable"
     ],
@@ -61679,10 +57473,8 @@
   {
     "agency_id": "94ed3310-f64b-55ec-992a-27ad35538944",
     "slug": "montgomery-county-tx-so",
-    "flock_active_slug": "montgomery-county-tx-so",
-    "flock_slugs": [
-      "montgomery-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montgomery County TX SO"
     ],
@@ -61706,10 +57498,8 @@
   {
     "agency_id": "5b1cc766-8466-5059-bb35-c320faf59410",
     "slug": "moore-ok-pd",
-    "flock_active_slug": "moore-ok-pd",
-    "flock_slugs": [
-      "moore-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moore OK PD"
     ],
@@ -61733,10 +57523,8 @@
   {
     "agency_id": "2d004929-4330-510c-9056-ce33792c82f7",
     "slug": "mora-county-nm-so-wagon-mound",
-    "flock_active_slug": "mora-county-nm-so-wagon-mound",
-    "flock_slugs": [
-      "mora-county-nm-so-wagon-mound"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mora County NM SO (Wagon Mound)"
     ],
@@ -61760,10 +57548,8 @@
   {
     "agency_id": "d59386e9-22cb-5891-98da-9b29ddf7e23d",
     "slug": "mount-pleasant-sc-pd",
-    "flock_active_slug": "mount-pleasant-sc-pd",
-    "flock_slugs": [
-      "mount-pleasant-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mount Pleasant SC PD"
     ],
@@ -61787,10 +57573,8 @@
   {
     "agency_id": "3e7b0689-4fc3-5d63-9a21-ed1124324c9a",
     "slug": "ms-flowood-pd",
-    "flock_active_slug": "ms-flowood-pd",
-    "flock_slugs": [
-      "ms-flowood-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "MS - Flowood PD"
     ],
@@ -61814,10 +57598,8 @@
   {
     "agency_id": "909d016c-6687-5858-8325-2915b3ea9332",
     "slug": "nags-head-nc-pd",
-    "flock_active_slug": "nags-head-nc-pd",
-    "flock_slugs": [
-      "nags-head-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nags Head NC PD"
     ],
@@ -61841,10 +57623,8 @@
   {
     "agency_id": "c6dd6ed7-4d15-5906-8d6e-162436ce453d",
     "slug": "nashville-intl-airport-tn-pd",
-    "flock_active_slug": "nashville-intl-airport-tn-pd",
-    "flock_slugs": [
-      "nashville-intl-airport-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nashville Intl Airport TN PD"
     ],
@@ -61867,10 +57647,8 @@
   {
     "agency_id": "3dc7c33e-27e6-5030-af70-d8f6c32c8e2c",
     "slug": "navajo-state-park-co-pd",
-    "flock_active_slug": "navajo-state-park-co-pd",
-    "flock_slugs": [
-      "navajo-state-park-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Navajo State Park CO PD"
     ],
@@ -61890,10 +57668,8 @@
   {
     "agency_id": "6fba84c6-74e6-52f4-9283-c25f3e34d2fe",
     "slug": "nebraska-state-patrol",
-    "flock_active_slug": "nebraska-state-patrol",
-    "flock_slugs": [
-      "nebraska-state-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nebraska State Patrol"
     ],
@@ -61917,10 +57693,8 @@
   {
     "agency_id": "64ca3508-6fe0-5890-883c-56bbbb1a1258",
     "slug": "neosho-county-ks-so",
-    "flock_active_slug": "neosho-county-ks-so",
-    "flock_slugs": [
-      "neosho-county-ks-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Neosho County KS SO"
     ],
@@ -61944,10 +57718,8 @@
   {
     "agency_id": "008ee670-d1c5-5aef-8d80-d4de0c93a4b3",
     "slug": "nevada-department-of-motor-vehicles",
-    "flock_active_slug": "nevada-department-of-motor-vehicles",
-    "flock_slugs": [
-      "nevada-department-of-motor-vehicles"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nevada Department of Motor Vehicles"
     ],
@@ -61971,10 +57743,8 @@
   {
     "agency_id": "1a0472b8-1949-57c1-a805-b0816c5fe2da",
     "slug": "new-albany-oh-pd",
-    "flock_active_slug": "new-albany-oh-pd",
-    "flock_slugs": [
-      "new-albany-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Albany OH PD"
     ],
@@ -61998,10 +57768,8 @@
   {
     "agency_id": "5c0dca83-2185-5743-9530-8a5ab37b414d",
     "slug": "new-baden-il-pd",
-    "flock_active_slug": "new-baden-il-pd",
-    "flock_slugs": [
-      "new-baden-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Baden IL PD"
     ],
@@ -62025,10 +57793,8 @@
   {
     "agency_id": "b83fe1ff-5331-5e8c-9154-2d0294836de5",
     "slug": "new-berlin-tx-marshals-office-inactive",
-    "flock_active_slug": "new-berlin-tx-marshals-office-inactive",
-    "flock_slugs": [
-      "new-berlin-tx-marshals-office-inactive"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Berlin TX Marshal's Office [Inactive]"
     ],
@@ -62051,10 +57817,8 @@
   {
     "agency_id": "851c5d00-3ce0-52ee-858e-7b4c075db0b8",
     "slug": "new-castle-pa-pd",
-    "flock_active_slug": "new-castle-pa-pd",
-    "flock_slugs": [
-      "new-castle-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Castle PA PD"
     ],
@@ -62078,10 +57842,8 @@
   {
     "agency_id": "dcac18ca-d5ec-536b-a47c-56cf6a4f0e18",
     "slug": "new-hanover-county-nc-so",
-    "flock_active_slug": "new-hanover-county-nc-so",
-    "flock_slugs": [
-      "new-hanover-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Hanover County NC SO"
     ],
@@ -62105,10 +57867,8 @@
   {
     "agency_id": "5d392622-a83a-5991-8984-ddd7e05a444a",
     "slug": "newton-county-ms-so",
-    "flock_active_slug": "newton-county-ms-so",
-    "flock_slugs": [
-      "newton-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newton County MS SO"
     ],
@@ -62132,10 +57892,8 @@
   {
     "agency_id": "4ce747c7-879a-54d9-ad52-c1642aa27690",
     "slug": "newton-ia-pd",
-    "flock_active_slug": "newton-ia-pd",
-    "flock_slugs": [
-      "newton-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newton IA PD"
     ],
@@ -62159,10 +57917,8 @@
   {
     "agency_id": "215cebdc-aa5c-5ba5-8fd6-cebe43ec83e6",
     "slug": "niagara-frontier-transit-authority-nfta-pd",
-    "flock_active_slug": "niagara-frontier-transit-authority-nfta-pd",
-    "flock_slugs": [
-      "niagara-frontier-transit-authority-nfta-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Niagara Frontier Transit Authority (NFTA) PD"
     ],
@@ -62185,10 +57941,8 @@
   {
     "agency_id": "2b23b9d7-cbcc-57a0-9c58-bfe3bf2470ae",
     "slug": "nichols-hills-ok-pd",
-    "flock_active_slug": "nichols-hills-ok-pd",
-    "flock_slugs": [
-      "nichols-hills-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nichols Hills OK PD"
     ],
@@ -62212,10 +57966,8 @@
   {
     "agency_id": "d0b5a36c-3a34-5076-9dd6-7a036418944d",
     "slug": "nm-farmington-pd",
-    "flock_active_slug": "nm-farmington-pd",
-    "flock_slugs": [
-      "nm-farmington-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "NM - Farmington PD"
     ],
@@ -62239,10 +57991,8 @@
   {
     "agency_id": "df066f18-14af-50b5-922b-ff032fd85f97",
     "slug": "nolensville-tn-pd",
-    "flock_active_slug": "nolensville-tn-pd",
-    "flock_slugs": [
-      "nolensville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nolensville TN PD"
     ],
@@ -62266,10 +58016,8 @@
   {
     "agency_id": "fca533ca-2430-50ea-bd3c-3fbef529bdf7",
     "slug": "north-platte-ne-pd",
-    "flock_active_slug": "north-platte-ne-pd",
-    "flock_slugs": [
-      "north-platte-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Platte NE PD"
     ],
@@ -62293,10 +58041,8 @@
   {
     "agency_id": "8d59e2ea-d555-578b-8293-c17a3cb59eb3",
     "slug": "north-ridgeville-oh-pd",
-    "flock_active_slug": "north-ridgeville-oh-pd",
-    "flock_slugs": [
-      "north-ridgeville-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Ridgeville OH PD"
     ],
@@ -62320,10 +58066,8 @@
   {
     "agency_id": "38e173a5-963b-571b-bf51-ca1e953ebffb",
     "slug": "north-salt-lake-ut-pd",
-    "flock_active_slug": "north-salt-lake-ut-pd",
-    "flock_slugs": [
-      "north-salt-lake-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Salt Lake UT PD"
     ],
@@ -62347,10 +58091,8 @@
   {
     "agency_id": "62040100-b594-5179-b053-168ec36b4ffc",
     "slug": "norwood-oh-pd",
-    "flock_active_slug": "norwood-oh-pd",
-    "flock_slugs": [
-      "norwood-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Norwood OH PD"
     ],
@@ -62374,10 +58116,8 @@
   {
     "agency_id": "0c83922a-8ab1-5532-8379-1c37cfcf6ec3",
     "slug": "nys-crime-analysis-center-network",
-    "flock_active_slug": "nys-crime-analysis-center-network",
-    "flock_slugs": [
-      "nys-crime-analysis-center-network"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "NYS Crime Analysis Center Network"
     ],
@@ -62401,10 +58141,8 @@
   {
     "agency_id": "4b1d39e7-f4a3-5eab-97fe-7ecd88faab94",
     "slug": "ocean-springs-ms-pd",
-    "flock_active_slug": "ocean-springs-ms-pd",
-    "flock_slugs": [
-      "ocean-springs-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ocean Springs MS PD"
     ],
@@ -62428,10 +58166,8 @@
   {
     "agency_id": "0dba0d36-b8ce-514e-8289-5766f927356b",
     "slug": "odessa-tx-pd",
-    "flock_active_slug": "odessa-tx-pd",
-    "flock_slugs": [
-      "odessa-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Odessa TX PD"
     ],
@@ -62455,10 +58191,8 @@
   {
     "agency_id": "d1957c33-6f4a-5e7b-9d6c-5aa357392a44",
     "slug": "ofallon-mo-pd",
-    "flock_active_slug": "ofallon-mo-pd",
-    "flock_slugs": [
-      "ofallon-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "O'Fallon MO PD"
     ],
@@ -62482,10 +58216,8 @@
   {
     "agency_id": "b0374e2f-594a-5a53-9595-aab16c7ed07b",
     "slug": "oglesby-il-pd",
-    "flock_active_slug": "oglesby-il-pd",
-    "flock_slugs": [
-      "oglesby-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oglesby IL PD"
     ],
@@ -62509,10 +58241,8 @@
   {
     "agency_id": "fb466a3f-e69c-5252-9b71-e2d7af224600",
     "slug": "oh-butler-county-so",
-    "flock_active_slug": "oh-butler-county-so",
-    "flock_slugs": [
-      "oh-butler-county-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "OH - Butler County SO"
     ],
@@ -62536,10 +58266,8 @@
   {
     "agency_id": "b4631624-5e89-5535-ba72-66acff799d59",
     "slug": "ohio-department-of-rehabilitation-and-correction-office-of-the-chief-inspector",
-    "flock_active_slug": "ohio-department-of-rehabilitation-and-correction-office-of-the-chief-inspector",
-    "flock_slugs": [
-      "ohio-department-of-rehabilitation-and-correction-office-of-the-chief-inspector"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ohio Department of Rehabilitation and Correction - Office of the Chief Inspector"
     ],
@@ -62556,10 +58284,8 @@
   {
     "agency_id": "87928568-1670-59b8-ab67-6d195bb233fc",
     "slug": "ohio-state-highway-patrol",
-    "flock_active_slug": "ohio-state-highway-patrol",
-    "flock_slugs": [
-      "ohio-state-highway-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ohio State Highway Patrol"
     ],
@@ -62583,10 +58309,8 @@
   {
     "agency_id": "435bc0e6-d538-5025-92b5-109406116c66",
     "slug": "oro-valley-az-pd",
-    "flock_active_slug": "oro-valley-az-pd",
-    "flock_slugs": [
-      "oro-valley-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oro Valley AZ PD"
     ],
@@ -62610,10 +58334,8 @@
   {
     "agency_id": "8f79bb55-a516-50a0-a66a-22f010014503",
     "slug": "orting-wa-pd",
-    "flock_active_slug": "orting-wa-pd",
-    "flock_slugs": [
-      "orting-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orting WA PD"
     ],
@@ -62637,10 +58359,8 @@
   {
     "agency_id": "f5aad76c-1d45-58dd-a8ca-c132070078eb",
     "slug": "othello-wa-pd",
-    "flock_active_slug": "othello-wa-pd",
-    "flock_slugs": [
-      "othello-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Othello WA PD"
     ],
@@ -62664,10 +58384,8 @@
   {
     "agency_id": "e0f061fe-b142-542c-9576-109751cd4bd8",
     "slug": "ottawa-county-mi-so",
-    "flock_active_slug": "ottawa-county-mi-so",
-    "flock_slugs": [
-      "ottawa-county-mi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ottawa County MI SO"
     ],
@@ -62691,10 +58409,8 @@
   {
     "agency_id": "44c61cec-7907-5006-bfc7-46912465c656",
     "slug": "ottawa-il-pd",
-    "flock_active_slug": "ottawa-il-pd",
-    "flock_slugs": [
-      "ottawa-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ottawa IL PD"
     ],
@@ -62718,10 +58434,8 @@
   {
     "agency_id": "834c601d-e3dc-55cf-8e9c-b05b610ef4ec",
     "slug": "oxford-ms-pd",
-    "flock_active_slug": "oxford-ms-pd",
-    "flock_slugs": [
-      "oxford-ms-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oxford MS PD"
     ],
@@ -62745,10 +58459,8 @@
   {
     "agency_id": "6880a588-c913-5ffd-a463-5b42414f9afe",
     "slug": "oxford-pd-oh",
-    "flock_active_slug": "oxford-pd-oh",
-    "flock_slugs": [
-      "oxford-pd-oh"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oxford PD - OH"
     ],
@@ -62772,10 +58484,8 @@
   {
     "agency_id": "21fb5336-7bb7-5cc1-a4da-706673c971ed",
     "slug": "page-az-pd",
-    "flock_active_slug": "page-az-pd",
-    "flock_slugs": [
-      "page-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Page AZ PD"
     ],
@@ -62799,10 +58509,8 @@
   {
     "agency_id": "595b29c9-298b-5175-b47f-9932aa857162",
     "slug": "palm-beach-county-fl-so",
-    "flock_active_slug": "palm-beach-county-fl-so",
-    "flock_slugs": [
-      "palm-beach-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Palm Beach County FL SO"
     ],
@@ -62826,10 +58534,8 @@
   {
     "agency_id": "43c4ccb8-3d21-5900-8d38-cceb4431949d",
     "slug": "panama-city-beach-fl-pd",
-    "flock_active_slug": "panama-city-beach-fl-pd",
-    "flock_slugs": [
-      "panama-city-beach-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Panama City Beach FL PD"
     ],
@@ -62853,10 +58559,8 @@
   {
     "agency_id": "8b81c0a3-0692-5a0c-b3b3-e650fc7562f9",
     "slug": "panama-city-fl-pd",
-    "flock_active_slug": "panama-city-fl-pd",
-    "flock_slugs": [
-      "panama-city-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Panama City FL PD"
     ],
@@ -62880,10 +58584,8 @@
   {
     "agency_id": "7ec33b25-4deb-5634-ab31-5eaa5bcc1075",
     "slug": "paris-tx-pd",
-    "flock_active_slug": "paris-tx-pd",
-    "flock_slugs": [
-      "paris-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paris TX PD"
     ],
@@ -62907,10 +58609,8 @@
   {
     "agency_id": "0c8cf0a7-49c7-5837-8dea-b983beaea542",
     "slug": "park-city-ks-pd",
-    "flock_active_slug": "park-city-ks-pd",
-    "flock_slugs": [
-      "park-city-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Park City KS PD"
     ],
@@ -62934,10 +58634,8 @@
   {
     "agency_id": "e1f96571-a743-54f4-872f-9ca305d4ee9f",
     "slug": "parker-az-pd",
-    "flock_active_slug": "parker-az-pd",
-    "flock_slugs": [
-      "parker-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Parker AZ PD"
     ],
@@ -62961,10 +58659,8 @@
   {
     "agency_id": "56f5b5ec-6c45-55f6-8fe8-d823a99c9175",
     "slug": "pasadena-tx-pd",
-    "flock_active_slug": "pasadena-tx-pd",
-    "flock_slugs": [
-      "pasadena-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pasadena TX PD"
     ],
@@ -62988,10 +58684,8 @@
   {
     "agency_id": "c67c6899-283e-5420-a550-bde165680c3c",
     "slug": "payson-az-pd",
-    "flock_active_slug": "payson-az-pd",
-    "flock_slugs": [
-      "payson-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Payson AZ PD"
     ],
@@ -63015,10 +58709,8 @@
   {
     "agency_id": "e2cf8439-aa23-50be-bb8a-43bd412c78b1",
     "slug": "peoria-il-pd",
-    "flock_active_slug": "peoria-il-pd",
-    "flock_slugs": [
-      "peoria-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peoria IL PD"
     ],
@@ -63042,10 +58734,8 @@
   {
     "agency_id": "000aeff9-f3bc-5c98-aa3e-ce3ebf346dff",
     "slug": "perry-county-mo-so",
-    "flock_active_slug": "perry-county-mo-so",
-    "flock_slugs": [
-      "perry-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Perry County MO SO"
     ],
@@ -63069,10 +58759,8 @@
   {
     "agency_id": "44f5dbfd-a873-5eab-aa2a-644efa3f49ee",
     "slug": "phoenix-az-pd",
-    "flock_active_slug": "phoenix-az-pd",
-    "flock_slugs": [
-      "phoenix-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Phoenix AZ PD"
     ],
@@ -63096,10 +58784,8 @@
   {
     "agency_id": "2b40708f-1f57-514a-8705-c1a04ec9d840",
     "slug": "pinellas-park-fl-pd",
-    "flock_active_slug": "pinellas-park-fl-pd",
-    "flock_slugs": [
-      "pinellas-park-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pinellas Park FL PD"
     ],
@@ -63123,10 +58809,8 @@
   {
     "agency_id": "dbfa88a4-ada9-52d1-912d-b5b911df81b3",
     "slug": "pleasant-grove-ut-pd",
-    "flock_active_slug": "pleasant-grove-ut-pd",
-    "flock_slugs": [
-      "pleasant-grove-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pleasant Grove UT PD"
     ],
@@ -63150,10 +58834,8 @@
   {
     "agency_id": "34c9d990-cc67-5908-8157-5da6d2f60d35",
     "slug": "pocatello-id-pd",
-    "flock_active_slug": "pocatello-id-pd",
-    "flock_slugs": [
-      "pocatello-id-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pocatello ID PD"
     ],
@@ -63177,10 +58859,8 @@
   {
     "agency_id": "ba6e5eb3-a55f-5972-8f0f-f20b4a795469",
     "slug": "polk-county-tx-so",
-    "flock_active_slug": "polk-county-tx-so",
-    "flock_slugs": [
-      "polk-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Polk County TX SO"
     ],
@@ -63204,10 +58884,8 @@
   {
     "agency_id": "37bd6460-ffaa-57e3-9c7c-38dd04b363c3",
     "slug": "portland-tn-pd",
-    "flock_active_slug": "portland-tn-pd",
-    "flock_slugs": [
-      "portland-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Portland TN PD"
     ],
@@ -63231,10 +58909,8 @@
   {
     "agency_id": "521b777d-c4d2-5cc8-a309-87d4f6ea8aec",
     "slug": "posey-county-in-so",
-    "flock_active_slug": "posey-county-in-so",
-    "flock_slugs": [
-      "posey-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Posey County IN SO"
     ],
@@ -63258,10 +58934,8 @@
   {
     "agency_id": "cf916c0a-c36c-52b7-9bd3-b82703c502bb",
     "slug": "precinct-3-tx",
-    "flock_active_slug": "precinct-3-tx",
-    "flock_slugs": [
-      "precinct-3-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Precinct 3 (TX)"
     ],
@@ -63281,10 +58955,8 @@
   {
     "agency_id": "51ecec58-0fd2-515c-8f77-3b26f748869c",
     "slug": "prescott-az-pd",
-    "flock_active_slug": "prescott-az-pd",
-    "flock_slugs": [
-      "prescott-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prescott AZ PD"
     ],
@@ -63308,10 +58980,8 @@
   {
     "agency_id": "c94ce662-7a0d-54c8-8bc5-396c277d837f",
     "slug": "prescott-valley-az-pd",
-    "flock_active_slug": "prescott-valley-az-pd",
-    "flock_slugs": [
-      "prescott-valley-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prescott Valley AZ PD"
     ],
@@ -63335,10 +59005,8 @@
   {
     "agency_id": "625dbd8a-ae33-5266-b527-38e98b850886",
     "slug": "prosper-tx-pd",
-    "flock_active_slug": "prosper-tx-pd",
-    "flock_slugs": [
-      "prosper-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Prosper TX PD"
     ],
@@ -63362,10 +59030,8 @@
   {
     "agency_id": "8380612b-60b2-5cc8-8715-cdce7597d598",
     "slug": "provo-ut-pd",
-    "flock_active_slug": "provo-ut-pd",
-    "flock_slugs": [
-      "provo-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Provo UT PD"
     ],
@@ -63389,10 +59055,8 @@
   {
     "agency_id": "789a7386-70db-5ab4-9f17-1a879bac4139",
     "slug": "purcell-ok-pd",
-    "flock_active_slug": "purcell-ok-pd",
-    "flock_slugs": [
-      "purcell-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Purcell OK PD"
     ],
@@ -63416,10 +59080,8 @@
   {
     "agency_id": "7dd7d8e3-8e4c-5ab0-b649-ebd9f5c15db9",
     "slug": "putnam-county-ga-so",
-    "flock_active_slug": "putnam-county-ga-so",
-    "flock_slugs": [
-      "putnam-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Putnam County GA SO"
     ],
@@ -63443,10 +59105,8 @@
   {
     "agency_id": "b111be54-e0b4-5bc2-83c9-ad2285eccaaf",
     "slug": "puyallup-wa-pd",
-    "flock_active_slug": "puyallup-wa-pd",
-    "flock_slugs": [
-      "puyallup-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Puyallup WA PD"
     ],
@@ -63470,10 +59130,8 @@
   {
     "agency_id": "32fb1f66-9353-5ecd-8dae-5f8575003109",
     "slug": "queen-creek-az-pd",
-    "flock_active_slug": "queen-creek-az-pd",
-    "flock_slugs": [
-      "queen-creek-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Queen Creek AZ PD"
     ],
@@ -63497,10 +59155,8 @@
   {
     "agency_id": "11d5533e-f466-51fe-8041-77a4ab2747b4",
     "slug": "quogue-village-ny-pd",
-    "flock_active_slug": "quogue-village-ny-pd",
-    "flock_slugs": [
-      "quogue-village-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Quogue Village NY PD"
     ],
@@ -63524,10 +59180,8 @@
   {
     "agency_id": "7cb7b666-5f1d-59c0-8b4b-6c4b3b0cab69",
     "slug": "radcliff-ky-pd",
-    "flock_active_slug": "radcliff-ky-pd",
-    "flock_slugs": [
-      "radcliff-ky-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Radcliff KY PD"
     ],
@@ -63551,10 +59205,8 @@
   {
     "agency_id": "5715ea99-2e73-5b6e-90f1-f90ee6bb9366",
     "slug": "raleigh-nc-pd",
-    "flock_active_slug": "raleigh-nc-pd",
-    "flock_slugs": [
-      "raleigh-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Raleigh NC PD"
     ],
@@ -63578,10 +59230,8 @@
   {
     "agency_id": "d67d2a8c-e3e5-5c81-bc15-ebf51f173ffb",
     "slug": "ranlo-nc-pd",
-    "flock_active_slug": "ranlo-nc-pd",
-    "flock_slugs": [
-      "ranlo-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ranlo NC PD"
     ],
@@ -63605,10 +59255,8 @@
   {
     "agency_id": "e8e3df19-452e-52b6-b729-08584f7eef0b",
     "slug": "reardan-wa-pd",
-    "flock_active_slug": "reardan-wa-pd",
-    "flock_slugs": [
-      "reardan-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reardan WA PD"
     ],
@@ -63632,10 +59280,8 @@
   {
     "agency_id": "926a7e76-714b-50a2-977e-522e4ec651ec",
     "slug": "republic-mo-pd",
-    "flock_active_slug": "republic-mo-pd",
-    "flock_slugs": [
-      "republic-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Republic MO PD"
     ],
@@ -63659,10 +59305,8 @@
   {
     "agency_id": "34238e0f-5a37-5ab3-8196-f540fafdf4d8",
     "slug": "richardson-tx-pd",
-    "flock_active_slug": "richardson-tx-pd",
-    "flock_slugs": [
-      "richardson-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richardson TX PD"
     ],
@@ -63686,10 +59330,8 @@
   {
     "agency_id": "7b9dbf06-a73b-532d-ba54-751ba8d15fe8",
     "slug": "richmond-va-pd",
-    "flock_active_slug": "richmond-va-pd",
-    "flock_slugs": [
-      "richmond-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richmond VA PD"
     ],
@@ -63713,10 +59355,8 @@
   {
     "agency_id": "bb5de54a-f407-5cf7-b3c8-33bfdb483e31",
     "slug": "riley-county-ks-pd",
-    "flock_active_slug": "riley-county-ks-pd",
-    "flock_slugs": [
-      "riley-county-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Riley County KS PD"
     ],
@@ -63740,10 +59380,8 @@
   {
     "agency_id": "670947e8-edc9-58ae-9beb-beae4e49f89f",
     "slug": "rochester-il-pd",
-    "flock_active_slug": "rochester-il-pd",
-    "flock_slugs": [
-      "rochester-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rochester IL PD"
     ],
@@ -63767,10 +59405,8 @@
   {
     "agency_id": "afde3f0a-f1c1-53db-afc4-e9cee1a84aa9",
     "slug": "rock-county-wi-so",
-    "flock_active_slug": "rock-county-wi-so",
-    "flock_slugs": [
-      "rock-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock County WI SO"
     ],
@@ -63794,10 +59430,8 @@
   {
     "agency_id": "d725bd66-8f9c-5680-999b-57ce4fd8799d",
     "slug": "rock-hill-sc-pd",
-    "flock_active_slug": "rock-hill-sc-pd",
-    "flock_slugs": [
-      "rock-hill-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rock Hill SC PD"
     ],
@@ -63821,10 +59455,8 @@
   {
     "agency_id": "c9d0d87b-e743-5a08-9e40-c4ef5dc780fb",
     "slug": "rockmart-ga-pd",
-    "flock_active_slug": "rockmart-ga-pd",
-    "flock_slugs": [
-      "rockmart-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockmart GA PD"
     ],
@@ -63848,10 +59480,8 @@
   {
     "agency_id": "136e595f-2c92-5a7d-9a1f-372dc4863daf",
     "slug": "rockport-tx-pd",
-    "flock_active_slug": "rockport-tx-pd",
-    "flock_slugs": [
-      "rockport-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rockport TX PD"
     ],
@@ -63875,10 +59505,8 @@
   {
     "agency_id": "eebbe2ac-796a-584c-b24b-2f656e8a41fd",
     "slug": "rocky-mountain-information-network-rminriss-az-deactivated",
-    "flock_active_slug": "rocky-mountain-information-network-rminriss-az-deactivated",
-    "flock_slugs": [
-      "rocky-mountain-information-network-rminriss-az-deactivated"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rocky Mountain Information Network (RMIN/RISS) AZ [DEACTIVATED]"
     ],
@@ -63900,10 +59528,8 @@
   {
     "agency_id": "1d4f66ee-62e0-54bd-8f6a-a43cf8e4f3a9",
     "slug": "roman-forest-tx-pd",
-    "flock_active_slug": "roman-forest-tx-pd",
-    "flock_slugs": [
-      "roman-forest-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roman Forest TX PD"
     ],
@@ -63927,10 +59553,8 @@
   {
     "agency_id": "051605ab-7ac8-56f7-b12d-7320f904e0a5",
     "slug": "roseburg-or-pd",
-    "flock_active_slug": "roseburg-or-pd",
-    "flock_slugs": [
-      "roseburg-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roseburg OR PD"
     ],
@@ -63954,10 +59578,8 @@
   {
     "agency_id": "e3ee8473-aae9-546a-9277-f18e29f30758",
     "slug": "roseville-mi-pd",
-    "flock_active_slug": "roseville-mi-pd",
-    "flock_slugs": [
-      "roseville-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roseville MI PD"
     ],
@@ -63981,10 +59603,8 @@
   {
     "agency_id": "e934dc11-8179-5a1a-b028-ba072831cb2e",
     "slug": "roswell-ga-pd",
-    "flock_active_slug": "roswell-ga-pd",
-    "flock_slugs": [
-      "roswell-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roswell GA PD"
     ],
@@ -64008,10 +59628,8 @@
   {
     "agency_id": "86a3568c-0e11-53a6-b757-d97aa0de98a7",
     "slug": "round-rock-tx-pd",
-    "flock_active_slug": "round-rock-tx-pd",
-    "flock_slugs": [
-      "round-rock-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Round Rock TX PD"
     ],
@@ -64035,10 +59653,8 @@
   {
     "agency_id": "606c2529-57c6-5734-8dee-09a0944ceab0",
     "slug": "routt-county-co-so",
-    "flock_active_slug": "routt-county-co-so",
-    "flock_slugs": [
-      "routt-county-co-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Routt County CO SO"
     ],
@@ -64062,10 +59678,8 @@
   {
     "agency_id": "695e90b7-0c1f-5418-9bde-8ee76627b67e",
     "slug": "safford-az-pd",
-    "flock_active_slug": "safford-az-pd",
-    "flock_slugs": [
-      "safford-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Safford AZ PD"
     ],
@@ -64089,10 +59703,8 @@
   {
     "agency_id": "6e7c1112-f4d2-5408-bf62-ddecf9ebf1b8",
     "slug": "saint-johns-az-pd",
-    "flock_active_slug": "saint-johns-az-pd",
-    "flock_slugs": [
-      "saint-johns-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Saint Johns AZ PD"
     ],
@@ -64116,10 +59728,8 @@
   {
     "agency_id": "206f1892-4cff-588d-9786-87b500fb9f3c",
     "slug": "salida-co-pd",
-    "flock_active_slug": "salida-co-pd",
-    "flock_slugs": [
-      "salida-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salida CO PD"
     ],
@@ -64143,10 +59753,8 @@
   {
     "agency_id": "741b299b-38d3-5dac-a5bb-d9e0b2e5317f",
     "slug": "salina-ks-pd",
-    "flock_active_slug": "salina-ks-pd",
-    "flock_slugs": [
-      "salina-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salina KS PD"
     ],
@@ -64170,10 +59778,8 @@
   {
     "agency_id": "e9ded2dd-ad71-5045-afc2-0b43f64cf93b",
     "slug": "salina-ut-pd",
-    "flock_active_slug": "salina-ut-pd",
-    "flock_slugs": [
-      "salina-ut-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salina UT PD"
     ],
@@ -64197,10 +59803,8 @@
   {
     "agency_id": "aed60235-93c4-59d1-b767-4d6e57a5e3d2",
     "slug": "san-antonio-tx-pd",
-    "flock_active_slug": "san-antonio-tx-pd",
-    "flock_slugs": [
-      "san-antonio-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Antonio TX PD"
     ],
@@ -64224,10 +59828,8 @@
   {
     "agency_id": "3cb1369c-bc00-5893-992d-00d7c8e27d4a",
     "slug": "san-augustine-county-tx-so",
-    "flock_active_slug": "san-augustine-county-tx-so",
-    "flock_slugs": [
-      "san-augustine-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Augustine County TX SO"
     ],
@@ -64251,10 +59853,8 @@
   {
     "agency_id": "0356e0c1-db5d-54dd-9651-f37bf59df0b1",
     "slug": "san-luis-az-pd",
-    "flock_active_slug": "san-luis-az-pd",
-    "flock_slugs": [
-      "san-luis-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Luis AZ PD"
     ],
@@ -64278,10 +59878,8 @@
   {
     "agency_id": "35bc91c3-215e-5473-9579-1c61c513dc76",
     "slug": "santa-rosa-county-fl-so",
-    "flock_active_slug": "santa-rosa-county-fl-so",
-    "flock_slugs": [
-      "santa-rosa-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Rosa County FL SO"
     ],
@@ -64305,10 +59903,8 @@
   {
     "agency_id": "567dbf89-5963-5504-b07c-f2e9d2330e3c",
     "slug": "sarpy-county-ne-so",
-    "flock_active_slug": "sarpy-county-ne-so",
-    "flock_slugs": [
-      "sarpy-county-ne-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sarpy County NE SO"
     ],
@@ -64332,10 +59928,8 @@
   {
     "agency_id": "7532d1c6-ec35-5d64-9f4d-fa8894124d57",
     "slug": "sauk-prairie-wi-pd",
-    "flock_active_slug": "sauk-prairie-wi-pd",
-    "flock_slugs": [
-      "sauk-prairie-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sauk Prairie WI PD"
     ],
@@ -64358,10 +59952,8 @@
   {
     "agency_id": "051760dd-02c4-51b0-8296-740b40fb1769",
     "slug": "sauk-village-il-pd",
-    "flock_active_slug": "sauk-village-il-pd",
-    "flock_slugs": [
-      "sauk-village-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sauk Village IL PD"
     ],
@@ -64385,10 +59977,8 @@
   {
     "agency_id": "e7dcce67-71f9-500a-bd1c-3727e117fd5d",
     "slug": "scarborough-me-pd",
-    "flock_active_slug": "scarborough-me-pd",
-    "flock_slugs": [
-      "scarborough-me-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scarborough ME PD"
     ],
@@ -64412,10 +60002,8 @@
   {
     "agency_id": "6f7a0c41-248c-578c-a271-21991ea20232",
     "slug": "schuyler-co-il-so",
-    "flock_active_slug": "schuyler-co-il-so",
-    "flock_slugs": [
-      "schuyler-co-il-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Schuyler Co. IL SO"
     ],
@@ -64439,10 +60027,8 @@
   {
     "agency_id": "9062d886-dfcd-59e5-abc2-a0b9d759f393",
     "slug": "scott-county-ms-so",
-    "flock_active_slug": "scott-county-ms-so",
-    "flock_slugs": [
-      "scott-county-ms-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scott County MS SO"
     ],
@@ -64466,10 +60052,8 @@
   {
     "agency_id": "dd8cb59c-d445-54d4-9aec-03638e42a8ce",
     "slug": "scottsbluff-ne-pd",
-    "flock_active_slug": "scottsbluff-ne-pd",
-    "flock_slugs": [
-      "scottsbluff-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Scottsbluff NE PD"
     ],
@@ -64493,10 +60077,8 @@
   {
     "agency_id": "a338f48c-3f75-5c78-9507-29b947bef3f4",
     "slug": "sealy-tx-pd",
-    "flock_active_slug": "sealy-tx-pd",
-    "flock_slugs": [
-      "sealy-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sealy TX PD"
     ],
@@ -64520,10 +60102,8 @@
   {
     "agency_id": "1459af8f-c2ff-5973-a5b0-d950ee9cc0fe",
     "slug": "selma-tx-pd",
-    "flock_active_slug": "selma-tx-pd",
-    "flock_slugs": [
-      "selma-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Selma TX PD"
     ],
@@ -64547,10 +60127,8 @@
   {
     "agency_id": "0d342315-96ad-56ff-8557-eae7accc1b66",
     "slug": "seymour-in-pd",
-    "flock_active_slug": "seymour-in-pd",
-    "flock_slugs": [
-      "seymour-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seymour IN PD"
     ],
@@ -64574,10 +60152,8 @@
   {
     "agency_id": "ed1f998c-5424-5460-9a84-285684b431fd",
     "slug": "shelby-county-ky-so",
-    "flock_active_slug": "shelby-county-ky-so",
-    "flock_slugs": [
-      "shelby-county-ky-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelby County KY SO"
     ],
@@ -64601,10 +60177,8 @@
   {
     "agency_id": "fe73dad3-4d22-51bc-ab2e-3a926149c846",
     "slug": "shelby-county-tn-so",
-    "flock_active_slug": "shelby-county-tn-so",
-    "flock_slugs": [
-      "shelby-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelby County TN SO"
     ],
@@ -64628,10 +60202,8 @@
   {
     "agency_id": "608a31fd-deba-5aa5-857a-d087201da78b",
     "slug": "shelbyville-tn-pd",
-    "flock_active_slug": "shelbyville-tn-pd",
-    "flock_slugs": [
-      "shelbyville-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shelbyville TN PD"
     ],
@@ -64655,10 +60227,8 @@
   {
     "agency_id": "6bcd3ffd-515a-5cbf-9506-bb96c66c73ff",
     "slug": "sioux-city-ia-pd",
-    "flock_active_slug": "sioux-city-ia-pd",
-    "flock_slugs": [
-      "sioux-city-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sioux City IA PD"
     ],
@@ -64682,10 +60252,8 @@
   {
     "agency_id": "d6e1b396-2954-5026-914f-f7986c1a2bb6",
     "slug": "skokie-il-pd",
-    "flock_active_slug": "skokie-il-pd",
-    "flock_slugs": [
-      "skokie-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Skokie IL PD"
     ],
@@ -64709,10 +60277,8 @@
   {
     "agency_id": "70a10d44-6bb5-5dca-8979-427c8db855cc",
     "slug": "slidell-la-pd",
-    "flock_active_slug": "slidell-la-pd",
-    "flock_slugs": [
-      "slidell-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Slidell LA PD"
     ],
@@ -64736,10 +60302,8 @@
   {
     "agency_id": "fb15f532-ff09-58b1-89eb-8e2a1047982f",
     "slug": "slinger-wi-pd",
-    "flock_active_slug": "slinger-wi-pd",
-    "flock_slugs": [
-      "slinger-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Slinger WI PD"
     ],
@@ -64763,10 +60327,8 @@
   {
     "agency_id": "42cc047d-6e84-5825-b6e5-6f01f5c0295e",
     "slug": "snyder-tx-pd",
-    "flock_active_slug": "snyder-tx-pd",
-    "flock_slugs": [
-      "snyder-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Snyder TX PD"
     ],
@@ -64790,10 +60352,8 @@
   {
     "agency_id": "187b1987-77fe-5ade-bd55-c990a8370b6b",
     "slug": "somerset-county-nj-prosecutors-office",
-    "flock_active_slug": "somerset-county-nj-prosecutors-office",
-    "flock_slugs": [
-      "somerset-county-nj-prosecutors-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Somerset County NJ Prosecutors Office"
     ],
@@ -64814,10 +60374,8 @@
   {
     "agency_id": "6d2789e3-41cc-5154-8588-01370a616fcf",
     "slug": "somerton-az-pd",
-    "flock_active_slug": "somerton-az-pd",
-    "flock_slugs": [
-      "somerton-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Somerton AZ PD"
     ],
@@ -64841,10 +60399,8 @@
   {
     "agency_id": "cb01b81f-bb94-5ffe-b3cc-21df118f78d4",
     "slug": "south-tucson-az-pd",
-    "flock_active_slug": "south-tucson-az-pd",
-    "flock_slugs": [
-      "south-tucson-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Tucson AZ PD"
     ],
@@ -64868,10 +60424,8 @@
   {
     "agency_id": "c8069b30-3898-5e41-ace6-d6fe53ea4f71",
     "slug": "splendora-tx-pd",
-    "flock_active_slug": "splendora-tx-pd",
-    "flock_slugs": [
-      "splendora-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Splendora TX PD"
     ],
@@ -64895,10 +60449,8 @@
   {
     "agency_id": "83af2f2e-4263-5b61-a419-485bea2445d6",
     "slug": "springfield-mo-pd",
-    "flock_active_slug": "springfield-mo-pd",
-    "flock_slugs": [
-      "springfield-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springfield MO PD"
     ],
@@ -64922,10 +60474,8 @@
   {
     "agency_id": "bf2b80b2-d258-558f-b1f1-fa17fb8b4af4",
     "slug": "springfield-or-pd",
-    "flock_active_slug": "springfield-or-pd",
-    "flock_slugs": [
-      "springfield-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springfield OR PD"
     ],
@@ -64949,10 +60499,8 @@
   {
     "agency_id": "8b54c3a9-adae-57b2-b7a6-d339e5e829fe",
     "slug": "springville-pd-ut",
-    "flock_active_slug": "springville-pd-ut",
-    "flock_slugs": [
-      "springville-pd-ut"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Springville PD (UT)"
     ],
@@ -64976,10 +60524,8 @@
   {
     "agency_id": "97198ba5-e2bf-5cff-9e4a-3b0df609a115",
     "slug": "st-charles-city-mo-pd",
-    "flock_active_slug": "st-charles-city-mo-pd",
-    "flock_slugs": [
-      "st-charles-city-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Charles City MO PD"
     ],
@@ -65003,10 +60549,8 @@
   {
     "agency_id": "3e9374ce-ce63-50f9-9212-5dfb50fbb366",
     "slug": "st-john-parish-la-so",
-    "flock_active_slug": "st-john-parish-la-so",
-    "flock_slugs": [
-      "st-john-parish-la-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. John Parish LA SO"
     ],
@@ -65030,10 +60574,8 @@
   {
     "agency_id": "1fd48543-8a0b-50b3-bdd5-69d51d203892",
     "slug": "sterling-heights-mi-pd",
-    "flock_active_slug": "sterling-heights-mi-pd",
-    "flock_slugs": [
-      "sterling-heights-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sterling Heights MI PD"
     ],
@@ -65057,10 +60599,8 @@
   {
     "agency_id": "6e599a4c-8505-5b91-9b17-5744dd2d45e5",
     "slug": "stevens-point-wi-pd",
-    "flock_active_slug": "stevens-point-wi-pd",
-    "flock_slugs": [
-      "stevens-point-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stevens Point WI PD"
     ],
@@ -65084,10 +60624,8 @@
   {
     "agency_id": "ccc4c230-3822-5695-9bc7-bd3c5b2647ab",
     "slug": "stone-county-mo-so",
-    "flock_active_slug": "stone-county-mo-so",
-    "flock_slugs": [
-      "stone-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stone County MO SO"
     ],
@@ -65111,10 +60649,8 @@
   {
     "agency_id": "8a9af692-fc85-5272-bd09-59d28e1dbc6f",
     "slug": "summerset-sd-pd",
-    "flock_active_slug": "summerset-sd-pd",
-    "flock_slugs": [
-      "summerset-sd-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Summerset SD PD"
     ],
@@ -65138,10 +60674,8 @@
   {
     "agency_id": "5c42e4c2-2b92-529e-9c9c-32bc5e2b1675",
     "slug": "tell-city-in-pd",
-    "flock_active_slug": "tell-city-in-pd",
-    "flock_slugs": [
-      "tell-city-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tell City IN PD"
     ],
@@ -65165,10 +60699,8 @@
   {
     "agency_id": "ba91d4d0-77fc-58c2-b154-efc7c1f1fb81",
     "slug": "tempe-az-pd",
-    "flock_active_slug": "tempe-az-pd",
-    "flock_slugs": [
-      "tempe-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tempe AZ PD"
     ],
@@ -65192,10 +60724,8 @@
   {
     "agency_id": "4cd5f427-1eb5-5f2f-b18d-3e6056bd8f57",
     "slug": "terre-haute-in-pd",
-    "flock_active_slug": "terre-haute-in-pd",
-    "flock_slugs": [
-      "terre-haute-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Terre Haute IN PD"
     ],
@@ -65219,10 +60749,8 @@
   {
     "agency_id": "3f34115e-d014-5ecf-b6f8-fecdb0a1855c",
     "slug": "terrell-tx-pd",
-    "flock_active_slug": "terrell-tx-pd",
-    "flock_slugs": [
-      "terrell-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Terrell TX PD"
     ],
@@ -65246,10 +60774,8 @@
   {
     "agency_id": "897d9bb2-612a-537e-8798-1be38b199173",
     "slug": "texas-department-of-criminal-justice",
-    "flock_active_slug": "texas-department-of-criminal-justice",
-    "flock_slugs": [
-      "texas-department-of-criminal-justice"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Texas Department of Criminal Justice"
     ],
@@ -65266,10 +60792,8 @@
   {
     "agency_id": "937893aa-d2ac-59c7-9f48-2a9fdada153a",
     "slug": "thatcher-az-pd",
-    "flock_active_slug": "thatcher-az-pd",
-    "flock_slugs": [
-      "thatcher-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thatcher AZ PD"
     ],
@@ -65293,10 +60817,8 @@
   {
     "agency_id": "4354a2c5-174d-57b3-9c1d-bfe102433c1b",
     "slug": "thomas-county-ga-so",
-    "flock_active_slug": "thomas-county-ga-so",
-    "flock_slugs": [
-      "thomas-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thomas County GA SO"
     ],
@@ -65320,10 +60842,8 @@
   {
     "agency_id": "cf1e330c-8a42-5cd9-813d-cfe383b83802",
     "slug": "thornton-co-pd",
-    "flock_active_slug": "thornton-co-pd",
-    "flock_slugs": [
-      "thornton-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Thornton CO PD"
     ],
@@ -65347,10 +60867,8 @@
   {
     "agency_id": "04516928-8a93-514b-9c9c-62e03f513eae",
     "slug": "tilden-township-pa-pd",
-    "flock_active_slug": "tilden-township-pa-pd",
-    "flock_slugs": [
-      "tilden-township-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tilden Township PA PD"
     ],
@@ -65374,10 +60892,8 @@
   {
     "agency_id": "f29eccd0-7d13-5090-82ee-e6c7bcde6431",
     "slug": "tolleson-az-pd",
-    "flock_active_slug": "tolleson-az-pd",
-    "flock_slugs": [
-      "tolleson-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tolleson AZ PD"
     ],
@@ -65401,10 +60917,8 @@
   {
     "agency_id": "53ffbcdb-8769-5593-8172-552c40426506",
     "slug": "tomball-tx-pd",
-    "flock_active_slug": "tomball-tx-pd",
-    "flock_slugs": [
-      "tomball-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tomball TX PD"
     ],
@@ -65428,10 +60942,8 @@
   {
     "agency_id": "cf25b645-2e7d-5c99-8906-9e133448366a",
     "slug": "tompkins-county-ny-sheriffs-office",
-    "flock_active_slug": "tompkins-county-ny-sheriffs-office",
-    "flock_slugs": [
-      "tompkins-county-ny-sheriffs-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tompkins County NY Sheriff's Office"
     ],
@@ -65452,10 +60964,8 @@
   {
     "agency_id": "26f7693b-ff64-5cd6-a5a1-24069f02d146",
     "slug": "tooele-city-pd-ut",
-    "flock_active_slug": "tooele-city-pd-ut",
-    "flock_slugs": [
-      "tooele-city-pd-ut"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tooele City PD UT"
     ],
@@ -65479,10 +60989,8 @@
   {
     "agency_id": "955adc5f-b3dc-50e5-bb79-543b859f9670",
     "slug": "town-of-groton-ct-pd",
-    "flock_active_slug": "town-of-groton-ct-pd",
-    "flock_slugs": [
-      "town-of-groton-ct-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Town of Groton CT PD"
     ],
@@ -65506,10 +61014,8 @@
   {
     "agency_id": "63a7c97f-01dc-5829-8f9a-78115774037d",
     "slug": "tulsa-ok-pd",
-    "flock_active_slug": "tulsa-ok-pd",
-    "flock_slugs": [
-      "tulsa-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tulsa OK PD"
     ],
@@ -65533,10 +61039,8 @@
   {
     "agency_id": "47442a40-32b6-542e-9eda-1150d3a157c5",
     "slug": "twin-falls-id-pd",
-    "flock_active_slug": "twin-falls-id-pd",
-    "flock_slugs": [
-      "twin-falls-id-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Twin Falls ID PD"
     ],
@@ -65560,10 +61064,8 @@
   {
     "agency_id": "30271515-19e9-5d6c-b059-716f6bde10e2",
     "slug": "university-of-iowa-pd-ia",
-    "flock_active_slug": "university-of-iowa-pd-ia",
-    "flock_slugs": [
-      "university-of-iowa-pd-ia"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of Iowa PD (IA)"
     ],
@@ -65587,10 +61089,8 @@
   {
     "agency_id": "1269bcf6-fa40-5f9d-9971-5adf34b430b1",
     "slug": "urbana-oh-pd",
-    "flock_active_slug": "urbana-oh-pd",
-    "flock_slugs": [
-      "urbana-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Urbana OH PD"
     ],
@@ -65614,10 +61114,8 @@
   {
     "agency_id": "d74ca0e6-320d-5187-8ba2-84280145b8e6",
     "slug": "ut-cedar-city-pd",
-    "flock_active_slug": "ut-cedar-city-pd",
-    "flock_slugs": [
-      "ut-cedar-city-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UT - Cedar City PD"
     ],
@@ -65641,10 +61139,8 @@
   {
     "agency_id": "eab53746-9866-59f2-b0a5-313f2dd081f0",
     "slug": "ut-southwestern-medical-center-tx",
-    "flock_active_slug": "ut-southwestern-medical-center-tx",
-    "flock_slugs": [
-      "ut-southwestern-medical-center-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UT Southwestern Medical Center TX"
     ],
@@ -65664,10 +61160,8 @@
   {
     "agency_id": "071f741a-c6e8-52ce-98c8-5d17f54f4de8",
     "slug": "valley-center-ks-dps",
-    "flock_active_slug": "valley-center-ks-dps",
-    "flock_slugs": [
-      "valley-center-ks-dps"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Valley Center KS DPS"
     ],
@@ -65691,10 +61185,8 @@
   {
     "agency_id": "59de19e5-7acd-54ac-b2eb-7406d7c16a32",
     "slug": "van-buren-ar-pd",
-    "flock_active_slug": "van-buren-ar-pd",
-    "flock_slugs": [
-      "van-buren-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Van Buren AR PD"
     ],
@@ -65718,10 +61210,8 @@
   {
     "agency_id": "5b8ad8b0-54e8-5de8-aa30-42599d0bc841",
     "slug": "vandalia-oh-pd",
-    "flock_active_slug": "vandalia-oh-pd",
-    "flock_slugs": [
-      "vandalia-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vandalia OH PD"
     ],
@@ -65745,10 +61235,8 @@
   {
     "agency_id": "250e4fe6-21c4-5eca-bb0a-b2551f6e7450",
     "slug": "vernon-county-wi-so",
-    "flock_active_slug": "vernon-county-wi-so",
-    "flock_slugs": [
-      "vernon-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vernon County WI SO"
     ],
@@ -65772,10 +61260,8 @@
   {
     "agency_id": "e13dcbcd-cee0-5861-bda9-588c44e0808c",
     "slug": "vestavia-hills-al-pd",
-    "flock_active_slug": "vestavia-hills-al-pd",
-    "flock_slugs": [
-      "vestavia-hills-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vestavia Hills AL PD"
     ],
@@ -65799,10 +61285,8 @@
   {
     "agency_id": "186b5acf-ad8b-5399-abd7-b710edbd10f8",
     "slug": "villa-park-il-pd",
-    "flock_active_slug": "villa-park-il-pd",
-    "flock_slugs": [
-      "villa-park-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Villa Park IL PD"
     ],
@@ -65826,10 +61310,8 @@
   {
     "agency_id": "78251503-0a56-5eac-b427-86125d6d5b3a",
     "slug": "villa-rica-ga-pd",
-    "flock_active_slug": "villa-rica-ga-pd",
-    "flock_slugs": [
-      "villa-rica-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Villa Rica GA PD"
     ],
@@ -65853,10 +61335,8 @@
   {
     "agency_id": "f296d328-075e-5fe0-8045-7ac2872648d8",
     "slug": "village-of-clearview-wv-pd",
-    "flock_active_slug": "village-of-clearview-wv-pd",
-    "flock_slugs": [
-      "village-of-clearview-wv-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village of Clearview WV PD"
     ],
@@ -65880,10 +61360,8 @@
   {
     "agency_id": "f9272fdb-537b-58f1-84b8-a211acf3998b",
     "slug": "walton-county-fl-so",
-    "flock_active_slug": "walton-county-fl-so",
-    "flock_slugs": [
-      "walton-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walton County FL SO"
     ],
@@ -65907,10 +61385,8 @@
   {
     "agency_id": "b1e9acd4-b9dc-54b3-9f4d-03a436d20cd6",
     "slug": "wapello-county-ia-so",
-    "flock_active_slug": "wapello-county-ia-so",
-    "flock_slugs": [
-      "wapello-county-ia-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wapello County IA SO"
     ],
@@ -65934,10 +61410,8 @@
   {
     "agency_id": "8721c793-b000-54e3-94ad-fb65d9f80c27",
     "slug": "warr-acres-ok-pd",
-    "flock_active_slug": "warr-acres-ok-pd",
-    "flock_slugs": [
-      "warr-acres-ok-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Warr Acres OK PD"
     ],
@@ -65961,10 +61435,8 @@
   {
     "agency_id": "bcc7a679-5503-5914-b325-8d6e9c54faa3",
     "slug": "washington-county-wi-so",
-    "flock_active_slug": "washington-county-wi-so",
-    "flock_slugs": [
-      "washington-county-wi-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washington County WI SO"
     ],
@@ -65988,10 +61460,8 @@
   {
     "agency_id": "4fae62ee-baa7-59b4-8174-aa5c82014015",
     "slug": "waxhaw-nc-pd",
-    "flock_active_slug": "waxhaw-nc-pd",
-    "flock_slugs": [
-      "waxhaw-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waxhaw NC PD"
     ],
@@ -66015,10 +61485,8 @@
   {
     "agency_id": "1a65f6ec-2755-5504-891b-d0f1bc8f3b93",
     "slug": "west-chester-oh-pd",
-    "flock_active_slug": "west-chester-oh-pd",
-    "flock_slugs": [
-      "west-chester-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Chester OH PD"
     ],
@@ -66042,10 +61510,8 @@
   {
     "agency_id": "a2967196-292a-5c73-acbd-800246914b57",
     "slug": "west-des-moines-ia-pd",
-    "flock_active_slug": "west-des-moines-ia-pd",
-    "flock_slugs": [
-      "west-des-moines-ia-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Des Moines IA PD"
     ],
@@ -66069,10 +61535,8 @@
   {
     "agency_id": "ff6a7fb4-eb0d-5bf1-b21b-9e8d48bccc5b",
     "slug": "west-springfield-ma-pd",
-    "flock_active_slug": "west-springfield-ma-pd",
-    "flock_slugs": [
-      "west-springfield-ma-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Springfield MA PD"
     ],
@@ -66096,10 +61560,8 @@
   {
     "agency_id": "06e6404d-739b-58cf-90d2-ddb1d702b8f1",
     "slug": "west-terre-haute-in-pd",
-    "flock_active_slug": "west-terre-haute-in-pd",
-    "flock_slugs": [
-      "west-terre-haute-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Terre Haute IN PD"
     ],
@@ -66123,10 +61585,8 @@
   {
     "agency_id": "b3fc1634-7746-5bd2-9b16-ae5d183c1048",
     "slug": "westminster-co-pd",
-    "flock_active_slug": "westminster-co-pd",
-    "flock_slugs": [
-      "westminster-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westminster CO PD"
     ],
@@ -66150,10 +61610,8 @@
   {
     "agency_id": "d86039c6-93d0-55fd-acd1-b4af855ffd27",
     "slug": "westworth-village-tx-pd",
-    "flock_active_slug": "westworth-village-tx-pd",
-    "flock_slugs": [
-      "westworth-village-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westworth Village TX PD"
     ],
@@ -66177,10 +61635,8 @@
   {
     "agency_id": "b50c68c1-cb1a-5994-9830-ff47fdf1ba1d",
     "slug": "wichita-ks-pd",
-    "flock_active_slug": "wichita-ks-pd",
-    "flock_slugs": [
-      "wichita-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wichita KS PD"
     ],
@@ -66204,10 +61660,8 @@
   {
     "agency_id": "72234afa-40cd-58d8-95bd-5f8faefa62a9",
     "slug": "willow-springs-il-pd",
-    "flock_active_slug": "willow-springs-il-pd",
-    "flock_slugs": [
-      "willow-springs-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Willow Springs IL PD"
     ],
@@ -66231,10 +61685,8 @@
   {
     "agency_id": "8503b239-ea18-5394-978d-71171e8ec104",
     "slug": "wilson-county-tx-so",
-    "flock_active_slug": "wilson-county-tx-so",
-    "flock_slugs": [
-      "wilson-county-tx-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wilson County TX SO"
     ],
@@ -66258,10 +61710,8 @@
   {
     "agency_id": "830d6172-7ff5-5c0a-9a31-4c3ae6a1417f",
     "slug": "windcrest-tx-pd",
-    "flock_active_slug": "windcrest-tx-pd",
-    "flock_slugs": [
-      "windcrest-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Windcrest TX PD"
     ],
@@ -66285,10 +61735,8 @@
   {
     "agency_id": "3af6dfa2-a6a9-5a4c-bcf4-c37f8829761c",
     "slug": "windsor-co-pd",
-    "flock_active_slug": "windsor-co-pd",
-    "flock_slugs": [
-      "windsor-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Windsor CO PD"
     ],
@@ -66312,10 +61760,8 @@
   {
     "agency_id": "a46e3da3-334c-58c5-a375-e13337e294a5",
     "slug": "winston-or-pd",
-    "flock_active_slug": "winston-or-pd",
-    "flock_slugs": [
-      "winston-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winston OR PD"
     ],
@@ -66339,10 +61785,8 @@
   {
     "agency_id": "5e4c9052-7c61-5186-96b8-950eee342c09",
     "slug": "woodbury-county-ia-so",
-    "flock_active_slug": "woodbury-county-ia-so",
-    "flock_slugs": [
-      "woodbury-county-ia-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodbury County IA SO"
     ],
@@ -66366,10 +61810,8 @@
   {
     "agency_id": "bdd1fcb4-f5a5-5515-8ab5-84e405da3600",
     "slug": "woodson-terrace-mo-pd",
-    "flock_active_slug": "woodson-terrace-mo-pd",
-    "flock_slugs": [
-      "woodson-terrace-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodson Terrace MO PD"
     ],
@@ -66393,10 +61835,8 @@
   {
     "agency_id": "dcfd9f8b-f9d7-5c37-ac54-c064a3e7fa6b",
     "slug": "woodstock-ga-pd",
-    "flock_active_slug": "woodstock-ga-pd",
-    "flock_slugs": [
-      "woodstock-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodstock GA PD"
     ],
@@ -66420,10 +61860,8 @@
   {
     "agency_id": "478d2789-c464-5914-8616-62e6ed2b3d1a",
     "slug": "wyoming-oh-pd",
-    "flock_active_slug": "wyoming-oh-pd",
-    "flock_slugs": [
-      "wyoming-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wyoming OH PD"
     ],
@@ -66447,10 +61885,8 @@
   {
     "agency_id": "5c703ef7-9b84-562a-8b8c-b4011feb6be7",
     "slug": "yakima-county-wa-so",
-    "flock_active_slug": "yakima-county-wa-so",
-    "flock_slugs": [
-      "yakima-county-wa-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yakima County WA SO"
     ],
@@ -66474,10 +61910,8 @@
   {
     "agency_id": "83b05b01-74fd-5e6d-9188-816a601a64dd",
     "slug": "yakima-wa-pd",
-    "flock_active_slug": "yakima-wa-pd",
-    "flock_slugs": [
-      "yakima-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yakima WA PD"
     ],
@@ -66501,10 +61935,8 @@
   {
     "agency_id": "b9d375c7-250d-5c0c-8430-a04fc2f3f654",
     "slug": "yancey-county-nc-so",
-    "flock_active_slug": "yancey-county-nc-so",
-    "flock_slugs": [
-      "yancey-county-nc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yancey County NC SO"
     ],
@@ -66528,10 +61960,8 @@
   {
     "agency_id": "b16e9798-9240-5823-a48c-cb630bd4c84a",
     "slug": "york-county-va-so",
-    "flock_active_slug": "york-county-va-so",
-    "flock_slugs": [
-      "york-county-va-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "York County VA SO"
     ],
@@ -66555,10 +61985,8 @@
   {
     "agency_id": "b07531d3-82c2-5a47-8e26-110ed4fc9242",
     "slug": "1800-block-s-orange-grove-ca",
-    "flock_active_slug": "1800-block-s-orange-grove-ca",
-    "flock_slugs": [
-      "1800-block-s-orange-grove-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "1800 Block S Orange Grove (CA)"
     ],
@@ -66578,10 +62006,8 @@
   {
     "agency_id": "2f6226a0-476b-51a7-85e3-bbf9cb76d96f",
     "slug": "18th-judicial-district-das-office-la-pd",
-    "flock_active_slug": "18th-judicial-district-das-office-la-pd",
-    "flock_slugs": [
-      "18th-judicial-district-das-office-la-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "18th Judicial District DA's Office- LA PD"
     ],
@@ -66603,10 +62029,8 @@
   {
     "agency_id": "85858ce8-5bbc-5b4f-8017-daf6107c7e28",
     "slug": "acratt-ca",
-    "flock_active_slug": "acratt-ca",
-    "flock_slugs": [
-      "acratt-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "ACRATT -CA"
     ],
@@ -66629,10 +62053,8 @@
   {
     "agency_id": "b572cf3e-7b46-57aa-a337-b438e3e62603",
     "slug": "adrian-mi-pd",
-    "flock_active_slug": "adrian-mi-pd",
-    "flock_slugs": [
-      "adrian-mi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Adrian MI PD"
     ],
@@ -66656,10 +62078,8 @@
   {
     "agency_id": "2f63da87-2936-5f56-8ad8-bdb9c3a0ba35",
     "slug": "akron-oh-pd",
-    "flock_active_slug": "akron-oh-pd",
-    "flock_slugs": [
-      "akron-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Akron OH PD"
     ],
@@ -66683,10 +62103,8 @@
   {
     "agency_id": "76c0abef-bb08-5240-a02b-e29b90ce3da1",
     "slug": "alcoa-tn-pd",
-    "flock_active_slug": "alcoa-tn-pd",
-    "flock_slugs": [
-      "alcoa-tn-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alcoa TN PD"
     ],
@@ -66710,10 +62128,8 @@
   {
     "agency_id": "cc269287-49ca-5831-af72-f6dacf356bd1",
     "slug": "alhambra-ca-pd",
-    "flock_active_slug": "alhambra-ca-pd",
-    "flock_slugs": [
-      "alhambra-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alhambra CA PD"
     ],
@@ -66737,10 +62153,8 @@
   {
     "agency_id": "73377a5f-3576-5463-a159-a8f5023d1e09",
     "slug": "alhambra-courtyard-shopping-center-alhambra-ca",
-    "flock_active_slug": "alhambra-courtyard-shopping-center-alhambra-ca",
-    "flock_slugs": [
-      "alhambra-courtyard-shopping-center-alhambra-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alhambra Courtyard Shopping Center- Alhambra (CA)"
     ],
@@ -66760,10 +62174,8 @@
   {
     "agency_id": "01f7379e-355c-5c9e-b078-d0b4fd9c69a8",
     "slug": "alpine-county-ca-so",
-    "flock_active_slug": "alpine-county-ca-so",
-    "flock_slugs": [
-      "alpine-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Alpine County CA SO"
     ],
@@ -66787,10 +62199,8 @@
   {
     "agency_id": "7f21a88e-2c0f-53d5-b5e3-22920a3f9872",
     "slug": "amador-county-ca-sheriffs-office",
-    "flock_active_slug": "amador-county-ca-sheriffs-office",
-    "flock_slugs": [
-      "amador-county-ca-sheriffs-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Amador County CA Sheriff's Office"
     ],
@@ -66814,10 +62224,8 @@
   {
     "agency_id": "8f77bd22-c4a3-5d91-9b83-0be357c7d7ec",
     "slug": "american-canyon-ca-pd",
-    "flock_active_slug": "american-canyon-ca-pd",
-    "flock_slugs": [
-      "american-canyon-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "American Canyon CA PD"
     ],
@@ -66841,10 +62249,8 @@
   {
     "agency_id": "5ef4b958-39f6-55aa-8339-2c655f10df3a",
     "slug": "ampm-beaumont-pd",
-    "flock_active_slug": "ampm-beaumont-pd",
-    "flock_slugs": [
-      "ampm-beaumont-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "AMPM - Beaumont PD"
     ],
@@ -66866,10 +62272,8 @@
   {
     "agency_id": "8754d3fd-a97d-5f59-acf3-7e33328b8792",
     "slug": "anaheim-ca-pd",
-    "flock_active_slug": "anaheim-ca-pd",
-    "flock_slugs": [
-      "anaheim-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anaheim CA PD"
     ],
@@ -66893,10 +62297,8 @@
   {
     "agency_id": "6fc47404-6f79-5f5d-ace0-18db02bc2391",
     "slug": "anderson-ca-pd",
-    "flock_active_slug": "anderson-ca-pd",
-    "flock_slugs": [
-      "anderson-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anderson CA PD"
     ],
@@ -66920,10 +62322,8 @@
   {
     "agency_id": "c03e0e31-0b46-538a-a399-1575a4b43204",
     "slug": "anderson-in-pd",
-    "flock_active_slug": "anderson-in-pd",
-    "flock_slugs": [
-      "anderson-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Anderson IN PD"
     ],
@@ -66947,10 +62347,8 @@
   {
     "agency_id": "adffbade-4d93-5a53-b1d6-c83d987b42e0",
     "slug": "angels-camp-ca-pd",
-    "flock_active_slug": "angels-camp-ca-pd",
-    "flock_slugs": [
-      "angels-camp-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Angels Camp CA PD"
     ],
@@ -66974,10 +62372,8 @@
   {
     "agency_id": "f4a21139-b8d6-5bed-959f-5a847ba09031",
     "slug": "arcadia-ca-pd",
-    "flock_active_slug": "arcadia-ca-pd",
-    "flock_slugs": [
-      "arcadia-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arcadia CA PD"
     ],
@@ -67001,10 +62397,8 @@
   {
     "agency_id": "89d05f4a-5f01-591a-b241-44223d0c216e",
     "slug": "arvin-ca-pd",
-    "flock_active_slug": "arvin-ca-pd",
-    "flock_slugs": [
-      "arvin-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Arvin CA PD"
     ],
@@ -67028,10 +62422,8 @@
   {
     "agency_id": "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c",
     "slug": "atwater-ca-pd",
-    "flock_active_slug": "atwater-ca-pd",
-    "flock_slugs": [
-      "atwater-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Atwater CA PD"
     ],
@@ -67055,10 +62447,8 @@
   {
     "agency_id": "d30c1555-ff35-55be-8226-4d5f62612e97",
     "slug": "avenal-ca-pd",
-    "flock_active_slug": "avenal-ca-pd",
-    "flock_slugs": [
-      "avenal-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avenal CA PD"
     ],
@@ -67082,10 +62472,8 @@
   {
     "agency_id": "cc02337b-23cf-5d95-864c-9b484c316d8c",
     "slug": "avon-in-pd",
-    "flock_active_slug": "avon-in-pd",
-    "flock_slugs": [
-      "avon-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Avon IN PD"
     ],
@@ -67109,10 +62497,8 @@
   {
     "agency_id": "2ae777d7-191d-5d9d-8740-e0b8dd82c4f8",
     "slug": "azusa-ca-pd",
-    "flock_active_slug": "azusa-ca-pd",
-    "flock_slugs": [
-      "azusa-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Azusa CA PD"
     ],
@@ -67136,10 +62522,8 @@
   {
     "agency_id": "35a898a6-482d-59e5-b592-2882674a68b4",
     "slug": "baldwin-county-ga-so",
-    "flock_active_slug": "baldwin-county-ga-so",
-    "flock_slugs": [
-      "baldwin-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Baldwin County GA SO"
     ],
@@ -67163,10 +62547,8 @@
   {
     "agency_id": "10e1a69f-8089-5a30-aa8b-d29302c691fc",
     "slug": "baytown-tx-pd",
-    "flock_active_slug": "baytown-tx-pd",
-    "flock_slugs": [
-      "baytown-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Baytown TX PD"
     ],
@@ -67190,10 +62572,8 @@
   {
     "agency_id": "7810622c-5cfd-5d8c-922a-9acd7e2ea391",
     "slug": "bear-valley-springs-ca-pd",
-    "flock_active_slug": "bear-valley-springs-ca-pd",
-    "flock_slugs": [
-      "bear-valley-springs-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bear Valley Springs CA PD"
     ],
@@ -67217,10 +62597,8 @@
   {
     "agency_id": "9e264173-f667-546e-afaf-544b5fa70371",
     "slug": "bel-air-hills-ca",
-    "flock_active_slug": "bel-air-hills-ca",
-    "flock_slugs": [
-      "bel-air-hills-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bel Air Hills (CA)"
     ],
@@ -67240,10 +62618,8 @@
   {
     "agency_id": "c36a31e6-7415-5c5d-95fe-729510df1066",
     "slug": "beverly-hills-unified-school-district-ca",
-    "flock_active_slug": "beverly-hills-unified-school-district-ca",
-    "flock_slugs": [
-      "beverly-hills-unified-school-district-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Beverly Hills Unified School District CA"
     ],
@@ -67263,10 +62639,8 @@
   {
     "agency_id": "ef0c3682-0153-527c-a973-0bb7b07056be",
     "slug": "bishop-ca-pd",
-    "flock_active_slug": "bishop-ca-pd",
-    "flock_slugs": [
-      "bishop-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bishop CA PD"
     ],
@@ -67290,10 +62664,8 @@
   {
     "agency_id": "d7c14d6d-c9ac-53b5-a108-f6101da72139",
     "slug": "blackmanleoni-public-safety-mi",
-    "flock_active_slug": "blackmanleoni-public-safety-mi",
-    "flock_slugs": [
-      "blackmanleoni-public-safety-mi"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blackman/Leoni Public Safety MI"
     ],
@@ -67315,10 +62687,8 @@
   {
     "agency_id": "c649eb74-6ffa-5be7-96b5-a08458128a6d",
     "slug": "bloomfield-nm-pd",
-    "flock_active_slug": "bloomfield-nm-pd",
-    "flock_slugs": [
-      "bloomfield-nm-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Bloomfield NM PD"
     ],
@@ -67342,10 +62712,8 @@
   {
     "agency_id": "39054b43-7c24-5b8f-a4ca-266e742af0d4",
     "slug": "blue-lake-rancheria-tribal-pd",
-    "flock_active_slug": "blue-lake-rancheria-tribal-pd",
-    "flock_slugs": [
-      "blue-lake-rancheria-tribal-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blue Lake Rancheria Tribal PD"
     ],
@@ -67367,10 +62735,8 @@
   {
     "agency_id": "ca169c85-b556-58a0-a0bc-988c09bc6d01",
     "slug": "blythe-ca-pd",
-    "flock_active_slug": "blythe-ca-pd",
-    "flock_slugs": [
-      "blythe-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Blythe CA PD"
     ],
@@ -67394,10 +62760,8 @@
   {
     "agency_id": "9bf26a51-28bf-519a-a823-3bc3df220f57",
     "slug": "brea-ca-pd",
-    "flock_active_slug": "brea-ca-pd",
-    "flock_slugs": [
-      "brea-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brea CA PD"
     ],
@@ -67421,10 +62785,8 @@
   {
     "agency_id": "de913a80-ceee-5eef-a74c-0093e8dcc033",
     "slug": "brentwood-ca-pd",
-    "flock_active_slug": "brentwood-ca-pd",
-    "flock_slugs": [
-      "brentwood-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brentwood CA PD"
     ],
@@ -67448,10 +62810,8 @@
   {
     "agency_id": "82b7d6b0-9096-560a-ad40-1a6ac8b928ce",
     "slug": "brookhaven-circle-ca",
-    "flock_active_slug": "brookhaven-circle-ca",
-    "flock_slugs": [
-      "brookhaven-circle-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Brookhaven Circle (CA)"
     ],
@@ -67471,10 +62831,8 @@
   {
     "agency_id": "d890fe3d-dbc9-56dc-9360-d977a774f0a5",
     "slug": "burbank-airport-ca-pd",
-    "flock_active_slug": "burbank-airport-ca-pd",
-    "flock_slugs": [
-      "burbank-airport-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burbank Airport CA PD"
     ],
@@ -67497,10 +62855,8 @@
   {
     "agency_id": "f4073ba9-2a85-50ab-82d6-1800ff5491c6",
     "slug": "burlingame-ca-pd",
-    "flock_active_slug": "burlingame-ca-pd",
-    "flock_slugs": [
-      "burlingame-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Burlingame CA PD"
     ],
@@ -67524,10 +62880,8 @@
   {
     "agency_id": "9f6b9744-828d-5dce-9160-54e355b51c4d",
     "slug": "ca-iipay-nation-of-santa-ysabel",
-    "flock_active_slug": "ca-iipay-nation-of-santa-ysabel",
-    "flock_slugs": [
-      "ca-iipay-nation-of-santa-ysabel"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CA Iipay Nation of Santa Ysabel"
     ],
@@ -67549,10 +62903,8 @@
   {
     "agency_id": "fc2484a4-1d34-59da-a19c-7287c6145501",
     "slug": "ca-newport-beach-country-club",
-    "flock_active_slug": "ca-newport-beach-country-club",
-    "flock_slugs": [
-      "ca-newport-beach-country-club"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CA- Newport Beach Country Club"
     ],
@@ -67572,10 +62924,8 @@
   {
     "agency_id": "12ebc7de-4d60-5ae0-adc4-dc634c1b344c",
     "slug": "ca-topgolf-usa-el-segundo",
-    "flock_active_slug": "ca-topgolf-usa-el-segundo",
-    "flock_slugs": [
-      "ca-topgolf-usa-el-segundo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CA - Topgolf USA El Segundo"
     ],
@@ -67595,10 +62945,8 @@
   {
     "agency_id": "ec0349b0-2d81-546b-acf9-ded505a551a7",
     "slug": "ca-wasco-pd",
-    "flock_active_slug": "ca-wasco-pd",
-    "flock_slugs": [
-      "ca-wasco-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CA - Wasco PD"
     ],
@@ -67622,10 +62970,8 @@
   {
     "agency_id": "3723f745-0b10-5d08-a5f2-750990665097",
     "slug": "cabana-isle-ca",
-    "flock_active_slug": "cabana-isle-ca",
-    "flock_slugs": [
-      "cabana-isle-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cabana Isle (CA)"
     ],
@@ -67645,10 +62991,8 @@
   {
     "agency_id": "338dc553-eb17-59c2-8ec8-2c1d6033907b",
     "slug": "cahuilla-tribal-gaming-agency-ca-rcsd",
-    "flock_active_slug": "cahuilla-tribal-gaming-agency-ca-rcsd",
-    "flock_slugs": [
-      "cahuilla-tribal-gaming-agency-ca-rcsd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cahuilla Tribal Gaming Agency CA - RCSD"
     ],
@@ -67670,10 +63014,8 @@
   {
     "agency_id": "eef11480-824c-5b76-9049-541470c862b1",
     "slug": "cal-fire",
-    "flock_active_slug": "cal-fire",
-    "flock_slugs": [
-      "cal-fire"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cal Fire"
     ],
@@ -67695,10 +63037,8 @@
   {
     "agency_id": "46022a7f-7efe-5f30-9695-ef9a6c9f2093",
     "slug": "cal-state-fullerton-ca",
-    "flock_active_slug": "cal-state-fullerton-ca",
-    "flock_slugs": [
-      "cal-state-fullerton-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cal State Fullerton (CA)"
     ],
@@ -67720,10 +63060,8 @@
   {
     "agency_id": "589597b2-0d45-5add-ac97-bf6a042fceae",
     "slug": "cal-state-san-bernadino-ca-pd",
-    "flock_active_slug": "cal-state-san-bernadino-ca-pd",
-    "flock_slugs": [
-      "cal-state-san-bernadino-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cal State San Bernadino CA PD"
     ],
@@ -67745,10 +63083,8 @@
   {
     "agency_id": "69489e25-1027-5396-86a7-c68d5111eecd",
     "slug": "calexico-ca-pd",
-    "flock_active_slug": "calexico-ca-pd",
-    "flock_slugs": [
-      "calexico-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calexico CA PD"
     ],
@@ -67772,10 +63108,8 @@
   {
     "agency_id": "6ef44a20-6901-53fd-b690-edd487d115d3",
     "slug": "calhoun-county-al-so",
-    "flock_active_slug": "calhoun-county-al-so",
-    "flock_slugs": [
-      "calhoun-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calhoun County AL SO"
     ],
@@ -67799,10 +63133,8 @@
   {
     "agency_id": "8a88be54-e69a-5e38-88f2-02bc79b89ebe",
     "slug": "california-city-pd-ca",
-    "flock_active_slug": "california-city-pd-ca",
-    "flock_slugs": [
-      "california-city-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California City PD CA"
     ],
@@ -67826,10 +63158,8 @@
   {
     "agency_id": "98a2b052-2421-5f90-a95c-88c85615e128",
     "slug": "california-department-of-corrections",
-    "flock_active_slug": "california-department-of-corrections",
-    "flock_slugs": [
-      "california-department-of-corrections"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California Department of Corrections"
     ],
@@ -67851,10 +63181,8 @@
   {
     "agency_id": "a0b27d09-cfa7-5b41-be70-1ecafb6dd3d5",
     "slug": "california-department-of-fish-wildlife-ca",
-    "flock_active_slug": "california-department-of-fish-wildlife-ca",
-    "flock_slugs": [
-      "california-department-of-fish-wildlife-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California Department of Fish & Wildlife (CA)"
     ],
@@ -67876,10 +63204,8 @@
   {
     "agency_id": "2549113a-a3d1-5d5c-9a3c-98fe21f27b17",
     "slug": "california-department-of-insurance-fraud",
-    "flock_active_slug": "california-department-of-insurance-fraud",
-    "flock_slugs": [
-      "california-department-of-insurance-fraud"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California Department of Insurance Fraud"
     ],
@@ -67902,10 +63228,8 @@
   {
     "agency_id": "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5",
     "slug": "california-highway-patrol",
-    "flock_active_slug": "california-highway-patrol",
-    "flock_slugs": [
-      "california-highway-patrol"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California Highway Patrol"
     ],
@@ -67930,10 +63254,8 @@
   {
     "agency_id": "12c4f64a-7e32-56ec-b95d-b0645a5d1a4b",
     "slug": "california-state-parks",
-    "flock_active_slug": "california-state-parks",
-    "flock_slugs": [
-      "california-state-parks"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California State Parks"
     ],
@@ -67955,10 +63277,8 @@
   {
     "agency_id": "9079f9e0-e3c2-5611-8f09-a0276b7911f8",
     "slug": "california-state-university-long-beach-campus-pd",
-    "flock_active_slug": "california-state-university-long-beach-campus-pd",
-    "flock_slugs": [
-      "california-state-university-long-beach-campus-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "California State University Long Beach Campus PD"
     ],
@@ -67981,10 +63301,8 @@
   {
     "agency_id": "752f6cb4-d099-5d28-b6eb-ebdaaa0f3000",
     "slug": "calle-roberto-west-ca",
-    "flock_active_slug": "calle-roberto-west-ca",
-    "flock_slugs": [
-      "calle-roberto-west-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Calle Roberto West (CA)"
     ],
@@ -68004,10 +63322,8 @@
   {
     "agency_id": "11780c28-0850-5ff1-807d-a472190781c7",
     "slug": "carson-city-nv-so",
-    "flock_active_slug": "carson-city-nv-so",
-    "flock_slugs": [
-      "carson-city-nv-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Carson City NV SO"
     ],
@@ -68031,10 +63347,8 @@
   {
     "agency_id": "9ac8088b-6a6c-550e-92ef-6b9e90470c4c",
     "slug": "central-marin-ca-pd",
-    "flock_active_slug": "central-marin-ca-pd",
-    "flock_slugs": [
-      "central-marin-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Central Marin CA PD"
     ],
@@ -68056,10 +63370,8 @@
   {
     "agency_id": "a76f1a12-ea0c-5138-9c77-57a4e6b510ca",
     "slug": "cerritos-college-ca-pd",
-    "flock_active_slug": "cerritos-college-ca-pd",
-    "flock_slugs": [
-      "cerritos-college-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cerritos College CA PD"
     ],
@@ -68082,10 +63394,8 @@
   {
     "agency_id": "3fc7d46a-3f58-5638-a86a-182bbaf116b4",
     "slug": "chabot-college-campus-safety-security-department-ca",
-    "flock_active_slug": "chabot-college-campus-safety-security-department-ca",
-    "flock_slugs": [
-      "chabot-college-campus-safety-security-department-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chabot College Campus Safety & Security Department CA"
     ],
@@ -68108,10 +63418,8 @@
   {
     "agency_id": "3dbed6a1-dadc-5951-b32d-32d3f816d17d",
     "slug": "chaffey-college-pd-ca",
-    "flock_active_slug": "chaffey-college-pd-ca",
-    "flock_slugs": [
-      "chaffey-college-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chaffey College PD (CA)"
     ],
@@ -68134,10 +63442,8 @@
   {
     "agency_id": "1430e4e5-d018-50ab-9b4a-d347c319e73e",
     "slug": "chambers-county-al-so",
-    "flock_active_slug": "chambers-county-al-so",
-    "flock_slugs": [
-      "chambers-county-al-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chambers County AL SO"
     ],
@@ -68161,10 +63467,8 @@
   {
     "agency_id": "fae06461-0698-548b-ad4e-a8e2b5d8539a",
     "slug": "chino-ca-pd",
-    "flock_active_slug": "chino-ca-pd",
-    "flock_slugs": [
-      "chino-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chino CA PD"
     ],
@@ -68188,10 +63492,8 @@
   {
     "agency_id": "ad2a4cd9-a2df-50b6-9c64-348bfa3b8caf",
     "slug": "chino-valley-az-pd",
-    "flock_active_slug": "chino-valley-az-pd",
-    "flock_slugs": [
-      "chino-valley-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Chino Valley AZ PD"
     ],
@@ -68215,10 +63517,8 @@
   {
     "agency_id": "3aad45fc-4bb4-56da-907c-f2a82be406df",
     "slug": "city-of-half-moon-bay",
-    "flock_active_slug": "city-of-half-moon-bay",
-    "flock_slugs": [
-      "city-of-half-moon-bay"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Half Moon Bay (SMCSO)"
     ],
@@ -68242,10 +63542,8 @@
   {
     "agency_id": "5610e604-ad2c-5626-8287-33433f9c275f",
     "slug": "city-of-newman-ca-pd",
-    "flock_active_slug": "city-of-newman-ca-pd",
-    "flock_slugs": [
-      "city-of-newman-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Newman CA PD"
     ],
@@ -68269,10 +63567,8 @@
   {
     "agency_id": "76cb73e9-49c4-5198-bf3e-a1c921e65231",
     "slug": "city-of-riverside-ca-pd",
-    "flock_active_slug": "city-of-riverside-ca-pd",
-    "flock_slugs": [
-      "city-of-riverside-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Riverside CA PD"
     ],
@@ -68296,10 +63592,8 @@
   {
     "agency_id": "2e8cee09-5590-5153-ab05-16a4c38f3959",
     "slug": "city-of-vallejo-ca",
-    "flock_active_slug": "city-of-vallejo-ca",
-    "flock_slugs": [
-      "city-of-vallejo-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "City of Vallejo (CA)"
     ],
@@ -68323,10 +63617,8 @@
   {
     "agency_id": "46f81c72-6a0c-559e-8e04-d696181aaa0e",
     "slug": "cjm-ron",
-    "flock_active_slug": "cjm-ron",
-    "flock_slugs": [
-      "cjm-ron"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CJM - Ron"
     ],
@@ -68342,10 +63634,8 @@
   {
     "agency_id": "3ccb7773-cd90-5c79-a676-eacfceed3115",
     "slug": "claremont-ca-pd",
-    "flock_active_slug": "claremont-ca-pd",
-    "flock_slugs": [
-      "claremont-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Claremont CA PD"
     ],
@@ -68369,10 +63659,8 @@
   {
     "agency_id": "b300fbd0-6bd8-5d1c-a943-0f0bcf55edc5",
     "slug": "class-acts-autobody-ca",
-    "flock_active_slug": "class-acts-autobody-ca",
-    "flock_slugs": [
-      "class-acts-autobody-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Class Acts Autobody (CA)"
     ],
@@ -68392,10 +63680,8 @@
   {
     "agency_id": "a21104f6-63a3-5730-8f5a-6a6801bb0e80",
     "slug": "clayton-ca-pd",
-    "flock_active_slug": "clayton-ca-pd",
-    "flock_slugs": [
-      "clayton-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clayton CA PD"
     ],
@@ -68419,10 +63705,8 @@
   {
     "agency_id": "15ef1d17-dfba-5844-9ce8-da8c2d9861f9",
     "slug": "clearwater-fl-pd",
-    "flock_active_slug": "clearwater-fl-pd",
-    "flock_slugs": [
-      "clearwater-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Clearwater FL PD"
     ],
@@ -68446,10 +63730,8 @@
   {
     "agency_id": "a24c4de9-ca70-5829-838e-12907c88c3a9",
     "slug": "cloverdale-ca-pd",
-    "flock_active_slug": "cloverdale-ca-pd",
-    "flock_slugs": [
-      "cloverdale-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cloverdale CA PD"
     ],
@@ -68473,10 +63755,8 @@
   {
     "agency_id": "6b9004ff-75a7-54a3-bff6-2095bb998de4",
     "slug": "coalinga-ca-pd",
-    "flock_active_slug": "coalinga-ca-pd",
-    "flock_slugs": [
-      "coalinga-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Coalinga CA PD"
     ],
@@ -68500,10 +63780,8 @@
   {
     "agency_id": "96ab8fbc-f76a-5cc0-8a9f-05dd6a836de8",
     "slug": "cobb-county-ga-pd",
-    "flock_active_slug": "cobb-county-ga-pd",
-    "flock_slugs": [
-      "cobb-county-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cobb County GA PD"
     ],
@@ -68527,10 +63805,8 @@
   {
     "agency_id": "ffa6dcd8-0e87-59a0-b27b-015382b55620",
     "slug": "collier-county-fl-so",
-    "flock_active_slug": "collier-county-fl-so",
-    "flock_slugs": [
-      "collier-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Collier County FL SO"
     ],
@@ -68554,10 +63830,8 @@
   {
     "agency_id": "7eb81cc8-f526-5959-9321-4f4ccb6c7b5c",
     "slug": "colton-ca-pd",
-    "flock_active_slug": "colton-ca-pd",
-    "flock_slugs": [
-      "colton-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colton CA PD"
     ],
@@ -68581,10 +63855,8 @@
   {
     "agency_id": "b0282cab-63a4-5000-be9e-b444def1f5fd",
     "slug": "colusa-ca-pd",
-    "flock_active_slug": "colusa-ca-pd",
-    "flock_slugs": [
-      "colusa-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Colusa CA PD"
     ],
@@ -68608,10 +63880,8 @@
   {
     "agency_id": "270aae46-f0d1-558e-bb3f-249d03b0510f",
     "slug": "concord-ca-pd",
-    "flock_active_slug": "concord-ca-pd",
-    "flock_slugs": [
-      "concord-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Concord CA PD"
     ],
@@ -68635,10 +63905,8 @@
   {
     "agency_id": "4e876f28-fcca-5c87-9e65-f0730980ea1d",
     "slug": "corcoran-ca-pd",
-    "flock_active_slug": "corcoran-ca-pd",
-    "flock_slugs": [
-      "corcoran-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Corcoran CA PD"
     ],
@@ -68662,10 +63930,8 @@
   {
     "agency_id": "4e67c5a9-b324-5d8a-a880-1c7ecc0cd846",
     "slug": "cornerstone-community-school-ca",
-    "flock_active_slug": "cornerstone-community-school-ca",
-    "flock_slugs": [
-      "cornerstone-community-school-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cornerstone Community School (CA)"
     ],
@@ -68688,10 +63954,8 @@
   {
     "agency_id": "66a4b49e-c138-5a25-9eff-3e28388407f5",
     "slug": "corona-ca-pd",
-    "flock_active_slug": "corona-ca-pd",
-    "flock_slugs": [
-      "corona-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Corona CA PD"
     ],
@@ -68715,10 +63979,8 @@
   {
     "agency_id": "d6c5ad02-cd10-5b27-b307-f1ecce74374f",
     "slug": "cotati-ca-pd",
-    "flock_active_slug": "cotati-ca-pd",
-    "flock_slugs": [
-      "cotati-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cotati CA PD"
     ],
@@ -68742,10 +64004,8 @@
   {
     "agency_id": "462eac38-7949-59ba-af6f-913445b1b334",
     "slug": "country-club-vista-ca",
-    "flock_active_slug": "country-club-vista-ca",
-    "flock_slugs": [
-      "country-club-vista-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Country Club Vista (CA)"
     ],
@@ -68765,10 +64025,8 @@
   {
     "agency_id": "7b25055d-119d-5a60-b457-2ee42f56dd20",
     "slug": "country-rose-ca",
-    "flock_active_slug": "country-rose-ca",
-    "flock_slugs": [
-      "country-rose-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Country Rose (CA)"
     ],
@@ -68788,10 +64046,8 @@
   {
     "agency_id": "1ff2d645-29d6-505b-bca1-271ddb4973ee",
     "slug": "covina-ca-pd",
-    "flock_active_slug": "covina-ca-pd",
-    "flock_slugs": [
-      "covina-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Covina CA PD"
     ],
@@ -68815,10 +64071,8 @@
   {
     "agency_id": "cc1000e2-0754-5577-95b3-76649924222d",
     "slug": "csu-long-beach-pd-ca",
-    "flock_active_slug": "csu-long-beach-pd-ca",
-    "flock_slugs": [
-      "csu-long-beach-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "CSU Long Beach PD (CA)"
     ],
@@ -68840,10 +64094,8 @@
   {
     "agency_id": "011d335d-6066-5c83-bc1c-2b6c3fb6a9c3",
     "slug": "cuyahoga-falls-oh-pd",
-    "flock_active_slug": "cuyahoga-falls-oh-pd",
-    "flock_slugs": [
-      "cuyahoga-falls-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cuyahoga Falls OH PD"
     ],
@@ -68867,10 +64119,8 @@
   {
     "agency_id": "5077b862-25fa-52a7-9ead-bb712a54b7af",
     "slug": "cypress-ca-pd",
-    "flock_active_slug": "cypress-ca-pd",
-    "flock_slugs": [
-      "cypress-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Cypress CA PD"
     ],
@@ -68894,10 +64144,8 @@
   {
     "agency_id": "34b09634-c949-542c-90ce-e790b877570d",
     "slug": "daly-city-ca-pd",
-    "flock_active_slug": "daly-city-ca-pd",
-    "flock_slugs": [
-      "daly-city-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Daly City CA PD"
     ],
@@ -68921,10 +64169,8 @@
   {
     "agency_id": "da6219bf-6886-513d-9175-e366f2ee23b5",
     "slug": "deactivated",
-    "flock_active_slug": "deactivated",
-    "flock_slugs": [
-      "deactivated"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "deactivated"
     ],
@@ -68940,10 +64186,8 @@
   {
     "agency_id": "4d52aa1d-f8c9-5b7f-91b5-36999d2eb021",
     "slug": "decatur-ga-pd",
-    "flock_active_slug": "decatur-ga-pd",
-    "flock_slugs": [
-      "decatur-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Decatur GA PD"
     ],
@@ -68967,10 +64211,8 @@
   {
     "agency_id": "e367ebeb-dc4e-5a59-8ee8-d86b25736442",
     "slug": "decommissioned-org",
-    "flock_active_slug": "decommissioned-org",
-    "flock_slugs": [
-      "decommissioned-org"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Decommissioned Org"
     ],
@@ -68988,10 +64230,8 @@
   {
     "agency_id": "098c0089-e37c-50d0-bafc-0387298e7108",
     "slug": "del-norte-county-ca-so",
-    "flock_active_slug": "del-norte-county-ca-so",
-    "flock_slugs": [
-      "del-norte-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Del Norte County CA SO"
     ],
@@ -69015,10 +64255,8 @@
   {
     "agency_id": "43959383-1338-5d3c-94c2-d9aad1829694",
     "slug": "delete",
-    "flock_active_slug": "delete",
-    "flock_slugs": [
-      "delete"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Delete"
     ],
@@ -69034,10 +64272,8 @@
   {
     "agency_id": "c03ecf42-93c9-5546-9a18-a929ea29ba77",
     "slug": "demo",
-    "flock_active_slug": "demo",
-    "flock_slugs": [
-      "demo"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Demo",
       "demo"
@@ -69054,10 +64290,8 @@
   {
     "agency_id": "00015f2d-ad5e-5b12-9811-04b7cb13827d",
     "slug": "desert-hot-springs-ca-pd",
-    "flock_active_slug": "desert-hot-springs-ca-pd",
-    "flock_slugs": [
-      "desert-hot-springs-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Desert Hot Springs CA PD"
     ],
@@ -69081,10 +64315,8 @@
   {
     "agency_id": "5fb54f1a-394c-521b-bb40-94ea865ead79",
     "slug": "district-12-ca",
-    "flock_active_slug": "district-12-ca",
-    "flock_slugs": [
-      "district-12-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "District #12 (CA)"
     ],
@@ -69104,10 +64336,8 @@
   {
     "agency_id": "b5a06458-86ec-5e2f-a673-172fdf4ac1af",
     "slug": "dnu",
-    "flock_active_slug": "dnu",
-    "flock_slugs": [
-      "dnu"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DNU"
     ],
@@ -69125,10 +64355,8 @@
   {
     "agency_id": "df99bb2b-942a-5619-8d74-b4f0264efea7",
     "slug": "dnu-glendale-pd-ca-condor",
-    "flock_active_slug": "dnu-glendale-pd-ca-condor",
-    "flock_slugs": [
-      "dnu-glendale-pd-ca-condor"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DNU - Glendale PD CA (Condor)"
     ],
@@ -69152,10 +64380,8 @@
   {
     "agency_id": "08b3a1c0-964c-5469-aaba-f76c8586a664",
     "slug": "dnu-santa-clara-university-campus-safety-raven",
-    "flock_active_slug": "dnu-santa-clara-university-campus-safety-raven",
-    "flock_slugs": [
-      "dnu-santa-clara-university-campus-safety-raven"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DNU - Santa Clara University Campus Safety (Raven)"
     ],
@@ -69180,10 +64406,8 @@
   {
     "agency_id": "2db45201-f8c3-5a62-9900-e2abcf268b30",
     "slug": "douglas-county-nv-so",
-    "flock_active_slug": "douglas-county-nv-so",
-    "flock_slugs": [
-      "douglas-county-nv-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Douglas County NV SO"
     ],
@@ -69207,10 +64431,8 @@
   {
     "agency_id": "e3bce61d-e4a4-59a0-a835-ef8070a7c064",
     "slug": "downey-pd-ca",
-    "flock_active_slug": "downey-pd-ca",
-    "flock_slugs": [
-      "downey-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Downey PD CA"
     ],
@@ -69234,10 +64456,8 @@
   {
     "agency_id": "19a23c27-bb4b-5dfe-880b-6220986f1fa6",
     "slug": "ds-towing",
-    "flock_active_slug": "ds-towing",
-    "flock_slugs": [
-      "ds-towing"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "D&S Towing"
     ],
@@ -69253,10 +64473,8 @@
   {
     "agency_id": "9d74c984-25bf-54bd-9971-40285a9f2eeb",
     "slug": "dublin-ca-pd",
-    "flock_active_slug": "dublin-ca-pd",
-    "flock_slugs": [
-      "dublin-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Dublin CA PD (ACSO)"
     ],
@@ -69280,10 +64498,8 @@
   {
     "agency_id": "f7d182f6-b252-53f8-aced-f246a52d3649",
     "slug": "duplicate-please-delete",
-    "flock_active_slug": "duplicate-please-delete",
-    "flock_slugs": [
-      "duplicate-please-delete"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "DUPLICATE PLEASE DELETE"
     ],
@@ -69301,10 +64517,8 @@
   {
     "agency_id": "ba6dffec-c362-5bc4-b042-eef688d730a2",
     "slug": "east-bay-parks-ca-pd",
-    "flock_active_slug": "east-bay-parks-ca-pd",
-    "flock_slugs": [
-      "east-bay-parks-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "East Bay Parks CA PD"
     ],
@@ -69326,10 +64540,8 @@
   {
     "agency_id": "5460d54d-6a3d-531b-a007-de6e9491f686",
     "slug": "el-centro-ca-pd",
-    "flock_active_slug": "el-centro-ca-pd",
-    "flock_slugs": [
-      "el-centro-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Centro CA PD"
     ],
@@ -69353,10 +64565,8 @@
   {
     "agency_id": "64da8ade-ab72-5519-8f11-b65be44e0387",
     "slug": "el-dorado-county-ca-so",
-    "flock_active_slug": "el-dorado-county-ca-so",
-    "flock_slugs": [
-      "el-dorado-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Dorado County CA SO"
     ],
@@ -69380,10 +64590,8 @@
   {
     "agency_id": "33355e4c-36f3-5437-8c38-46dca8c24adc",
     "slug": "el-monte-ca-pd",
-    "flock_active_slug": "el-monte-ca-pd",
-    "flock_slugs": [
-      "el-monte-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "El Monte CA PD"
     ],
@@ -69407,10 +64615,8 @@
   {
     "agency_id": "16449917-ee53-5406-ade9-4b7361ec7ba2",
     "slug": "elk-grove-ca-pd",
-    "flock_active_slug": "elk-grove-ca-pd",
-    "flock_slugs": [
-      "elk-grove-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Elk Grove CA PD"
     ],
@@ -69434,10 +64640,8 @@
   {
     "agency_id": "d7e16a10-5d8e-5ca4-934e-84cefe8840dc",
     "slug": "encino-ca",
-    "flock_active_slug": "encino-ca",
-    "flock_slugs": [
-      "encino-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Encino (CA)"
     ],
@@ -69457,10 +64661,8 @@
   {
     "agency_id": "7d2b8047-a15b-524a-bc77-627e8eeab00a",
     "slug": "escalon-ca-pd",
-    "flock_active_slug": "escalon-ca-pd",
-    "flock_slugs": [
-      "escalon-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Escalon CA PD"
     ],
@@ -69484,10 +64686,8 @@
   {
     "agency_id": "d7367d10-43b4-570f-b5a1-3e8d2a4a118b",
     "slug": "fairway-eighteen-by-hqt-development-ca",
-    "flock_active_slug": "fairway-eighteen-by-hqt-development-ca",
-    "flock_slugs": [
-      "fairway-eighteen-by-hqt-development-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fairway Eighteen by HQT Development (CA)"
     ],
@@ -69507,10 +64707,8 @@
   {
     "agency_id": "db6a00fb-f7e5-571a-9a1a-4221e0a320f9",
     "slug": "farmersville-ca-pd",
-    "flock_active_slug": "farmersville-ca-pd",
-    "flock_slugs": [
-      "farmersville-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Farmersville CA PD"
     ],
@@ -69534,10 +64732,8 @@
   {
     "agency_id": "5557c1c6-7c12-5720-b9a3-09763bf45365",
     "slug": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
-    "flock_active_slug": "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd",
-    "flock_slugs": [
-      "federal-loma-linda-healthcare-system-ca-veterans-affairs-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "[Federal] Loma Linda Healthcare System CA Veterans Affairs PD"
     ],
@@ -69560,10 +64756,8 @@
   {
     "agency_id": "5c953e17-7cdc-54c8-a702-acf43351f0f1",
     "slug": "fedex-corporation",
-    "flock_active_slug": "fedex-corporation",
-    "flock_slugs": [
-      "fedex-corporation"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "FedEx Corporation"
     ],
@@ -69579,10 +64773,8 @@
   {
     "agency_id": "a0a5200d-ae91-57da-8e6c-bc14c3f42b1e",
     "slug": "florence-al-pd",
-    "flock_active_slug": "florence-al-pd",
-    "flock_slugs": [
-      "florence-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Florence AL PD"
     ],
@@ -69606,10 +64798,8 @@
   {
     "agency_id": "040a02b2-2734-5d96-9f70-2d4b27ee2001",
     "slug": "fms-ca",
-    "flock_active_slug": "fms-ca",
-    "flock_slugs": [
-      "fms-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "FMS (CA)"
     ],
@@ -69629,10 +64819,8 @@
   {
     "agency_id": "dead7dd4-476d-528d-92bd-89a198d5f518",
     "slug": "foothill-deanza-ca-pd",
-    "flock_active_slug": "foothill-deanza-ca-pd",
-    "flock_slugs": [
-      "foothill-deanza-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Foothill-DeAnza CA PD"
     ],
@@ -69652,10 +64840,8 @@
   {
     "agency_id": "65f406c8-21a0-5d6c-b021-c7ee7a8ec74b",
     "slug": "fort-worth-tx-pd",
-    "flock_active_slug": "fort-worth-tx-pd",
-    "flock_slugs": [
-      "fort-worth-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fort Worth TX PD"
     ],
@@ -69679,10 +64865,8 @@
   {
     "agency_id": "45b18cd2-8cf5-56c3-beb5-d3ff59fb351b",
     "slug": "foster-farms-inc-ca",
-    "flock_active_slug": "foster-farms-inc-ca",
-    "flock_slugs": [
-      "foster-farms-inc-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Foster Farms Inc. (CA)"
     ],
@@ -69702,10 +64886,8 @@
   {
     "agency_id": "418c6009-e224-5071-9158-50c8bfaf8034",
     "slug": "fountain-walk-ca",
-    "flock_active_slug": "fountain-walk-ca",
-    "flock_slugs": [
-      "fountain-walk-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fountain Walk (CA)"
     ],
@@ -69725,10 +64907,8 @@
   {
     "agency_id": "80f246ff-0054-5b13-84e7-6bb6fc954b50",
     "slug": "fowler-ca-pd",
-    "flock_active_slug": "fowler-ca-pd",
-    "flock_slugs": [
-      "fowler-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fowler CA PD"
     ],
@@ -69752,10 +64932,8 @@
   {
     "agency_id": "f296ea7d-37b7-583c-aef6-5058b2df232d",
     "slug": "fremont-ca-pd",
-    "flock_active_slug": "fremont-ca-pd",
-    "flock_slugs": [
-      "fremont-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fremont CA PD"
     ],
@@ -69779,10 +64957,8 @@
   {
     "agency_id": "54ec60dd-900e-55cb-9eaf-b9db3c9481c6",
     "slug": "fresno-ca-pd",
-    "flock_active_slug": "fresno-ca-pd",
-    "flock_slugs": [
-      "fresno-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Fresno CA PD"
     ],
@@ -69806,10 +64982,8 @@
   {
     "agency_id": "b79270e4-262d-5069-ba04-0e4aa6298b3d",
     "slug": "garden-grove-ca-pd",
-    "flock_active_slug": "garden-grove-ca-pd",
-    "flock_slugs": [
-      "garden-grove-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Garden Grove CA PD"
     ],
@@ -69833,10 +65007,8 @@
   {
     "agency_id": "211a52aa-e418-5cb5-bfaa-9e969c7a152d",
     "slug": "ggtpc-ca",
-    "flock_active_slug": "ggtpc-ca",
-    "flock_slugs": [
-      "ggtpc-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "GGTPC (CA)"
     ],
@@ -69856,10 +65028,8 @@
   {
     "agency_id": "4ff77c1c-b4cf-59cc-89fd-10897c420245",
     "slug": "glen-cove-community-association-ca",
-    "flock_active_slug": "glen-cove-community-association-ca",
-    "flock_slugs": [
-      "glen-cove-community-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glen Cove Community Association (CA)"
     ],
@@ -69879,10 +65049,8 @@
   {
     "agency_id": "a76648d4-dba1-53e2-b8f0-f68803d13bf4",
     "slug": "glen-cove-marina-ca",
-    "flock_active_slug": "glen-cove-marina-ca",
-    "flock_slugs": [
-      "glen-cove-marina-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glen Cove Marina (CA)"
     ],
@@ -69902,10 +65070,8 @@
   {
     "agency_id": "9f648985-e0fa-595a-acd3-3d06bc7d84c6",
     "slug": "glencoe-al-pd",
-    "flock_active_slug": "glencoe-al-pd",
-    "flock_slugs": [
-      "glencoe-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glencoe AL PD"
     ],
@@ -69929,10 +65095,8 @@
   {
     "agency_id": "939ef9db-dfdc-5abc-b689-da79c79d085c",
     "slug": "glendora-ca-pd",
-    "flock_active_slug": "glendora-ca-pd",
-    "flock_slugs": [
-      "glendora-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Glendora (CA) PD"
     ],
@@ -69956,10 +65120,8 @@
   {
     "agency_id": "d3abc55d-1db8-50de-9e6f-031bca3e9a07",
     "slug": "gold-hills-ca",
-    "flock_active_slug": "gold-hills-ca",
-    "flock_slugs": [
-      "gold-hills-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gold Hills (CA)"
     ],
@@ -69979,10 +65141,8 @@
   {
     "agency_id": "9d8d18a4-c601-5cc0-a010-a069da1d4820",
     "slug": "goodland-avenue-ca",
-    "flock_active_slug": "goodland-avenue-ca",
-    "flock_slugs": [
-      "goodland-avenue-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goodland Avenue (CA)"
     ],
@@ -70002,10 +65162,8 @@
   {
     "agency_id": "68f7ba36-e76d-5e86-919f-f3e572a3e40d",
     "slug": "goshen-in-pd",
-    "flock_active_slug": "goshen-in-pd",
-    "flock_slugs": [
-      "goshen-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goshen IN PD"
     ],
@@ -70029,10 +65187,8 @@
   {
     "agency_id": "abd9ac18-4eff-57ec-9008-7c62a27c374c",
     "slug": "goshen-village-ny-pd",
-    "flock_active_slug": "goshen-village-ny-pd",
-    "flock_slugs": [
-      "goshen-village-ny-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Goshen Village NY PD"
     ],
@@ -70056,10 +65212,8 @@
   {
     "agency_id": "f918e92d-ce22-5c49-96f3-241cc46df474",
     "slug": "grants-pass-or-pd",
-    "flock_active_slug": "grants-pass-or-pd",
-    "flock_slugs": [
-      "grants-pass-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Grants Pass OR PD"
     ],
@@ -70083,10 +65237,8 @@
   {
     "agency_id": "e9c8dd45-83aa-52bd-84a7-74f535d37604",
     "slug": "great-wolf-lodge-corporate",
-    "flock_active_slug": "great-wolf-lodge-corporate",
-    "flock_slugs": [
-      "great-wolf-lodge-corporate"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Great Wolf Lodge - Corporate"
     ],
@@ -70102,10 +65254,8 @@
   {
     "agency_id": "270fd3ce-aefb-503a-82e0-36ea52c1ba28",
     "slug": "greenfield-ca-pd",
-    "flock_active_slug": "greenfield-ca-pd",
-    "flock_slugs": [
-      "greenfield-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Greenfield CA PD"
     ],
@@ -70129,10 +65279,8 @@
   {
     "agency_id": "d0843cde-d450-5617-b977-103218524b39",
     "slug": "gustine-pd-ca",
-    "flock_active_slug": "gustine-pd-ca",
-    "flock_slugs": [
-      "gustine-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Gustine PD CA"
     ],
@@ -70156,10 +65304,8 @@
   {
     "agency_id": "4cea309b-ec8b-5ba0-a4cd-7218383c9f01",
     "slug": "hardin-county-tn-so",
-    "flock_active_slug": "hardin-county-tn-so",
-    "flock_slugs": [
-      "hardin-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hardin County TN SO"
     ],
@@ -70183,10 +65329,8 @@
   {
     "agency_id": "97649e58-de88-55fd-856e-6dcf8f23f518",
     "slug": "haven-north-village",
-    "flock_active_slug": "haven-north-village",
-    "flock_slugs": [
-      "haven-north-village"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Haven North Village"
     ],
@@ -70202,10 +65346,8 @@
   {
     "agency_id": "9535f26d-b219-55da-bb80-7de676b4b0ed",
     "slug": "hawks-pointe-ca",
-    "flock_active_slug": "hawks-pointe-ca",
-    "flock_slugs": [
-      "hawks-pointe-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hawks Pointe (CA)"
     ],
@@ -70225,10 +65367,8 @@
   {
     "agency_id": "38082941-85be-5f33-9a53-20afd458675a",
     "slug": "hawthorne-ca-pd",
-    "flock_active_slug": "hawthorne-ca-pd",
-    "flock_slugs": [
-      "hawthorne-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hawthorne CA PD"
     ],
@@ -70252,10 +65392,8 @@
   {
     "agency_id": "b6c359ce-910d-5e1c-b894-638cc3830c87",
     "slug": "helena-al-pd",
-    "flock_active_slug": "helena-al-pd",
-    "flock_slugs": [
-      "helena-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Helena AL PD"
     ],
@@ -70279,10 +65417,8 @@
   {
     "agency_id": "13422e46-1750-5a1f-865c-a7219949a2ef",
     "slug": "hemet-ca-pd",
-    "flock_active_slug": "hemet-ca-pd",
-    "flock_slugs": [
-      "hemet-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hemet CA PD"
     ],
@@ -70306,10 +65442,8 @@
   {
     "agency_id": "ab72c709-a28e-5f83-b6ab-8dfe17c4cd40",
     "slug": "hendry-county-fl-so",
-    "flock_active_slug": "hendry-county-fl-so",
-    "flock_slugs": [
-      "hendry-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hendry County FL SO"
     ],
@@ -70333,10 +65467,8 @@
   {
     "agency_id": "e9d63958-c540-592f-aeb5-6fc9953296ef",
     "slug": "hermosa-beach-pd-ca",
-    "flock_active_slug": "hermosa-beach-pd-ca",
-    "flock_slugs": [
-      "hermosa-beach-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hermosa Beach PD CA"
     ],
@@ -70360,10 +65492,8 @@
   {
     "agency_id": "06983d50-75a9-526c-9de2-fc7a4e530efd",
     "slug": "heron-bay-spyglass-hills-homeowners-association-ca",
-    "flock_active_slug": "heron-bay-spyglass-hills-homeowners-association-ca",
-    "flock_slugs": [
-      "heron-bay-spyglass-hills-homeowners-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Heron Bay Spyglass Hills Homeowners Association (CA)"
     ],
@@ -70383,10 +65513,8 @@
   {
     "agency_id": "c673daa5-68e3-565b-894d-638a7ff7704d",
     "slug": "hestia-lei-ca",
-    "flock_active_slug": "hestia-lei-ca",
-    "flock_slugs": [
-      "hestia-lei-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hestia Lei (CA)"
     ],
@@ -70406,10 +65534,8 @@
   {
     "agency_id": "427dee70-92d1-5f3d-a2eb-d81f1a69251f",
     "slug": "hiddenbrooke-ca",
-    "flock_active_slug": "hiddenbrooke-ca",
-    "flock_slugs": [
-      "hiddenbrooke-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hiddenbrooke (CA)"
     ],
@@ -70429,10 +65555,8 @@
   {
     "agency_id": "1a3173cf-12ce-5cb8-8b2e-d55f3c7a90dc",
     "slug": "highlands-hoa-ca",
-    "flock_active_slug": "highlands-hoa-ca",
-    "flock_slugs": [
-      "highlands-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Highlands HOA (CA)"
     ],
@@ -70452,10 +65576,8 @@
   {
     "agency_id": "d30e791e-779f-59ff-b24d-c5b05a3798ab",
     "slug": "hillside-il-pd",
-    "flock_active_slug": "hillside-il-pd",
-    "flock_slugs": [
-      "hillside-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hillside IL PD"
     ],
@@ -70479,10 +65601,8 @@
   {
     "agency_id": "000dcf5b-5217-5ca6-aa52-9139bdfab38d",
     "slug": "holiday-gardens-ca",
-    "flock_active_slug": "holiday-gardens-ca",
-    "flock_slugs": [
-      "holiday-gardens-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Holiday Gardens (CA)"
     ],
@@ -70502,10 +65622,8 @@
   {
     "agency_id": "fdac9783-5c94-569a-a931-165dcb32a434",
     "slug": "home-depot-corporation",
-    "flock_active_slug": "home-depot-corporation",
-    "flock_slugs": [
-      "home-depot-corporation"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Home Depot Corporation"
     ],
@@ -70521,10 +65639,8 @@
   {
     "agency_id": "cdf53878-f007-5349-82c3-c198d69e4737",
     "slug": "houston-metro-transit-authority-tx",
-    "flock_active_slug": "houston-metro-transit-authority-tx",
-    "flock_slugs": [
-      "houston-metro-transit-authority-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Houston Metro Transit Authority (TX)"
     ],
@@ -70540,10 +65656,8 @@
   {
     "agency_id": "030b796b-eb59-5d03-8f7f-b1d5ce1a005c",
     "slug": "houston-tx-pd",
-    "flock_active_slug": "houston-tx-pd",
-    "flock_slugs": [
-      "houston-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Houston TX PD"
     ],
@@ -70567,10 +65681,8 @@
   {
     "agency_id": "22be4e07-6927-58af-b2fe-b74885b935ec",
     "slug": "hunters-trail-ca",
-    "flock_active_slug": "hunters-trail-ca",
-    "flock_slugs": [
-      "hunters-trail-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hunters Trail (CA)"
     ],
@@ -70590,10 +65702,8 @@
   {
     "agency_id": "27d3370c-1004-57a6-b76f-c2efedaefc53",
     "slug": "huntington-beach-ca-pd",
-    "flock_active_slug": "huntington-beach-ca-pd",
-    "flock_slugs": [
-      "huntington-beach-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntington Beach CA PD"
     ],
@@ -70617,10 +65727,8 @@
   {
     "agency_id": "b9ffc1f3-6d5d-58c4-9b67-baadaa5fbb64",
     "slug": "huntsville-al-pd",
-    "flock_active_slug": "huntsville-al-pd",
-    "flock_slugs": [
-      "huntsville-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Huntsville AL PD"
     ],
@@ -70644,10 +65752,8 @@
   {
     "agency_id": "55db20ff-e7cc-54e9-8115-34d66ff7e188",
     "slug": "imperial-city-ca-pd",
-    "flock_active_slug": "imperial-city-ca-pd",
-    "flock_slugs": [
-      "imperial-city-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Imperial City CA PD"
     ],
@@ -70671,10 +65777,8 @@
   {
     "agency_id": "862d352e-a1e3-5445-b9ad-abb1a479b8bf",
     "slug": "imperial-county-ca-so",
-    "flock_active_slug": "imperial-county-ca-so",
-    "flock_slugs": [
-      "imperial-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Imperial County CA SO"
     ],
@@ -70698,10 +65802,8 @@
   {
     "agency_id": "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3",
     "slug": "indio-ca-pd",
-    "flock_active_slug": "indio-ca-pd",
-    "flock_slugs": [
-      "indio-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Indio CA PD"
     ],
@@ -70725,10 +65827,8 @@
   {
     "agency_id": "981e7edd-d5e6-549a-9c63-9f5e6e6238a9",
     "slug": "inglewood-ca-pd",
-    "flock_active_slug": "inglewood-ca-pd",
-    "flock_slugs": [
-      "inglewood-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Inglewood CA PD"
     ],
@@ -70752,10 +65852,8 @@
   {
     "agency_id": "af06af64-75fc-584c-bae8-75df54671e05",
     "slug": "irondale-al-pd",
-    "flock_active_slug": "irondale-al-pd",
-    "flock_slugs": [
-      "irondale-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Irondale AL PD"
     ],
@@ -70779,10 +65877,8 @@
   {
     "agency_id": "62bc6f36-2586-513f-b541-c9a4bcd1cfb7",
     "slug": "ironridge-at-portola-hills-ca",
-    "flock_active_slug": "ironridge-at-portola-hills-ca",
-    "flock_slugs": [
-      "ironridge-at-portola-hills-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "IronRidge at Portola Hills (CA)"
     ],
@@ -70802,10 +65898,8 @@
   {
     "agency_id": "42ac4d61-32cd-5fa4-aa11-b6713123a5c7",
     "slug": "irvine-ca-pd",
-    "flock_active_slug": "irvine-ca-pd",
-    "flock_slugs": [
-      "irvine-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Irvine CA PD"
     ],
@@ -70829,10 +65923,8 @@
   {
     "agency_id": "c1460b89-41f6-5f80-8e31-203920db6642",
     "slug": "irwindale-ca-pd",
-    "flock_active_slug": "irwindale-ca-pd",
-    "flock_slugs": [
-      "irwindale-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Irwindale CA PD"
     ],
@@ -70856,10 +65948,8 @@
   {
     "agency_id": "fad50c3f-54b7-5bac-9093-b41b977dac71",
     "slug": "jaime-le-training",
-    "flock_active_slug": "jaime-le-training",
-    "flock_slugs": [
-      "jaime-le-training"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jaime LE Training"
     ],
@@ -70875,10 +65965,8 @@
   {
     "agency_id": "3ecbed4b-50ac-597f-bba9-52444f7189f7",
     "slug": "jasper-county-in-so",
-    "flock_active_slug": "jasper-county-in-so",
-    "flock_slugs": [
-      "jasper-county-in-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jasper County IN SO"
     ],
@@ -70902,10 +65990,8 @@
   {
     "agency_id": "e67b2296-f7a6-5fcd-96d8-ea4b91c8c534",
     "slug": "jonesboro-ar-pd",
-    "flock_active_slug": "jonesboro-ar-pd",
-    "flock_slugs": [
-      "jonesboro-ar-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Jonesboro AR PD"
     ],
@@ -70929,10 +66015,8 @@
   {
     "agency_id": "7929aea5-907c-554a-be3f-2e9053c94df8",
     "slug": "kerman-ca-pd",
-    "flock_active_slug": "kerman-ca-pd",
-    "flock_slugs": [
-      "kerman-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kerman CA PD"
     ],
@@ -70956,10 +66040,8 @@
   {
     "agency_id": "1360ff78-db4c-529a-b889-81746642325e",
     "slug": "kern-county-ca-so",
-    "flock_active_slug": "kern-county-ca-so",
-    "flock_slugs": [
-      "kern-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kern County CA SO"
     ],
@@ -70983,10 +66065,8 @@
   {
     "agency_id": "b2a9efa4-a1a1-5962-9f3f-4d36a50cce99",
     "slug": "kerrigan-ranch-ii-ca",
-    "flock_active_slug": "kerrigan-ranch-ii-ca",
-    "flock_slugs": [
-      "kerrigan-ranch-ii-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kerrigan Ranch II (CA)"
     ],
@@ -71006,10 +66086,8 @@
   {
     "agency_id": "e1477d78-c4eb-51cb-956d-8fe1cf3ab242",
     "slug": "kings-county-sheriffs-office-ca",
-    "flock_active_slug": "kings-county-sheriffs-office-ca",
-    "flock_slugs": [
-      "kings-county-sheriffs-office-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kings County Sheriff's Office CA"
     ],
@@ -71033,10 +66111,8 @@
   {
     "agency_id": "0eef94a0-897c-5598-902b-a289e5f23e28",
     "slug": "kingsburg-ca-pd",
-    "flock_active_slug": "kingsburg-ca-pd",
-    "flock_slugs": [
-      "kingsburg-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Kingsburg CA PD"
     ],
@@ -71060,10 +66136,8 @@
   {
     "agency_id": "4219823b-c553-51fd-9a9b-5618cb5f82b5",
     "slug": "la-habra-ca-pd",
-    "flock_active_slug": "la-habra-ca-pd",
-    "flock_slugs": [
-      "la-habra-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Habra CA PD"
     ],
@@ -71087,10 +66161,8 @@
   {
     "agency_id": "dbfeb93f-10ea-5aaf-8862-a6b186764b79",
     "slug": "la-mesa-ca-pd",
-    "flock_active_slug": "la-mesa-ca-pd",
-    "flock_slugs": [
-      "la-mesa-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Mesa CA PD"
     ],
@@ -71114,10 +66186,8 @@
   {
     "agency_id": "7bcfacdc-986f-51c5-b5fb-fa8e89d4baa3",
     "slug": "la-paz-county-az-so",
-    "flock_active_slug": "la-paz-county-az-so",
-    "flock_slugs": [
-      "la-paz-county-az-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Paz County AZ SO"
     ],
@@ -71141,10 +66211,8 @@
   {
     "agency_id": "727915ef-bda7-5399-8e79-0369d7bb7782",
     "slug": "la-verne-ca-pd",
-    "flock_active_slug": "la-verne-ca-pd",
-    "flock_slugs": [
-      "la-verne-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Verne CA PD"
     ],
@@ -71168,10 +66236,8 @@
   {
     "agency_id": "8cbeae6b-148f-5f0b-b524-a90475b8f2c2",
     "slug": "la-verne-live-oak-ca",
-    "flock_active_slug": "la-verne-live-oak-ca",
-    "flock_slugs": [
-      "la-verne-live-oak-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "La Verne Live Oak (CA)"
     ],
@@ -71191,10 +66257,8 @@
   {
     "agency_id": "59158344-4894-55be-bc8a-de15bcb986f0",
     "slug": "laguna-beach-ca-pd",
-    "flock_active_slug": "laguna-beach-ca-pd",
-    "flock_slugs": [
-      "laguna-beach-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Laguna Beach CA PD"
     ],
@@ -71218,10 +66282,8 @@
   {
     "agency_id": "65131837-e542-51b5-9c61-28181333089f",
     "slug": "lake-county-da-ca",
-    "flock_active_slug": "lake-county-da-ca",
-    "flock_slugs": [
-      "lake-county-da-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake County DA CA"
     ],
@@ -71245,10 +66307,8 @@
   {
     "agency_id": "80913cc4-83c1-5cbf-8002-39e41fc36521",
     "slug": "lake-havasu-city-az-pd",
-    "flock_active_slug": "lake-havasu-city-az-pd",
-    "flock_slugs": [
-      "lake-havasu-city-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lake Havasu City AZ PD"
     ],
@@ -71272,10 +66332,8 @@
   {
     "agency_id": "4d51cf25-3dd8-5b26-ae54-6c0b50511be2",
     "slug": "lakeport-ca-pd",
-    "flock_active_slug": "lakeport-ca-pd",
-    "flock_slugs": [
-      "lakeport-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lakeport CA PD"
     ],
@@ -71299,10 +66357,8 @@
   {
     "agency_id": "aecd81f3-fb7f-579a-895a-44d90a82a427",
     "slug": "lancaster-ca-pd",
-    "flock_active_slug": "lancaster-ca-pd",
-    "flock_slugs": [
-      "lancaster-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lancaster CA PD"
     ],
@@ -71326,10 +66382,8 @@
   {
     "agency_id": "852accd8-58d8-5121-8906-3c8bb117e303",
     "slug": "landmark-limited-group-of-companies",
-    "flock_active_slug": "landmark-limited-group-of-companies",
-    "flock_slugs": [
-      "landmark-limited-group-of-companies"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Landmark Limited Group of Companies"
     ],
@@ -71345,10 +66399,8 @@
   {
     "agency_id": "03f39921-e81f-5d88-ba5a-cf79a6969ecb",
     "slug": "las-vegas-metro-nv-pd",
-    "flock_active_slug": "las-vegas-metro-nv-pd",
-    "flock_slugs": [
-      "las-vegas-metro-nv-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Las Vegas Metro NV PD"
     ],
@@ -71372,10 +66424,8 @@
   {
     "agency_id": "7b4d182e-412e-59e3-9967-75d4f4f1bedf",
     "slug": "lasd-ca-san-dimas-station",
-    "flock_active_slug": "lasd-ca-san-dimas-station",
-    "flock_slugs": [
-      "lasd-ca-san-dimas-station"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "LASD CA - San Dimas Station"
     ],
@@ -71397,10 +66447,8 @@
   {
     "agency_id": "7932e34a-0d6d-524b-9e26-543d66b8b93c",
     "slug": "lathrop-ca-pd",
-    "flock_active_slug": "lathrop-ca-pd",
-    "flock_slugs": [
-      "lathrop-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lathrop CA PD"
     ],
@@ -71424,10 +66472,8 @@
   {
     "agency_id": "70d9a3e7-a4b3-5ecd-b578-24c2d48ba88d",
     "slug": "lexington-sc-pd",
-    "flock_active_slug": "lexington-sc-pd",
-    "flock_slugs": [
-      "lexington-sc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lexington SC PD"
     ],
@@ -71451,10 +66497,8 @@
   {
     "agency_id": "094c575d-913f-5b3c-b633-90c27e848019",
     "slug": "lindsay-public-safety-department-ca",
-    "flock_active_slug": "lindsay-public-safety-department-ca",
-    "flock_slugs": [
-      "lindsay-public-safety-department-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lindsay Public Safety Department CA"
     ],
@@ -71476,10 +66520,8 @@
   {
     "agency_id": "980706f2-3871-5539-b697-f6718fd0cc87",
     "slug": "longshore-cove-ca",
-    "flock_active_slug": "longshore-cove-ca",
-    "flock_slugs": [
-      "longshore-cove-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Longshore Cove (CA)"
     ],
@@ -71499,10 +66541,8 @@
   {
     "agency_id": "ea91bafe-b935-5f29-bf40-896f155a1d1c",
     "slug": "los-alamitos-pd-ca",
-    "flock_active_slug": "los-alamitos-pd-ca",
-    "flock_slugs": [
-      "los-alamitos-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Los Alamitos PD CA"
     ],
@@ -71526,10 +66566,8 @@
   {
     "agency_id": "e1a20804-c286-5bfd-8967-06a5293c5d2c",
     "slug": "los-alto-hills-ca-pd",
-    "flock_active_slug": "los-alto-hills-ca-pd",
-    "flock_slugs": [
-      "los-alto-hills-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Los Alto Hills CA PD"
     ],
@@ -71551,10 +66589,8 @@
   {
     "agency_id": "a17a8e7d-6ebb-50e2-ad83-14ecd689e810",
     "slug": "los-angeles-ca-pd",
-    "flock_active_slug": "los-angeles-ca-pd",
-    "flock_slugs": [
-      "los-angeles-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Los Angeles CA PD"
     ],
@@ -71578,10 +66614,8 @@
   {
     "agency_id": "943b3fc4-e976-51f5-b793-7f83c9ed9076",
     "slug": "los-angeles-county-ca-sd",
-    "flock_active_slug": "los-angeles-county-ca-sd",
-    "flock_slugs": [
-      "los-angeles-county-ca-sd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Los Angeles County CA SD"
     ],
@@ -71605,10 +66639,8 @@
   {
     "agency_id": "94fd017f-e470-5a9f-b74f-8c73c4c26660",
     "slug": "los-angeles-port-police-ca",
-    "flock_active_slug": "los-angeles-port-police-ca",
-    "flock_slugs": [
-      "los-angeles-port-police-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Los Angeles Port Police CA"
     ],
@@ -71630,10 +66662,8 @@
   {
     "agency_id": "1d149e61-3d04-531d-87d2-8e2ec6e0844a",
     "slug": "lowes-corporation",
-    "flock_active_slug": "lowes-corporation",
-    "flock_slugs": [
-      "lowes-corporation"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lowe's Corporation"
     ],
@@ -71649,10 +66679,8 @@
   {
     "agency_id": "e7331865-34fd-5831-8028-c63398d95e55",
     "slug": "madera-county-so-ca",
-    "flock_active_slug": "madera-county-so-ca",
-    "flock_slugs": [
-      "madera-county-so-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Madera County SO CA"
     ],
@@ -71676,10 +66704,8 @@
   {
     "agency_id": "99d9bd61-b63e-56a4-b58e-f81858136cd1",
     "slug": "mahoning-twp-pa-pd",
-    "flock_active_slug": "mahoning-twp-pa-pd",
-    "flock_slugs": [
-      "mahoning-twp-pa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mahoning Twp PA PD"
     ],
@@ -71701,10 +66727,8 @@
   {
     "agency_id": "681413b8-0ba8-5bcd-a4c6-3bb4f9cc3ee7",
     "slug": "mare-island-ca",
-    "flock_active_slug": "mare-island-ca",
-    "flock_slugs": [
-      "mare-island-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mare Island (CA)"
     ],
@@ -71724,10 +66748,8 @@
   {
     "agency_id": "0649c75b-a49d-5ec7-a240-18692dea2047",
     "slug": "marin-county-ca-da",
-    "flock_active_slug": "marin-county-ca-da",
-    "flock_slugs": [
-      "marin-county-ca-da"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marin County CA DA"
     ],
@@ -71751,10 +66773,8 @@
   {
     "agency_id": "337d2d0a-e6e0-5920-b671-87b14aa321a2",
     "slug": "marshall-canyon-estates-ca",
-    "flock_active_slug": "marshall-canyon-estates-ca",
-    "flock_slugs": [
-      "marshall-canyon-estates-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marshall Canyon Estates (CA)"
     ],
@@ -71774,10 +66794,8 @@
   {
     "agency_id": "c74c5b71-d041-5be4-b4b5-6e140c649a43",
     "slug": "marysville-ca-pd",
-    "flock_active_slug": "marysville-ca-pd",
-    "flock_slugs": [
-      "marysville-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Marysville CA PD"
     ],
@@ -71801,10 +66819,8 @@
   {
     "agency_id": "8a94dd8e-1e82-55b0-81d0-935bbf9ccc89",
     "slug": "matteson-il-pd",
-    "flock_active_slug": "matteson-il-pd",
-    "flock_slugs": [
-      "matteson-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Matteson IL PD"
     ],
@@ -71828,10 +66844,8 @@
   {
     "agency_id": "2d8a2244-adfe-5132-93bb-374be19d0f32",
     "slug": "mcfarland-ca-pd",
-    "flock_active_slug": "mcfarland-ca-pd",
-    "flock_slugs": [
-      "mcfarland-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McFarland CA PD"
     ],
@@ -71855,10 +66869,8 @@
   {
     "agency_id": "52421068-08e8-5522-8cd4-26dabfe25eaa",
     "slug": "mchenry-county-conservation-district-il-pd",
-    "flock_active_slug": "mchenry-county-conservation-district-il-pd",
-    "flock_slugs": [
-      "mchenry-county-conservation-district-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "McHenry County Conservation District IL PD"
     ],
@@ -71880,10 +66892,8 @@
   {
     "agency_id": "b7368687-c755-557e-b85e-d46a303a6852",
     "slug": "meadowood-ca",
-    "flock_active_slug": "meadowood-ca",
-    "flock_slugs": [
-      "meadowood-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Meadowood (CA)"
     ],
@@ -71903,10 +66913,8 @@
   {
     "agency_id": "b6388c0f-b716-5756-b1a7-18dc6ab75e91",
     "slug": "melrose-action-ca",
-    "flock_active_slug": "melrose-action-ca",
-    "flock_slugs": [
-      "melrose-action-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Melrose Action (CA)"
     ],
@@ -71926,10 +66934,8 @@
   {
     "agency_id": "e30ffc94-490f-502f-be3b-5a2b873c0bf1",
     "slug": "mendota-ca-pd",
-    "flock_active_slug": "mendota-ca-pd",
-    "flock_slugs": [
-      "mendota-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mendota CA PD"
     ],
@@ -71953,10 +66959,8 @@
   {
     "agency_id": "e7b93869-9da4-5d24-b2d1-e173b8a79642",
     "slug": "mercury-insurance-ca",
-    "flock_active_slug": "mercury-insurance-ca",
-    "flock_slugs": [
-      "mercury-insurance-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mercury Insurance (CA)"
     ],
@@ -71976,10 +66980,8 @@
   {
     "agency_id": "7d349876-8c78-56a8-b2b3-12e9606719f1",
     "slug": "mesa-verde-ca",
-    "flock_active_slug": "mesa-verde-ca",
-    "flock_slugs": [
-      "mesa-verde-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mesa Verde (CA)"
     ],
@@ -72003,10 +67005,8 @@
   {
     "agency_id": "3fa6fc23-7bf6-5590-9865-6ef5de35d80f",
     "slug": "middlebury-in-pd",
-    "flock_active_slug": "middlebury-in-pd",
-    "flock_slugs": [
-      "middlebury-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Middlebury IN PD"
     ],
@@ -72030,10 +67030,8 @@
   {
     "agency_id": "3ab7378e-0fad-5bec-bcce-2c4f81e1cd59",
     "slug": "midwick-collection-ca",
-    "flock_active_slug": "midwick-collection-ca",
-    "flock_slugs": [
-      "midwick-collection-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Midwick Collection (CA)"
     ],
@@ -72053,10 +67051,8 @@
   {
     "agency_id": "59e2385f-2649-5b82-9bf7-aee2e73b0af1",
     "slug": "milpitas-ca-pd",
-    "flock_active_slug": "milpitas-ca-pd",
-    "flock_slugs": [
-      "milpitas-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milpitas CA PD"
     ],
@@ -72080,10 +67076,8 @@
   {
     "agency_id": "fc4c4659-5262-572a-b3d0-6bf50591125e",
     "slug": "milton-ga-pd",
-    "flock_active_slug": "milton-ga-pd",
-    "flock_slugs": [
-      "milton-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Milton GA PD"
     ],
@@ -72107,10 +67101,8 @@
   {
     "agency_id": "f9c972d0-1a0d-5e7b-b9eb-e4e662598fd6",
     "slug": "miraleste-hills",
-    "flock_active_slug": "miraleste-hills",
-    "flock_slugs": [
-      "miraleste-hills"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Miraleste Hills"
     ],
@@ -72126,10 +67118,8 @@
   {
     "agency_id": "05c21e46-75a4-579f-927e-9b69e81f29b2",
     "slug": "modesto-ca-pd",
-    "flock_active_slug": "modesto-ca-pd",
-    "flock_slugs": [
-      "modesto-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Modesto CA PD"
     ],
@@ -72153,10 +67143,8 @@
   {
     "agency_id": "22cd299e-0742-5372-8e88-9918667f9f5a",
     "slug": "mohave-county-az-so",
-    "flock_active_slug": "mohave-county-az-so",
-    "flock_slugs": [
-      "mohave-county-az-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mohave County AZ SO"
     ],
@@ -72181,10 +67169,8 @@
   {
     "agency_id": "c3560776-9492-50ab-b355-4eba892ca2bc",
     "slug": "monroe-ga-pd",
-    "flock_active_slug": "monroe-ga-pd",
-    "flock_slugs": [
-      "monroe-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monroe GA PD"
     ],
@@ -72208,10 +67194,8 @@
   {
     "agency_id": "853e0abd-afea-5c18-be2d-78a2e1ba4ce9",
     "slug": "monster-energy-corporate-office-ca",
-    "flock_active_slug": "monster-energy-corporate-office-ca",
-    "flock_slugs": [
-      "monster-energy-corporate-office-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monster Energy Corporate Office (CA)"
     ],
@@ -72234,10 +67218,8 @@
   {
     "agency_id": "11cb11f9-469e-5be8-a6c7-e1e00ca4d9eb",
     "slug": "montebello-ca-pd",
-    "flock_active_slug": "montebello-ca-pd",
-    "flock_slugs": [
-      "montebello-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Montebello CA PD"
     ],
@@ -72261,10 +67243,8 @@
   {
     "agency_id": "9b7b7208-5747-5e9c-bdcb-ed7b430686fd",
     "slug": "monterey-county-ca-so",
-    "flock_active_slug": "monterey-county-ca-so",
-    "flock_slugs": [
-      "monterey-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monterey County CA SO"
     ],
@@ -72289,10 +67269,8 @@
   {
     "agency_id": "5d80780f-d47b-5f56-acf4-a457bbb421ac",
     "slug": "monterey-county-district-attorneys-office",
-    "flock_active_slug": "monterey-county-district-attorneys-office",
-    "flock_slugs": [
-      "monterey-county-district-attorneys-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Monterey County District Attorney's Office"
     ],
@@ -72314,10 +67292,8 @@
   {
     "agency_id": "24f0f643-2aed-507a-be1f-caf34584912f",
     "slug": "moraga-ca-pd",
-    "flock_active_slug": "moraga-ca-pd",
-    "flock_slugs": [
-      "moraga-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Moraga CA PD"
     ],
@@ -72341,10 +67317,8 @@
   {
     "agency_id": "13a62f9a-07fc-5d1c-863a-b7ecae793505",
     "slug": "mountain-house-ca",
-    "flock_active_slug": "mountain-house-ca",
-    "flock_slugs": [
-      "mountain-house-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain House (CA)"
     ],
@@ -72368,10 +67342,8 @@
   {
     "agency_id": "e9a5ef79-d14a-5bf4-91e2-99b75939f983",
     "slug": "napa-county-ca-probation-department",
-    "flock_active_slug": "napa-county-ca-probation-department",
-    "flock_slugs": [
-      "napa-county-ca-probation-department"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Napa County (CA) Probation Department"
     ],
@@ -72394,10 +67366,8 @@
   {
     "agency_id": "fb49463a-c0c0-5bc7-90a0-545bef9f3301",
     "slug": "navajo-county-az-so",
-    "flock_active_slug": "navajo-county-az-so",
-    "flock_slugs": [
-      "navajo-county-az-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Navajo County AZ SO"
     ],
@@ -72422,10 +67392,8 @@
   {
     "agency_id": "44163a0c-70d8-505f-b51b-a3a552320af8",
     "slug": "nephi-pd-ut",
-    "flock_active_slug": "nephi-pd-ut",
-    "flock_slugs": [
-      "nephi-pd-ut"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nephi PD UT"
     ],
@@ -72449,10 +67417,8 @@
   {
     "agency_id": "30ad58b9-4925-5815-8213-036be93d86a9",
     "slug": "nevada-city-ca-pd",
-    "flock_active_slug": "nevada-city-ca-pd",
-    "flock_slugs": [
-      "nevada-city-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Nevada City CA PD"
     ],
@@ -72476,10 +67442,8 @@
   {
     "agency_id": "e27f1b8b-4591-51db-8a36-db468464e1b9",
     "slug": "new-castle-county-de-pd",
-    "flock_active_slug": "new-castle-county-de-pd",
-    "flock_slugs": [
-      "new-castle-county-de-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "New Castle County DE PD"
     ],
@@ -72503,10 +67467,8 @@
   {
     "agency_id": "5aad1905-8ff9-5a45-931a-7298f983153a",
     "slug": "newark-ca-pd",
-    "flock_active_slug": "newark-ca-pd",
-    "flock_slugs": [
-      "newark-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newark CA PD"
     ],
@@ -72530,10 +67492,8 @@
   {
     "agency_id": "74177e29-6bac-5f35-8a72-d1fa6e6c4357",
     "slug": "newells-mobile-city-ca",
-    "flock_active_slug": "newells-mobile-city-ca",
-    "flock_slugs": [
-      "newells-mobile-city-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Newell's Mobile City (CA)"
     ],
@@ -72553,10 +67513,8 @@
   {
     "agency_id": "89bb3ead-5e04-51d3-a009-32d155e36a87",
     "slug": "north-kern-cemetery-district-ca-pd",
-    "flock_active_slug": "north-kern-cemetery-district-ca-pd",
-    "flock_slugs": [
-      "north-kern-cemetery-district-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "North Kern Cemetery District CA PD"
     ],
@@ -72578,10 +67536,8 @@
   {
     "agency_id": "5f507ed1-8694-50cb-b6a5-f3261d6f6a3c",
     "slug": "oak-valley-ii-ca",
-    "flock_active_slug": "oak-valley-ii-ca",
-    "flock_slugs": [
-      "oak-valley-ii-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oak Valley II (CA)"
     ],
@@ -72601,10 +67557,8 @@
   {
     "agency_id": "81ba4320-6065-5064-a966-5b03022434ab",
     "slug": "ogden-dunes-in-pd",
-    "flock_active_slug": "ogden-dunes-in-pd",
-    "flock_slugs": [
-      "ogden-dunes-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ogden Dunes IN PD"
     ],
@@ -72628,10 +67582,8 @@
   {
     "agency_id": "56f9a46f-863a-5d77-b2c9-72403bb11a8e",
     "slug": "old",
-    "flock_active_slug": "old",
-    "flock_slugs": [
-      "old"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Old"
     ],
@@ -72648,10 +67600,8 @@
   {
     "agency_id": "49b7e68a-8261-5236-85bc-9854e46387a9",
     "slug": "olinda-ranch-community-ca",
-    "flock_active_slug": "olinda-ranch-community-ca",
-    "flock_slugs": [
-      "olinda-ranch-community-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Olinda Ranch Community (CA)"
     ],
@@ -72671,10 +67621,8 @@
   {
     "agency_id": "c9751186-93a1-586a-96c0-92bfc49d6c54",
     "slug": "olivewood-community-association-ca",
-    "flock_active_slug": "olivewood-community-association-ca",
-    "flock_slugs": [
-      "olivewood-community-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Olivewood Community Association (CA)"
     ],
@@ -72694,10 +67642,8 @@
   {
     "agency_id": "f404cc12-352c-5e5c-969f-995c17d8640f",
     "slug": "ontario-oh-pd",
-    "flock_active_slug": "ontario-oh-pd",
-    "flock_slugs": [
-      "ontario-oh-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ontario OH PD"
     ],
@@ -72721,10 +67667,8 @@
   {
     "agency_id": "adae2f31-2d45-52bc-8c24-c07babbd4508",
     "slug": "orange-beach-al-pd",
-    "flock_active_slug": "orange-beach-al-pd",
-    "flock_slugs": [
-      "orange-beach-al-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange Beach AL PD"
     ],
@@ -72748,10 +67692,8 @@
   {
     "agency_id": "2693f816-23d4-58ad-bdb7-0d851e03b3d6",
     "slug": "orange-coast-college-campus-ca-pd",
-    "flock_active_slug": "orange-coast-college-campus-ca-pd",
-    "flock_slugs": [
-      "orange-coast-college-campus-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange Coast College Campus CA PD"
     ],
@@ -72774,10 +67716,8 @@
   {
     "agency_id": "74719b7b-43cb-57ec-a0bc-26515454b5dc",
     "slug": "orange-county-ca-da-office",
-    "flock_active_slug": "orange-county-ca-da-office",
-    "flock_slugs": [
-      "orange-county-ca-da-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange County (CA) DA Office"
     ],
@@ -72799,10 +67739,8 @@
   {
     "agency_id": "a2c03da5-7700-5042-8d22-ab98c8a1c7f2",
     "slug": "orange-county-fire-authority-ca",
-    "flock_active_slug": "orange-county-fire-authority-ca",
-    "flock_slugs": [
-      "orange-county-fire-authority-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange County Fire Authority (CA)"
     ],
@@ -72824,10 +67762,8 @@
   {
     "agency_id": "c45e5dc2-fd51-530a-8b09-3488758f9328",
     "slug": "orange-county-fl-so",
-    "flock_active_slug": "orange-county-fl-so",
-    "flock_slugs": [
-      "orange-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange County FL SO"
     ],
@@ -72851,10 +67787,8 @@
   {
     "agency_id": "2c981ce6-8d54-565f-bb99-ac885eee8769",
     "slug": "orange-county-so-ca",
-    "flock_active_slug": "orange-county-so-ca",
-    "flock_slugs": [
-      "orange-county-so-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange County SO CA"
     ],
@@ -72878,10 +67812,8 @@
   {
     "agency_id": "508e3f9d-bcc2-5540-b89f-73dd04f6676a",
     "slug": "orange-cove-ca-pd",
-    "flock_active_slug": "orange-cove-ca-pd",
-    "flock_slugs": [
-      "orange-cove-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orange Cove CA PD"
     ],
@@ -72905,10 +67837,8 @@
   {
     "agency_id": "5a4bfc03-5e3c-5d3b-8371-fe7beac76e1f",
     "slug": "orlando-fl-pd",
-    "flock_active_slug": "orlando-fl-pd",
-    "flock_slugs": [
-      "orlando-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Orlando FL PD"
     ],
@@ -72932,10 +67862,8 @@
   {
     "agency_id": "2e1e1b36-7a6b-5c97-8143-65347503186c",
     "slug": "oxnard-ca-pd",
-    "flock_active_slug": "oxnard-ca-pd",
-    "flock_slugs": [
-      "oxnard-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oxnard CA PD"
     ],
@@ -72959,10 +67887,8 @@
   {
     "agency_id": "3e018e17-0297-5a20-8959-c960ed0a14b3",
     "slug": "pacific-palisades-residents-association-ca",
-    "flock_active_slug": "pacific-palisades-residents-association-ca",
-    "flock_slugs": [
-      "pacific-palisades-residents-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pacific Palisades Residents Association (CA)"
     ],
@@ -72982,10 +67908,8 @@
   {
     "agency_id": "942d7467-8fdc-590a-850b-76df3b0f6167",
     "slug": "pacifica-san-juan",
-    "flock_active_slug": "pacifica-san-juan",
-    "flock_slugs": [
-      "pacifica-san-juan"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pacifica San Juan"
     ],
@@ -73001,10 +67925,8 @@
   {
     "agency_id": "9ce29f9b-9f24-5a82-a3f2-7608d5a40501",
     "slug": "paradise-valley-az-pd",
-    "flock_active_slug": "paradise-valley-az-pd",
-    "flock_slugs": [
-      "paradise-valley-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Paradise Valley AZ PD"
     ],
@@ -73028,10 +67950,8 @@
   {
     "agency_id": "b257e032-9568-5909-a43e-1c7934119ad9",
     "slug": "peotone-il-pd",
-    "flock_active_slug": "peotone-il-pd",
-    "flock_slugs": [
-      "peotone-il-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peotone IL PD"
     ],
@@ -73055,10 +67975,8 @@
   {
     "agency_id": "6923dc3e-4533-5c70-bdfc-073a1e360ac6",
     "slug": "peppertree-bend-ca",
-    "flock_active_slug": "peppertree-bend-ca",
-    "flock_slugs": [
-      "peppertree-bend-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Peppertree Bend (CA)"
     ],
@@ -73078,10 +67996,8 @@
   {
     "agency_id": "d5eacec5-3e5c-52b2-be12-07db63b34db2",
     "slug": "pittsboro-in-pd",
-    "flock_active_slug": "pittsboro-in-pd",
-    "flock_slugs": [
-      "pittsboro-in-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pittsboro IN PD"
     ],
@@ -73105,10 +68021,8 @@
   {
     "agency_id": "ee39b0f7-1dd6-5526-88ce-57e3dd7d8488",
     "slug": "placentia-ca-pd",
-    "flock_active_slug": "placentia-ca-pd",
-    "flock_slugs": [
-      "placentia-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Placentia CA PD"
     ],
@@ -73132,10 +68046,8 @@
   {
     "agency_id": "296ca8d3-956b-5f18-8743-2bd6c53e41f9",
     "slug": "placer-county-ca-da-office",
-    "flock_active_slug": "placer-county-ca-da-office",
-    "flock_slugs": [
-      "placer-county-ca-da-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Placer County CA DA Office"
     ],
@@ -73157,10 +68069,8 @@
   {
     "agency_id": "59b1f730-2412-5790-92fd-a707e3ac23cd",
     "slug": "pleasant-hill-ca-pd",
-    "flock_active_slug": "pleasant-hill-ca-pd",
-    "flock_slugs": [
-      "pleasant-hill-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pleasant Hill CA PD"
     ],
@@ -73184,10 +68094,8 @@
   {
     "agency_id": "62f9d91a-99cb-5428-8312-38718e2196ed",
     "slug": "pomona-ca-pd",
-    "flock_active_slug": "pomona-ca-pd",
-    "flock_slugs": [
-      "pomona-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Pomona CA PD"
     ],
@@ -73211,10 +68119,8 @@
   {
     "agency_id": "56464d81-cdfa-542c-ae8d-b2c30eb1c71d",
     "slug": "quiet-harbor",
-    "flock_active_slug": "quiet-harbor",
-    "flock_slugs": [
-      "quiet-harbor"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Quiet Harbor"
     ],
@@ -73230,10 +68136,8 @@
   {
     "agency_id": "d66535a5-d9f6-5a8f-a7ed-48c00cfd91f3",
     "slug": "redding-pd-ca",
-    "flock_active_slug": "redding-pd-ca",
-    "flock_slugs": [
-      "redding-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Redding PD - CA"
     ],
@@ -73257,10 +68161,8 @@
   {
     "agency_id": "02126911-e73c-519e-b23b-8bc1cfb0d92d",
     "slug": "redondo-beach-ca-pd",
-    "flock_active_slug": "redondo-beach-ca-pd",
-    "flock_slugs": [
-      "redondo-beach-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Redondo Beach CA PD"
     ],
@@ -73284,10 +68186,8 @@
   {
     "agency_id": "16fa6eb0-e52b-5dc8-b2a5-4d9babbec252",
     "slug": "reflections-hoa-ca",
-    "flock_active_slug": "reflections-hoa-ca",
-    "flock_slugs": [
-      "reflections-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reflections HOA (CA)"
     ],
@@ -73307,10 +68207,8 @@
   {
     "agency_id": "d0b9ceb5-ac4a-505b-b767-83abcc3f5347",
     "slug": "reno-nv-pd",
-    "flock_active_slug": "reno-nv-pd",
-    "flock_slugs": [
-      "reno-nv-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Reno NV PD"
     ],
@@ -73334,10 +68232,8 @@
   {
     "agency_id": "76ffd436-962c-5842-92bc-1fb2c82f20dd",
     "slug": "rialto-pd-ca",
-    "flock_active_slug": "rialto-pd-ca",
-    "flock_slugs": [
-      "rialto-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rialto PD CA"
     ],
@@ -73361,10 +68257,8 @@
   {
     "agency_id": "da68a0d1-cb53-5035-a69a-6e68e21fe5ef",
     "slug": "richland-county-sc-so",
-    "flock_active_slug": "richland-county-sc-so",
-    "flock_slugs": [
-      "richland-county-sc-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richland County SC SO"
     ],
@@ -73388,10 +68282,8 @@
   {
     "agency_id": "fb63b4c3-2516-5d13-9633-c5319bec1ee1",
     "slug": "richmond-housing-authority-ca-pd",
-    "flock_active_slug": "richmond-housing-authority-ca-pd",
-    "flock_slugs": [
-      "richmond-housing-authority-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Richmond Housing Authority CA PD"
     ],
@@ -73413,10 +68305,8 @@
   {
     "agency_id": "8d7fd470-fecf-5788-921d-7f82bc634a71",
     "slug": "rio-hondo-college-pd-ca",
-    "flock_active_slug": "rio-hondo-college-pd-ca",
-    "flock_slugs": [
-      "rio-hondo-college-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rio Hondo College PD CA"
     ],
@@ -73439,10 +68329,8 @@
   {
     "agency_id": "d7e600e3-b7e1-5f8e-b1a7-6166c6932df5",
     "slug": "ripon-ca-pd",
-    "flock_active_slug": "ripon-ca-pd",
-    "flock_slugs": [
-      "ripon-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ripon CA PD"
     ],
@@ -73466,10 +68354,8 @@
   {
     "agency_id": "be4d4df1-462d-554f-b8fb-6139ed84e8a0",
     "slug": "ritchie-brothers-auctioneers",
-    "flock_active_slug": "ritchie-brothers-auctioneers",
-    "flock_slugs": [
-      "ritchie-brothers-auctioneers"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ritchie Brothers Auctioneers"
     ],
@@ -73485,10 +68371,8 @@
   {
     "agency_id": "bcd09a39-214a-55f3-b3b7-4e6e1ef26176",
     "slug": "riv-co-arson-tf-ca-pd",
-    "flock_active_slug": "riv-co-arson-tf-ca-pd",
-    "flock_slugs": [
-      "riv-co-arson-tf-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "RIV CO ARSON TF CA PD"
     ],
@@ -73510,10 +68394,8 @@
   {
     "agency_id": "650ab346-a013-56f6-a970-1bf8a61acb18",
     "slug": "riverside-county-ca-district-attorney",
-    "flock_active_slug": "riverside-county-ca-district-attorney",
-    "flock_slugs": [
-      "riverside-county-ca-district-attorney"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Riverside County CA District Attorney"
     ],
@@ -73538,10 +68420,8 @@
   {
     "agency_id": "8eb76a20-5443-5363-978b-807ae1b5d530",
     "slug": "rocklin-ca-pd",
-    "flock_active_slug": "rocklin-ca-pd",
-    "flock_slugs": [
-      "rocklin-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rocklin CA PD"
     ],
@@ -73565,10 +68445,8 @@
   {
     "agency_id": "366eac9d-3114-5e9e-a23a-a1ac15aedb7f",
     "slug": "rose-hills-memorial-park-mortuary-ca",
-    "flock_active_slug": "rose-hills-memorial-park-mortuary-ca",
-    "flock_slugs": [
-      "rose-hills-memorial-park-mortuary-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rose Hills Memorial Park & Mortuary (CA)"
     ],
@@ -73588,10 +68466,8 @@
   {
     "agency_id": "26ed4286-4037-515f-a9f8-f411f8303bc0",
     "slug": "roseville-ca-pd",
-    "flock_active_slug": "roseville-ca-pd",
-    "flock_slugs": [
-      "roseville-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Roseville CA PD"
     ],
@@ -73615,10 +68491,8 @@
   {
     "agency_id": "f314d73b-0427-5f5b-af2d-74b824eef8ab",
     "slug": "round-valley-indian-tribes-ca",
-    "flock_active_slug": "round-valley-indian-tribes-ca",
-    "flock_slugs": [
-      "round-valley-indian-tribes-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Round Valley Indian Tribes CA"
     ],
@@ -73638,10 +68512,8 @@
   {
     "agency_id": "3371578e-575d-5750-9a72-ffcdbcdd1e03",
     "slug": "rountree-road-neighborhood-ca",
-    "flock_active_slug": "rountree-road-neighborhood-ca",
-    "flock_slugs": [
-      "rountree-road-neighborhood-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Rountree Road Neighborhood (CA)"
     ],
@@ -73661,10 +68533,8 @@
   {
     "agency_id": "6a2741a1-b6d5-5537-9963-9f2fb2b2447e",
     "slug": "sacramento-ca-da",
-    "flock_active_slug": "sacramento-ca-da",
-    "flock_slugs": [
-      "sacramento-ca-da"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sacramento CA DA"
     ],
@@ -73688,10 +68558,8 @@
   {
     "agency_id": "bae9861d-a7ef-567d-b31b-a627075decf9",
     "slug": "sacramento-ca-pd",
-    "flock_active_slug": "sacramento-ca-pd",
-    "flock_slugs": [
-      "sacramento-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sacramento CA PD"
     ],
@@ -73715,10 +68583,8 @@
   {
     "agency_id": "90910dc9-55ae-5362-93c3-d00246b75cac",
     "slug": "sacramento-county-ca-so",
-    "flock_active_slug": "sacramento-county-ca-so",
-    "flock_slugs": [
-      "sacramento-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sacramento County CA SO"
     ],
@@ -73742,10 +68608,8 @@
   {
     "agency_id": "6c12c240-c390-5c0f-b570-8900c2366343",
     "slug": "sacramento-county-parks-department-ca",
-    "flock_active_slug": "sacramento-county-parks-department-ca",
-    "flock_slugs": [
-      "sacramento-county-parks-department-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sacramento County Parks Department CA"
     ],
@@ -73770,10 +68634,8 @@
   {
     "agency_id": "844ec58f-3abf-5a88-a280-2ba0f235264a",
     "slug": "salinas-ca-pd",
-    "flock_active_slug": "salinas-ca-pd",
-    "flock_slugs": [
-      "salinas-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Salinas CA PD"
     ],
@@ -73797,10 +68659,8 @@
   {
     "agency_id": "3684a873-d18a-57d8-a30b-c1fe3b4c93a3",
     "slug": "san-benito-county-so-ca",
-    "flock_active_slug": "san-benito-county-so-ca",
-    "flock_slugs": [
-      "san-benito-county-so-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Benito County SO CA"
     ],
@@ -73824,10 +68684,8 @@
   {
     "agency_id": "eb8124e9-87f6-5e8b-b887-8a02105ea18e",
     "slug": "san-bernardino-community-college-ca-pd",
-    "flock_active_slug": "san-bernardino-community-college-ca-pd",
-    "flock_slugs": [
-      "san-bernardino-community-college-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Bernardino Community College CA PD"
     ],
@@ -73850,10 +68708,8 @@
   {
     "agency_id": "79b569e0-f635-5cbe-9be7-bb5ed9d00482",
     "slug": "san-bernardino-county-ca-human-services-law-enforcement",
-    "flock_active_slug": "san-bernardino-county-ca-human-services-law-enforcement",
-    "flock_slugs": [
-      "san-bernardino-county-ca-human-services-law-enforcement"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Bernardino County CA Human Services [Law Enforcement]"
     ],
@@ -73876,10 +68732,8 @@
   {
     "agency_id": "0fafb2c6-af8b-5e57-abec-c9a469d32327",
     "slug": "san-bernardino-county-ca-so",
-    "flock_active_slug": "san-bernardino-county-ca-so",
-    "flock_slugs": [
-      "san-bernardino-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Bernardino County CA SO"
     ],
@@ -73904,10 +68758,8 @@
   {
     "agency_id": "b66facad-4ee0-558e-8bfe-32d1894afad1",
     "slug": "san-diego-harbor-ca-pd",
-    "flock_active_slug": "san-diego-harbor-ca-pd",
-    "flock_slugs": [
-      "san-diego-harbor-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Diego Harbor CA PD"
     ],
@@ -73929,10 +68781,8 @@
   {
     "agency_id": "2e9edae6-7b5a-5b86-bd0e-c3e06b3d96d0",
     "slug": "san-fernando-ca-pd",
-    "flock_active_slug": "san-fernando-ca-pd",
-    "flock_slugs": [
-      "san-fernando-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Fernando CA PD"
     ],
@@ -73956,10 +68806,8 @@
   {
     "agency_id": "0c16750f-dc42-5f60-9071-6ebb60654027",
     "slug": "san-francisco-district-attorney-ca",
-    "flock_active_slug": "san-francisco-district-attorney-ca",
-    "flock_slugs": [
-      "san-francisco-district-attorney-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Francisco District Attorney CA"
     ],
@@ -73984,10 +68832,8 @@
   {
     "agency_id": "1b7f2e03-aea6-57dd-9a58-f75d98eb2c74",
     "slug": "san-joaquin-ca-da",
-    "flock_active_slug": "san-joaquin-ca-da",
-    "flock_slugs": [
-      "san-joaquin-ca-da"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Joaquin CA DA"
     ],
@@ -74011,10 +68857,8 @@
   {
     "agency_id": "afc27a65-11a4-5c6e-9c22-3d94e875a399",
     "slug": "san-joaquin-delta-college-pd-ca",
-    "flock_active_slug": "san-joaquin-delta-college-pd-ca",
-    "flock_slugs": [
-      "san-joaquin-delta-college-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Joaquin Delta College PD (CA)"
     ],
@@ -74037,10 +68881,8 @@
   {
     "agency_id": "8269106d-e127-5d07-97fe-d7963b813025",
     "slug": "san-jose-evergreen-community-college-campus-pd-ca",
-    "flock_active_slug": "san-jose-evergreen-community-college-campus-pd-ca",
-    "flock_slugs": [
-      "san-jose-evergreen-community-college-campus-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Jose - Evergreen Community College Campus PD CA"
     ],
@@ -74063,10 +68905,8 @@
   {
     "agency_id": "fd81cdb7-d353-5d60-b5be-145011443df5",
     "slug": "san-jose-state-university-ca",
-    "flock_active_slug": "san-jose-state-university-ca",
-    "flock_slugs": [
-      "san-jose-state-university-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Jose State University CA"
     ],
@@ -74089,10 +68929,8 @@
   {
     "agency_id": "bdf7188e-c215-549a-bbfd-4c50ba5b0be0",
     "slug": "san-juan-bautista-ca",
-    "flock_active_slug": "san-juan-bautista-ca",
-    "flock_slugs": [
-      "san-juan-bautista-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Juan Bautista CA"
     ],
@@ -74116,10 +68954,8 @@
   {
     "agency_id": "484fbe20-7e66-5e78-b0d1-592e137257a3",
     "slug": "san-leandro-ca-pd",
-    "flock_active_slug": "san-leandro-ca-pd",
-    "flock_slugs": [
-      "san-leandro-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Leandro CA PD"
     ],
@@ -74143,10 +68979,8 @@
   {
     "agency_id": "332407d3-a475-546c-88c0-b2046bb47ca7",
     "slug": "san-luis-obispo-ca-pd",
-    "flock_active_slug": "san-luis-obispo-ca-pd",
-    "flock_slugs": [
-      "san-luis-obispo-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Luis Obispo CA PD"
     ],
@@ -74170,10 +69004,8 @@
   {
     "agency_id": "06f1b20d-a403-5088-9d3a-d8df6edcb126",
     "slug": "san-luis-obispo-county-ca-sheriff",
-    "flock_active_slug": "san-luis-obispo-county-ca-sheriff",
-    "flock_slugs": [
-      "san-luis-obispo-county-ca-sheriff"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Luis Obispo County (CA) Sheriff"
     ],
@@ -74195,10 +69027,8 @@
   {
     "agency_id": "e0b44c96-8eee-5425-abe1-00ef89d519bd",
     "slug": "san-pablo-ca-pd",
-    "flock_active_slug": "san-pablo-ca-pd",
-    "flock_slugs": [
-      "san-pablo-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Pablo CA PD"
     ],
@@ -74222,10 +69052,8 @@
   {
     "agency_id": "f17f02e4-77c4-50ca-a858-8e388e2b8e85",
     "slug": "san-pasqual-ca-pd",
-    "flock_active_slug": "san-pasqual-ca-pd",
-    "flock_slugs": [
-      "san-pasqual-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Pasqual CA PD"
     ],
@@ -74247,10 +69075,8 @@
   {
     "agency_id": "70e82b2b-8338-517d-a602-8705d9a524e2",
     "slug": "san-ramon-ca-pd",
-    "flock_active_slug": "san-ramon-ca-pd",
-    "flock_slugs": [
-      "san-ramon-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "San Ramon CA PD"
     ],
@@ -74274,10 +69100,8 @@
   {
     "agency_id": "dddefaf4-84f7-5857-8011-45b6eda02991",
     "slug": "sand-city-ca-pd",
-    "flock_active_slug": "sand-city-ca-pd",
-    "flock_slugs": [
-      "sand-city-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sand City CA PD"
     ],
@@ -74301,10 +69125,8 @@
   {
     "agency_id": "e35b094f-0435-50b5-a03c-e644ad6144be",
     "slug": "sanger-ca-pd",
-    "flock_active_slug": "sanger-ca-pd",
-    "flock_slugs": [
-      "sanger-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sanger CA PD"
     ],
@@ -74328,10 +69150,8 @@
   {
     "agency_id": "859a9edf-ef08-56b8-bb5c-db50aa11cad9",
     "slug": "santa-anita-oaks-ca",
-    "flock_active_slug": "santa-anita-oaks-ca",
-    "flock_slugs": [
-      "santa-anita-oaks-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Anita Oaks (CA)"
     ],
@@ -74351,10 +69171,8 @@
   {
     "agency_id": "409e0107-b585-5909-bb57-7603baa9360c",
     "slug": "santa-barbara-county-ca-so",
-    "flock_active_slug": "santa-barbara-county-ca-so",
-    "flock_slugs": [
-      "santa-barbara-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Barbara County CA SO"
     ],
@@ -74378,10 +69196,8 @@
   {
     "agency_id": "6be9f842-1658-5490-8be4-14b77cc1e96d",
     "slug": "santa-clara-da-ca",
-    "flock_active_slug": "santa-clara-da-ca",
-    "flock_slugs": [
-      "santa-clara-da-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Clara DA CA"
     ],
@@ -74405,10 +69221,8 @@
   {
     "agency_id": "6c6b2202-9b87-5c04-b232-040a4f6e1468",
     "slug": "santa-maria-ca-pd",
-    "flock_active_slug": "santa-maria-ca-pd",
-    "flock_slugs": [
-      "santa-maria-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Maria CA PD"
     ],
@@ -74432,10 +69246,8 @@
   {
     "agency_id": "4428f521-1969-5e78-9f02-2ff4495e7f72",
     "slug": "santa-monica-ca-pd",
-    "flock_active_slug": "santa-monica-ca-pd",
-    "flock_slugs": [
-      "santa-monica-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Monica CA PD"
     ],
@@ -74459,10 +69271,8 @@
   {
     "agency_id": "9a02b7a4-b078-5f90-9323-a684dcda6674",
     "slug": "santa-rosa-band-of-cahuilla-indians-ca",
-    "flock_active_slug": "santa-rosa-band-of-cahuilla-indians-ca",
-    "flock_slugs": [
-      "santa-rosa-band-of-cahuilla-indians-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Santa Rosa Band of Cahuilla Indians CA"
     ],
@@ -74484,10 +69294,8 @@
   {
     "agency_id": "a057049d-8be7-595b-bb9f-8755d18ea194",
     "slug": "sarasota-county-fl-so",
-    "flock_active_slug": "sarasota-county-fl-so",
-    "flock_slugs": [
-      "sarasota-county-fl-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sarasota County FL SO"
     ],
@@ -74511,10 +69319,8 @@
   {
     "agency_id": "98c98e27-7c96-5f33-9f93-9a658d56c4b3",
     "slug": "sarasota-fl-pd",
-    "flock_active_slug": "sarasota-fl-pd",
-    "flock_slugs": [
-      "sarasota-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sarasota FL PD"
     ],
@@ -74538,10 +69344,8 @@
   {
     "agency_id": "56155ca3-fe36-5359-84bd-1feb3daa9d83",
     "slug": "seal-beach-ca-pd",
-    "flock_active_slug": "seal-beach-ca-pd",
-    "flock_slugs": [
-      "seal-beach-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Seal Beach CA PD"
     ],
@@ -74565,10 +69369,8 @@
   {
     "agency_id": "bc17b741-df64-54cc-a3cc-62bd3fa08f65",
     "slug": "sedgwick-ks-pd",
-    "flock_active_slug": "sedgwick-ks-pd",
-    "flock_slugs": [
-      "sedgwick-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sedgwick KS PD"
     ],
@@ -74592,10 +69394,8 @@
   {
     "agency_id": "03c310c0-6e05-5ad2-872a-d4e8b804358f",
     "slug": "selma-ca-pd",
-    "flock_active_slug": "selma-ca-pd",
-    "flock_slugs": [
-      "selma-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Selma CA PD"
     ],
@@ -74619,10 +69419,8 @@
   {
     "agency_id": "45b455ec-b554-58dd-9cc9-e5e3bb290808",
     "slug": "senoia-ga-pd",
-    "flock_active_slug": "senoia-ga-pd",
-    "flock_slugs": [
-      "senoia-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Senoia GA PD"
     ],
@@ -74646,10 +69444,8 @@
   {
     "agency_id": "6db175fe-bff6-58bc-a911-d688f797fda9",
     "slug": "shafter-pd-ca",
-    "flock_active_slug": "shafter-pd-ca",
-    "flock_slugs": [
-      "shafter-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shafter PD CA"
     ],
@@ -74673,10 +69469,8 @@
   {
     "agency_id": "0a4e711e-2f15-5549-aedd-f78cca464fc3",
     "slug": "shasta-arson-task-force-ca",
-    "flock_active_slug": "shasta-arson-task-force-ca",
-    "flock_slugs": [
-      "shasta-arson-task-force-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shasta Arson Task Force CA"
     ],
@@ -74698,10 +69492,8 @@
   {
     "agency_id": "e4029280-c00b-58d0-b32e-4d944be14df8",
     "slug": "sherwood-village-anaheim-ca",
-    "flock_active_slug": "sherwood-village-anaheim-ca",
-    "flock_slugs": [
-      "sherwood-village-anaheim-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sherwood Village-Anaheim (CA)"
     ],
@@ -74721,10 +69513,8 @@
   {
     "agency_id": "42ffc6f8-66bc-5d89-a53b-e3e030c26177",
     "slug": "shore-cliffs-ca",
-    "flock_active_slug": "shore-cliffs-ca",
-    "flock_slugs": [
-      "shore-cliffs-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Shore Cliffs (CA)"
     ],
@@ -74744,10 +69534,8 @@
   {
     "agency_id": "e087cf69-734d-5470-9f56-84a19ba42d9f",
     "slug": "sierra-madre-ca-pd",
-    "flock_active_slug": "sierra-madre-ca-pd",
-    "flock_slugs": [
-      "sierra-madre-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sierra Madre CA PD"
     ],
@@ -74771,10 +69559,8 @@
   {
     "agency_id": "fc97bf62-065b-507f-a327-4fd4c94453c6",
     "slug": "signal-hill-ca-pd",
-    "flock_active_slug": "signal-hill-ca-pd",
-    "flock_slugs": [
-      "signal-hill-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Signal Hill CA PD"
     ],
@@ -74798,10 +69584,8 @@
   {
     "agency_id": "b1b2a97d-0513-5ec3-86ef-3a6351dd2c58",
     "slug": "simon-property-group-hq-in",
-    "flock_active_slug": "simon-property-group-hq-in",
-    "flock_slugs": [
-      "simon-property-group-hq-in"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Simon Property Group HQ (IN)"
     ],
@@ -74817,10 +69601,8 @@
   {
     "agency_id": "1cb34efd-a1f4-55a7-8e18-afe3ad69412b",
     "slug": "siskiyou-county-so-ca",
-    "flock_active_slug": "siskiyou-county-so-ca",
-    "flock_slugs": [
-      "siskiyou-county-so-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Siskiyou County SO CA"
     ],
@@ -74844,10 +69626,8 @@
   {
     "agency_id": "81e727b4-f1d6-5aea-8cd4-db0cf88a7306",
     "slug": "solano-county-da-ca",
-    "flock_active_slug": "solano-county-da-ca",
-    "flock_slugs": [
-      "solano-county-da-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Solano County DA CA"
     ],
@@ -74871,10 +69651,8 @@
   {
     "agency_id": "99e640ed-c175-5ce6-90c8-5ea55dfa2ed3",
     "slug": "solano-county-special-investigations-bureau",
-    "flock_active_slug": "solano-county-special-investigations-bureau",
-    "flock_slugs": [
-      "solano-county-special-investigations-bureau"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Solano County Special Investigations Bureau"
     ],
@@ -74897,10 +69675,8 @@
   {
     "agency_id": "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4",
     "slug": "soledad-ca-pd",
-    "flock_active_slug": "soledad-ca-pd",
-    "flock_slugs": [
-      "soledad-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Soledad CA PD"
     ],
@@ -74924,10 +69700,8 @@
   {
     "agency_id": "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2",
     "slug": "sonoma-county-ca-so",
-    "flock_active_slug": "sonoma-county-ca-so",
-    "flock_slugs": [
-      "sonoma-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sonoma County CA SO"
     ],
@@ -74951,10 +69725,8 @@
   {
     "agency_id": "df046d0d-e4db-592a-89b0-646313b2ecb3",
     "slug": "south-sioux-city-ne-pd",
-    "flock_active_slug": "south-sioux-city-ne-pd",
-    "flock_slugs": [
-      "south-sioux-city-ne-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "South Sioux City NE PD"
     ],
@@ -74978,10 +69750,8 @@
   {
     "agency_id": "33f2410a-d3bc-59c8-9076-2f363c25b8ea",
     "slug": "sparks-police-department-nv",
-    "flock_active_slug": "sparks-police-department-nv",
-    "flock_slugs": [
-      "sparks-police-department-nv"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sparks Police Department - NV"
     ],
@@ -75004,10 +69774,8 @@
   {
     "agency_id": "db8b5934-0b06-5420-893c-9295c3aaf07d",
     "slug": "st-charles-county-mo-pd",
-    "flock_active_slug": "st-charles-county-mo-pd",
-    "flock_slugs": [
-      "st-charles-county-mo-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Charles County MO PD"
     ],
@@ -75031,10 +69799,8 @@
   {
     "agency_id": "ec6ab4f5-f3f8-5312-925f-9394a5877d27",
     "slug": "st-francois-county-mo-so",
-    "flock_active_slug": "st-francois-county-mo-so",
-    "flock_slugs": [
-      "st-francois-county-mo-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "St. Francois County MO SO"
     ],
@@ -75058,10 +69824,8 @@
   {
     "agency_id": "08bd5589-6ad6-5be4-bea5-60bd90bf6883",
     "slug": "stallion-springs-ca-pd",
-    "flock_active_slug": "stallion-springs-ca-pd",
-    "flock_slugs": [
-      "stallion-springs-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Stallion Springs CA PD"
     ],
@@ -75085,10 +69849,8 @@
   {
     "agency_id": "23deb1ec-b95d-59ba-b737-ecbaf3bc9c2c",
     "slug": "suisun-city-ca-pd",
-    "flock_active_slug": "suisun-city-ca-pd",
-    "flock_slugs": [
-      "suisun-city-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Suisun City CA PD"
     ],
@@ -75112,10 +69874,8 @@
   {
     "agency_id": "132bc98f-aebb-52c5-b98b-6dbbec94ad46",
     "slug": "sumner-county-tn-so",
-    "flock_active_slug": "sumner-county-tn-so",
-    "flock_slugs": [
-      "sumner-county-tn-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sumner County TN SO"
     ],
@@ -75139,10 +69899,8 @@
   {
     "agency_id": "48ca1693-7f6e-5f8c-a4ab-5cb0c18c319e",
     "slug": "sundance-ca",
-    "flock_active_slug": "sundance-ca",
-    "flock_slugs": [
-      "sundance-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sundance (CA)"
     ],
@@ -75162,10 +69920,8 @@
   {
     "agency_id": "d9342287-962b-509a-9861-e44e0172394e",
     "slug": "sutter-county-ca-so",
-    "flock_active_slug": "sutter-county-ca-so",
-    "flock_slugs": [
-      "sutter-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sutter County CA SO"
     ],
@@ -75189,10 +69945,8 @@
   {
     "agency_id": "884e9ea9-0bb4-516d-8115-721962e6e300",
     "slug": "sycamore-place-ca",
-    "flock_active_slug": "sycamore-place-ca",
-    "flock_slugs": [
-      "sycamore-place-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Sycamore Place (CA)"
     ],
@@ -75212,10 +69966,8 @@
   {
     "agency_id": "c381f451-5a62-51e2-bb73-cb592b9371ec",
     "slug": "taft-ca-pd",
-    "flock_active_slug": "taft-ca-pd",
-    "flock_slugs": [
-      "taft-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Taft CA PD"
     ],
@@ -75239,10 +69991,8 @@
   {
     "agency_id": "9d20e130-64d6-5b99-aaf0-28740d1fcc92",
     "slug": "tarpon-springs-fl-pd",
-    "flock_active_slug": "tarpon-springs-fl-pd",
-    "flock_slugs": [
-      "tarpon-springs-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tarpon Springs FL PD"
     ],
@@ -75266,10 +70016,8 @@
   {
     "agency_id": "9873a872-c374-51e3-b9ea-6a6c427b932c",
     "slug": "tehachapi-ca-pd",
-    "flock_active_slug": "tehachapi-ca-pd",
-    "flock_slugs": [
-      "tehachapi-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tehachapi CA PD"
     ],
@@ -75293,10 +70041,8 @@
   {
     "agency_id": "2279723d-b2cf-59d8-8732-4fdefd822546",
     "slug": "tehama-county-ca-so",
-    "flock_active_slug": "tehama-county-ca-so",
-    "flock_slugs": [
-      "tehama-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tehama County CA SO"
     ],
@@ -75320,10 +70066,8 @@
   {
     "agency_id": "c34885fe-6219-5859-9574-d45240dd1af9",
     "slug": "temecula-ca-pd",
-    "flock_active_slug": "temecula-ca-pd",
-    "flock_slugs": [
-      "temecula-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Temecula CA PD"
     ],
@@ -75347,10 +70091,8 @@
   {
     "agency_id": "c7562b2e-899d-51ac-bbf0-4cde526babff",
     "slug": "test-demo-1234",
-    "flock_active_slug": "test-demo-1234",
-    "flock_slugs": [
-      "test-demo-1234"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Test Demo 1234"
     ],
@@ -75366,10 +70108,8 @@
   {
     "agency_id": "2b9c0fdc-5497-5022-8ee4-5ae8cd221ddf",
     "slug": "texas-city-tx-pd",
-    "flock_active_slug": "texas-city-tx-pd",
-    "flock_slugs": [
-      "texas-city-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Texas City TX PD"
     ],
@@ -75393,10 +70133,8 @@
   {
     "agency_id": "344abfc1-75f0-51e5-bd7e-6ba54ac13609",
     "slug": "the-landing-at-wildflower-station-ca",
-    "flock_active_slug": "the-landing-at-wildflower-station-ca",
-    "flock_slugs": [
-      "the-landing-at-wildflower-station-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "The Landing at Wildflower Station (CA)"
     ],
@@ -75416,10 +70154,8 @@
   {
     "agency_id": "890a202a-dd97-5136-8f4f-5fc64e60b29c",
     "slug": "the-lewis-group-of-companies",
-    "flock_active_slug": "the-lewis-group-of-companies",
-    "flock_slugs": [
-      "the-lewis-group-of-companies"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "The Lewis Group of Companies"
     ],
@@ -75435,10 +70171,8 @@
   {
     "agency_id": "1e8076f1-9739-5576-aa76-10a687e68446",
     "slug": "tift-county-ga-so",
-    "flock_active_slug": "tift-county-ga-so",
-    "flock_slugs": [
-      "tift-county-ga-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tift County GA SO"
     ],
@@ -75462,10 +70196,8 @@
   {
     "agency_id": "ca08fcba-f0f8-5ecc-8fea-4338abcb187e",
     "slug": "tifton-ga-pd",
-    "flock_active_slug": "tifton-ga-pd",
-    "flock_slugs": [
-      "tifton-ga-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tifton GA PD"
     ],
@@ -75489,10 +70221,8 @@
   {
     "agency_id": "225a622c-c9c8-5b37-818c-cdd5cbdec38d",
     "slug": "titusville-fl-pd",
-    "flock_active_slug": "titusville-fl-pd",
-    "flock_slugs": [
-      "titusville-fl-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Titusville FL PD"
     ],
@@ -75516,10 +70246,8 @@
   {
     "agency_id": "8dde57df-a338-5e82-ab54-c0ebc13d9720",
     "slug": "toluca-lake-ca",
-    "flock_active_slug": "toluca-lake-ca",
-    "flock_slugs": [
-      "toluca-lake-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Toluca Lake (CA)"
     ],
@@ -75539,10 +70267,8 @@
   {
     "agency_id": "311ff8a6-de97-5bdb-abba-9d5b9a21d66e",
     "slug": "tombstone-marshals-office-az",
-    "flock_active_slug": "tombstone-marshals-office-az",
-    "flock_slugs": [
-      "tombstone-marshals-office-az"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tombstone Marshals Office (AZ)"
     ],
@@ -75565,10 +70291,8 @@
   {
     "agency_id": "a064cac6-6a2e-5c77-bd96-c106cb96bd61",
     "slug": "total-wine-more-md",
-    "flock_active_slug": "total-wine-more-md",
-    "flock_slugs": [
-      "total-wine-more-md"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Total Wine & More (MD)"
     ],
@@ -75584,10 +70308,8 @@
   {
     "agency_id": "72812ca1-c7b8-5c94-8327-508726647ad8",
     "slug": "trinity-county-so-ca",
-    "flock_active_slug": "trinity-county-so-ca",
-    "flock_slugs": [
-      "trinity-county-so-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Trinity County SO CA"
     ],
@@ -75611,10 +70333,8 @@
   {
     "agency_id": "8fb27794-b88c-5373-b6a1-da64ae2f059c",
     "slug": "tulare-ca-pd",
-    "flock_active_slug": "tulare-ca-pd",
-    "flock_slugs": [
-      "tulare-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tulare CA PD"
     ],
@@ -75638,10 +70358,8 @@
   {
     "agency_id": "4cc1fd23-7711-52b8-be07-9d6e1ad7b364",
     "slug": "tulare-county-ca-so",
-    "flock_active_slug": "tulare-county-ca-so",
-    "flock_slugs": [
-      "tulare-county-ca-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tulare County CA SO"
     ],
@@ -75666,10 +70384,8 @@
   {
     "agency_id": "b1eec57c-0fcc-5546-bfb6-7005adc695d3",
     "slug": "turlock-ca-pd",
-    "flock_active_slug": "turlock-ca-pd",
-    "flock_slugs": [
-      "turlock-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Turlock CA PD"
     ],
@@ -75693,10 +70409,8 @@
   {
     "agency_id": "9eb7354b-b6ff-590b-b3bb-f097e0b30033",
     "slug": "tustin-ca-pd",
-    "flock_active_slug": "tustin-ca-pd",
-    "flock_slugs": [
-      "tustin-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tustin CA PD"
     ],
@@ -75720,10 +70434,8 @@
   {
     "agency_id": "61d84379-7a54-5b45-8292-ef44a2e1a1f3",
     "slug": "tustin-fields-ca",
-    "flock_active_slug": "tustin-fields-ca",
-    "flock_slugs": [
-      "tustin-fields-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tustin Fields (CA)"
     ],
@@ -75743,10 +70455,8 @@
   {
     "agency_id": "6978140c-1211-52e1-8c04-94d5a9791efe",
     "slug": "uc-irvine-campus-pd-ca",
-    "flock_active_slug": "uc-irvine-campus-pd-ca",
-    "flock_slugs": [
-      "uc-irvine-campus-pd-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "UC Irvine Campus PD CA"
     ],
@@ -75769,10 +70479,8 @@
   {
     "agency_id": "3f7eb8d2-ed50-5eac-9b8c-ac66584c00aa",
     "slug": "ukiah-ca-pd",
-    "flock_active_slug": "ukiah-ca-pd",
-    "flock_slugs": [
-      "ukiah-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ukiah CA PD"
     ],
@@ -75796,10 +70504,8 @@
   {
     "agency_id": "dde5fe3d-8dc6-5d4d-af6a-a28a62387cf6",
     "slug": "ukiah-fire-ca-fd",
-    "flock_active_slug": "ukiah-fire-ca-fd",
-    "flock_slugs": [
-      "ukiah-fire-ca-fd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ukiah Fire CA FD"
     ],
@@ -75821,10 +70527,8 @@
   {
     "agency_id": "e3faac7d-da12-5ca3-8d6b-9c11184d0919",
     "slug": "ulta-il",
-    "flock_active_slug": "ulta-il",
-    "flock_slugs": [
-      "ulta-il"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ulta (IL)"
     ],
@@ -75840,10 +70544,8 @@
   {
     "agency_id": "b3d62a9b-027b-58ce-a4ee-2378e02cd8f7",
     "slug": "ulysses-ks-pd",
-    "flock_active_slug": "ulysses-ks-pd",
-    "flock_slugs": [
-      "ulysses-ks-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ulysses KS PD"
     ],
@@ -75867,10 +70569,8 @@
   {
     "agency_id": "ecce0cdb-25b8-5f79-9108-3be60c1dc775",
     "slug": "university-of-ca-santa-barbara-ca-pd",
-    "flock_active_slug": "university-of-ca-santa-barbara-ca-pd",
-    "flock_slugs": [
-      "university-of-ca-santa-barbara-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of CA - Santa Barbara CA PD"
     ],
@@ -75893,10 +70593,8 @@
   {
     "agency_id": "eaef691d-609c-566f-ad67-3a187a241852",
     "slug": "university-of-california-berkeley",
-    "flock_active_slug": "university-of-california-berkeley",
-    "flock_slugs": [
-      "university-of-california-berkeley"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of California, Berkeley"
     ],
@@ -75919,10 +70617,8 @@
   {
     "agency_id": "89890ca4-4ace-50e7-a722-b23d22753898",
     "slug": "university-of-north-texas-at-denton-pd-tx",
-    "flock_active_slug": "university-of-north-texas-at-denton-pd-tx",
-    "flock_slugs": [
-      "university-of-north-texas-at-denton-pd-tx"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of North Texas at Denton PD (TX)"
     ],
@@ -75945,10 +70641,8 @@
   {
     "agency_id": "b1647bf6-e1ab-502c-be02-022861ee94ca",
     "slug": "university-of-san-francisco-ca-pd",
-    "flock_active_slug": "university-of-san-francisco-ca-pd",
-    "flock_slugs": [
-      "university-of-san-francisco-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of San Francisco CA PD"
     ],
@@ -75971,10 +70665,8 @@
   {
     "agency_id": "c246371a-5810-5428-b861-52b526e54678",
     "slug": "university-of-the-pacific-ca",
-    "flock_active_slug": "university-of-the-pacific-ca",
-    "flock_slugs": [
-      "university-of-the-pacific-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "University of the Pacific (CA)"
     ],
@@ -75997,10 +70689,8 @@
   {
     "agency_id": "11949eb7-26df-5b98-a23d-ac249879ec01",
     "slug": "upland-ca-pd",
-    "flock_active_slug": "upland-ca-pd",
-    "flock_slugs": [
-      "upland-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Upland CA PD"
     ],
@@ -76024,10 +70714,8 @@
   {
     "agency_id": "1406641c-043e-5440-8311-1b12d05131f5",
     "slug": "valley-circle-estates-ca",
-    "flock_active_slug": "valley-circle-estates-ca",
-    "flock_slugs": [
-      "valley-circle-estates-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Valley Circle Estates (CA)"
     ],
@@ -76047,10 +70735,8 @@
   {
     "agency_id": "e2af06fe-90f6-56aa-adc6-4afeb0c38e9e",
     "slug": "valley-glen-neighborhood-watch-ca",
-    "flock_active_slug": "valley-glen-neighborhood-watch-ca",
-    "flock_slugs": [
-      "valley-glen-neighborhood-watch-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Valley Glen Neighborhood Watch (CA)"
     ],
@@ -76070,10 +70756,8 @@
   {
     "agency_id": "21325cff-0c27-5601-a897-ef4965469a6c",
     "slug": "valley-glen-vose-neighborhood-watch-ca",
-    "flock_active_slug": "valley-glen-vose-neighborhood-watch-ca",
-    "flock_slugs": [
-      "valley-glen-vose-neighborhood-watch-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "VALLEY GLEN VOSE NEIGHBORHOOD WATCH (CA)"
     ],
@@ -76093,10 +70777,8 @@
   {
     "agency_id": "78e157c7-b826-5702-b5b3-d846c68ea601",
     "slug": "ventura-ca-pd",
-    "flock_active_slug": "ventura-ca-pd",
-    "flock_slugs": [
-      "ventura-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ventura CA PD"
     ],
@@ -76120,10 +70802,8 @@
   {
     "agency_id": "b592938c-c2c4-597c-b6cd-2bbb3b52447b",
     "slug": "ventura-county-district-attorneys-office-ca",
-    "flock_active_slug": "ventura-county-district-attorneys-office-ca",
-    "flock_slugs": [
-      "ventura-county-district-attorneys-office-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Ventura County District Attorney's Office CA"
     ],
@@ -76145,10 +70825,8 @@
   {
     "agency_id": "a5b59684-abcc-5a43-949d-3aec089d30a4",
     "slug": "vernon-ca-pd",
-    "flock_active_slug": "vernon-ca-pd",
-    "flock_slugs": [
-      "vernon-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Vernon CA PD"
     ],
@@ -76172,10 +70850,8 @@
   {
     "agency_id": "ce304605-e2bb-5b09-b2bf-0c04b423dc92",
     "slug": "view-park-hoa-ca",
-    "flock_active_slug": "view-park-hoa-ca",
-    "flock_slugs": [
-      "view-park-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "View Park HOA (CA)"
     ],
@@ -76195,10 +70871,8 @@
   {
     "agency_id": "a97028a3-2232-51da-94c3-9d73434149a9",
     "slug": "villa-del-mar-ca",
-    "flock_active_slug": "villa-del-mar-ca",
-    "flock_slugs": [
-      "villa-del-mar-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Villa Del Mar (CA)"
     ],
@@ -76218,10 +70892,8 @@
   {
     "agency_id": "518ec1a5-7eaa-5959-b698-ecc97e2aa4c6",
     "slug": "village-at-hiddenbrooke-ca",
-    "flock_active_slug": "village-at-hiddenbrooke-ca",
-    "flock_slugs": [
-      "village-at-hiddenbrooke-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village at Hiddenbrooke (CA)"
     ],
@@ -76241,10 +70913,8 @@
   {
     "agency_id": "cadbc0e5-90bb-552a-8ed6-63c6bbe8ce42",
     "slug": "village-pointe-ca",
-    "flock_active_slug": "village-pointe-ca",
-    "flock_slugs": [
-      "village-pointe-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Village Pointe (CA)"
     ],
@@ -76264,10 +70934,8 @@
   {
     "agency_id": "458b707c-5b99-5ec3-95c8-f7c9ae95ee0d",
     "slug": "walnut-creek-ca-pd",
-    "flock_active_slug": "walnut-creek-ca-pd",
-    "flock_slugs": [
-      "walnut-creek-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Walnut Creek CA PD"
     ],
@@ -76291,10 +70959,8 @@
   {
     "agency_id": "e7def38e-0798-58d3-81a3-43f1e46b242f",
     "slug": "washoe-county-nv-so",
-    "flock_active_slug": "washoe-county-nv-so",
-    "flock_slugs": [
-      "washoe-county-nv-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Washoe County NV SO"
     ],
@@ -76319,10 +70985,8 @@
   {
     "agency_id": "bbb4b898-29a3-54f2-b36c-002472ed784c",
     "slug": "waterstone-community-association-ca",
-    "flock_active_slug": "waterstone-community-association-ca",
-    "flock_slugs": [
-      "waterstone-community-association-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waterstone Community Association (CA)"
     ],
@@ -76342,10 +71006,8 @@
   {
     "agency_id": "3de0eb7e-fdc2-5be6-8b80-b5aecee3b5e3",
     "slug": "waterstone-hoa-ca",
-    "flock_active_slug": "waterstone-hoa-ca",
-    "flock_slugs": [
-      "waterstone-hoa-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Waterstone HOA (CA)"
     ],
@@ -76365,10 +71027,8 @@
   {
     "agency_id": "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f",
     "slug": "west-valley-mission-college-dist-campus-ca",
-    "flock_active_slug": "west-valley-mission-college-dist-campus-ca",
-    "flock_slugs": [
-      "west-valley-mission-college-dist-campus-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "West Valley Mission College Dist Campus (CA)"
     ],
@@ -76391,10 +71051,8 @@
   {
     "agency_id": "88641902-bc0f-5740-baef-47f0c280b455",
     "slug": "western-states-information-network-ca",
-    "flock_active_slug": "western-states-information-network-ca",
-    "flock_slugs": [
-      "western-states-information-network-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Western States Information Network (CA)"
     ],
@@ -76417,10 +71075,8 @@
   {
     "agency_id": "e9e62ca5-9bde-5fbd-a96e-e7ee780cfc20",
     "slug": "westfield-park-recreation-and-parkways",
-    "flock_active_slug": "westfield-park-recreation-and-parkways",
-    "flock_slugs": [
-      "westfield-park-recreation-and-parkways"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westfield Park Recreation and Parkways"
     ],
@@ -76436,10 +71092,8 @@
   {
     "agency_id": "47a01976-2030-52f3-9c3f-3347ce75fcf7",
     "slug": "westmorland-ca-pd",
-    "flock_active_slug": "westmorland-ca-pd",
-    "flock_slugs": [
-      "westmorland-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westmorland CA PD"
     ],
@@ -76463,10 +71117,8 @@
   {
     "agency_id": "5bee2f78-b95b-530f-847b-588127e925db",
     "slug": "westpark-las-palmas-ca",
-    "flock_active_slug": "westpark-las-palmas-ca",
-    "flock_slugs": [
-      "westpark-las-palmas-ca"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westpark Las Palmas (CA)"
     ],
@@ -76486,10 +71138,8 @@
   {
     "agency_id": "01183c44-3a5a-55a0-8601-cfe794ea28ff",
     "slug": "westwood-village",
-    "flock_active_slug": "westwood-village",
-    "flock_slugs": [
-      "westwood-village"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Westwood Village"
     ],
@@ -76505,10 +71155,8 @@
   {
     "agency_id": "d8a94e88-50c9-5801-aa66-3716e0f4b648",
     "slug": "wheatland-ca-pd",
-    "flock_active_slug": "wheatland-ca-pd",
-    "flock_slugs": [
-      "wheatland-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wheatland CA PD"
     ],
@@ -76532,10 +71180,8 @@
   {
     "agency_id": "19f7b6cc-d156-57a7-9f61-a0e846b224f2",
     "slug": "whittier-ca-pd",
-    "flock_active_slug": "whittier-ca-pd",
-    "flock_slugs": [
-      "whittier-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Whittier CA PD"
     ],
@@ -76559,10 +71205,8 @@
   {
     "agency_id": "0cd01be2-9f1c-5cae-a15e-e83ae5de9e77",
     "slug": "wichita-falls-tx-pd",
-    "flock_active_slug": "wichita-falls-tx-pd",
-    "flock_slugs": [
-      "wichita-falls-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Wichita Falls TX PD"
     ],
@@ -76586,10 +71230,8 @@
   {
     "agency_id": "48f57cd3-d6ca-5d95-aef9-ae970aad823f",
     "slug": "willits-ca-pd",
-    "flock_active_slug": "willits-ca-pd",
-    "flock_slugs": [
-      "willits-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Willits CA PD"
     ],
@@ -76613,10 +71255,8 @@
   {
     "agency_id": "cf61829f-2b2f-5cec-863f-2d174bae940d",
     "slug": "windsor-ca-pd",
-    "flock_active_slug": "windsor-ca-pd",
-    "flock_slugs": [
-      "windsor-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Windsor CA PD"
     ],
@@ -76640,10 +71280,8 @@
   {
     "agency_id": "069764d3-6b36-5e35-ba95-2e4b38441b0e",
     "slug": "winters-ca-pd",
-    "flock_active_slug": "winters-ca-pd",
-    "flock_slugs": [
-      "winters-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Winters CA PD"
     ],
@@ -76667,10 +71305,8 @@
   {
     "agency_id": "84006518-b4f2-528e-9094-f7a94132223f",
     "slug": "woodlake-ca-pd",
-    "flock_active_slug": "woodlake-ca-pd",
-    "flock_slugs": [
-      "woodlake-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Woodlake CA PD"
     ],
@@ -76694,10 +71330,8 @@
   {
     "agency_id": "36d68f61-6c39-53ec-815e-c0853fca118d",
     "slug": "yreka-ca-pd",
-    "flock_active_slug": "yreka-ca-pd",
-    "flock_slugs": [
-      "yreka-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yreka CA PD"
     ],
@@ -76721,10 +71355,8 @@
   {
     "agency_id": "5b3abf70-5581-5412-8165-b9b12db5a69b",
     "slug": "yuba-county-sheriffs-office",
-    "flock_active_slug": "yuba-county-sheriffs-office",
-    "flock_slugs": [
-      "yuba-county-sheriffs-office"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Yuba County Sheriffs Office"
     ],
@@ -76741,10 +71373,8 @@
   {
     "agency_id": "7ed4d91c-73bc-5a97-838c-2c87fccbff9e",
     "slug": "union-pacific-railroad-pd",
-    "flock_active_slug": "union-pacific-railroad-pd",
-    "flock_slugs": [
-      "union-pacific-railroad-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Union Pacific Railroad PD"
     ],
@@ -76767,10 +71397,8 @@
   {
     "agency_id": "978d5b81-63f1-5f5d-bf83-4f108c15abcb",
     "slug": "flock-safety-vendor",
-    "flock_active_slug": "flock-safety-vendor",
-    "flock_slugs": [
-      "flock-safety-vendor"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flock Safety (vendor)"
     ],
@@ -76793,10 +71421,8 @@
   {
     "agency_id": "dea3892a-1d23-535d-ac5d-f3f8f975c712",
     "slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
-    "flock_active_slug": "yuba-county-ca-so-hotlists-alerted-on-california-svs",
-    "flock_slugs": [
-      "yuba-county-ca-so-hotlists-alerted-on-california-svs"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "yuba-county-ca-so-hotlists-alerted-on-california-svs"
     ],
@@ -76817,10 +71443,8 @@
   {
     "agency_id": "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
     "slug": "mountain-view-ca-pd",
-    "flock_active_slug": "mountain-view-ca-pd",
-    "flock_slugs": [
-      "mountain-view-ca-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Mountain View Police Department"
     ],
@@ -76893,10 +71517,8 @@
   {
     "agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "slug": "austin-tx-pd",
-    "flock_active_slug": "austin-tx-pd",
-    "flock_slugs": [
-      "austin-tx-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Austin Police Department"
     ],
@@ -76921,10 +71543,8 @@
   {
     "agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "slug": "denver-co-pd",
-    "flock_active_slug": "denver-co-pd",
-    "flock_slugs": [
-      "denver-co-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Denver Police Department"
     ],
@@ -76949,10 +71569,8 @@
   {
     "agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "slug": "charlottesville-va-pd",
-    "flock_active_slug": "charlottesville-va-pd",
-    "flock_slugs": [
-      "charlottesville-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Charlottesville Police Department"
     ],
@@ -76977,10 +71595,8 @@
   {
     "agency_id": "4cec1b92-d54e-5ef1-aebb-11d93521b4a5",
     "slug": "staunton-va-pd",
-    "flock_active_slug": "staunton-va-pd",
-    "flock_slugs": [
-      "staunton-va-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Staunton Police Department"
     ],
@@ -77005,10 +71621,8 @@
   {
     "agency_id": "86e9b8be-f02d-50c0-a0f8-9ed7b2b378a4",
     "slug": "flagstaff-az-pd",
-    "flock_active_slug": "flagstaff-az-pd",
-    "flock_slugs": [
-      "flagstaff-az-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Flagstaff Police Department"
     ],
@@ -77057,10 +71671,8 @@
   {
     "agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
     "slug": "eugene-or-pd",
-    "flock_active_slug": "eugene-or-pd",
-    "flock_slugs": [
-      "eugene-or-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Eugene Police Department"
     ],
@@ -77109,10 +71721,8 @@
   {
     "agency_id": "2cc3a31d-7f98-5714-bc85-927815444575",
     "slug": "tompkins-county-ny-so",
-    "flock_active_slug": "tompkins-county-ny-so",
-    "flock_slugs": [
-      "tompkins-county-ny-so"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Tompkins County Sheriff's Office"
     ],
@@ -77137,10 +71747,8 @@
   {
     "agency_id": "b994e41b-23e6-5392-ba7b-821af80978f0",
     "slug": "hillsborough-nc-pd",
-    "flock_active_slug": "hillsborough-nc-pd",
-    "flock_slugs": [
-      "hillsborough-nc-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Hillsborough Police Department"
     ],
@@ -77189,10 +71797,8 @@
   {
     "agency_id": "5b70f7bd-e72b-5f98-b6f2-58a611e13ed3",
     "slug": "lynnwood-wa-pd",
-    "flock_active_slug": "lynnwood-wa-pd",
-    "flock_slugs": [
-      "lynnwood-wa-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Lynnwood Police Department"
     ],
@@ -77241,10 +71847,8 @@
   {
     "agency_id": "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712",
     "slug": "oshkosh-wi-pd",
-    "flock_active_slug": "oshkosh-wi-pd",
-    "flock_slugs": [
-      "oshkosh-wi-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Oshkosh Police Department"
     ],
@@ -77269,10 +71873,8 @@
   {
     "agency_id": "50dc11c1-7f4e-557f-b65c-6666d43832a0",
     "slug": "windsor-ct-pd",
-    "flock_active_slug": "windsor-ct-pd",
-    "flock_slugs": [
-      "windsor-ct-pd"
-    ],
+    "flock_active_slug": null,
+    "flock_slugs": [],
     "flock_names": [
       "Windsor Police Department"
     ],

--- a/scripts/build_agency_registry.py
+++ b/scripts/build_agency_registry.py
@@ -196,12 +196,106 @@ def classify(name):
 
 
 
+def confirmed_slugs(data_dir, probe_state=None):
+    """Return the set of slugs we have evidence are real Flock portals.
+
+    A slug is confirmed when:
+      - there's a parsed `.json` capture under `<data_dir>/<slug>/`
+        (main crawler archived it cleanly), OR
+      - there's a `.txt` under `<data_dir>/<slug>/` (the crawler hit
+        a real portal page; the parser may have failed downstream
+        but the slug itself is real — Flock served a 200), OR
+      - slug_probe declared it `found` in its state file.
+
+    Anything else is speculative — a `name_to_slug` guess that nobody
+    has actually verified.
+    """
+    confirmed = set()
+    if data_dir.is_dir():
+        from lib import portal_jsons, portal_txts
+        for slug_dir in data_dir.iterdir():
+            if not slug_dir.is_dir() or slug_dir.name.startswith("."):
+                continue
+            if portal_jsons(slug_dir) or portal_txts(slug_dir):
+                confirmed.add(slug_dir.name)
+    if probe_state:
+        for ag in probe_state.get("agencies", {}).values():
+            found = ag.get("found")
+            if found:
+                confirmed.add(found)
+    return confirmed
+
+
+def prune_speculative_slugs(registry, confirmed):
+    """Mutate `registry` in place: set `flock_active_slug` to None and
+    trim `flock_slugs` for entries whose slugs aren't in `confirmed`.
+
+    Returns a dict of stats: {pruned_active, pruned_slugs, kept}.
+    """
+    pruned_active = 0
+    pruned_slugs_total = 0
+    kept = 0
+    for e in registry:
+        original_slugs = list(e.get("flock_slugs", []))
+        confirmed_for_entry = [s for s in original_slugs if s in confirmed]
+        active = e.get("flock_active_slug")
+        if active in confirmed:
+            new_active = active
+        elif confirmed_for_entry:
+            # Active wasn't confirmed but some other historical slug is —
+            # promote that one. Rare but possible (e.g. Flock renamed
+            # the slug, we captured under the new one but the registry
+            # still pointed at the old).
+            new_active = confirmed_for_entry[0]
+        else:
+            new_active = None
+        if new_active != active:
+            pruned_active += 1
+        pruned_slugs_total += len(original_slugs) - len(confirmed_for_entry)
+        e["flock_active_slug"] = new_active
+        e["flock_slugs"] = confirmed_for_entry
+        if confirmed_for_entry:
+            kept += 1
+    return {
+        "pruned_active": pruned_active,
+        "pruned_slugs": pruned_slugs_total,
+        "kept": kept,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build agency registry")
     parser.add_argument("--merge", action="store_true",
                         help="Merge new agencies into existing registry, keeping manual edits")
+    parser.add_argument("--prune", action="store_true",
+                        help="Nullify speculative flock_active_slug / flock_slugs (only confirmed slugs survive). Mutually exclusive with --merge.")
     parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
     args = parser.parse_args()
+
+    if args.prune:
+        if args.merge:
+            print("ERROR: --prune and --merge are mutually exclusive", file=sys.stderr)
+            sys.exit(1)
+        if not REGISTRY_PATH.exists():
+            print("ERROR: registry doesn't exist; nothing to prune", file=sys.stderr)
+            sys.exit(1)
+        registry = json.loads(REGISTRY_PATH.read_text())
+        # Probe state contributes confirmed slugs even when no .json is
+        # on disk yet — happens when probe just hit but hasn't run
+        # archive_agency, or when the captured artifact wasn't committed.
+        probe_state_path = args.data_dir / ".slug_probe_state.json"
+        probe_state = (
+            json.loads(probe_state_path.read_text())
+            if probe_state_path.exists() else None
+        )
+        confirmed = confirmed_slugs(args.data_dir, probe_state)
+        print(f"Confirmed slugs (have .txt/.json or probe-found): {len(confirmed)}")
+        stats = prune_speculative_slugs(registry, confirmed)
+        print(f"Pruned flock_active_slug on {stats['pruned_active']} entries")
+        print(f"Removed {stats['pruned_slugs']} speculative entries from flock_slugs")
+        print(f"Entries with at least one confirmed slug: {stats['kept']}")
+        REGISTRY_PATH.write_text(json.dumps(registry, indent=2) + "\n")
+        return
 
     data_dir = args.data_dir
 
@@ -299,11 +393,16 @@ def main():
 
         state = detect_state(flock_name)
         flags = detect_flags(flock_name)
+        # New entries from peer-outbound names start with no confirmed
+        # Flock slug — `slug` is a stable internal key derived from the
+        # name (used for dedup), but flock_active_slug / flock_slugs only
+        # get populated by a successful capture or a slug_probe hit.
+        # Speculative guesses don't claim to be slugs.
         entry = {
             "agency_id": candidate_id,
             "slug": slug,
-            "flock_active_slug": slug,
-            "flock_slugs": [slug],
+            "flock_active_slug": None,
+            "flock_slugs": [],
             "flock_names": [flock_name],
             "display_name": None,
             "agency_role": cls["agency_role"],
@@ -313,6 +412,14 @@ def main():
             "flags": flags,
             "geo": {"kind": "state-only", "state": state} if state else None,
         }
+        # If `slug` (the internal key) happens to match a directory we
+        # captured, the slug IS confirmed and should populate the flock
+        # fields. The discovery side of build_agency_registry already
+        # iterates crawled_slugs upstream; this is for the case where
+        # the resolved-from-name slug coincidentally matches.
+        if slug in crawled_slugs:
+            entry["flock_active_slug"] = slug
+            entry["flock_slugs"] = [slug]
         registry.append(entry)
         seen_ids.add(candidate_id)
         new_count += 1

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -52,7 +52,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from lib import (
     BASE_URL, FAILED_FILE, USER_AGENT,
     dedupe, load_json, save_json,
-    name_to_slug, portal_jsons, portal_txts, resolve_agency,
+    portal_jsons, portal_txts, resolve_agency,
 )
 
 DEFAULT_DATA_DIR = Path("assets/transparency.flocksafety.com")
@@ -910,15 +910,16 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
         return ("failed", "parse_error"), []
 
     portal_data["crawled_at"] = crawled_at
-    # Resolve sharing names to slugs for depth crawling
+    # Resolve sharing names to slugs for depth crawling. Only registry-
+    # confirmed slugs (flock_active_slug set after a real capture or
+    # probe hit) propagate — name_to_slug guesses are slug_probe's job
+    # now, not the crawler's. A peer-outbound name without a registry
+    # match drops out here; it'll get added as a stub on the next
+    # build_agency_registry --merge run and slug_probe will try it.
     for name in portal_data.get("sharing_outbound", []):
         entry = resolve_agency(name=name)
         if entry and entry.get("flock_active_slug"):
             discovered_slugs.append(entry["flock_active_slug"])
-        else:
-            guessed = name_to_slug(name)
-            if guessed:
-                discovered_slugs.append(guessed)
 
     if not force and prev_hash == current_hash:
         print(f"    unchanged since last capture, skipping")
@@ -1126,10 +1127,10 @@ def cmd_crawl(args):
                                 entry = resolve_agency(name=name)
                                 if entry and entry.get("flock_active_slug"):
                                     discovered_from_existing.append(entry["flock_active_slug"])
-                                else:
-                                    guessed = name_to_slug(name)
-                                    if guessed:
-                                        discovered_from_existing.append(guessed)
+                                # else: no registry-confirmed slug for this
+                                # peer-outbound name. Drop it — slug_probe
+                                # owns first-try discovery now, so the crawler
+                                # never spends rate budget on speculative guesses.
 
                 # Eligible candidate slugs this level = the current seed list plus
                 # anything discovered in the outbound of fresh neighbors. Merging

--- a/tests/test_registry_prune.py
+++ b/tests/test_registry_prune.py
@@ -1,0 +1,162 @@
+"""Tests for the registry-prune helper in build_agency_registry.
+
+Speculative slugs (`name_to_slug` guesses that nobody verified) shouldn't
+appear in `flock_active_slug` or `flock_slugs` — those fields claim the
+slug is real. The prune helper removes claims that aren't backed by a
+captured `.json` on disk or a slug_probe `found` record.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from build_agency_registry import confirmed_slugs, prune_speculative_slugs
+
+
+def test_prune_nullifies_active_when_unconfirmed():
+    """The most common case: an entry whose flock_active_slug came from
+    name_to_slug() never actually got captured. Active goes to None,
+    flock_slugs empties out."""
+    registry = [{
+        "agency_id": "x",
+        "slug": "abilene-ks-pd",
+        "flock_active_slug": "abilene-ks-pd",
+        "flock_slugs": ["abilene-ks-pd"],
+        "flock_names": ["Abilene KS PD"],
+    }]
+    stats = prune_speculative_slugs(registry, confirmed=set())
+    assert registry[0]["flock_active_slug"] is None
+    assert registry[0]["flock_slugs"] == []
+    assert stats["pruned_active"] == 1
+
+
+def test_prune_preserves_confirmed_active():
+    """Slugs with on-disk captures (or probe-found state) survive
+    untouched. This is the load-bearing assertion — we mustn't lose
+    the 193 confirmed real slugs."""
+    registry = [{
+        "agency_id": "x",
+        "slug": "alameda-ca-pd",
+        "flock_active_slug": "alameda-ca-pd",
+        "flock_slugs": ["alameda-ca-pd"],
+        "flock_names": ["Alameda CA PD"],
+    }]
+    stats = prune_speculative_slugs(registry, confirmed={"alameda-ca-pd"})
+    assert registry[0]["flock_active_slug"] == "alameda-ca-pd"
+    assert registry[0]["flock_slugs"] == ["alameda-ca-pd"]
+    assert stats["pruned_active"] == 0
+    assert stats["kept"] == 1
+
+
+def test_prune_promotes_other_confirmed_slug_when_active_is_speculative():
+    """If active is speculative but flock_slugs contains a confirmed
+    historical slug, promote it. Rare but real: Flock renamed an
+    agency's slug, we crawled under the new name, but registry still
+    pointed at the old."""
+    registry = [{
+        "agency_id": "x",
+        "slug": "alameda-ca-pd",
+        "flock_active_slug": "old-speculative-guess",
+        "flock_slugs": ["old-speculative-guess", "alameda-ca-pd"],
+        "flock_names": ["Alameda CA PD"],
+    }]
+    prune_speculative_slugs(registry, confirmed={"alameda-ca-pd"})
+    assert registry[0]["flock_active_slug"] == "alameda-ca-pd"
+    assert registry[0]["flock_slugs"] == ["alameda-ca-pd"]
+
+
+def test_prune_drops_speculative_history_keeping_confirmed_active():
+    """flock_slugs may carry a speculative tail from prior name_to_slug
+    guesses; those drop out even when active is confirmed."""
+    registry = [{
+        "agency_id": "x",
+        "slug": "alameda-ca-pd",
+        "flock_active_slug": "alameda-ca-pd",
+        "flock_slugs": ["alameda-ca-pd", "alameda-pd-ca", "alameda-ca"],
+        "flock_names": ["Alameda CA PD"],
+    }]
+    prune_speculative_slugs(registry, confirmed={"alameda-ca-pd"})
+    assert registry[0]["flock_active_slug"] == "alameda-ca-pd"
+    assert registry[0]["flock_slugs"] == ["alameda-ca-pd"]
+
+
+def test_prune_leaves_already_null_active_alone():
+    """Idempotent: a second prune run on the result of the first must
+    be a no-op."""
+    registry = [{
+        "agency_id": "x",
+        "slug": "x-pd",
+        "flock_active_slug": None,
+        "flock_slugs": [],
+        "flock_names": ["X PD"],
+    }]
+    stats = prune_speculative_slugs(registry, confirmed=set())
+    assert registry[0]["flock_active_slug"] is None
+    assert registry[0]["flock_slugs"] == []
+    assert stats["pruned_active"] == 0
+
+
+def test_prune_does_not_drop_entries():
+    """Pruning never removes a registry entry — peer-outbound discovery
+    is still useful signal even when we can't (yet) crawl the agency.
+    Entries become probe-tier-A targets for later confirmation."""
+    registry = [
+        {"agency_id": "a", "slug": "a", "flock_active_slug": "a-spec",
+         "flock_slugs": ["a-spec"], "flock_names": ["A"]},
+        {"agency_id": "b", "slug": "b", "flock_active_slug": "b-real",
+         "flock_slugs": ["b-real"], "flock_names": ["B"]},
+    ]
+    prune_speculative_slugs(registry, confirmed={"b-real"})
+    assert len(registry) == 2
+    assert {e["agency_id"] for e in registry} == {"a", "b"}
+
+
+# ── confirmed_slugs ─────────────────────────────────────────────
+
+
+def test_confirmed_slugs_walks_data_dir(tmp_path):
+    """A slug is confirmed when there's a parsed .json under its
+    directory. Missing dir or empty dir = not confirmed."""
+    base = tmp_path / "transparency"
+    base.mkdir()
+    (base / "alameda-ca-pd").mkdir()
+    (base / "alameda-ca-pd" / "2026-04-19.json").write_text("{}")
+    (base / "no-data").mkdir()  # exists but empty
+    (base / ".hidden_dotfile").mkdir()  # hidden state dirs ignored
+    confirmed = confirmed_slugs(base)
+    assert confirmed == {"alameda-ca-pd"}
+
+
+def test_confirmed_slugs_includes_probe_found(tmp_path):
+    """Probe can confirm a slug before the captured artifact is on
+    disk — e.g. probe just ran but archive_agency hasn't completed
+    yet, or the artifacts weren't committed. Probe state is the
+    secondary source of truth."""
+    base = tmp_path / "transparency"
+    base.mkdir()
+    state = {"agencies": {
+        "aid-1": {"found": "probe-only-confirmed-pd"},
+        "aid-2": {"found": None},  # not found yet, ignored
+        "aid-3": {},                # never probed, ignored
+    }}
+    confirmed = confirmed_slugs(base, probe_state=state)
+    assert confirmed == {"probe-only-confirmed-pd"}
+
+
+def test_confirmed_slugs_handles_missing_data_dir(tmp_path):
+    """Fresh checkouts without crawled data shouldn't crash the prune."""
+    missing = tmp_path / "does-not-exist"
+    assert confirmed_slugs(missing) == set()
+
+
+def test_confirmed_slugs_includes_txt_only_directories(tmp_path):
+    """A `.txt` capture without a `.json` means the parser failed,
+    but the slug itself is real — Flock served a 200 with portal
+    content. The parser bug is a separate problem; the slug shouldn't
+    be pruned just because we can't parse it yet."""
+    base = tmp_path / "transparency"
+    base.mkdir()
+    (base / "txt-only").mkdir()
+    (base / "txt-only" / "2026-04-19.txt").write_text("page text")
+    assert confirmed_slugs(base) == {"txt-only"}


### PR DESCRIPTION
Step 2b of the slug-cleanup plan. Closes the speculative-slug pipeline so cmd_crawl stops wasting hourly slots on name_to_slug guesses that nobody verified.

## What changes

### Code (commit 1)
1. **build_agency_registry**: new entries get \`flock_active_slug=None\` and \`flock_slugs=[]\`. The internal \`slug\` field stays as-is (it's a name-derived stable dedup key, not a Flock URL claim). Crawled directories whose name matches the derived slug still populate the flock fields — that's a real confirmation.
2. **--prune mode**: walks the existing registry, nullifies \`flock_active_slug\` / trims \`flock_slugs\` for entries whose slugs aren't backed by on-disk capture (\`.txt\` or \`.json\`) or a slug_probe \`found\` record.
3. **cmd_crawl + archive_agency**: drop the \`name_to_slug(name)\` fallback in peer-outbound resolution. Names without a registry-confirmed slug get dropped at discovery — slug_probe owns first-try discovery now (PR #235).

### Data (commit 2)
One-shot prune of \`assets/agency_registry.json\`:
\`\`\`
Confirmed slugs (.txt/.json or probe-found): 193
Pruned flock_active_slug on 2698 entries
Removed 2700 speculative entries from flock_slugs
Entries with at least one confirmed slug: 193
\`\`\`
Total registry size unchanged (2,901 entries). Peer-outbound discovery is still valuable signal even for agencies we can't yet crawl. Pruned entries become tier-A targets for slug_probe.

## What this fixes

Before this PR, cmd_crawl's level-1 BFS would resolve peer-outbound names to a registry's \`flock_active_slug\` — but for ~93% of registry entries that slug was a \`name_to_slug\` guess, never confirmed. The crawler wasted slots probing 404s. The user reported seeing the third slot of every 3-slot batch consumed this way.

After this PR:
- The registry only claims slugs we have evidence for.
- The crawler only follows confirmed slugs at level 1.
- Fresh peer-outbound names that don't resolve get registered (by build_agency_registry) as null-active stubs, which slug_probe (PR #235) picks up as tier A.
- Net effect: cmd_crawl spends its 3 hourly slots on stale-but-confirmed refresh; slug_probe spends its 3 hourly slots on discovery + variant search.

## Test plan
- [x] \`uv run pytest tests/test_registry_prune.py tests/test_slug_probe.py tests/test_eyesonflock_lookup.py tests/test_flock_transparency_headings.py tests/test_flock_csv.py tests/test_geo_cache.py\` (116 tests pass)
- [x] \`uv run python scripts/build_agency_registry.py --prune\` against live registry → expected counts
- [x] \`uv run python scripts/build_agency_registry.py --merge\` against the post-prune registry — preserves the 193 confirmed actives
- [ ] After merge: confirm next refresh run only touches stale-but-confirmed slugs (no \`HTTP 404\` waste at level 1)
- [ ] After merge: confirm slug_probe tier A populates with the ~2,700 newly-pruned entries