### PR TITLE
fix(parse): soft-fail per file so one bad slug doesn't block the batch

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -84,18 +84,22 @@ jobs:
               --delay 1 | tee /tmp/crawl.log
           fi
 
+      - name: Parse new data
+        run: uv run python scripts/flock_transparency.py parse | tee -a /tmp/crawl.log
+
       - name: Surface parser failures as an issue
         if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Crawl logs `PARSE_ERROR: <slug> <date> :: <error>` whenever
-          # the parser trips on a new format variant (the .txt/.html are
-          # still saved, the slug is not permanently quarantined).
-          # Surface those into a single rolling issue so we notice.
+          # Both crawl and parse log `PARSE_ERROR: <slug> <date> :: <error>`
+          # whenever the parser trips on a new format variant (the .txt/.html
+          # are still saved, the slug is not permanently quarantined).
+          # Surface those into a single rolling issue so we notice. Runs
+          # after parse so parse-time-only errors get captured too.
           if [ ! -f /tmp/crawl.log ]; then exit 0; fi
-          ERRORS=$(grep -E "^\s+PARSE_ERROR: " /tmp/crawl.log || true)
+          ERRORS=$(grep -E "PARSE_ERROR: " /tmp/crawl.log | sort -u || true)
           if [ -z "$ERRORS" ]; then exit 0; fi
           {
             echo "Parser tripped on one or more agency portals. Files were"
@@ -117,9 +121,6 @@ jobs:
               --label parser \
               --body-file /tmp/parse-issue-body.md
           fi
-
-      - name: Parse new data
-        run: uv run python scripts/flock_transparency.py parse
 
       - name: Install Tesseract (cached)
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -1244,6 +1244,7 @@ def cmd_crawl(args):
 def cmd_parse(args):
     data_dir = args.data_dir
     count = 0
+    failed = 0
 
     slug_dirs = sorted(data_dir.iterdir()) if not args.slug else [data_dir / args.slug]
 
@@ -1269,7 +1270,18 @@ def cmd_parse(args):
                 page_html = html_path.read_text(encoding="utf-8")
                 bold_headings = extract_bold_headings(page_html)
 
-            portal_data = parse_portal_text(raw_text, slug, datestamp, bold_headings=bold_headings)
+            try:
+                portal_data = parse_portal_text(raw_text, slug, datestamp, bold_headings=bold_headings)
+            except ValueError as e:
+                # Soft-fail per file (mirrors cmd_crawl): one slug's new
+                # heading variant must not block parsing of other slugs
+                # captured in the same batch. The .txt/.html stay on
+                # disk; `parse --force --slug <slug>` re-tries once the
+                # parser is fixed. The PARSE_ERROR marker is grepped by
+                # the workflow's issue-surfacing step.
+                print(f"    PARSE_ERROR: {slug} {datestamp} :: {e}")
+                failed += 1
+                continue
 
             # Preserve crawled_at from existing JSON (set during crawl, not recoverable from .txt)
             if json_path.exists():
@@ -1295,7 +1307,10 @@ def cmd_parse(args):
             print(f"  {slug}/{datestamp}.json — {cameras} cameras, {orgs} orgs")
             count += 1
 
-    print(f"\nParsed {count} file(s).")
+    summary = f"\nParsed {count} file(s)."
+    if failed:
+        summary += f" {failed} failed (see PARSE_ERROR lines above)."
+    print(summary)
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_cmd_parse_soft_fail.py
+++ b/tests/test_cmd_parse_soft_fail.py
@@ -1,0 +1,54 @@
+"""cmd_parse must soft-fail per file: one slug whose .txt trips the
+parser (e.g. unrecognized bold heading after a Flock layout change)
+must not block the other slugs in the same batch from producing JSON.
+
+Mirrors the soft-fail pattern already in cmd_crawl (PARSE_ERROR line
++ keep going). The PARSE_ERROR marker is grepped by the workflow's
+issue-surfacing step.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import flock_transparency
+from flock_transparency import cmd_parse
+
+
+def test_cmd_parse_soft_fails_per_slug(tmp_path, capsys, monkeypatch):
+    good = tmp_path / "boomtown-ca-pd"
+    good.mkdir()
+    (good / "2026-05-05.txt").write_text("good txt body")
+
+    bad = tmp_path / "sometown-ca-pd"
+    bad.mkdir()
+    (bad / "2026-05-05.txt").write_text("bad txt body")
+
+    # Stub parse_portal_text so the test pins the cmd_parse loop's
+    # behavior, not the parser's heading map. The real parser is
+    # exercised by tests/test_flock_transparency_headings.py.
+    def fake_parse(raw_text, slug, datestamp, bold_headings=None):
+        if slug == "sometown-ca-pd":
+            raise ValueError(f"{slug} {datestamp}: simulated heading miss")
+        return {"crawled_slug": slug, "archived_date": datestamp,
+                "camera_count": 12, "sharing_outbound": []}
+
+    monkeypatch.setattr(flock_transparency, "parse_portal_text", fake_parse)
+
+    args = types.SimpleNamespace(data_dir=tmp_path, slug=None, force=False)
+    cmd_parse(args)
+
+    assert (good / "2026-05-05.json").exists(), (
+        "good slug must still produce JSON when a sibling slug fails"
+    )
+    assert not (bad / "2026-05-05.json").exists(), (
+        "failed slug must NOT produce a stub JSON — that pollutes "
+        "downstream consumers (build_history, build_map)"
+    )
+
+    out = capsys.readouterr().out
+    assert "PARSE_ERROR: sometown-ca-pd 2026-05-05" in out, (
+        "PARSE_ERROR marker is grepped by the workflow's issue step"
+    )
+    assert "Parsed 1 file(s). 1 failed" in out


### PR DESCRIPTION
## Summary

`cmd_crawl` already tolerates per-slug parse failures: it logs `PARSE_ERROR: <slug> <date> :: <error>`, keeps going, and leaves the `.txt`/`.html` on disk for later re-parse via `parse --force --slug <slug>`.

`cmd_parse` did not. The first slug whose heading map missed crashed the whole "Parse new data" workflow step — discarding the successfully-parsed JSON for the other slugs in the batch and blocking the commit / PR-update steps. PR #244 is one such error; without this change every new heading variant becomes a hard outage.

## Changes

- `scripts/flock_transparency.py`: `cmd_parse` catches `ValueError` per file, logs the same `PARSE_ERROR` marker `cmd_crawl` uses, continues. Prints failure count in the summary line.
- `.github/workflows/refresh-flock-data.yml`:
  - Tee parse output into `/tmp/crawl.log` so parse-time errors get surfaced.
  - Move "Surface parser failures as an issue" to **after** parse so it captures both crawl- and parse-time errors in one rolling issue.

## Test plan

- [x] `pytest tests/test_cmd_parse_soft_fail.py` — new regression test pins the soft-fail loop
- [x] `pytest tests/` — full suite passes (464)
- [ ] Next scheduled scrape: a fail on one slug commits the other two and updates the rolling issue