### PR TITLE
fix(parser): handle (ALPR) heading and Operating System overview

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -359,7 +359,7 @@ _DYNAMIC_HEADINGS = [
     (re.compile(r"^Last Updated:", re.IGNORECASE), "last_updated"),
     (re.compile(r"^(Link to |To view ).+", re.IGNORECASE), "policy_info"),
     (re.compile(r"^(Full ALPR|Full LPR|Full ALPRY).+", re.IGNORECASE), "alpr_policy"),
-    (re.compile(r"^.+ (ALPR|LPR) Policy.*$", re.IGNORECASE), "alpr_policy"),
+    (re.compile(r"^.+[\s(](ALPR|LPR)[\s)]\s*Policy.*$", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+Police Department Policy Manual.*$", re.IGNORECASE), "alpr_policy"),
     # Agency-prefixed bare "Policy" headings, e.g.
     # "Marin County Sheriff's Office Policy" — Flock now bolds these
@@ -721,10 +721,10 @@ def parse_portal_text(raw_text, slug, datestamp, bold_headings=None):
     outbound_names = _parse_org_names(fields.get("orgs_granted_access", ""))
     inbound_names = _parse_org_names(fields.get("orgs_sharing_with", ""))
 
-    # Extract the agency name from the overview text. Pattern:
-    #   "<Agency Name> uses Flock Safety [LPR ][Tt]echnology..."
-    # Some agencies (e.g. Casa Grande AZ PD) have "LPR Technology" in the
-    # boilerplate, others have plain "technology" — match both.
+    #   "<Agency Name> uses Flock Safety's Operating System..."
+    # Flock has rephrased the boilerplate over time — older portals say
+    # "uses Flock Safety [LPR] technology", newer ones (seen on pacifica
+    # 2026-05-06) say "uses Flock Safety's Operating System". Match either.
     #
     # Some agencies write a custom overview that doesn't follow the
     # boilerplate at all. NCRIC's reads "***draft version*** The Northern
@@ -735,16 +735,19 @@ def parse_portal_text(raw_text, slug, datestamp, bold_headings=None):
     # we actually want to catch (Flock rephrased their boilerplate).
     overview = fields.get("overview", "")
     crawled_name = None
-    flock_marker_re = re.compile(r" uses Flock Safety (?:LPR )?[Tt]echnology")
+    flock_marker_re = re.compile(
+        r" uses Flock Safety(?:'s)? "
+        r"(?:LPR )?(?:[Tt]echnology|Operating System)"
+    )
     m = flock_marker_re.search(overview)
     if m:
         crawled_name = overview[:m.start()].strip()
     elif overview.strip() and "Flock Safety" in overview:
         raise ValueError(
             f"{slug} {datestamp}: overview mentions Flock Safety but the "
-            f"agency-name marker (' uses Flock Safety [LPR] [Tt]echnology') "
-            f"doesn't match — Flock may have rephrased the boilerplate. "
-            f"Update parse_portal_text."
+            f"agency-name marker (' uses Flock Safety[\\'s] [LPR] "
+            f"[Tt]echnology|Operating System') doesn't match — Flock may "
+            f"have rephrased the boilerplate. Update parse_portal_text."
         )
 
     # Fail-loud: each bold heading should resolve to something in

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -465,3 +465,63 @@ def test_month_year_bold_heading_does_not_raise():
         text, "test-agency", "2026-05-03",
         bold_headings={"What's Detected", "April 2026", "January 2026"},
     )
+
+
+def test_alpr_acronym_in_parens_classifies_as_alpr_policy():
+    """Belmont/Pacifica (2026-05-06) introduced a heading shape with
+    the (ALPR) acronym in parentheses rather than space-delimited:
+    "Belmont Police Department - Automated License Plate Readers (ALPR) Policy".
+    The dynamic regex must accept either ' ALPR ' or '(ALPR)' as a
+    boundary so this routes to alpr_policy."""
+    from flock_transparency import _match_heading_kind
+    field, _ = _match_heading_kind(
+        "Belmont Police Department - Automated License Plate Readers (ALPR) Policy"
+    )
+    assert field == "alpr_policy"
+    field, _ = _match_heading_kind(
+        "Pacifica Police Department Automated License Plate Reader (ALPR) Policy"
+    )
+    assert field == "alpr_policy"
+    # The space-delimited variant must still match.
+    field, _ = _match_heading_kind("Foo ALPR Policy")
+    assert field == "alpr_policy"
+    field, _ = _match_heading_kind("Foo LPR Policy")
+    assert field == "alpr_policy"
+
+
+def test_overview_marker_accepts_operating_system_phrasing():
+    """Flock rephrased the overview boilerplate from
+    '<Agency> uses Flock Safety [LPR] technology' to
+    "<Agency> uses Flock Safety's Operating System" (seen on
+    pacifica-ca-pd 2026-05-06). Both must extract crawled_name."""
+    # Old phrasing: " uses Flock Safety LPR technology"
+    text_old = (
+        "Overview\n\n"
+        "The Foo PD uses Flock Safety LPR technology to capture evidence.\n\n"
+    )
+    result = parse_portal_text(
+        text_old, "foo-pd", "2026-05-06",
+        bold_headings={"Overview"},
+    )
+    assert result["crawled_name"] == "The Foo PD"
+    # New phrasing: " uses Flock Safety's Operating System"
+    text_new = (
+        "Overview\n\n"
+        "The Pacifica Police Department uses Flock Safety's Operating "
+        "System to capture objective evidence.\n\n"
+    )
+    result = parse_portal_text(
+        text_new, "pacifica-ca-pd", "2026-05-06",
+        bold_headings={"Overview"},
+    )
+    assert result["crawled_name"] == "The Pacifica Police Department"
+    # Plain "technology" variant (no LPR) must still work.
+    text_plain = (
+        "Overview\n\n"
+        "Bar PD uses Flock Safety technology for ALPR.\n\n"
+    )
+    result = parse_portal_text(
+        text_plain, "bar-pd", "2026-05-06",
+        bold_headings={"Overview"},
+    )
+    assert result["crawled_name"] == "Bar PD"


### PR DESCRIPTION
## Summary

Two parser failures from the 2026-05-06 Flock refresh (issue #223):

- **belmont-ca-pd**: bold heading `Belmont Police Department - Automated License Plate Readers (ALPR) Policy` not in `_HEADING_MAP`. The dynamic regex `^.+ (ALPR|LPR) Policy.*$` required ` ALPR ` (space-delimited) and didn't accept the parenthesized form. Relaxed to `^.+[\s(](ALPR|LPR)[\s)]\s*Policy.*$`.

- **pacifica-ca-pd**: overview now reads "*The Pacifica Police Department uses Flock Safety's Operating System to capture objective evidence...*" — Flock retired the older "uses Flock Safety [LPR] technology" boilerplate. Marker regex extended to accept either phrasing (and the optional `'s`).

Both pacifica's `(ALPR) Policy` heading and belmont's are covered by the same regex fix.

This unblocks PR #252 (rolling Flock refresh) — once merged, the next workflow run will re-parse the 2026-05-06 HTML and produce JSON for both slugs, replacing the misleading stale-pair diff in #252's body.

## Test plan

- [x] New tests in `test_flock_transparency_headings.py` cover both shapes:
  - `(ALPR)` parenthesized acronym → `alpr_policy`
  - `Operating System` overview phrasing → extracts `crawled_name`
  - Existing space-delimited and `technology` variants still pass
- [x] Full `test_flock_transparency_headings.py` suite passes (26/26)
- [ ] After merge: re-trigger refresh workflow; confirm belmont/pacifica produce 2026-05-06 JSON without `PARSE_ERROR`