### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -172,9 +172,10 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T01:16:29.210234+00:00",
+      "last_probed": "2026-05-06T05:01:09.418082+00:00",
       "tried": {
         "national-city-ca-po": "http_404",
+        "national-city-ca-police": "http_404",
         "national-city-ca-police-department": "http_404"
       }
     },
@@ -789,6 +790,14 @@
         "rio-hondo-college-ca-pd": "http_404"
       }
     },
+    "8f99f695-5554-5fd5-9b6c-63a683f21d55": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T05:01:00.395429+00:00",
+      "tried": {
+        "concordia-ks-pd": "http_404"
+      }
+    },
     "8fb27794-b88c-5373-b6a1-da64ae2f059c": {
       "exhausted": false,
       "found": null,
@@ -796,6 +805,14 @@
       "tried": {
         "tulare-ca-po": "http_404",
         "tulare-ca-police-department": "http_404"
+      }
+    },
+    "8fd5e75d-ca68-57b6-b38a-2328f0671f69": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T05:01:05.056366+00:00",
+      "tried": {
+        "jackson-county-mi-so": "http_404"
       }
     },
     "9079f9e0-e3c2-5611-8f09-a0276b7911f8": {
@@ -1323,6 +1340,6 @@
       }
     }
   },
-  "updated": "2026-05-05T23:35:49.463371+00:00",
+  "updated": "2026-05-06T05:01:09.454921+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.