### PR TITLE
docs: add PRA drafting standards + boilerplate template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,49 @@ The PDF generator (`scripts/md_to_pdf.py`) parses the findings markdown by split
   conflict (no line-level overlap), so CI runs `scripts/lint_findings.py`
   on every PR to catch that. Run it locally before pushing when adding a
   source row: `python3 scripts/lint_findings.py`.
+
+## PRA Drafting Standards
+
+When drafting California Public Records Act requests for SMPD, follow
+these rules. A boilerplate template lives at
+`assets/san-mateo-public-records/_PRA_TEMPLATE.md`.
+
+**Voice and posture:**
+- State facts and ask questions; never use prescriptive "cannot/may not" language
+- Do not pre-emptively reveal evidence that contradicts SMPD's position — wait for their answer first ("let them swing first")
+- When narrowing a filed PRA mid-stream, prefer explicit replacement language over withdrawing
+
+**Always include:**
+- Existing records only: `Gov. Code § 7922.530; Sierra Club v. Superior Court (2013) 57 Cal.4th 157`
+- Per-item response: "If no records exist for any individual item, please respond to that item separately"
+- Segregability: `Gov. Code § 7922.525(b)` — produce all reasonably segregable non-exempt portions
+- Denial requirements: specific exemption citation per `§ 7922.540` for each withheld record
+
+**Always pre-address these exemptions:**
+- `§ 7923.600` (investigation records): records requested are administrative/operational, not compiled for a specific investigation
+- `Civil Code § 1798.90.55(b)` (ALPR sharing restriction): records *about* ALPR activity are not "ALPR information" per `§ 1798.90.5(c)`; the restriction applies to sharing data outward, not to producing records documenting activity
+- Records held by Flock Safety: `Gov. Code § 7920.530` + `City of San Jose v. Superior Court (2017) 2 Cal.5th 608` + `MSA § 4.1`; cite `W012570-041926` as precedent for production of this record type
+- Attorney-client privilege on legal analyses: existence must be confirmed even if contents are withheld; ask for date and general subject matter
+
+**Search scope notes:**
+- Explicitly list non-responsive record types when likely to be confused with responsive ones
+- Identify which items are internal records (not satisfiable via any email corpus), outbound SMPD records (not in inbound corpus), or email records
+- Camera-sharing notifications ("Camera Access Request from [Agency]," "[Agency] shared Flock cameras with you") are frequently produced as a substitute — note explicitly when they are not responsive
+
+**Purpose statements:**
+- Open complex requests with a brief Purpose section stating what the request seeks to determine
+- This is different from stating an expected conclusion — stating purpose helps the searcher and makes "no responsive records" self-defining
+- Do NOT state what you expect to find ("let them swing first" still applies to conclusions)
+
+**Re-filings:**
+- State the original PRA number and filing date
+- Use "closed without a statutory basis" if no exemption was cited
+- Ask for urgency corresponding to time already elapsed
+- Note that the re-filing includes scope clarifications to reduce review burden
+- When re-filing a multi-item PRA closed into a wrong corpus, split by item type: internal records / outbound SMPD records / email-eligible — file separately
+
+**Tactical withdrawal:**
+- If a PRA is being used as a catch-all to absorb other requests, withdraw it with a letter explaining why
+- State the right to re-file with narrowed scope
+- Send to the chief, not just the records center
+- Letter should be short and factual: what happened, consequence (documents removed from queue), expectation (remaining work moves faster)

