### PR TITLE
fix(ci): fetch-depth:0 for bot-branch workflows — fix spurious rebase conflicts

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -44,6 +44,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # Need full history so the rebase below can find a common ancestor
+          # with origin/article-registry-bot. With the default shallow clone,
+          # rebase treats the histories as unrelated and replays every bot
+          # commit onto main, blowing up with add/add conflicts on shared
+          # files.
+          fetch-depth: 0
           # PAT (if configured) attributes the resulting PR to a human
           # so CI doesn't require approval-for-bots on every run.
           token: ${{ secrets.REFRESH_PAT || github.token }}

--- a/.github/workflows/discover-articles.yml
+++ b/.github/workflows/discover-articles.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # See article-registry.yml — full history required for the rebase
+          # below to find a common ancestor with origin/article-registry-bot.
+          fetch-depth: 0
           token: ${{ secrets.REFRESH_PAT || github.token }}
 
       - name: Set up long-lived branch

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # Need full history so the rebase below can find a common ancestor
+          # with origin/flock-refresh. With the default shallow clone, rebase
+          # treats the histories as unrelated and replays every branch commit
+          # onto main, blowing up with add/add conflicts on shared files.
+          fetch-depth: 0
           # Using a PAT (if configured) makes git push + gh pr create attribute
           # to the PAT owner, so the resulting pull_request event's
           # triggering_actor is a human. Without this, GITHUB_TOKEN-authored
@@ -44,7 +49,14 @@ jobs:
           git fetch origin flock-refresh || true
           if git rev-parse --verify origin/flock-refresh >/dev/null 2>&1; then
             git checkout flock-refresh
-            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+            # See article-registry.yml — never auto-reset to main on rebase
+            # failure. It silently destroys accumulated bot work. Abort and
+            # fail loudly; a human resolves and force-pushes.
+            git rebase origin/main || {
+              git rebase --abort
+              echo "::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually. NOT auto-resetting (would destroy unmerged work)."
+              exit 1
+            }
           else
             git checkout -b flock-refresh
           fi


### PR DESCRIPTION
## Summary

- `actions/checkout@v6` defaults to `fetch-depth: 1` (shallow clone). With shallow histories on both sides, `git merge-base` finds no common ancestor between the long-lived bot branch and `origin/main`. The rebase then replays every commit on the bot branch from commit 1, producing `add/add` conflicts on every shared file path (`Rebasing (1/702)` in the failed run).
- `probe-slugs.yml` already had `fetch-depth: 0` with a comment explaining exactly this. Added the same to `article-registry.yml`, `discover-articles.yml`, and `refresh-flock-data.yml`.
- Also replaced the silent `git reset --hard origin/main` fallback in `refresh-flock-data.yml` with the same loud-fail-and-abort pattern used in `article-registry.yml`. The reset was silently destroying accumulated flock-refresh work on any conflict — the exact failure mode `article-registry.yml` was rewritten to prevent after a prior incident.

## Test plan
- [ ] Trigger `article-registry.yml` manually after merge — rebase step should succeed on existing `article-registry-bot`
- [ ] Same for `refresh-flock-data.yml` on `flock-refresh`