### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -60,5 +60,5 @@
     "https://www.eff.org/deeplinks/2026/04/claw-back",
     "https://www.eff.org/deeplinks/2025/11/how-cops-are-using-flock-safetys-alpr-network-surveil-protesters-and-activists"
   ],
-  "last_run": "2026-05-06T22:06:02Z"
+  "last_run": "2026-05-06T23:04:41Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -60,5 +60,5 @@
     "https://www.eff.org/deeplinks/2026/04/claw-back",
     "https://www.eff.org/deeplinks/2025/11/how-cops-are-using-flock-safetys-alpr-network-surveil-protesters-and-activists"
   ],
-  "last_run": "2026-05-06T23:04:41Z"
+  "last_run": "2026-05-07T00:00:58Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 59
- Curation: enriched: 52 · mechanical: 6 · needs_review: 1
- Scanner: WARNINGS: 52 · REVIEW REQUIRED: 6 · CLEAN: 1
- Wayback: poll-failed: 25 · submit-failed: 19 · saved: 13 · existing: 1 · save-failed: 1
- PDF: rendered: 59
- Top sources: eff.org (25), kqed.org (9), aclu.org (9), 404media.co (6), epic.org (5), npr.org (2), themarkup.org (1), smdailyjournal.com (1)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
