### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -60,5 +60,5 @@
     "https://www.eff.org/deeplinks/2026/04/claw-back",
     "https://www.eff.org/deeplinks/2025/11/how-cops-are-using-flock-safetys-alpr-network-surveil-protesters-and-activists"
   ],
-  "last_run": "2026-05-07T00:00:58Z"
+  "last_run": "2026-05-07T03:58:33Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -60,5 +60,5 @@
     "https://www.eff.org/deeplinks/2026/04/claw-back",
     "https://www.eff.org/deeplinks/2025/11/how-cops-are-using-flock-safetys-alpr-network-surveil-protesters-and-activists"
   ],
-  "last_run": "2026-05-07T03:58:33Z"
+  "last_run": "2026-05-07T06:48:14Z"
 }

--- a/assets/articles/queue/d6157331.json
+++ b/assets/articles/queue/d6157331.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.berkeleyside.org/2026/05/06/berkeley-flock-surveillance-contract-memo-confidential",
+  "source_domain": "berkeleyside.org",
+  "discovered_at": "2026-05-07T17:14:59Z",
+  "discovered_by": "rss:berkeleyside.org"
+}

--- a/assets/articles/queue/ee1191f6.json
+++ b/assets/articles/queue/ee1191f6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
+  "source_domain": "epic.org",
+  "discovered_at": "2026-05-07T17:14:58Z",
+  "discovered_by": "rss:epic.org"
+}

--- a/assets/articles/queue/feedb45d.json
+++ b/assets/articles/queue/feedb45d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe",
+  "source_domain": "berkeleyside.org",
+  "discovered_at": "2026-05-07T17:14:59Z",
+  "discovered_by": "rss:berkeleyside.org"
+}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 59
- Curation: enriched: 45 · mechanical: 13 · needs_review: 1
- Scanner: WARNINGS: 52 · REVIEW REQUIRED: 6 · CLEAN: 1
- Wayback: poll-failed: 25 · submit-failed: 19 · saved: 13 · existing: 1 · save-failed: 1
- PDF: rendered: 59
- Top sources: eff.org (25), kqed.org (9), aclu.org (9), 404media.co (6), epic.org (5), npr.org (2), themarkup.org (1), smdailyjournal.com (1)
- Queue remaining: 0 priority + 3 auto = 3

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
