### PR TITLE
fix(parser): gate overview-marker check on "Flock Safety" mention

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -725,18 +725,26 @@ def parse_portal_text(raw_text, slug, datestamp, bold_headings=None):
     #   "<Agency Name> uses Flock Safety [LPR ][Tt]echnology..."
     # Some agencies (e.g. Casa Grande AZ PD) have "LPR Technology" in the
     # boilerplate, others have plain "technology" — match both.
+    #
+    # Some agencies write a custom overview that doesn't follow the
+    # boilerplate at all. NCRIC's reads "***draft version*** The Northern
+    # California Regional Intelligence Center is a multi-jurisdiction
+    # government program..." and never mentions Flock Safety. For those
+    # crawled_name stays None silently — we only raise when "Flock Safety"
+    # IS mentioned but the marker shape doesn't match, which is the case
+    # we actually want to catch (Flock rephrased their boilerplate).
     overview = fields.get("overview", "")
     crawled_name = None
     flock_marker_re = re.compile(r" uses Flock Safety (?:LPR )?[Tt]echnology")
     m = flock_marker_re.search(overview)
     if m:
         crawled_name = overview[:m.start()].strip()
-    elif overview.strip():
+    elif overview.strip() and "Flock Safety" in overview:
         raise ValueError(
-            f"{slug} {datestamp}: overview is non-empty but agency-name "
-            f"marker (' uses Flock Safety [LPR] [Tt]echnology') not found — "
-            f"Flock may have rephrased the overview boilerplate. Update "
-            f"parse_portal_text."
+            f"{slug} {datestamp}: overview mentions Flock Safety but the "
+            f"agency-name marker (' uses Flock Safety [LPR] [Tt]echnology') "
+            f"doesn't match — Flock may have rephrased the boilerplate. "
+            f"Update parse_portal_text."
         )
 
     # Fail-loud: each bold heading should resolve to something in

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -312,21 +312,19 @@ def test_stub_page_without_portal_markers_does_not_raise():
                       bold_headings=set())
 
 
-def test_overview_without_flock_marker_raises():
-    """If the overview body is non-empty but the agency-name marker
-    'uses Flock Safety technology' is missing, Flock rephrased their
-    boilerplate — surface that instead of silently dropping crawled_name.
-    """
+def test_overview_mentioning_flock_without_marker_raises():
+    """If the overview mentions Flock Safety but the agency-name marker
+    ('X uses Flock Safety [LPR] [Tt]echnology') doesn't match, that
+    points at Flock rephrasing their boilerplate — surface it instead
+    of silently dropping crawled_name."""
     import pytest
-    # Overview is detected as a heading; body is overview prose with
-    # no "uses Flock Safety technology" marker.
     text = "\n".join([
         "Overview",
         "",
-        "Some agency description that doesn't contain the expected marker.",
+        "Some agency partners with Flock Safety to deploy ALPR cameras.",
         "",
     ])
-    with pytest.raises(ValueError, match="agency-name marker"):
+    with pytest.raises(ValueError, match="Flock may have rephrased"):
         parse_portal_text(text, "test-agency", "2026-05-03",
                           bold_headings={"Overview"})
 
@@ -336,6 +334,26 @@ def test_empty_overview_does_not_raise():
     crawled_name stays None, that's a known/acceptable state."""
     text = "Overview\n\n\n"
     result = parse_portal_text(text, "test-agency", "2026-05-03",
+                               bold_headings={"Overview"})
+    assert result["crawled_name"] is None
+
+
+def test_custom_non_boilerplate_overview_does_not_raise():
+    """Some agencies write their own overview that doesn't follow the
+    Flock Safety boilerplate at all — NCRIC (Northern California
+    Regional Intelligence Center) starts with '***draft version***'
+    and never mentions Flock Safety. The marker check is gated on
+    'Flock Safety' appearing in the overview, so non-boilerplate
+    customizations don't trip it; crawled_name stays None silently."""
+    text = "\n".join([
+        "Overview",
+        "",
+        "***draft version*** The Northern California Regional Intelligence "
+        "Center (NCRIC) is a multi-jurisdiction government program that "
+        "serves fifteen counties in Northern California.",
+        "",
+    ])
+    result = parse_portal_text(text, "ncric", "2026-05-05",
                                bold_headings={"Overview"})
     assert result["crawled_name"] is None
 


### PR DESCRIPTION
## Summary

NCRIC (Northern California Regional Intelligence Center) tripped \`PARSE_ERROR: ncric 2026-05-05 :: ncric 2026-05-05: overview is non-empty but agency-name marker (' uses Flock Safety [LPR] [Tt]echnology') not found\`. With the soft-fail change in \`f041081\` it no longer halts the workflow, but it surfaces noise on every refresh.

## What changed

The marker check at [scripts/flock_transparency.py:734](scripts/flock_transparency.py#L734) was added to catch cases where Flock rephrases their boilerplate — but it also catches agencies who write a custom, non-boilerplate overview. NCRIC's reads:

> \`***draft version*** The Northern California Regional Intelligence Center is a multi-jurisdiction government program...\`

Never mentions Flock Safety at all — it's a fusion center using Flock as a customer, not the standard agency boilerplate.

The fix gates the raise on \`"Flock Safety"\` actually appearing in the overview:
- Mentions Flock Safety + marker doesn't match → raise (real Flock rephrase, want to surface)
- Doesn't mention Flock Safety → custom overview, \`crawled_name\` stays \`None\` silently (same outcome as the empty-overview case)

## Test plan

- [x] \`uv run pytest tests/test_flock_transparency_headings.py\` (26 tests; updated the existing rephrase-detection test to use overview text that DOES mention Flock; added a new test pinning NCRIC's actual content shape)
- [x] \`uv run python scripts/flock_transparency.py parse --slug ncric --force\` — re-parses the 2026-05-05 capture cleanly (24 cameras, 319 orgs)