### PR TITLE
fix(justifications): partner bars for no-justification agencies + label scoping

### DIFF
--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -1720,12 +1720,19 @@
       : '';
 
     var hasOwnAudit = agencyData.has_own_audit !== false;
+    var hasJustification = agencyData.has_justification_column !== false;
+    // Own bars are only useful when both an audit AND a justification
+    // column exist. Agencies that publish an audit-CSV with no
+    // reason/offenseType/caseNumber column (Fontana, Menlo Park) have
+    // an audit full of (blank) rows; the no-justification callout
+    // tells that story better than a single "(blank)" bar would.
+    var hasUsableOwnBars = hasOwnAudit && hasJustification;
     var extRows = (agencyData.external_aggregated &&
                    agencyData.external_aggregated.rows) || [];
     var extTotal = (agencyData.external_aggregated &&
                     agencyData.external_aggregated.total_broad_searches) || 0;
-    var ownVerbatim = agencyData.verbatim || [];
-    var ownTotal = agencyData.row_count || 0;
+    var ownVerbatim = hasUsableOwnBars ? (agencyData.verbatim || []) : [];
+    var ownTotal = hasUsableOwnBars ? (agencyData.row_count || 0) : 0;
     var threshold = (agencyData.external_aggregated &&
                      agencyData.external_aggregated.threshold) || 100;
     var bimodalCaveat = (extRows.length && !hideExternal)
@@ -1733,6 +1740,29 @@
     var barsHtml = ownVerbatim.length || extRows.length
       ? renderBars(ownVerbatim, ownTotal, extRows, extTotal)
       : '';
+
+    // Top-of-section header content varies by case:
+    //   - usable own bars: brief disclaimer, then bimodal caveat + bars
+    //   - own audit but no justification column: callout + bimodal
+    //     caveat + partner-only bars
+    //   - no own audit at all: bimodal caveat + partner-only bars
+    var topReasonsBody;
+    if (hasUsableOwnBars) {
+      topReasonsBody = '<p class="bars-disclaimer">' +
+        'Local rows are typed in (or chosen from a dropdown) by the searching officer. ' +
+        'Nothing in the audit system validates that the entered reason aligns with the actual ' +
+        'reason for the search, or that the search was authorized.' +
+        '</p>' +
+        bimodalCaveat +
+        barsHtml;
+    } else if (hasOwnAudit && !hasJustification) {
+      topReasonsBody = renderNoJustificationCallout(agencyData) +
+        bimodalCaveat +
+        barsHtml;
+    } else {
+      topReasonsBody = bimodalCaveat + barsHtml;
+    }
+
     var ownSections = hasOwnAudit
       ? (windowBanner +
         blurb +
@@ -1740,21 +1770,15 @@
         renderUses(agencyData) +
         renderLongActiveCases(agencyData.long_active_cases, agencyData.display_name) +
         '<h2>Top reasons</h2>' +
-        (agencyData.has_justification_column === false
-          ? renderNoJustificationCallout(agencyData)
-          : '<p class="bars-disclaimer">' +
-            'Local rows are typed in (or chosen from a dropdown) by the searching officer. ' +
-            'Nothing in the audit system validates that the entered reason aligns with the actual ' +
-            'reason for the search, or that the search was authorized.' +
-            '</p>' +
-            bimodalCaveat +
-            barsHtml))
+        topReasonsBody)
       : renderNoOwnAuditBanner(agencyData) +
         renderUses(agencyData) +
         '<h2>Top reasons</h2>' +
-        bimodalCaveat +
-        barsHtml;
-    var ownTrailingSections = hasOwnAudit
+        topReasonsBody;
+    // Heatmap and codes table need own audit data with a justification
+    // column. Agencies whose audit lacks the column have nothing to
+    // populate those sections with.
+    var ownTrailingSections = hasUsableOwnBars
       ? ('<h2>Search timing (day &times; hour, Pacific Time)</h2>' +
         renderHeatmap(agencyData.hour_dow, agencyData.timed_rows) +
         '<h2>Detected California penal / vehicle codes</h2>' +

--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -545,7 +545,8 @@
       breakdown += '</div>';
     }
     return '<div class="external-summary">' +
