### PR TITLE
fix(tests): replace networkidle wait with domcontentloaded to fix CI hang

### DIFF
--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -365,7 +365,7 @@ class TestLayout:
     def test_ui_elements_and_overlays(self, browser):
         """All UI elements exist, and no unregistered overlays are present."""
         page = browser.new_page(viewport={"width": 1440, "height": 900})
-        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html", wait_until="networkidle")
+        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html", wait_until="domcontentloaded")
         page.wait_for_selector("#map", state="visible", timeout=10000)
 
         # Every element in _UI_ELEMENTS must exist
@@ -402,7 +402,7 @@ class TestLayout:
     def test_layout_at_viewport(self, browser, vp):
         """No overlaps, all elements visible and within viewport bounds."""
         page = browser.new_page(viewport={"width": vp["width"], "height": vp["height"]})
-        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html", wait_until="networkidle")
+        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html", wait_until="domcontentloaded")
         page.wait_for_selector("#map", state="visible", timeout=10000)
 
         # -- No element overlap --
@@ -453,7 +453,7 @@ class TestLayout:
     def test_flag_banner_after_click(self, browser, vp):
         """After selecting an agency with flags, banner should not overlap search and be fully visible."""
         page = browser.new_page(viewport={"width": vp["width"], "height": vp["height"]})
-        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html#san-mateo-ca-pd", wait_until="networkidle")
+        page.goto(f"http://127.0.0.1:{self.port}/sharing_map.html#san-mateo-ca-pd", wait_until="domcontentloaded")
         page.wait_for_selector("#map", state="visible", timeout=10000)
         # Give JS time to process the hash
         page.wait_for_timeout(500)


### PR DESCRIPTION
## Summary

The scheduled `Refresh Flock Transparency Data` workflow has been failing since 2026-05-08 01:26 UTC. CI hangs at `tests/test_map_smoke.py::TestLayout::test_ui_elements_and_overlays` until the runner is killed (e.g. [run 25562867011](https://github.com/none-below/sm-alpr/actions/runs/25562867011) hung 22 min, [25556958059](https://github.com/none-below/sm-alpr/actions/runs/25556958059) hung 47 min). Same test passes locally in 2s.

Root cause: `page.goto(..., wait_until="networkidle")` waits for 500ms of zero network activity. The sharing-map page loads from `unpkg.com` (Leaflet), `gc.zgo.at` (Goatcounter), and OpenStreetMap tile servers — on a flaky GH Actions network, any of those keeping retries means the page never reaches network idle.

Each `page.goto` is already followed by `page.wait_for_selector("#map", state="visible", timeout=10000)`. All asserted elements (`#map`, `#search-box`, `#flag-banner`, `.info-panel`, `.legend`, `.back-link`) exist as static HTML, present at `domcontentloaded`. So switching is safe and fails fast (10s) if Leaflet is unreachable, instead of hanging the runner.

## Test plan

- [x] All 9 `TestLayout` tests pass locally (6.13s)
- [ ] Next scheduled `refresh-flock-data` run completes the test step and reaches `Commit and push`