### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -281,6 +281,14 @@
         "albion-mi-dps-mi-pd": "http_404"
       }
     },
+    "356e30e5-12d3-5ff7-b563-6de8c10c553b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T22:41:16.413690+00:00",
+      "tried": {
+        "columbus-oh-pd": "http_404"
+      }
+    },
     "3684a873-d18a-57d8-a30b-c1fe3b4c93a3": {
       "exhausted": false,
       "found": null,
@@ -843,6 +851,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "9dc845ac-23af-554b-a04b-cdcda0f2cf0a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T22:41:21.381900+00:00",
+      "tried": {
+        "carlsbad-nm-po": "http_404"
+      }
+    },
     "9eb7354b-b6ff-590b-b3bb-f097e0b30033": {
       "exhausted": false,
       "found": null,
@@ -971,6 +987,14 @@
       "last_probed": "2026-04-24T10:55:13.729041+00:00",
       "tried": {
         "san-diego-harbor-ca-po": "http_404"
+      }
+    },
+    "b78b4a4c-e8ea-5a96-9edd-585d0b0d1ce1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T22:41:09.841422+00:00",
+      "tried": {
+        "oak-park-il-pd": "http_404"
       }
     },
     "b79270e4-262d-5069-ba04-0e4aa6298b3d": {
@@ -1275,6 +1299,6 @@
       }
     }
   },
-  "updated": "2026-05-05T21:45:54.820918+00:00",
+  "updated": "2026-05-05T22:41:21.421045+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.