### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T09:48:46Z"
+  "last_run": "2026-05-08T11:40:55Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T03:49:41Z"
+  "last_run": "2026-05-08T06:06:46Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T07:56:32Z"
+  "last_run": "2026-05-08T09:48:46Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T14:11:20Z"
+  "last_run": "2026-05-08T16:25:57Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T06:06:46Z"
+  "last_run": "2026-05-08T07:56:32Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T11:40:55Z"
+  "last_run": "2026-05-08T14:11:20Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -63,5 +63,5 @@
     "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
     "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe"
   ],
-  "last_run": "2026-05-08T00:02:46Z"
+  "last_run": "2026-05-08T03:49:41Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 62
- Curation: enriched: 52 · mechanical: 9 · needs_review: 1
- Scanner: WARNINGS: 52 · REVIEW REQUIRED: 9 · CLEAN: 1
- Wayback: poll-failed: 27 · submit-failed: 19 · saved: 14 · existing: 1 · save-failed: 1
- PDF: rendered: 62
- Top sources: eff.org (25), kqed.org (9), aclu.org (9), 404media.co (6), epic.org (6), npr.org (2), berkeleyside.org (2), themarkup.org (1)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