-      '<div class="external-summary-label">Searches by agencies with shared access</div>' +
+      '<div class="external-summary-label">Searches by agencies with shared access to ' +
+      escapeHTML(agencyData.display_name) + '&rsquo;s data</div>' +
       '<strong>' + totalSearches.toLocaleString() + '</strong> broad-reach ' +
       'searches by <strong>' + sources + '</strong> of ' + outboundTotal +
       ' agencies that ' + escapeHTML(agencyData.display_name) +
@@ -609,59 +610,6 @@
       'than the bimodal split.' +
       '</div>' +
       '</div>';
-  }
-
-  function renderExternalSection(agencyData) {
-    var ext = agencyData.external_aggregated;
-    if (!ext || !ext.rows || !ext.rows.length) return '';
-    if (hideExternal) {
-      return '<h2 id="external-bars">Searches by agencies with shared access</h2>' +
-        '<p class="external-hidden-note">' +
-        'Hidden &mdash; toggle <em>Show only this agency&rsquo;s own searches</em> ' +
-        'off above to reveal partner searches that likely touched this data.' +
-        '</p>';
-    }
-    var threshold = ext.threshold || 100;
-    var rows = ext.rows;
-    var totalSearches = ext.total_broad_searches || 0;
-    var totalForPct = totalSearches || 1;
-    var html = '<h2 id="external-bars">Searches by agencies with shared access</h2>' +
-      renderNcDistributionCaveat(threshold) +
-      '<p class="bars-disclaimer external-caveat">' +
-      'Heuristic: Flock doesn&rsquo;t expose which networks each search ' +
-      'hit, so we treat any search reaching &ge; ' + threshold +
-      ' networks as having likely touched this agency&rsquo;s data. ' +
-      'A search reaching exactly 99 networks would be excluded; one ' +
-      'reaching 100+ is included regardless of which networks it actually ' +
-      'queried.' +
-      '</p>' +
-      '<div class="bar-list bar-list-external">';
-    for (var i = 0; i < rows.length; i++) {
-      var phrase = rows[i][0];
-      var count = rows[i][1];
-      var topSources = rows[i][2] || [];
-      var sharePct = (100 * count / totalForPct);
-      var w = Math.max(1, Math.round(sharePct));
-      var srcHtml = '';
-      for (var s = 0; s < topSources.length; s++) {
-        srcHtml += '<span class="ext-source">' +
-          escapeHTML(topSources[s][0]) + ' (' +
-          topSources[s][1].toLocaleString() + ')</span>';
-      }
-      html += '<div class="bar-item bar-item-external">' +
-        '<div class="bar-item-main">' +
-        '<span class="bar-track">' +
-        '<span class="bar bar-external" style="width:' + w + '%"></span>' +
-        '<span class="bar-pct">' + sharePct.toFixed(1) + '%</span>' +
-        '</span>' +
-        '<span class="bar-count">' + count.toLocaleString() + '</span>' +
-        '<span class="phrase-text">' + escapeHTML(phrase) + '</span>' +
-        '</div>' +
-        (srcHtml ? '<div class="ext-sources">' + srcHtml + '</div>' : '') +
-        '</div>';
-    }
-    html += '</div>';
-    return html;
   }
 
   // For the small set of agencies whose audit CSV schema entirely


### PR DESCRIPTION
## Summary

Two related fixes:

1. **Partner bars for no-justification agencies** — Fontana and Menlo Park publish audit CSVs whose schema lacks the justification column entirely. PR #249 had them rendering only the no-justification callout under \"Top reasons\", with the partner-side broad-reach bars hidden. Those bars carry the only meaningful signal for what's actually running against this agency's data, so they should still render. Now: callout + bimodal caveat + partner bar list. Trailing sections (heatmap, codes table) still gate on `hasUsableOwnBars` since they have nothing to populate from.

2. **Scope the cross-agency label to the agency name** — \"Searches by agencies with shared access\" reads as a generic stat. Now reads \"Searches by agencies with shared access to **San Mateo CA PD's** data\" (or whatever the active agency is). Makes clear it's computed for this specific agency.

Also drops `renderExternalSection`, dead since PR #249 merged the external bars into `renderBars`.

## Test plan

- [ ] Menlo Park — no-justification callout AT TOP of \"Top reasons\", followed by bimodal caveat, followed by partner-only bar list (purple)
- [ ] Fontana — same shape
- [ ] San Mateo PD — top stats label says \"…shared access to San Mateo CA PD's data\"
- [ ] EPA, Bakersfield, Visalia — full local + partner merged list still renders unchanged