### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -196,14 +196,15 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-06T23:37:02.987479+00:00",
+      "last_probed": "2026-05-07T08:07:26.793491+00:00",
       "tried": {
         "national-city-ca": "http_404",
         "national-city-ca-po": "http_404",
         "national-city-ca-police": "http_404",
         "national-city-ca-police-department": "http_404",
         "national-city-ca-ps": "http_404",
-        "national-city-pd-ca": "http_404"
+        "national-city-pd-ca": "http_404",
+        "national-city-po-ca": "http_404"
       }
     },
     "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
@@ -606,6 +607,14 @@
         "pomona-ca-po": "http_404"
       }
     },
+    "6318e935-4c02-5b9a-822e-7a5a10f531e7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-07T08:07:13.973209+00:00",
+      "tried": {
+        "spring-arbor-mi-pd": "http_404"
+      }
+    },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
       "exhausted": false,
       "found": null,
@@ -802,6 +811,14 @@
       "last_probed": "2026-05-06T20:13:20.079871+00:00",
       "tried": {
         "harris-county-tx-so": "http_404"
+      }
+    },
+    "7b176a82-055c-505b-b86f-055f1e8dadb1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-07T08:07:20.273373+00:00",
+      "tried": {
+        "amarillo-tx-po": "http_404"
       }
     },
     "7d2b8047-a15b-524a-bc77-627e8eeab00a": {
@@ -1517,6 +1534,6 @@
       }
     }
   },
-  "updated": "2026-05-07T05:04:19.131531+00:00",
+  "updated": "2026-05-07T08:07:26.829989+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.