### PR TITLE
fix(pra-download): skip known-broken portal attachments

### DIFF
--- a/scripts/pra_download.py
+++ b/scripts/pra_download.py
@@ -377,6 +377,15 @@ SSESSIONID_RE = re.compile(r"[?&]sSessionID=[^&]*")
 DOWNLOAD_TIMEOUT_MS = 60_000  # portal pre-signs S3 URLs; can take several seconds
 NAV_TIMEOUT_MS = 20_000
 
+# Per-request attachment labels that are known to be unretrievable from the
+# portal — e.g., uploads where the original filename couldn't be parsed and
+# the portal serves a broken anchor. Without skipping, save_pdf_via_click
+# hangs the full DOWNLOAD_TIMEOUT_MS waiting for a download event that
+# never fires, every run.
+SKIP_ATTACHMENTS: dict[str, frozenset[str]] = {
+    "W012462-040226": frozenset({"download"}),
+}
+
 
 def load_config() -> dict:
     if not CONFIG_PATH.exists():
@@ -1019,6 +1028,7 @@ def process_request(page: Page, home_url: str, request_id: str,
         # clicks while still distinguishing two anchors that share a label
         # (e.g. two attachments uploaded with the same filename).
         processed: set[tuple[str, str, str]] = set()
+        skip_labels = SKIP_ATTACHMENTS.get(request_id, frozenset())
         while True:
             current = _get_attachment_anchors(page)
             target_el = None
@@ -1040,6 +1050,11 @@ def process_request(page: Page, home_url: str, request_id: str,
             if target_el is None or target_key is None:
                 break
             processed.add(target_key)
+
+            if target_label in skip_labels:
+                counts["skipped"] += 1
+                file_status("skipped", f"{target_label} (known broken)")
+                continue
 
             if target_label in existing or sanitize(target_label) in existing:
                 counts["skipped"] += 1


### PR DESCRIPTION
## Summary

The W012462-040226 portal currently exposes a broken attachment anchor (label "download", no working href) — likely an upload where the original filename couldn't be parsed. Without a skip, every scrape stalls the full DOWNLOAD_TIMEOUT_MS (60s) waiting for a download event that never fires.

Adds a `SKIP_ATTACHMENTS` map keyed by request_id. The skip happens before the existing-file check, so the broken label never reaches `save_pdf_via_click`.

## Test plan
- [x] Syntax check (ast.parse) and `--help` output unchanged
- [ ] Next scrape of W012462-040226 doesn't hang on the broken anchor