### PR TITLE
feat(justifications): all-agencies coverage + interleaved bars + cross-links

### DIFF
--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -463,18 +463,44 @@
   // attributes the top N sources inline.
   var hideExternal = false;
 
-  function renderExternalSection(agencyData) {
+  // For agencies without their own published audit. Replaces the
+  // data-window banner / stats grid / own-audit framing with a
+  // brief "no own audit" callout that surfaces what's known: this
+  // agency exists in the sharing graph and has audit-publishing
+  // partners; the partner picture below tells the cross-agency story
+  // for this agency's data.
+  function renderNoOwnAuditBanner(agencyData) {
+    var ext = agencyData.external_aggregated || {};
+    var outboundTotal = ext.outbound_total || 0;
+    var sources = ext.sources_with_data || 0;
+    var portalLink = 'https://transparency.flocksafety.com/' +
+      encodeURIComponent(agencyData.slug);
+    return '<div class="no-own-audit-banner">' +
+      '<div class="no-own-audit-head">' +
+      'No own search audit published' +
+      '</div>' +
+      '<div class="no-own-audit-body">' +
+      escapeHTML(agencyData.display_name) +
+      ' does not publish its own Public Search Audit, so there is no ' +
+      'record of searches its own staff ran against ALPR data. The ' +
+      'cross-agency picture below comes from the ' + sources +
+      ' of ' + outboundTotal + ' partner agencies (with shared access ' +
+      'to this data) that do publish audits. ' +
+      '<a href="' + portalLink + '" target="_blank" rel="noopener">' +
+      'View on Flock transparency portal &rarr;</a>' +
+      '</div>' +
+      '</div>';
+  }
+
+  // Numbers + breakdown for the cross-agency external view. Renders
+  // near the top of the page (above the agency's own bars) so the
+  // headline volume reads first; the bars-with-attribution detail
+  // lives in renderExternalSection further down.
+  function renderExternalStats(agencyData) {
     var ext = agencyData.external_aggregated;
     if (!ext || !ext.rows || !ext.rows.length) return '';
-    if (hideExternal) {
-      return '<h2>Searches by agencies with shared access</h2>' +
-        '<p class="external-hidden-note">' +
-        'Hidden &mdash; toggle <em>Show only this agency&rsquo;s own searches</em> ' +
-        'off above to reveal partner searches that likely touched this data.' +
-        '</p>';
-    }
+    if (hideExternal) return '';
     var threshold = ext.threshold || 100;
-    var rows = ext.rows;
     var totalSearches = ext.total_broad_searches || 0;
     var sources = ext.sources_with_data || 0;
     var outboundTotal = ext.outbound_total || 0;
@@ -483,11 +509,7 @@
     var silent = ext.partners_silent_count || 0;
     var medianBroad = ext.median_broad_per_reporter || 0;
     var nonAudit = s30Only + silent;
-    // If non-reporting partners are similarly active to reporters,
-    // each contributes ~medianBroad broad-reach searches that this
-    // page can't see. The estimate is order-of-magnitude, not precise.
     var estimatedTotal = totalSearches + medianBroad * nonAudit;
-    var totalForPct = totalSearches || 1;
     var breakdown = '';
     if (nonAudit > 0) {
       breakdown = '<div class="external-breakdown">' +
@@ -522,17 +544,89 @@
       }
       breakdown += '</div>';
     }
-    var html = '<h2>Searches by agencies with shared access</h2>' +
-      '<div class="external-summary">' +
+    return '<div class="external-summary">' +
+      '<div class="external-summary-label">Searches by agencies with shared access</div>' +
       '<strong>' + totalSearches.toLocaleString() + '</strong> broad-reach ' +
       'searches by <strong>' + sources + '</strong> of ' + outboundTotal +
       ' agencies that ' + escapeHTML(agencyData.display_name) +
       ' shares its data to. ' +
       'Each is a search that reached &ge; ' + threshold +
       ' networks &mdash; broad enough that this agency&rsquo;s data was ' +
-      'almost certainly included.' +
+      'almost certainly included. ' +
+      '<a class="external-summary-jump" href="#external-bars">' +
+      'Top phrases &darr;</a>' +
       breakdown +
+      '</div>';
+  }
+
+  // Inline mini bar chart of the global networkCount distribution.
+  // Anchors the threshold ("we use 100+") to the empirical bimodal
+  // pattern: most searches are either 1-9 networks or 100+, with very
+  // little in between. Lets the reader see why the exact threshold
+  // matters less than it sounds.
+  function renderNcDistributionCaveat(threshold) {
+    if (!currentNcDistribution) return '';
+    var buckets = currentNcDistribution.buckets || {};
+    var total = currentNcDistribution.total || 0;
+    if (!total) return '';
+    var labels = ['1', '2-9', '10-99', '100+'];
+    var pcts = labels.map(function (k) {
+      return total > 0 ? (100 * (buckets[k] || 0) / total) : 0;
+    });
+    var bars = '<div class="nc-dist-bars">';
+    for (var i = 0; i < labels.length; i++) {
+      var isBroad = labels[i] === '100+';
+      var cls = 'nc-dist-bar' + (isBroad ? ' nc-dist-bar-broad' : '');
+      bars += '<div class="' + cls + '" title="' + labels[i] +
+        ' networks: ' + (buckets[labels[i]] || 0).toLocaleString() +
+        ' searches (' + pcts[i].toFixed(1) + '%)">' +
+        '<div class="nc-dist-bar-label">' + labels[i] + ' nets</div>' +
+        '<div class="nc-dist-bar-fill" style="height:' +
+        Math.max(2, Math.round(pcts[i])) + '%"></div>' +
+        '<div class="nc-dist-bar-pct">' + pcts[i].toFixed(0) + '%</div>' +
+        '</div>';
+    }
+    bars += '</div>';
+    return '<div class="nc-dist-caveat">' +
+      '<div class="nc-dist-caveat-head">' +
+      'Why a &ge; ' + threshold + '-network threshold?' +
       '</div>' +
+      '<div class="nc-dist-caveat-body">' +
+      'Across all ' + (currentAgencyCount || '') +
+      ' audit-publishing CA agencies, search reach is bimodal &mdash; ' +
+      'most searches go either to a small set of direct partners or ' +
+      'to a broad slice of the state, with very little in between:' +
+      '</div>' +
+      bars +
+      '<div class="nc-dist-caveat-foot">' +
+      'A search reaching <strong>2&ndash;9 networks</strong> stayed ' +
+      'within direct partners. A search reaching <strong>100+</strong> ' +
+      'is wide enough that this agency&rsquo;s data is very likely ' +
+      'included, though Flock doesn&rsquo;t publish exactly which ' +
+      'networks each search touched. The middle band (10&ndash;99) ' +
+      'accounts for only <strong>' + pcts[2].toFixed(1) +
+      '%</strong> of all searches, so the exact cutoff matters less ' +
+      'than the bimodal split.' +
+      '</div>' +
+      '</div>';
+  }
+
+  function renderExternalSection(agencyData) {
+    var ext = agencyData.external_aggregated;
+    if (!ext || !ext.rows || !ext.rows.length) return '';
+    if (hideExternal) {
+      return '<h2 id="external-bars">Searches by agencies with shared access</h2>' +
+        '<p class="external-hidden-note">' +
+        'Hidden &mdash; toggle <em>Show only this agency&rsquo;s own searches</em> ' +
+        'off above to reveal partner searches that likely touched this data.' +
+        '</p>';
+    }
+    var threshold = ext.threshold || 100;
+    var rows = ext.rows;
+    var totalSearches = ext.total_broad_searches || 0;
+    var totalForPct = totalSearches || 1;
+    var html = '<h2 id="external-bars">Searches by agencies with shared access</h2>' +
+      renderNcDistributionCaveat(threshold) +
       '<p class="bars-disclaimer external-caveat">' +
       'Heuristic: Flock doesn&rsquo;t expose which networks each search ' +
       'hit, so we treat any search reaching &ge; ' + threshold +
@@ -600,30 +694,83 @@
       '</div></div>';
   }
 
