### PR TITLE
fix(parser): map agency-prefixed bare-Policy headings to policy_info

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -361,6 +361,12 @@ _DYNAMIC_HEADINGS = [
     (re.compile(r"^(Full ALPR|Full LPR|Full ALPRY).+", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+ (ALPR|LPR) Policy.*$", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+Police Department Policy Manual.*$", re.IGNORECASE), "alpr_policy"),
+    # Agency-prefixed bare "Policy" headings, e.g.
+    # "Marin County Sheriff's Office Policy" — Flock now bolds these
+    # standalone where they used to live as body text under Additional
+    # Info. The ALPR-specific patterns above win first; this catches the
+    # generic policy-link variant.
+    (re.compile(r"^.+(?:Police Department|Sheriff(?:'s)?(?: Office)?|Police Bureau) Policy$", re.IGNORECASE), "policy_info"),
     # Success-story subheadings — agencies post titled excerpts under
     # "Success Stories" (e.g. "Yuba County SO - Facebook Post - …").
     (re.compile(r"^.+ - Facebook Post - .+$", re.IGNORECASE), "success_stories"),

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -16,6 +16,7 @@ from flock_transparency import (
     extract_bold_headings,
     parse_sections,
     parse_portal_text,
+    _match_heading,
     _parse_number,
     _parse_org_names,
 )
@@ -177,6 +178,26 @@ def test_parse_org_names_handles_one_per_line_layout():
     assert _parse_org_names(body_legacy) == [
         "Albany CA PD", "Antioch CA PD", "Arcadia CA PD", "Avenal CA PD",
     ]
+
+
+def test_agency_prefixed_policy_heading_maps_to_policy_info():
+    """Flock now bolds agency-prefixed policy headings like
+    "Marin County Sheriff's Office Policy" as standalone <h*>. They
+    used to live as body text under Additional Info. The dynamic
+    pattern catches these variants and routes them to policy_info,
+    while the existing ALPR-specific patterns still win for things
+    like "X Police Department ALPR Policy".
+    """
+    assert _match_heading(
+        "Marin County Sheriff's Office Policy"
+    ) == "policy_info"
+    assert _match_heading("X Police Department Policy") == "policy_info"
+    assert _match_heading("Y Police Bureau Policy") == "policy_info"
+    # ALPR-specific dynamic patterns still take precedence
+    assert _match_heading("X Police Department ALPR Policy") == "alpr_policy"
+    # Exact-mapped headings unaffected
+    assert _match_heading("Hotlist Policy") == "hotlist_policy"
+    assert _match_heading("Sharing Policy") == "sharing_with_partners"
 
 
 def test_parse_org_names_description_only_empty_table():


### PR DESCRIPTION
## Summary

The 23:14 UTC scrape after PR #241 merged tripped on a *different* parser issue: marin-county-ca-so now bolds **"Marin County Sheriff's Office Policy"** as a standalone heading. Previously this lived as body text under Additional Info (the body holds a URL to policy-426.pdf).

The fail-loud unrecognized-bold-heading guard correctly halted the parse. This adds a dynamic heading pattern catching agency-prefixed bare-Policy headings (Police Department / Sheriff's Office / Police Bureau Policy) and routing them to `policy_info`. ALPR-specific patterns above still win for "X Police Department ALPR Policy" etc.

## Test plan

- [x] `pytest tests/test_flock_transparency_headings.py` — 25 passed (1 new)
- [ ] Re-run the scrape; marin-county-ca-so should parse cleanly

CI run that surfaced this: https://github.com/none-below/sm-alpr/actions/runs/25407422999/job/74521468304