### PR TITLE
chore(refresh): run flock scrape every 30 minutes

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -2,7 +2,7 @@ name: Refresh Flock Transparency Data
 
 on:
   schedule:
-    - cron: '17 * * * *'   # hourly at :17
+    - cron: '17,47 * * * *'   # every 30 minutes at :17 and :47
   workflow_dispatch:
     inputs:
       batch_size:


### PR DESCRIPTION
## Summary

Changes the flock-refresh cron from hourly (`17 * * * *`) to every 30 minutes (`17,47 * * * *`). Doubles per-day fetch volume; per-run batch size and 1s delay are unchanged.

## Test plan

- [ ] Confirm next run fires at :17 or :47
- [ ] Watch for any portal-side throttling (none observed historically)