--- a/assets/san-mateo-public-records/_PRA_TEMPLATE.md
+++ b/assets/san-mateo-public-records/_PRA_TEMPLATE.md
@@ -1,0 +1,64 @@
+# PRA Template — SMPD / City of San Mateo
+
+Boilerplate sections for California Public Records Act requests.
+Copy and adapt. See CLAUDE.md § "PRA Drafting Standards" for rules.
+
+---
+
+## Purpose statement (for complex requests)
+
+**Purpose**
+
+This request seeks to determine [WHAT THE REQUEST IS TRYING TO ESTABLISH — e.g., "whether SMPD has received any notification that Flock Safety has exercised its authority under § 5.3, and whether SMPD has any mechanism by which it would become aware of such a disclosure"].
+
+---
+
+## Opening citation
+
+Pursuant to the California Public Records Act (Gov. Code § 7920 et seq.), I request the following records [SCOPE DESCRIPTION].
+
+This request seeks existing records only (Gov. Code § 7922.530; Sierra Club v. Superior Court (2013) 57 Cal.4th 157).
+
+---
+
+## Re-filing opener (when applicable)
+
+This request is a re-filing of [ORIGINAL PRA NUMBER], which was closed without a statutory basis into [CORPUS PRA] on [DATE]. [CORPUS PRA] has been withdrawn. This request seeks a direct response.
+
+This request was originally filed on [ORIGINAL DATE]. I ask that the Department treat this re-filing with corresponding urgency given the time already elapsed.
+
+---
+
+## Search scope note (adapt as needed)
+
+[DESCRIBE WHAT IS NOT RESPONSIVE — e.g., camera-sharing notifications, voluntary sharing decisions, inter-agency network emails]
+
+The following are not responsive to this request:
+- Camera-sharing notifications ("Camera Access Request from [Agency]," "[Agency] shared Flock cameras with you," or equivalent inter-agency network-sharing emails)
+- Records of SMPD's deliberate sharing decisions with partner agencies through the Flock network
+
+[DESCRIBE WHAT RESPONSIVE RECORDS LOOK LIKE — helps the searcher and makes "no responsive records" answers more meaningful]
+
+Items [X] and [Y] seek internal SMPD records — memoranda, tracking records, analyses. They are not email records and cannot be satisfied through review of any @flocksafety.com email corpus.
+
+Item [Z] includes communications sent by SMPD to Flock Safety. These are outbound records and would not appear in any corpus limited to inbound @flocksafety.com emails.
+
+---
+
+## Anticipated exemption issues
+
+**Gov. Code § 7923.600 (investigation records).** The records requested are [administrative/operational/contract administration] records — not files compiled in connection with any particular investigation.
+
+**Civil Code § 1798.90.55(b) (ALPR sharing restriction).** The records requested [describe what they document — e.g., "vendor contract compliance"] are not "ALPR information" as defined in § 1798.90.5(c). § 1798.90.55(b) restricts SMPD from sharing ALPR information outward; it does not exempt records documenting [the activity in question].
+
+**Records held by Flock Safety.** MSA § 4.1 establishes SMPD's ownership of data processed by Flock on SMPD's behalf. Under Gov. Code § 7920.530 and City of San Jose v. Superior Court (2017) 2 Cal.5th 608, records held by Flock as SMPD's contractor are SMPD records regardless of physical location. SMPD has already produced records of this type from Flock under W012570-041926.
+
+**Attorney-client privilege (Item [X] if applicable).** If a responsive record is withheld as attorney-client privileged, please confirm that such a record exists and identify it by date and general subject matter.
+
+---
+
+## Segregability and denial requirements
+
+If any portion of any item is withheld, please produce all reasonably segregable non-exempt portions (Gov. Code § 7922.525(b)) and identify each withheld record with a specific exemption citation per § 7922.540.
+
+If no records exist for any individual item, please respond to that item separately and continue processing the remaining items.


### PR DESCRIPTION
## Summary
- Adds a "PRA Drafting Standards" section to CLAUDE.md documenting voice/posture, mandatory inclusions, exemption pre-addressals, scope-note conventions, purpose statements, re-filing structure, and tactical-withdrawal patterns developed across recent SMPD filings.
- Adds `assets/san-mateo-public-records/_PRA_TEMPLATE.md` as a copy-paste boilerplate referencing those standards.

## Test plan
- [ ] Spot-check CLAUDE.md renders cleanly on GitHub
- [ ] Confirm `_PRA_TEMPLATE.md` lives where CLAUDE.md says it does