-  function renderBars(items, total) {
-    if (!items.length) {
+  // Single external row rendered inline in the merged bar list.
+  // External rows have no per-phrase detail (no codes/flags/timing
+  // grids — those come from per-agency audits we don't have for the
+  // partner who actually ran the search), so this row is read-only,
+  // distinct purple styling, with source-attribution chips below.
+  function renderExternalBarRow(row, combinedTotal) {
+    var phrase = row[0];
+    var count = row[1];
+    var topSources = row[2] || [];
+    var sharePct = combinedTotal > 0 ? (100 * count / combinedTotal) : 0;
+    var w = Math.max(1, Math.round(sharePct));
+    var srcHtml = '';
+    for (var s = 0; s < topSources.length; s++) {
+      srcHtml += '<span class="ext-source">' +
+        escapeHTML(topSources[s][0]) + ' (' +
+        topSources[s][1].toLocaleString() + ')</span>';
+    }
+    return '<div class="bar-item bar-item-external">' +
+      '<div class="bar-item-main">' +
+      '<span class="bar-track">' +
+      '<span class="bar bar-external" style="width:' + w + '%"></span>' +
+      '<span class="bar-pct">' + sharePct.toFixed(1) + '%</span>' +
+      '</span>' +
+      '<span class="bar-count">' + count.toLocaleString() + '</span>' +
+      '<span class="phrase-text">' + escapeHTML(phrase) + '</span>' +
+      '<span class="ext-badge">via partners</span>' +
+      '</div>' +
+      (srcHtml ? '<div class="ext-sources">' + srcHtml + '</div>' : '') +
+      '</div>';
+  }
+
+  function renderBars(items, total, externalRows, externalTotal) {
+    if (!items.length && (!externalRows || !externalRows.length)) {
       return '<div class="empty">No phrases to display for this agency.</div>';
     }
     var displayItems = aggregateItems(items, currentViewMode);
+    var hasExternal = !hideExternal && externalRows && externalRows.length &&
+                      currentViewMode === 'phrase';
+    var combinedTotal = (total || 0) +
+      (hasExternal ? (externalTotal || 0) : 0);
     var filterBarHtml = currentViewMode === 'phrase' ? renderFilterBar(items) : '';
     var hint = currentViewMode === 'phrase'
-      ? 'Click any row for per-phrase detail (timing, network reach, daily cadence).'
+      ? (hasExternal
+          ? 'Local rows (blue) and partner rows (purple) are interleaved by raw count; ' +
+            'percentages are share of all known volume (this agency&rsquo;s own + partners). ' +
+            'Click a local row for per-phrase detail.'
+          : 'Click any row for per-phrase detail (timing, network reach, daily cadence).')
       : 'Aggregated view &mdash; phrases with multiple codes are counted under each, so totals can exceed search count. ' +
         'Switch back to <em>Phrase</em> grouping for clickable rows with detail.';
     var html = renderViewModeToggle() +
       filterBarHtml +
       '<div class="bar-list-hint">' + hint + '</div>' +
       '<div class="bar-list">';
-    items = displayItems;
-    for (var i = 0; i < items.length; i++) {
-      var phrase = items[i][0];
-      var count = items[i][1];
-      var codes = items[i][2] || [];
-      var detail = items[i][3];
-      var sharePct = total > 0 ? (100 * count / total) : 0;
-      // Bar fill is the absolute share of total searches — a 12%
-      // phrase fills 12% of the track. The cap of 100% naturally
-      // applies; min 1% so even tiny entries show a visible nub.
+    // Build a merged list of {type, count, ...} for unified sort.
+    // Aggregated views (code/category) skip external since external
+    // rows have no codes/categories to bucket against.
+    var merged = [];
+    for (var i = 0; i < displayItems.length; i++) {
+      merged.push({ type: 'own', count: displayItems[i][1], item: displayItems[i] });
+    }
+    if (hasExternal) {
+      for (var j = 0; j < externalRows.length; j++) {
+        merged.push({ type: 'ext', count: externalRows[j][1], row: externalRows[j] });
+      }
+    }
+    merged.sort(function (a, b) { return b.count - a.count; });
+    for (var mi = 0; mi < merged.length; mi++) {
+      if (merged[mi].type === 'ext') {
+        html += renderExternalBarRow(merged[mi].row, combinedTotal);
+        continue;
+      }
+      var rowItem = merged[mi].item;
+      var phrase = rowItem[0];
+      var count = rowItem[1];
+      var codes = rowItem[2] || [];
+      var detail = rowItem[3];
+      var sharePct = combinedTotal > 0 ? (100 * count / combinedTotal) : 0;
       var w = Math.max(1, Math.round(sharePct));
 
       // Code-identification pills (orange) sit next to the phrase so
@@ -669,7 +816,7 @@
         ' data-flag-kinds="' + escapeHTML(flagKinds) + '"' +
         ' data-code-labels="' + escapeHTML(codeLabels) + '"' +
         ' data-categories="' + escapeHTML(rowCats) + '"';
-      var drilldown = items[i][4];
+      var drilldown = rowItem[4];
       if (isAggregated) {
         rowAttrs += ' data-aggregated="1"';
         if (drilldown && drilldown.type) {
@@ -1376,6 +1523,7 @@
   var currentAgencyData = null;
   var currentSlug = '';
   var currentAgencyCount = 0;
+  var currentNcDistribution = null;
 
   // Populate the per-phrase context maps that handleExpandClick reads.
   // Counts come from verbatim AND long-active-cases so all three
@@ -1571,28 +1719,54 @@
         '</div>'
       : '';
 
+    var hasOwnAudit = agencyData.has_own_audit !== false;
+    var extRows = (agencyData.external_aggregated &&
+                   agencyData.external_aggregated.rows) || [];
+    var extTotal = (agencyData.external_aggregated &&
+                    agencyData.external_aggregated.total_broad_searches) || 0;
+    var ownVerbatim = agencyData.verbatim || [];
+    var ownTotal = agencyData.row_count || 0;
+    var threshold = (agencyData.external_aggregated &&
+                     agencyData.external_aggregated.threshold) || 100;
+    var bimodalCaveat = (extRows.length && !hideExternal)
+      ? renderNcDistributionCaveat(threshold) : '';
+    var barsHtml = ownVerbatim.length || extRows.length
+      ? renderBars(ownVerbatim, ownTotal, extRows, extTotal)
+      : '';
+    var ownSections = hasOwnAudit
+      ? (windowBanner +
+        blurb +
+        stats +
+        renderUses(agencyData) +
+        renderLongActiveCases(agencyData.long_active_cases, agencyData.display_name) +
+        '<h2>Top reasons</h2>' +
+        (agencyData.has_justification_column === false
+          ? renderNoJustificationCallout(agencyData)
+          : '<p class="bars-disclaimer">' +
+            'Local rows are typed in (or chosen from a dropdown) by the searching officer. ' +
+            'Nothing in the audit system validates that the entered reason aligns with the actual ' +
+            'reason for the search, or that the search was authorized.' +
+            '</p>' +
+            bimodalCaveat +
+            barsHtml))
+      : renderNoOwnAuditBanner(agencyData) +
+        renderUses(agencyData) +
+        '<h2>Top reasons</h2>' +
+        bimodalCaveat +
+        barsHtml;
+    var ownTrailingSections = hasOwnAudit
+      ? ('<h2>Search timing (day &times; hour, Pacific Time)</h2>' +
+        renderHeatmap(agencyData.hour_dow, agencyData.timed_rows) +
+        '<h2>Detected California penal / vehicle codes</h2>' +
+        renderCodes(agencyData.penal_codes))
+      : '';
+
     return '<h1>' + escapeHTML(agencyData.display_name) + '</h1>' +
       '<p class="subtitle">ALPR search justifications</p>' +
-      windowBanner +
-      blurb +
-      stats +
       localToggle +
-      renderUses(agencyData) +
-      renderLongActiveCases(agencyData.long_active_cases, agencyData.display_name) +
-      '<h2>Top reasons (this agency&rsquo;s own searches)</h2>' +
-      (agencyData.has_justification_column === false
-        ? renderNoJustificationCallout(agencyData)
-        : '<p class="bars-disclaimer">' +
-          'These reasons are typed in (or chosen from a dropdown) by the searching officer. ' +
-          'Nothing in the audit system validates that the entered reason aligns with the actual ' +
-          'reason for the search, or that the search was authorized.' +
-          '</p>' +
-          renderBars(agencyData.verbatim, agencyData.row_count)) +
-      renderExternalSection(agencyData) +
-      '<h2>Search timing (day &times; hour, Pacific Time)</h2>' +
-      renderHeatmap(agencyData.hour_dow, agencyData.timed_rows) +
-      '<h2>Detected California penal / vehicle codes</h2>' +
-      renderCodes(agencyData.penal_codes) +
+      renderExternalStats(agencyData) +
+      ownSections +
+      ownTrailingSections +
       '<div class="footnote">' +
       'Source: this agency’s Public Search Audit CSV, embedded in its Flock Safety transparency portal. ' +
       'Rows are deduplicated by ID across every scrape we have, so the audit window can extend ' +
@@ -1734,7 +1908,9 @@
       })
       .then(function (data) {
         var agencies = data.agencies || {};
-        currentAgencyCount = data.agency_count || Object.keys(agencies).length;
+        currentAgencyCount = data.agencies_with_own_audit ||
+          data.agency_count || Object.keys(agencies).length;
+        currentNcDistribution = data.network_count_distribution || null;
         var slug = getInitialSlug(agencies);
         wireAgencySearch(agencies, slug);
         installPhraseContext(slug ? agencies[slug] : null);

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -2587,6 +2587,10 @@
 
     const params = new URLSearchParams(location.search);
     const slug = params.get("agency");
+    const justLink = document.getElementById("justifications-link");
+    if (justLink && slug) {
+      justLink.href = "justifications.html?agency=" + encodeURIComponent(slug);
+    }
     if (!slug) {
       document.getElementById("report").innerHTML = `
         <div class="error-box">

--- a/docs/justifications.html
+++ b/docs/justifications.html
@@ -565,6 +565,92 @@
     font-style: italic;
   }
 
+  .no-own-audit-banner {
+    margin: 12px 0;
+    padding: 12px 16px;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-left: 4px solid #f59e0b;
+    border-radius: 4px;
+  }
+  .no-own-audit-head {
+    font-size: 11pt;
+    font-weight: 700;
+    color: #92400e;
+    margin-bottom: 4px;
+  }
+  .no-own-audit-body {
+    font-size: 10.5pt;
+    color: #78350f;
+    line-height: 1.5;
+  }
+  .no-own-audit-body a {
+    color: #92400e;
+    text-decoration: none;
+    border-bottom: 1px dotted #92400e;
+  }
+  .no-own-audit-body a:hover { border-bottom-style: solid; }
+
+  /* Bimodal-distribution mini chart for the broad-reach caveat. */
+  .nc-dist-caveat {
+    margin: 10px 0 14px;
+    padding: 10px 14px;
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    border-radius: 4px;
+    font-size: 10pt;
+    color: #4c1d95;
+  }
+  .nc-dist-caveat-head {
+    font-weight: 700;
+    color: #5b21b6;
+    margin-bottom: 4px;
+    font-size: 10.5pt;
+  }
+  .nc-dist-caveat-body { line-height: 1.5; }
+  .nc-dist-caveat-foot {
+    margin-top: 8px;
+    line-height: 1.5;
+    font-size: 9.5pt;
+  }
+  .nc-dist-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    height: 90px;
+    margin: 8px 0 4px;
+    padding: 0 8px;
+  }
+  .nc-dist-bar {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100%;
+    cursor: default;
+  }
+  .nc-dist-bar-label {
+    font-size: 8.5pt;
+    color: #6d28d9;
+    margin-bottom: 2px;
+    font-variant-numeric: tabular-nums;
+  }
+  .nc-dist-bar-fill {
+    width: 80%;
+    background: #c4b5fd;
+    border-radius: 3px 3px 0 0;
+    min-height: 2px;
+  }
+  .nc-dist-bar-broad .nc-dist-bar-fill { background: #7c3aed; }
+  .nc-dist-bar-pct {
+    font-size: 8pt;
+    color: #5b21b6;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+
   .external-summary {
     background: #f5f3ff;
     border: 1px solid #ddd6fe;
@@ -576,6 +662,24 @@
     color: #4c1d95;
     line-height: 1.5;
   }
+  .external-summary-label {
+    display: block;
+    font-size: 8.5pt;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-weight: 700;
+    color: #5b21b6;
+    margin-bottom: 4px;
+  }
+  .external-summary-jump {
+    color: #6d28d9;
+    text-decoration: none;
+    border-bottom: 1px dotted #6d28d9;
+    font-size: 9.5pt;
+    margin-left: 4px;
+    white-space: nowrap;
+  }
+  .external-summary-jump:hover { border-bottom-style: solid; }
   .external-summary strong {
     color: #5b21b6;
     font-variant-numeric: tabular-nums;
@@ -623,6 +727,19 @@
     cursor: default;
   }
   .bar-item-external:hover { background: #f5f3ff; }
+  .ext-badge {
+    flex: 0 0 auto;
+    font-size: 8.5pt;
+    color: #6d28d9;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #ede9fe;
+    border: 1px solid #ddd6fe;
+    white-space: nowrap;
+  }
   .bar-item-external .bar.bar-external {
     background: #7c3aed;
   }

--- a/docs/report.html
+++ b/docs/report.html
@@ -952,6 +952,7 @@
 <div class="toolbar">
   <a href="sharing_map.html" title="Back to the interactive map">&larr; Back to Map</a>
   <a href="index.html">Investigation home</a>
+  <a href="justifications.html" id="justifications-link" title="Search-justification analysis for this agency">Justifications</a>
   <div class="agency-search" id="agency-search">
     <input type="text" id="agency-search-input" placeholder="Jump to another agency&hellip;" autocomplete="off" spellcheck="false">
     <div class="search-results" id="agency-search-results" role="listbox"></div>

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -773,6 +773,38 @@ def gather_external_aggregated(slug, agency_id, graph, by_id, by_slug):
     }
 
 
+def compute_global_nc_distribution(audit_paths):
+    """Aggregate networkCount distribution across all audit-publishing
+    agencies. Surfaces the bimodal pattern (most searches go to
+    1 network or 2-9, or jump to 100+; rare in between) so the page
+    can justify its broad-reach threshold.
+    """
+    buckets = {"1": 0, "2-9": 0, "10-99": 0, "100+": 0}
+    total = 0
+    for path in audit_paths.values():
+        try:
+            d = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for r in d.get("rows") or []:
+            try:
+                nc = int(r.get("networkCount") or 0)
+            except (TypeError, ValueError):
+                continue
+            if nc < 1:
+                continue
+            total += 1
+            if nc == 1:
+                buckets["1"] += 1
+            elif nc < 10:
+                buckets["2-9"] += 1
+            elif nc < 100:
+                buckets["10-99"] += 1
+            else:
+                buckets["100+"] += 1
+    return {"buckets": buckets, "total": total}
+
+
 def main():
     if not AUDIT_DIR.exists():
         print(f"missing {AUDIT_DIR}; run build_audit_log.py first", file=sys.stderr)
@@ -792,15 +824,28 @@ def main():
             by_slug.setdefault(fs, entry)
     graph = load_sharing_graph()
 
+    # Map each known audit-publishing slug to the registry agency_id
+    # so the audit set can be probed by either key. process_agency
+    # iterates the audit JSONs; the all-agency loop below uses this
+    # set to know which entry provides own-audit data.
+    audit_slugs_to_paths = {}
+    for path in sorted(AUDIT_DIR.glob("*.json")):
+        audit_slugs_to_paths[path.stem] = path
+
     out = {}
     skipped = 0
-    for path in sorted(AUDIT_DIR.glob("*.json")):
-        slug = path.stem
+    own_audit_count = 0
+    external_only_count = 0
+
+    # Pass 1 — agencies with their own audit. Same processing as
+    # before; sets has_own_audit = True.
+    for slug, path in sorted(audit_slugs_to_paths.items()):
         entry = by_slug.get(slug)
         agency_data = process_agency(path)
         if agency_data is None:
             skipped += 1
             continue
+        agency_data["has_own_audit"] = True
         agency_data["slug"] = slug
         agency_data["display_name"] = (
             (entry.get("display_name") if entry else None)
@@ -816,6 +861,56 @@ def main():
         if ext:
             agency_data["external_aggregated"] = ext
         out[slug] = agency_data
+        own_audit_count += 1
+
+    # Pass 2 — every other CA agency in the registry. Emit a stripped-
+    # down entry when external_aggregated has content, so the page
+    # renders the cross-agency story even though the agency itself
+    # publishes no audit. Skip non-CA agencies and ones with no
+    # outbound recipients of any kind.
+    for entry in registry:
+        slug = entry.get("slug")
+        if not slug or slug in out:
+            continue
+        # Audit-publishing-but-different-slug case: skip if any of the
+        # entry's flock_slugs matches an audit we already wrote.
+        if any(fs in out for fs in (entry.get("flock_slugs") or [])):
+            continue
+        # CA-only filter: state code lives in the geo block, but slug
+        # convention is reliable enough — CA agencies have "-ca-" in
+        # the slug. Out-of-state agencies use the same Flock platform
+        # and could theoretically be in CA's outbound graph, but the
+        # justifications page is San Mateo / California-focused.
+        if "-ca-" not in slug and not slug.endswith("-ca"):
+            continue
+        agency_id = entry.get("agency_id")
+        if not agency_id:
+            continue
+        ext = gather_external_aggregated(slug, agency_id, graph, by_id, by_slug)
+        if not ext:
+            continue
+        agency_data = {
+            "has_own_audit": False,
+            "slug": slug,
+            "display_name": (
+                entry.get("display_name")
+                or (entry.get("flock_names") or [None])[0]
+                or slug
+            ),
+            # Skip own-audit-derived fields. UI checks has_own_audit
+            # to know whether to render those sections.
+            "row_count": 0,
+            "external_aggregated": ext,
+        }
+        aup, pu = latest_portal_uses(slug)
+        if aup:
+            agency_data["acceptable_use_policy"] = aup
+        if pu:
+            agency_data["prohibited_uses"] = pu
+        out[slug] = agency_data
+        external_only_count += 1
+
+    nc_dist = compute_global_nc_distribution(audit_slugs_to_paths)
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -823,10 +918,18 @@ def main():
         "top_verbatim_cap": TOP_VERBATIM,
         "top_tokens_cap": TOP_TOKENS,
         "agency_count": len(out),
+        "agencies_with_own_audit": own_audit_count,
+        "agencies_external_only": external_only_count,
+        "network_count_distribution": nc_dist,
+        "broad_reach_threshold": BROAD_REACH_THRESHOLD,
         "agencies": out,
     }
     OUT_PATH.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n")
-    print(f"wrote {OUT_PATH}: {len(out)} agencies, skipped {skipped}")
+    print(
+        f"wrote {OUT_PATH}: {len(out)} agencies "
+        f"({own_audit_count} with own audit, "
+        f"{external_only_count} external-only), skipped {skipped}"
+    )
     return 0
 
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -450,6 +450,7 @@ Promise.all([
       : '';
     html += '<h3>' + escapeHtml(agencyInfo[m.slug]?.name || m.slug) + ' <a href="' + escapeHtml(shareUrl) + '" data-share-url="' + escapeHtml(shareUrl) + '" style="font-size:14px;text-decoration:none" title="Copy link">\ud83d\udd17</a></h3>';
     html += '<p class="stat"><a href="report.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb;font-weight:600">View full report \u2192</a>';
+    html += ' &middot; <a href="justifications.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb">Justifications \u2192</a>';
     if (m.crawled) {
       html += ' &middot; <a href="https://transparency.flocksafety.com/' + safeSlug(m.slug) + '" target="_blank" style="color:#2563eb">Transparency portal \u2197</a>';
     }


### PR DESCRIPTION
## Summary

Five things bundled (each individually small but they're conceptually one iteration on the cross-agency story):

1. **Stats up top** — cross-agency headline number + \"How undercounted is this number?\" breakdown moves above the agency's own-data sections so the volume framing reads first. Detail bars still anchor at `#external-bars` and the top summary has a jump link.

2. **All-agencies coverage** — build script now iterates the registry, not just the 80 audit-publishing agencies. CA agencies that don't publish their own audit but appear as outbound recipients of audit-publishing agencies get a stripped-down page (no data window banner / stats grid / own bars / heatmap / codes table; replaced with a \"No own search audit published\" amber banner). 310 agencies total now (80 own-audit, 230 external-only).

3. **Interleaved local + partner bar list** — single \"Top reasons\" section mixes own (blue) and partner (purple) rows sorted by raw count; share % computed against combined volume. Local-only toggle still hides partner rows.

4. **Cross-links** — report.html toolbar gets a \"Justifications\" link populated from `?agency=<slug>`; sharing-map agency popup adds a \"Justifications →\" link next to \"View full report\".

5. **Bimodal caveat** — build computes the global networkCount distribution across all 80 audit-publishing agencies' rows. Page renders an inline mini-chart above the bar list showing the bimodal pattern (38% narrow, 3% middle, 59% broad) so the `≥ 100` threshold is anchored to empirical data.

Type-ahead agency selector (mirrors `report.js`) replaces the old `<select>` dropdown so it scales to the larger list.

## Test plan

- [ ] `uv run python scripts/build_justifications.py` writes ~310 agencies
- [ ] EPA: shows merged bar list with interleaved local + partner rows
- [ ] Burlingame (external-only): shows the \"No own audit published\" banner + partner bars
- [ ] Type-ahead jump from \"oak\" → Oakland; ↓/↑/Enter navigate
- [ ] Local-only checkbox hides all partner rows
- [ ] Bimodal mini-chart renders with 4 bars; the 100+ bar (purple) is the tallest
- [ ] report.html: \"Justifications\" link in toolbar carries the agency slug
- [ ] sharing_map.html: clicking an agency, \"Justifications →\" link appears in the side panel

## Follow-ups (queued, not in this PR)

- Phase 3 polish: consistent agency-selector population across the type-ahead — currently only loads agencies in `justifications.json`, but for cross-linking from the sharing map we may land on a slug that has no entry. Right now we render a 404 message; a friendlier fallback would point back to the per-agency report.
- The audit-lacks-justification-column finding (Fontana, Menlo Park) belongs as a check in `scripts/build_report_data.py` — still queued.