### PR TITLE
feat(justifications): cross-agency external-search section + magnitude estimate

### DIFF
--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -454,6 +454,122 @@
     return html;
   }
 
+  // External-search section: aggregated broad-reach searches by
+  // agencies with shared access to this agency's data. The "broad
+  // reach" threshold is networkCount >= 100 — Flock doesn't expose
+  // which networks each search actually hit, so we use that as a
+  // proxy for "this search probably touched this agency's data."
+  // Each bar row totals across contributing source agencies and
+  // attributes the top N sources inline.
+  var hideExternal = false;
+
+  function renderExternalSection(agencyData) {
+    var ext = agencyData.external_aggregated;
+    if (!ext || !ext.rows || !ext.rows.length) return '';
+    if (hideExternal) {
+      return '<h2>Searches by agencies with shared access</h2>' +
+        '<p class="external-hidden-note">' +
+        'Hidden &mdash; toggle <em>Show only this agency&rsquo;s own searches</em> ' +
+        'off above to reveal partner searches that likely touched this data.' +
+        '</p>';
+    }
+    var threshold = ext.threshold || 100;
+    var rows = ext.rows;
+    var totalSearches = ext.total_broad_searches || 0;
+    var sources = ext.sources_with_data || 0;
+    var outboundTotal = ext.outbound_total || 0;
+    var s30Only = ext.partners_searches_only_count || 0;
+    var s30OnlyTotal = ext.partners_searches_only_total || 0;
+    var silent = ext.partners_silent_count || 0;
+    var medianBroad = ext.median_broad_per_reporter || 0;
+    var nonAudit = s30Only + silent;
+    // If non-reporting partners are similarly active to reporters,
+    // each contributes ~medianBroad broad-reach searches that this
+    // page can't see. The estimate is order-of-magnitude, not precise.
+    var estimatedTotal = totalSearches + medianBroad * nonAudit;
+    var totalForPct = totalSearches || 1;
+    var breakdown = '';
+    if (nonAudit > 0) {
+      breakdown = '<div class="external-breakdown">' +
+        '<div class="external-breakdown-head">' +
+        'How undercounted is this number?' +
+        '</div>' +
+        '<ul>' +
+        '<li><strong>' + sources.toLocaleString() + '</strong> partners ' +
+        'publish full audit detail &mdash; the bars below sum their ' +
+        'broad-reach activity (' + totalSearches.toLocaleString() + ').</li>';
+      if (s30Only > 0) {
+        breakdown += '<li><strong>' + s30Only.toLocaleString() + '</strong> ' +
+          'partners publish a 30-day total but no per-search detail ' +
+          '(' + s30OnlyTotal.toLocaleString() + ' total searches combined; ' +
+          'broad-reach share isn&rsquo;t visible).</li>';
+      }
+      if (silent > 0) {
+        breakdown += '<li><strong>' + silent.toLocaleString() + '</strong> ' +
+          'partners publish neither &mdash; search volume entirely unknown.</li>';
+      }
+      breakdown += '</ul>';
+      if (medianBroad > 0 && estimatedTotal > totalSearches) {
+        breakdown += '<div class="external-breakdown-est">' +
+          'The median audit-publishing partner ran <strong>' +
+          medianBroad.toLocaleString() + '</strong> broad-reach searches ' +
+          'in this window. If the ' + nonAudit.toLocaleString() +
+          ' non-detail partners are similarly active, the actual broad-reach ' +
+          'volume against this data is closer to <strong>~' +
+          estimatedTotal.toLocaleString() + '</strong> than the visible ' +
+          totalSearches.toLocaleString() + '.' +
+          '</div>';
+      }
+      breakdown += '</div>';
+    }
+    var html = '<h2>Searches by agencies with shared access</h2>' +
+      '<div class="external-summary">' +
+      '<strong>' + totalSearches.toLocaleString() + '</strong> broad-reach ' +
+      'searches by <strong>' + sources + '</strong> of ' + outboundTotal +
+      ' agencies that ' + escapeHTML(agencyData.display_name) +
+      ' shares its data to. ' +
+      'Each is a search that reached &ge; ' + threshold +
+      ' networks &mdash; broad enough that this agency&rsquo;s data was ' +
+      'almost certainly included.' +
+      breakdown +
+      '</div>' +
+      '<p class="bars-disclaimer external-caveat">' +
+      'Heuristic: Flock doesn&rsquo;t expose which networks each search ' +
+      'hit, so we treat any search reaching &ge; ' + threshold +
+      ' networks as having likely touched this agency&rsquo;s data. ' +
+      'A search reaching exactly 99 networks would be excluded; one ' +
+      'reaching 100+ is included regardless of which networks it actually ' +
+      'queried.' +
+      '</p>' +
+      '<div class="bar-list bar-list-external">';
+    for (var i = 0; i < rows.length; i++) {
+      var phrase = rows[i][0];
+      var count = rows[i][1];
+      var topSources = rows[i][2] || [];
+      var sharePct = (100 * count / totalForPct);
+      var w = Math.max(1, Math.round(sharePct));
+      var srcHtml = '';
+      for (var s = 0; s < topSources.length; s++) {
+        srcHtml += '<span class="ext-source">' +
+          escapeHTML(topSources[s][0]) + ' (' +
+          topSources[s][1].toLocaleString() + ')</span>';
+      }
+      html += '<div class="bar-item bar-item-external">' +
+        '<div class="bar-item-main">' +
+        '<span class="bar-track">' +
+        '<span class="bar bar-external" style="width:' + w + '%"></span>' +
+        '<span class="bar-pct">' + sharePct.toFixed(1) + '%</span>' +
+        '</span>' +
+        '<span class="bar-count">' + count.toLocaleString() + '</span>' +
+        '<span class="phrase-text">' + escapeHTML(phrase) + '</span>' +
+        '</div>' +
+        (srcHtml ? '<div class="ext-sources">' + srcHtml + '</div>' : '') +
+        '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
   // For the small set of agencies whose audit CSV schema entirely
   // omits any justification field — not even an empty column — we
   // render a structural-transparency callout instead of bars.
@@ -1071,6 +1187,15 @@
   // for the clicked phrase. Single delegated listener attached at
   // init time.
   function handleExpandClick(ev) {
+    // Local-only toggle — flip the global flag and re-render.
+    if (ev.target && ev.target.id === 'local-only-toggle') {
+      hideExternal = !!ev.target.checked;
+      if (currentAgencyData) {
+        document.getElementById('page').innerHTML =
+          renderAgency(currentAgencyData, currentSlug);
+      }
+      return;
+    }
     // View-mode toggle buttons — change mode and re-render.
     var modeBtn = ev.target.closest('.view-mode-btn');
     if (modeBtn) {
@@ -1431,14 +1556,30 @@
           : '') +
       '</div>';
 
+    var hasExternal = agencyData.external_aggregated &&
+      agencyData.external_aggregated.rows &&
+      agencyData.external_aggregated.rows.length;
+    var localToggle = hasExternal
+      ? '<div class="local-toggle">' +
+        '<label>' +
+        '<input type="checkbox" id="local-only-toggle"' +
+        (hideExternal ? ' checked' : '') + '> ' +
+        'Show only this agency&rsquo;s own searches ' +
+        '<span class="local-toggle-hint">(hide partner searches that ' +
+        'likely touched this data)</span>' +
+        '</label>' +
+        '</div>'
+      : '';
+
     return '<h1>' + escapeHTML(agencyData.display_name) + '</h1>' +
       '<p class="subtitle">ALPR search justifications</p>' +
       windowBanner +
       blurb +
       stats +
+      localToggle +
       renderUses(agencyData) +
       renderLongActiveCases(agencyData.long_active_cases, agencyData.display_name) +
-      '<h2>Top reasons by count</h2>' +
+      '<h2>Top reasons (this agency&rsquo;s own searches)</h2>' +
       (agencyData.has_justification_column === false
         ? renderNoJustificationCallout(agencyData)
         : '<p class="bars-disclaimer">' +
@@ -1447,6 +1588,7 @@
           'reason for the search, or that the search was authorized.' +
           '</p>' +
           renderBars(agencyData.verbatim, agencyData.row_count)) +
+      renderExternalSection(agencyData) +
       '<h2>Search timing (day &times; hour, Pacific Time)</h2>' +
       renderHeatmap(agencyData.hour_dow, agencyData.timed_rows) +
       '<h2>Detected California penal / vehicle codes</h2>' +
@@ -1469,31 +1611,109 @@
       '</div>';
   }
 
-  function populateSelect(agencies, currentSlug) {
-    var sel = document.getElementById('agency-select');
-    sel.innerHTML = '';
-    var slugs = Object.keys(agencies);
-    slugs.sort(function (a, b) {
-      return agencies[a].display_name.localeCompare(agencies[b].display_name);
+  // Type-ahead "jump to agency" search. Mirrors report.js's selector
+  // so users moving between the per-agency report and this page get
+  // the same affordance. Ranks exact > startsWith > contains, caps at
+  // 12 results. ↓/↑ to move, Enter to open, Esc to close.
+  function wireAgencySearch(agencies, currentSlug) {
+    var input = document.getElementById('agency-search-input');
+    var results = document.getElementById('agency-search-results');
+    if (!input || !results) return;
+    var index = Object.keys(agencies).map(function (slug) {
+      var a = agencies[slug];
+      return {
+        slug: slug,
+        name: a.display_name || slug,
+        rowCount: a.row_count || 0,
+        _nameLower: (a.display_name || slug).toLowerCase(),
+      };
     });
-    for (var i = 0; i < slugs.length; i++) {
-      var s = slugs[i];
-      var opt = document.createElement('option');
-      opt.value = s;
-      opt.textContent = agencies[s].display_name +
-        ' (' + agencies[s].row_count.toLocaleString() + ' searches)';
-      if (s === currentSlug) opt.selected = true;
-      sel.appendChild(opt);
+    var highlightIdx = -1;
+
+    function doSearch(q) {
+      q = q.trim().toLowerCase();
+      if (!q) {
+        results.classList.remove('open');
+        results.innerHTML = '';
+        highlightIdx = -1;
+        return;
+      }
+      var matches = [];
+      for (var i = 0; i < index.length; i++) {
+        var e = index[i];
+        if (e.slug === currentSlug) continue;
+        var n = e._nameLower;
+        var score = 0;
+        if (n === q) score = 100;
+        else if (n.startsWith(q)) score = 50;
+        else if (n.indexOf(q) !== -1) score = 10;
+        if (score > 0) matches.push({ e: e, score: score });
+      }
+      matches.sort(function (a, b) {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.e._nameLower.localeCompare(b.e._nameLower);
+      });
+      var shown = matches.slice(0, 12);
+      if (!shown.length) {
+        results.innerHTML = '<div class="sr-empty">No matching agencies</div>';
+      } else {
+        results.innerHTML = shown.map(function (m) {
+          return '<a href="justifications.html?agency=' +
+            encodeURIComponent(m.e.slug) + '">' +
+            escapeHTML(m.e.name) + '</a>';
+        }).join('');
+      }
+      results.classList.add('open');
+      highlightIdx = -1;
     }
-    sel.addEventListener('change', function () {
-      var newSlug = sel.value;
-      // Use replaceState rather than pushState so back-button doesn't
-      // cycle through every agency the user previewed.
-      history.replaceState(null, '', '?agency=' + encodeURIComponent(newSlug));
-      var data = agencies[newSlug];
-      installPhraseContext(data);
-      document.getElementById('page').innerHTML =
-        renderAgency(data, newSlug);
+
+    function updateHighlight() {
+      var links = results.querySelectorAll('a');
+      for (var i = 0; i < links.length; i++) {
+        if (i === highlightIdx) links[i].classList.add('hl');
+        else links[i].classList.remove('hl');
+      }
+      if (highlightIdx >= 0 && links[highlightIdx]) {
+        links[highlightIdx].scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    input.addEventListener('input', function () { doSearch(input.value); });
+    input.addEventListener('keydown', function (e) {
+      var links = results.querySelectorAll('a');
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (!results.classList.contains('open')) doSearch(input.value);
+        if (links.length) {
+          highlightIdx = Math.min(highlightIdx + 1, links.length - 1);
+          updateHighlight();
+        }
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (links.length) {
+          highlightIdx = Math.max(highlightIdx - 1, 0);
+          updateHighlight();
+        }
+      } else if (e.key === 'Enter') {
+        if (highlightIdx >= 0 && links[highlightIdx]) {
+          e.preventDefault();
+          window.location.href = links[highlightIdx].href;
+        } else if (links.length === 1) {
+          e.preventDefault();
+          window.location.href = links[0].href;
+        }
+      } else if (e.key === 'Escape') {
+        results.classList.remove('open');
+        input.blur();
+      }
+    });
+    input.addEventListener('focus', function () {
+      if (input.value.trim()) doSearch(input.value);
+    });
+    document.addEventListener('click', function (e) {
+      if (!e.target.closest('#agency-search')) {
+        results.classList.remove('open');
+      }
     });
   }
 
@@ -1516,7 +1736,7 @@
         var agencies = data.agencies || {};
         currentAgencyCount = data.agency_count || Object.keys(agencies).length;
         var slug = getInitialSlug(agencies);
-        populateSelect(agencies, slug);
+        wireAgencySearch(agencies, slug);
         installPhraseContext(slug ? agencies[slug] : null);
         document.getElementById('page').innerHTML =
           renderAgency(slug ? agencies[slug] : null, slug || '');

--- a/docs/justifications.html
+++ b/docs/justifications.html
@@ -23,7 +23,7 @@
     padding: 0 8px;
     flex-wrap: wrap;
   }
-  .toolbar a, .toolbar select {
+  .toolbar a {
     font-size: 13px;
     padding: 6px 12px;
     border-radius: 6px;
@@ -34,8 +34,60 @@
     font-family: inherit;
   }
   .toolbar a:hover { background: #eff6ff; }
-  .toolbar select { min-width: 280px; }
   .toolbar .spacer { flex: 1; }
+  .toolbar .agency-search {
+    position: relative;
+    flex: 0 1 300px;
+    min-width: 180px;
+  }
+  .toolbar .agency-search input {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    box-sizing: border-box;
+    background: white;
+  }
+  .toolbar .agency-search input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37,99,235,0.15);
+  }
+  .toolbar .agency-search .search-results {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 100;
+    display: none;
+  }
+  .toolbar .agency-search .search-results.open { display: block; }
+  .toolbar .agency-search .search-results a {
+    display: block;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 0;
+    text-decoration: none;
+    color: #111;
+    font-size: 13px;
+  }
+  .toolbar .agency-search .search-results a:hover,
+  .toolbar .agency-search .search-results a.hl {
+    background: #eff6ff;
+  }
+  .toolbar .agency-search .search-results .sr-empty {
+    padding: 6px 10px;
+    color: #6b7280;
+    font-size: 13px;
+  }
   .page {
     max-width: 960px;
     margin: 0 auto;
@@ -480,6 +532,125 @@
   .no-justification-schema {
     font-size: 10pt;
     margin: 6px 0 !important;
+  }
+
+  .local-toggle {
+    margin: 12px 0 4px;
+    padding: 8px 12px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 10pt;
+  }
+  .local-toggle label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .local-toggle input { cursor: pointer; }
+  .local-toggle-hint {
+    color: #64748b;
+    font-size: 9.5pt;
+  }
+  .external-hidden-note {
+    margin: 6px 0 14px;
+    padding: 8px 12px;
+    background: #f8fafc;
+    border: 1px dashed #cbd5e1;
+    border-radius: 4px;
+    font-size: 9.5pt;
+    color: #64748b;
+    font-style: italic;
+  }
+
+  .external-summary {
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    border-left: 4px solid #7c3aed;
+    border-radius: 4px;
+    padding: 10px 14px;
+    margin: 8px 0;
+    font-size: 10.5pt;
+    color: #4c1d95;
+    line-height: 1.5;
+  }
+  .external-summary strong {
+    color: #5b21b6;
+    font-variant-numeric: tabular-nums;
+  }
+  .external-breakdown {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid #ddd6fe;
+    font-size: 10pt;
+  }
+  .external-breakdown-head {
+    font-weight: 700;
+    color: #5b21b6;
+    margin-bottom: 4px;
+  }
+  .external-breakdown ul {
+    margin: 4px 0 0 0;
+    padding-left: 22px;
+  }
+  .external-breakdown li {
+    margin: 3px 0;
+    color: #4c1d95;
+  }
+  .external-breakdown-est {
+    margin-top: 8px;
+    padding: 6px 10px;
+    background: #ede9fe;
+    border-left: 3px solid #7c3aed;
+    border-radius: 3px;
+    color: #4c1d95;
+    font-size: 9.5pt;
+  }
+  .external-caveat {
+    background: #faf5ff !important;
+    border-left-color: #a78bfa !important;
+    color: #5b21b6 !important;
+    font-style: italic;
+  }
+  .bar-list-external {
+    border-top: 1px solid #ddd6fe;
+  }
+  .bar-item-external {
+    border-left: 3px solid #7c3aed;
+    background: #faf5ff;
+    cursor: default;
+  }
+  .bar-item-external:hover { background: #f5f3ff; }
+  .bar-item-external .bar.bar-external {
+    background: #7c3aed;
+  }
+  .bar-item-external .phrase-text {
+    color: #5b21b6;
+    text-decoration: none;
+    cursor: default;
+  }
+  .ext-sources {
+    margin-top: 4px;
+    padding-left: 112px;
+    line-height: 1.7;
+    font-size: 9pt;
+    color: #6d28d9;
+  }
+  .ext-source {
+    display: inline-block;
+    margin-right: 6px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #ede9fe;
+    color: #5b21b6;
+    border: 1px solid #ddd6fe;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  @media (max-width: 720px) {
+    .ext-sources { padding-left: 72px; }
   }
 
   .bars-disclaimer {
@@ -1022,9 +1193,10 @@
 <div class="toolbar">
   <a href="index.html">&larr; Investigation home</a>
   <a href="sharing_map.html">Sharing map</a>
-  <select id="agency-select" aria-label="Select agency">
-    <option>Loading agencies&hellip;</option>
-  </select>
+  <div class="agency-search" id="agency-search">
+    <input type="text" id="agency-search-input" placeholder="Jump to another agency&hellip;" autocomplete="off" spellcheck="false">
+    <div class="search-results" id="agency-search-results" role="listbox"></div>
+  </div>
   <div class="spacer"></div>
 </div>
 

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -41,10 +41,20 @@ from lib import load_registry, portal_jsons  # noqa: E402
 
 AUDIT_DIR = Path("docs/data/audit")
 PORTAL_DIR = Path("assets/transparency.flocksafety.com")
+SHARING_GRAPH_PATH = PORTAL_DIR / ".sharing_graph_full.json"
 OUT_PATH = Path("docs/data/justifications.json")
 
 TOP_VERBATIM = 50
 TOP_TOKENS = 50
+
+# Threshold for "this search probably touched the subject agency's data".
+# Flock doesn't expose which networks each search actually hit, so the
+# heuristic is: a high networkCount means the search reached most of the
+# state, which would in practice include any given agency's data. The
+# UI surfaces this as a caveat, not a precise count.
+BROAD_REACH_THRESHOLD = 100
+TOP_EXTERNAL = 50
+TOP_SOURCES_PER_PHRASE = 4
 
 # Words that don't carry signal in a justification cloud — common
 # English stopwords plus ALPR-specific filler ("vehicle", "search",
@@ -590,19 +600,197 @@ def process_agency(audit_path):
     }
 
 
+def load_sharing_graph():
+    """Return the sharing graph as {agency_id: graph_entry}, or {} if missing.
+
+    The graph is built by build_sharing_graph.py and stored at
+    .sharing_graph_full.json under the portal-data directory. Each
+    agency entry has sharing_outbound_ids / sharing_inbound_ids
+    arrays of agency UUIDs.
+    """
+    if not SHARING_GRAPH_PATH.exists():
+        return {}
+    try:
+        g = json.loads(SHARING_GRAPH_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return g.get("agencies") or {}
+
+
+def gather_external_aggregated(slug, agency_id, graph, by_id, by_slug):
+    """For each agency this agency shares to (its outbound list), pull
+    that agency's broad-reach audit rows and aggregate them by phrase.
+
+    The framing: "agencies with shared access to your data also search
+    that data." We can't tell from Flock which networks each search
+    actually hit, so the proxy is networkCount >= BROAD_REACH_THRESHOLD
+    (statewide-or-broader reach) — those searches almost certainly
+    included the subject agency's data.
+
+    Returns None if the subject agency has no outbound list or no
+    audit-publishing recipients. Otherwise returns a dict with:
+      - rows: top phrases by count, each as
+        [phrase, total_count, [[source_name, count], ...]]
+      - sources_with_data: count of recipient agencies that contributed
+      - outbound_total: count of all outbound recipients (whether or
+        not they publish an audit)
+      - threshold: the networkCount cutoff used
+    """
+    if not agency_id:
+        return None
+    graph_entry = graph.get(agency_id) or {}
+    outbound_ids = graph_entry.get("sharing_outbound_ids") or []
+    if not outbound_ids:
+        return None
+    by_phrase = {}
+    sources_with_data = 0
+    sources_total_searches = 0
+    # Per-source broad-reach counts (for median + extrapolation).
+    broad_counts_per_reporter = []
+    # Partner categorization for the magnitude-estimation note: not
+    # every outbound recipient publishes an audit; some publish only a
+    # 30-day total; some publish nothing. Surfacing these breakdowns
+    # tells the reader how undercounted the visible numbers are.
+    partners_searches_only_count = 0
+    partners_searches_only_total = 0
+    partners_silent_count = 0
+
+    for tid in outbound_ids:
+        treg = by_id.get(tid)
+        if not treg:
+            partners_silent_count += 1
+            continue
+        candidate_slugs = []
+        if treg.get("slug"):
+            candidate_slugs.append(treg["slug"])
+        for fs in treg.get("flock_slugs") or []:
+            if fs not in candidate_slugs:
+                candidate_slugs.append(fs)
+        target_audit_path = None
+        target_slug = None
+        for cs in candidate_slugs:
+            ap = AUDIT_DIR / f"{cs}.json"
+            if ap.exists():
+                target_audit_path = ap
+                target_slug = cs
+                break
+        if target_audit_path:
+            try:
+                tdata = json.loads(target_audit_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                tdata = None
+            if tdata is None:
+                partners_silent_count += 1
+                continue
+            rows = tdata.get("rows") or []
+            broad_count_for_source = 0
+            target_name = treg.get("display_name") or target_slug
+            for r in rows:
+                try:
+                    nc = int(r.get("networkCount") or 0)
+                except (TypeError, ValueError):
+                    nc = 0
+                if nc < BROAD_REACH_THRESHOLD:
+                    continue
+                raw = r.get("reason")
+                if raw is None or not str(raw).strip():
+                    raw = r.get("offenseType")
+                if raw is None or not str(raw).strip():
+                    raw = r.get("caseNumber")
+                norm = normalize_reason(raw)
+                if norm is None:
+                    continue
+                entry = by_phrase.setdefault(
+                    norm, {"count": 0, "by_source": Counter()}
+                )
+                entry["count"] += 1
+                entry["by_source"][target_name] += 1
+                broad_count_for_source += 1
+            if broad_count_for_source > 0:
+                sources_with_data += 1
+                sources_total_searches += broad_count_for_source
+                broad_counts_per_reporter.append(broad_count_for_source)
+            else:
+                # Audit exists but has no broad-reach rows. Treat as
+                # silent for magnitude purposes — broad-reach is the
+                # signal we care about here.
+                partners_silent_count += 1
+            continue
+
+        # No audit data — try the portal for a 30-day total.
+        portal_s30 = None
+        for cs in candidate_slugs:
+            pd_dir = PORTAL_DIR / cs
+            if not pd_dir.is_dir():
+                continue
+            paths = portal_jsons(pd_dir)
+            if not paths:
+                continue
+            try:
+                pj = json.loads(paths[-1].read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            s30 = pj.get("searches_30d")
+            if s30 in (None, ""):
+                continue
+            try:
+                portal_s30 = int(s30)
+                break
+            except (TypeError, ValueError):
+                continue
+        if portal_s30 is not None:
+            partners_searches_only_count += 1
+            partners_searches_only_total += portal_s30
+        else:
+            partners_silent_count += 1
+
+    if not by_phrase:
+        return None
+
+    sorted_phrases = sorted(
+        by_phrase.items(), key=lambda kv: -kv[1]["count"]
+    )[:TOP_EXTERNAL]
+    out_rows = []
+    for phrase, data in sorted_phrases:
+        sources = data["by_source"].most_common(TOP_SOURCES_PER_PHRASE)
+        out_rows.append([phrase, data["count"], sources])
+
+    median_broad = None
+    if broad_counts_per_reporter:
+        sc = sorted(broad_counts_per_reporter)
+        median_broad = sc[len(sc) // 2]
+
+    return {
+        "rows": out_rows,
+        "sources_with_data": sources_with_data,
+        "outbound_total": len(outbound_ids),
+        "total_broad_searches": sources_total_searches,
+        "threshold": BROAD_REACH_THRESHOLD,
+        "median_broad_per_reporter": median_broad,
+        "partners_searches_only_count": partners_searches_only_count,
+        "partners_searches_only_total": partners_searches_only_total,
+        "partners_silent_count": partners_silent_count,
+    }
+
+
 def main():
     if not AUDIT_DIR.exists():
         print(f"missing {AUDIT_DIR}; run build_audit_log.py first", file=sys.stderr)
         return 1
     registry = load_registry()
     by_slug = {}
+    by_id = {}
     for entry in registry:
+        aid = entry.get("agency_id")
+        if aid:
+            by_id[aid] = entry
         slug = entry.get("slug")
         if not slug:
             continue
         by_slug[slug] = entry
         for fs in entry.get("flock_slugs") or []:
             by_slug.setdefault(fs, entry)
+    graph = load_sharing_graph()
 
     out = {}
     skipped = 0
@@ -623,6 +811,10 @@ def main():
             agency_data["acceptable_use_policy"] = aup
         if pu:
             agency_data["prohibited_uses"] = pu
+        agency_id = entry.get("agency_id") if entry else None
+        ext = gather_external_aggregated(slug, agency_id, graph, by_id, by_slug)
+        if ext:
+            agency_data["external_aggregated"] = ext
         out[slug] = agency_data
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

The justifications page only shows searches an agency's own staff ran. Partners with shared access also search this agency's data, and those searches appear in the partners' audits — invisible from this page until now.

This PR adds a **\"Searches by agencies with shared access\"** section that:
- Aggregates broad-reach searches (`networkCount ≥ 100`, a proxy for \"this search probably touched the subject's data\") from every audit-publishing recipient in the subject's outbound list.
- Renders aggregated phrases with top-source attribution chips per row.
- Shows a **\"How undercounted is this number?\" breakdown** with three buckets — audit-publishing partners, partners that publish only a 30-day total, silent partners — plus an order-of-magnitude estimate based on the median broad-reach count per reporting partner.

Example for East Palo Alto:
- 32,590 broad-reach searches visible across 65 audit-publishing partners.
- 77 partners publish a 30-day total but no detail (49,468 combined; broad-reach share invisible).
- 162 partners publish neither.
- Estimate: median audit partner ran 191 broad-reach. If the 239 non-detail partners are similarly active, the actual broad-reach total is closer to ~78K than 32K.

## UI tweaks bundled in

- **Type-ahead agency selector** — replaces the `<select>` dropdown with the same selector pattern used in `report.js`. Scales to bigger lists.
- **\"Show only this agency's own searches\" toggle** — checkbox above the page body to collapse the external section when the user wants to focus on own data.

## Caveats surfaced in the UI

- Italic note that the `≥100` threshold is a heuristic; Flock doesn't expose which networks each search actually hit.
- The non-detail partners' 30-day totals are *all* searches, not just broad-reach — the bullet acknowledges \"broad-reach share isn't visible.\"

## Test plan

- [ ] Build runs cleanly (`uv run python scripts/build_justifications.py`)
- [ ] EPA shows the external section with the breakdown bullets
- [ ] Fontana / Menlo Park (no own audit) still show the no-justification callout AND get the external section
- [ ] Type-ahead selector — type \"oak\" → Oakland resolves; ↓/↑ + Enter navigate
- [ ] Local-only toggle hides the external section and shows the dashed \"Hidden\" placeholder
- [ ] Source chips link visually to their agency name; counts add up to the row total

## Follow-ups (queued, not in this PR)

- Extend page to non-audit-publishing agencies (currently 80 → potentially 1000+ in CA). The data plumbing here works for them too, but `build_justifications.py` only iterates over audit JSONs; we'd need to also iterate the sharing graph to find every target agency.
- Replace the median-based estimate with a more rigorous one once we have ground truth (e.g. from a PRA asking Flock for cross-agency search totals).