### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -434,6 +434,14 @@
         "cal-state-fullerton-pd-ca": "http_404"
       }
     },
+    "46f1735b-02e4-5214-8a37-823e4d0eccae": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T22:35:36.337112+00:00",
+      "tried": {
+        "byron-il-pd": "http_404"
+      }
+    },
     "47a01976-2030-52f3-9c3f-3347ce75fcf7": {
       "exhausted": false,
       "found": null,
@@ -628,9 +636,10 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-06T20:13:29.467607+00:00",
+      "last_probed": "2026-05-06T22:35:40.798615+00:00",
       "tried": {
-        "beverly-hills-ca-po": "http_404"
+        "beverly-hills-ca-po": "http_404",
+        "beverly-hills-ca-police-department": "http_404"
       }
     },
     "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd": {
@@ -888,6 +897,14 @@
       "tried": {
         "california-state-university-long-beach-campus-ca-pd": "http_404",
         "california-state-university-long-beach-campus-ca-ps": "http_404"
+      }
+    },
+    "934736dd-26af-5d3a-9c48-317b892cc0df": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T22:35:30.234785+00:00",
+      "tried": {
+        "lincolnshire-il-pd": "http_404"
       }
     },
     "94fd017f-e470-5a9f-b74f-8c73c4c26660": {
@@ -1449,6 +1466,6 @@
       }
     }
   },
-  "updated": "2026-05-06T21:46:59.381290+00:00",
+  "updated": "2026-05-06T22:35:40.834901+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -180,13 +180,14 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-06T21:46:59.349048+00:00",
+      "last_probed": "2026-05-06T23:37:02.987479+00:00",
       "tried": {
         "national-city-ca": "http_404",
         "national-city-ca-po": "http_404",
         "national-city-ca-police": "http_404",
         "national-city-ca-police-department": "http_404",
-        "national-city-ca-ps": "http_404"
+        "national-city-ca-ps": "http_404",
+        "national-city-pd-ca": "http_404"
       }
     },
     "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
@@ -448,6 +449,14 @@
       "last_probed": "2026-04-26T18:30:06.441152+00:00",
       "tried": {
         "westmorland-ca-po": "http_404"
+      }
+    },
+    "48a65226-c77c-557d-ac4a-fa2f396f2672": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T23:36:56.663068+00:00",
+      "tried": {
+        "chesterfield-county-va-po": "http_404"
       }
     },
     "4a99a1f3-e9ec-5fdc-b620-ba8c356dc19c": {
@@ -1175,6 +1184,14 @@
         "university-of-the-pacific-ca-pd": "http_404"
       }
     },
+    "c7335eaf-bc00-59fa-bfff-e5992d32041d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-06T23:36:51.670523+00:00",
+      "tried": {
+        "sardis-city-al-pd": "http_404"
+      }
+    },
     "ca169c85-b556-58a0-a0bc-988c09bc6d01": {
       "exhausted": false,
       "found": null,
@@ -1466,6 +1483,6 @@
       }
     }
   },
-  "updated": "2026-05-06T22:35:40.834901+00:00",
+  "updated": "2026-05-06T23:37:03.022727+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -28,6 +28,14 @@
         "redondo-beach-ca-police-department": "http_404"
       }
     },
+    "029812b1-3af3-5baf-bcec-7c7bacbda20d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-07T01:25:13.095888+00:00",
+      "tried": {
+        "somerset-ma-pd": "http_404"
+      }
+    },
     "03c310c0-6e05-5ad2-872a-d4e8b804358f": {
       "exhausted": false,
       "found": null,
@@ -645,9 +653,10 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-06T22:35:40.798615+00:00",
+      "last_probed": "2026-05-07T01:25:24.787526+00:00",
       "tried": {
         "beverly-hills-ca-po": "http_404",
+        "beverly-hills-ca-police": "http_404",
         "beverly-hills-ca-police-department": "http_404"
       }
     },
@@ -906,6 +915,14 @@
       "tried": {
         "california-state-university-long-beach-campus-ca-pd": "http_404",
         "california-state-university-long-beach-campus-ca-ps": "http_404"
+      }
+    },
+    "925ee626-f5b9-5fa4-b079-55cb545544e8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-07T01:25:18.705444+00:00",
+      "tried": {
+        "hillsborough-county-fl-so": "http_404"
       }
     },
     "934736dd-26af-5d3a-9c48-317b892cc0df": {
@@ -1483,6 +1500,6 @@
       }
     }
   },
-  "updated": "2026-05-06T23:37:03.022727+00:00",
+  "updated": "2026-05-07T01:25:24.827990+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.