### PR TITLE
fix(parser): drop description-only body when sharing table is empty

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -613,6 +613,11 @@ def _strip_leading_description(body):
     return body
 
 
+_ORG_DESCRIPTION_RE = re.compile(
+    r"^Organizations (?:granted access to|sharing with) .+ data\.$"
+)
+
+
 def _parse_org_names(body):
     """Extract org names from a shared-orgs section body.
 
@@ -625,13 +630,18 @@ def _parse_org_names(body):
     if not body:
         return []
     body = _strip_leading_description(body)
-    # If body has multiple non-blank lines and most lack commas, treat as
-    # one-agency-per-line (2026 layout). Otherwise fall back to comma split.
     lines = [L.strip() for L in body.split("\n") if L.strip()]
+    # Drop the description sentence — _strip_leading_description only
+    # fires when ≥2 paragraphs are present, so when the table is empty
+    # the lone description line survives and would be parsed as a fake
+    # org name (PR #240).
+    lines = [L for L in lines if not _ORG_DESCRIPTION_RE.match(L)]
+    if not lines:
+        return []
     if len(lines) >= 3 and sum(1 for L in lines if "," not in L) >= len(lines) * 0.8:
         raw = lines
     else:
-        raw = [n.strip() for n in body.replace("\n", " ").split(", ") if n.strip()]
+        raw = [n.strip() for n in " ".join(lines).split(", ") if n.strip()]
     names = []
     for part in raw:
         merge = names and (

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -179,6 +179,19 @@ def test_parse_org_names_handles_one_per_line_layout():
     ]
 
 
+def test_parse_org_names_description_only_empty_table():
+    """When the sharing table is empty, the 2026 layout still renders
+    the description sentence on its own. It must not be mistaken for a
+    one-agency list (regression: PR #240 picked up
+    "Organizations granted access to Carmel CA PD data." as an org)."""
+    assert _parse_org_names(
+        "Organizations granted access to Carmel CA PD data."
+    ) == []
+    assert _parse_org_names(
+        "Organizations sharing with Culver City CA PD data."
+    ) == []
+
+
 def test_extract_bold_headings_matches_2026_layout():
     """The 2026 layout uses font-weight:600 for field headings (was
     700) and h3 + text-transform:uppercase for section dividers."""


### PR DESCRIPTION
## Summary

When a Flock portal's sharing table is empty, the 2026 layout still renders the description sentence ("Organizations granted access to *Agency* data.") as the section body. `_strip_leading_description` only fires for ≥2 paragraphs, so the lone description survived and `_parse_org_names` returned it as a single fake org name.

PR #240 surfaced this for `carmel-ca-pd` and `culver-city-ca-pd` — both produced a bogus `sharing_outbound: +1` diff.

## Fix

Added an `_ORG_DESCRIPTION_RE` filter in `_parse_org_names` that drops description-pattern lines after `_strip_leading_description`. Regression test pins both the granted-access and sharing-with phrasings.

## Test plan

- [x] `pytest tests/test_flock_transparency_headings.py` — 24 passed (2 new)
- [ ] Re-run the hourly scrape; carmel/culver outbound should stay `[]`