### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -340,6 +340,14 @@
         "chabot-college-campus-safety-security-ca-ps": "http_404"
       }
     },
+    "4025af52-9657-5a91-8d91-5e7b16129898": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T23:35:44.087950+00:00",
+      "tried": {
+        "shorewood-il-pd": "http_404"
+      }
+    },
     "4219823b-c553-51fd-9a9b-5618cb5f82b5": {
       "exhausted": false,
       "found": null,
@@ -347,6 +355,14 @@
       "tried": {
         "la-habra-ca-po": "http_404",
         "la-habra-ca-police-department": "http_404"
+      }
+    },
+    "4249ff72-bd1e-59e2-85eb-a28c4ceb012a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T23:35:38.211486+00:00",
+      "tried": {
+        "huntington-county-in-so": "http_404"
       }
     },
     "42ac4d61-32cd-5fa4-aa11-b6713123a5c7": {
@@ -901,6 +917,14 @@
         "orange-county-fire-authority-ca-fire": "http_404"
       }
     },
+    "a3181593-1121-5cc0-aae2-beb7d164ed58": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-05T23:35:49.425866+00:00",
+      "tried": {
+        "hollister-ca-po": "http_404"
+      }
+    },
     "a5b59684-abcc-5a43-949d-3aec089d30a4": {
       "exhausted": false,
       "found": null,
@@ -1299,6 +1323,6 @@
       }
     }
   },
-  "updated": "2026-05-05T22:41:21.421045+00:00",
+  "updated": "2026-05-05T23:35:49.463371+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.