### PR TITLE
feat(articles): import contract-termination ledger to seed article queue

### DIFF
--- a/assets/articles/queue/00c5460d.json
+++ b/assets/articles/queue/00c5460d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2025/12/06/eugene-springfield-end-flock-cameras/",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/015a19fa.json
+++ b/assets/articles/queue/015a19fa.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.mv-voice.com/public-safety/2026/02/02/mountain-view-police-turn-off-license-plate-cameras-after-data-sharing-breach/",
+  "source_domain": "mv-voice.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/02e8fa46.json
+++ b/assets/articles/queue/02e8fa46.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenorthwestern.com/story/news/local/oshkosh/2026/04/22/oshkosh-rescinds-flock-safety-contract-after-police-chief-raises-concerns/89745485007/",
+  "source_domain": "thenorthwestern.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/04141c2e.json
+++ b/assets/articles/queue/04141c2e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-charlottesville-turns-off-flock-license-plate-cameras-after-concerns-raised/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/08fc71d4.json
+++ b/assets/articles/queue/08fc71d4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.hngnews.com/leader_independent/news/local/dane-county-board-votes-to-cut-funding-for-flock-license-plate-reader-cameras/article_df6d5043-0b19-4053-8510-ff5aacfc463b.html",
+  "source_domain": "hngnews.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/096b7db2.json
+++ b/assets/articles/queue/096b7db2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/police-pause-flock-access",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/096ce258.json
+++ b/assets/articles/queue/096ce258.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kgun9.com/news/community-inspired-journalism/cochise-county/sierra-vista-city-council-directs-staff-to-end-flock-license-plate-reader-contract",
+  "source_domain": "kgun9.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/102b9a56.json
+++ b/assets/articles/queue/102b9a56.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/186c45d6.json
+++ b/assets/articles/queue/186c45d6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/austin-license-plate-readers-ends-privacy-concerns/269-4dc64690-c6c0-4ace-a009-fd8a13f69113",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/1c516f34.json
+++ b/assets/articles/queue/1c516f34.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2026/02/25/coralville-removes-flock-cameras-after-council-votes-end-contract/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/25614d8f.json
+++ b/assets/articles/queue/25614d8f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://skamaniasheriff.com/2025/11/12/flock-cameras-disabled-after-recent-court-decision/",
+  "source_domain": "skamaniasheriff.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/276ca70b.json
+++ b/assets/articles/queue/276ca70b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/news/local/flagstaff-flock-safety-cameras-ended",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/29511307.json
+++ b/assets/articles/queue/29511307.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety",
+  "source_domain": "wskg.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/31be2445.json
+++ b/assets/articles/queue/31be2445.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://lookouteugene-springfield.com/story/latest-news/2025/12/09/flock-activated-camera-during-pause-chief-says-pushing-city-to-axe-contract/",
+  "source_domain": "lookouteugene-springfield.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/3badff42.json
+++ b/assets/articles/queue/3badff42.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.klcc.org/breaking/2025-12-05/eugene-and-springfield-both-announce-end-of-flock-camera-usage",
+  "source_domain": "klcc.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/3d066a7a.json
+++ b/assets/articles/queue/3d066a7a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/09/26/evanston-ends-flock-alpr",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/3dacdbaa.json
+++ b/assets/articles/queue/3dacdbaa.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/hays-county/hays-county-contract-flock-license-plate-reader-cameras/269-f7276915-920a-4216-add1-42fbf17a0056",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/44bb97bc.json
+++ b/assets/articles/queue/44bb97bc.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2026/01/08/bend-flock-cameras-ai-license-plate-camera-law-enforcement/",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/4ac4fa5c.json
+++ b/assets/articles/queue/4ac4fa5c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated",
+  "source_domain": "cambridgema.gov",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/4add73e6.json
+++ b/assets/articles/queue/4add73e6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/local/article-olympia-flock",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/51caefc6.json
+++ b/assets/articles/queue/51caefc6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras",
+  "source_domain": "freep.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5643b6a9.json
+++ b/assets/articles/queue/5643b6a9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/caldwell-county/lockhart-city-council-rejects-flock-ai-cameras-in-6-1-vote/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/56722e58.json
+++ b/assets/articles/queue/56722e58.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.clickorlando.com/news/local/2021/08/12/shocking-violation-of-procedure-lake-county-commissioners-order-takedown-of-traffic-surveillance-cameras/",
+  "source_domain": "clickorlando.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/57d670e3.json
+++ b/assets/articles/queue/57d670e3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/austin/2025-07-01/austin-ends-flock-cameras",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5ab5f60f.json
+++ b/assets/articles/queue/5ab5f60f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5b0224ea.json
+++ b/assets/articles/queue/5b0224ea.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/",
+  "source_domain": "richmondside.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5cf82328.json
+++ b/assets/articles/queue/5cf82328.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns-2/",
+  "source_domain": "washingtonretail.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5e1bc92f.json
+++ b/assets/articles/queue/5e1bc92f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.goskagit.com/news/local_news/sedro-woolley-turns-off-law-enforcement-cameras-while-it-seeks-court-ruling/article_d0d0bdb9-6502-4686-94ae-346289afd535.html",
+  "source_domain": "goskagit.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/5ef22215.json
+++ b/assets/articles/queue/5ef22215.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://shorewoodmn.gov/Blog.aspx?IID=21",
+  "source_domain": "shorewoodmn.gov",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/608f063d.json
+++ b/assets/articles/queue/608f063d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.columbian.com/news/2025/skamania-county-flock",
+  "source_domain": "columbian.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/67034313.json
+++ b/assets/articles/queue/67034313.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2025/12/02/eugene-ends-flock-alpr",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/684b315e.json
+++ b/assets/articles/queue/684b315e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.heraldnet.com/news/mountlake-terrace-cancels-flock",
+  "source_domain": "heraldnet.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/6876fea4.json
+++ b/assets/articles/queue/6876fea4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.chronline.com/stories/controversial-flock-license-plate-readers-shut-off-by-another-eastern-washington-city",
+  "source_domain": "chronline.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/6a0d18bf.json
+++ b/assets/articles/queue/6a0d18bf.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wbir.com/article/news/crime/10investigates-knoxville-license-plate-reader-cameras-turned-off-contract-lapse/51-3cadec96-a281-49e8-ab41-c3e9ff4a12df",
+  "source_domain": "wbir.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/6a752c87.json
+++ b/assets/articles/queue/6a752c87.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://vimeo.com/showcase/7323755",
+  "source_domain": "vimeo.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/6ab24183.json
+++ b/assets/articles/queue/6ab24183.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras",
+  "source_domain": "whsv.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/6f98bb1b.json
+++ b/assets/articles/queue/6f98bb1b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oakpark.com/2025/08/05/oak-park-ends-flock-cameras",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/76b8edf0.json
+++ b/assets/articles/queue/76b8edf0.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wpri.com/news/local-news/east-bay/warren-rejects-proposal-to-install-flock-camera/",
+  "source_domain": "wpri.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/78239aff.json
+++ b/assets/articles/queue/78239aff.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2024/02/17/big-brother-or-crime-fighter-elbert-county-says-no-to-license-plate-readers-521d798c-caac-11ee-a37b-7b0672ff5019/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/794cac8f.json
+++ b/assets/articles/queue/794cac8f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://kstp.com/kstp-news/top-news/roadside-cameras-going-dark-another-department-makes-changes-to-program-over-accountability-concerns/",
+  "source_domain": "kstp.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/7e7e0e76.json
+++ b/assets/articles/queue/7e7e0e76.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.seattletimes.com/seattle-news/politics/redmond-suspends-flock-cameras",
+  "source_domain": "seattletimes.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/891fc29c.json
+++ b/assets/articles/queue/891fc29c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.koamnewsnow.com/news/top-stories/seneca-police-end-flock-camera-contract-after-less-than-90-days/article_d493c47c-a4ab-4270-83c9-f52e784b24ea.html",
+  "source_domain": "koamnewsnow.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/8987c104.json
+++ b/assets/articles/queue/8987c104.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.heraldnet.com/2025/09/10/stanwood-pauses-flock-cameras-amid-public-records-lawsuits/",
+  "source_domain": "heraldnet.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/8e93c581.json
+++ b/assets/articles/queue/8e93c581.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://bloomington.in.gov/news/2026/04/15/6521",
+  "source_domain": "bloomington.in.gov",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/91d29b0b.json
+++ b/assets/articles/queue/91d29b0b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.heraldnet.com/news/lynnwood-pauses-flock-cameras",
+  "source_domain": "heraldnet.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/92690a5c.json
+++ b/assets/articles/queue/92690a5c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.natickreport.com/2026/01/natick-select-board-quashes-flock-license-plate-reader-pilot-police-chief-apologizes-explains/",
+  "source_domain": "natickreport.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/9a62041a.json
+++ b/assets/articles/queue/9a62041a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://laist.com/news/south-pasadena-cancels-flock-safety-contract-privacy-concerns",
+  "source_domain": "laist.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/9d0dadf7.json
+++ b/assets/articles/queue/9d0dadf7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/verona-flock-renewal-vote",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/9da938a7.json
+++ b/assets/articles/queue/9da938a7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.cbsnews.com/colorado/news/license-plate-reading-cameras-colorado-regulation-misuse/",
+  "source_domain": "cbsnews.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/a16553bd.json
+++ b/assets/articles/queue/a16553bd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://sanjosespotlight.com/fact-brief-does-campbell-have-a-partnership-with-flock-cameras/",
+  "source_domain": "sanjosespotlight.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/a39de56d.json
+++ b/assets/articles/queue/a39de56d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondstandard.com/community/2025/12/09/richmond-police-suspend-system-that-automatically-reads-license-plates/",
+  "source_domain": "richmondstandard.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/a8bf3f70.json
+++ b/assets/articles/queue/a8bf3f70.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2023/06/13/oakland-flock-vote",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/a8f3fa73.json
+++ b/assets/articles/queue/a8f3fa73.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://abc7news.com/post/santa-clara-county-stop-using-flock-safety-cameras-several-cities-privacy-concerns/18646060/",
+  "source_domain": "abc7news.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/ac2c4a60.json
+++ b/assets/articles/queue/ac2c4a60.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.watertownmanews.com/2026/01/28/watertown-cancelling-contract-for-flock-license-plate-reading-cameras/",
+  "source_domain": "watertownmanews.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/b677cb26.json
+++ b/assets/articles/queue/b677cb26.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2025/05/05/denver-city-council-flock-vote",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/b68161dc.json
+++ b/assets/articles/queue/b68161dc.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://woodburnindependent.com/2025/11/11/woodburn-suspends-flock-safety-license-plate-cameras-amid-concerns-of-federal-ice-enforcement/",
+  "source_domain": "woodburnindependent.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/b848930a.json
+++ b/assets/articles/queue/b848930a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://spectrumlocalnews.com/nys/central-ny/public-safety/2026/03/23/syracuse-common-council-revokes-contract-with-flock",
+  "source_domain": "spectrumlocalnews.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/bc1715a5.json
+++ b/assets/articles/queue/bc1715a5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.heraldnet.com/news/stanwood-flock-paused",
+  "source_domain": "heraldnet.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/bd42a91a.json
+++ b/assets/articles/queue/bd42a91a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.northcountrypublicradio.org/news/story/53078/20260302/police-stop-installing-surveillance-cameras-in-saranac-lake-for-now",
+  "source_domain": "northcountrypublicradio.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/bf6ddb88.json
+++ b/assets/articles/queue/bf6ddb88.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kgun9.com/news/community-inspired-journalism/south-tucson/south-tucson-ends-flock-camera-contract-city-now-searching-for-alternatives",
+  "source_domain": "kgun9.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/c0f4c80f.json
+++ b/assets/articles/queue/c0f4c80f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cbsaustin.com/news/local/san-marcos-city-council-ends-flock-safety-contract-seeking-new-options",
+  "source_domain": "cbsaustin.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/c465049c.json
+++ b/assets/articles/queue/c465049c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.examiner-enterprise.com/story/news/2024/02/06/washington-county-flock",
+  "source_domain": "examiner-enterprise.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/ca8f8cb2.json
+++ b/assets/articles/queue/ca8f8cb2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.fauquiernow.com/news/not-on-our-watch-warrenton-town-council-reverses-course-on-license-plate-readers/article_9a1c02ac-5f77-47c7-a270-06f49ab98332.html",
+  "source_domain": "fauquiernow.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/cd3db00f.json
+++ b/assets/articles/queue/cd3db00f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wfsb.com/2026/02/20/windsor-suspends-license-plate-readers-amid-privacy-concerns/",
+  "source_domain": "wfsb.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/cfb28850.json
+++ b/assets/articles/queue/cfb28850.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.toledoblade.com/local/county/2024/01/18/lucas-county-flock-contract",
+  "source_domain": "toledoblade.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/d0163141.json
+++ b/assets/articles/queue/d0163141.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/renton-police-shut-down-license-plate-cameras-comply-with-new-privacy-law/JHCHPR4FQBGKNJOOWZ7LM3J6W4/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/d81aaf66.json
+++ b/assets/articles/queue/d81aaf66.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.news10.com/news/rensselaer-county/troy-city-council-tables-flock-camera-contract-renewal/",
+  "source_domain": "news10.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/d8f57a54.json
+++ b/assets/articles/queue/d8f57a54.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://lookouteugene-springfield.com/story/latest-news/2025/12/10/lane-county-sheriffs-office-suspends-flock-safety-contract/",
+  "source_domain": "lookouteugene-springfield.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/dc16fb00.json
+++ b/assets/articles/queue/dc16fb00.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.mlive.com/news/saginaw-bay-city/2025/11/bay-city-commission-rejects-contract-for-license-plate-readers-following-backlash.html",
+  "source_domain": "mlive.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/dc6fd4ec.json
+++ b/assets/articles/queue/dc6fd4ec.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.9news.com/article/news/local/denver-removing-flock-cameras-new-axon-contract/73-640b5af3-7c87-4fea-8aa1-2510ad3257b8",
+  "source_domain": "9news.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/de41d9f0.json
+++ b/assets/articles/queue/de41d9f0.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.santacruzsentinel.com/2026/01/13/santa-cruz-votes-to-terminate-its-contract-with-flock-safety/",
+  "source_domain": "santacruzsentinel.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/e447442c.json
+++ b/assets/articles/queue/e447442c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/texas/2025-12-03/san-marcos-flock-cameras",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/e49e1842.json
+++ b/assets/articles/queue/e49e1842.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://content.govdelivery.com/accounts/ILEVANSTON/bulletins/3efa81d",
+  "source_domain": "content.govdelivery.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/e593c846.json
+++ b/assets/articles/queue/e593c846.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.newsobserver.com/news/local/article-hillsborough-flock",
+  "source_domain": "newsobserver.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/e647f969.json
+++ b/assets/articles/queue/e647f969.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.scarsdale.gov/DocumentCenter/View/10994/08062025-Mayoral-Letter",
+  "source_domain": "scarsdale.gov",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/e75ff526.json
+++ b/assets/articles/queue/e75ff526.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.geekwire.com/2025/washington-state-cities-turn-off-license-plate-reader-cameras-amid-ruling-on-data-access/",
+  "source_domain": "geekwire.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/ea691d02.json
+++ b/assets/articles/queue/ea691d02.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://patch.com/connecticut/windsor/windsor-votes-8-1-shut-down-flock-license-plate-reader-cameras",
+  "source_domain": "patch.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/ee60ec6b.json
+++ b/assets/articles/queue/ee60ec6b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.applevalleynewsnow.com/news/walla-walla-police-end-flock-license-plate-cameras-over-safety-and-legal-concerns/article_ec96e8f8-a14e-43b3-b6b2-7d53846dd659.html",
+  "source_domain": "applevalleynewsnow.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/f10d9c74.json
+++ b/assets/articles/queue/f10d9c74.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.krem.com/article/news/local/spokane-county-deactivates-license-plate-reader-washington-privacy-law/293-72ea9980-dbd1-430a-b4b0-67dae541dfa1",
+  "source_domain": "krem.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/f33f4bae.json
+++ b/assets/articles/queue/f33f4bae.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.nbc26.com/sturgeonbay/sturgeon-bay-discontinues-the-use-of-flock-cameras",
+  "source_domain": "nbc26.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/f384485e.json
+++ b/assets/articles/queue/f384485e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/pierce-county-sheriffs-office-deactivates-its-automated-license-plate-readers/TXPVNII6B5D3LDKKYMOP3FW2IY/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/f45c6571.json
+++ b/assets/articles/queue/f45c6571.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.timesunion.com/news/article/poestenkill-rejects-flock-cameras",
+  "source_domain": "timesunion.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/f6640370.json
+++ b/assets/articles/queue/f6640370.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.govtech.com/public-safety/eureka-calif-votes-no-on-license-plate-reader-cameras",
+  "source_domain": "govtech.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fb72d400.json
+++ b/assets/articles/queue/fb72d400.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.losaltosonline.com/news/los-altos-hills-to-remove-alpr-cameras/article_59f90aa8-14c1-4309-9f7f-12d16c649d9e.html",
+  "source_domain": "losaltosonline.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fb88089e.json
+++ b/assets/articles/queue/fb88089e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://theportager.com/kent-city-council-rejects-video-surveillance-contract-with-flock/",
+  "source_domain": "theportager.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fce9e52b.json
+++ b/assets/articles/queue/fce9e52b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://lookouteugene-springfield.com/story/justice/2025/12/05/eugene-announces-termination-of-flock-contract/",
+  "source_domain": "lookouteugene-springfield.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fe5bfdf2.json
+++ b/assets/articles/queue/fe5bfdf2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://ithacavoice.org/2026/04/county-legislature-ends-contract-with-flock-safety/",
+  "source_domain": "ithacavoice.org",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fe840f13.json
+++ b/assets/articles/queue/fe840f13.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wkow.com/news/city-of-verona-votes-to-not-renew-flock-cameras/article_083afa08-5b8a-4955-9876-ad8fd2b9f3aa.html",
+  "source_domain": "wkow.com",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/articles/queue/fece9588.json
+++ b/assets/articles/queue/fece9588.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oxnard.gov/pd-news/news-release-oxnard-police-department-suspends-use-of-flock-safety-automated-license-plate-readers-02-27-26",
+  "source_domain": "oxnard.gov",
+  "discovered_at": "2026-05-08T17:23:52Z",
+  "discovered_by": "termination-ledger-import"
+}

--- a/assets/sources.json
+++ b/assets/sources.json
@@ -4,9 +4,9 @@
     "domain": "lowercase apex domain (no scheme, no path, no www)",
     "tier": "1 = wire/papers of record / professional editorial, 2 = beat/advocacy outlets, 3 = blogs/social/uncurated",
     "name": "human-readable publisher name",
-    "stance": "neutral | critical | supportive | industry | unknown — posture toward law-enforcement surveillance",
+    "stance": "neutral | critical | supportive | industry | unknown \u2014 posture toward law-enforcement surveillance",
     "last_reviewed": "YYYY-MM-DD when tier/stance was last confirmed by a human",
-    "feed_url": "(optional) RSS/Atom feed URL — scripts/discover_articles.py polls this and auto-queues items matching ALPR keywords",
+    "feed_url": "(optional) RSS/Atom feed URL \u2014 scripts/discover_articles.py polls this and auto-queues items matching ALPR keywords",
     "notes": "free-form"
   },
   "_handler_policy": {
@@ -17,39 +17,886 @@
     "tier_3_any": "deterministic extraction only; quotes hand-pasted"
   },
   "sources": [
-    {"domain": "nytimes.com",            "tier": 1, "name": "The New York Times",          "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "washingtonpost.com",     "tier": 1, "name": "The Washington Post",         "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "reuters.com",            "tier": 1, "name": "Reuters",                     "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "apnews.com",             "tier": 1, "name": "Associated Press",            "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "sfchronicle.com",        "tier": 1, "name": "San Francisco Chronicle",     "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": "Hard paywall; no public RSS. Discoverable via search mode."},
-    {"domain": "mercurynews.com",        "tier": 1, "name": "San Jose Mercury News",       "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": "MediaNews Group; direct feed blocked (403). Discoverable via search mode."},
-    {"domain": "latimes.com",            "tier": 1, "name": "Los Angeles Times",           "stance": "neutral",    "last_reviewed": "2026-04-27", "feed_url": "https://www.latimes.com/california/rss2.0.xml", "notes": "California desk feed."},
-    {"domain": "sacbee.com",             "tier": 1, "name": "Sacramento Bee",              "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": "Arc CMS; no public RSS. Discoverable via search mode."},
-    {"domain": "smdailyjournal.com",     "tier": 1, "name": "San Mateo Daily Journal",     "stance": "neutral",    "last_reviewed": "2026-04-27", "notes": "Local paper for SMPD coverage."},
-    {"domain": "kqed.org",               "tier": 1, "name": "KQED",                        "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://ww2.kqed.org/news/feed/", "notes": "WordPress-backed news CMS at ww2 subdomain; main site is React SPA with no feed."},
-    {"domain": "npr.org",                "tier": 1, "name": "NPR",                         "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://feeds.npr.org/1001/rss.xml", "notes": ""},
-    {"domain": "calmatters.org",         "tier": 1, "name": "CalMatters",                  "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://calmatters.org/feed/", "notes": "Statewide California policy journalism; strong legislature and municipal government beat."},
-    {"domain": "eastbaytimes.com",       "tier": 1, "name": "East Bay Times",              "stance": "neutral",    "last_reviewed": "2026-05-07", "notes": "MediaNews Group; direct feed blocked (403). Covers El Cerrito, Oakland, Alameda County. Discoverable via search mode."},
-
-    {"domain": "eff.org",                "tier": 2, "name": "Electronic Frontier Foundation", "stance": "critical", "last_reviewed": "2026-04-27", "feed_url": "https://www.eff.org/rss/updates.xml", "notes": "Privacy/surveillance advocacy."},
-    {"domain": "aclu.org",               "tier": 2, "name": "ACLU (national)",             "stance": "critical",   "last_reviewed": "2026-05-07", "feed_url": "https://www.aclu.org/feed", "notes": ""},
-    {"domain": "aclunorcal.org",         "tier": 2, "name": "ACLU of Northern California", "stance": "critical",   "last_reviewed": "2026-05-07", "feed_url": "https://www.aclunorcal.org/feed/", "notes": "Formerly aclunc.org; redirects to aclunorcal.org."},
-    {"domain": "epic.org",               "tier": 2, "name": "Electronic Privacy Information Center", "stance": "critical", "last_reviewed": "2026-05-07", "feed_url": "https://epic.org/feed/", "notes": ""},
-    {"domain": "themarkup.org",          "tier": 2, "name": "The Markup",                  "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://themarkup.org/feeds/rss.xml", "notes": "Accountability journalism, tech/algorithm beat."},
-    {"domain": "404media.co",            "tier": 2, "name": "404 Media",                   "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://www.404media.co/rss/", "notes": "Tech/surveillance reporting; covers prompt-injection beats — scanner-flagged content may be a quoted attack, not a real one."},
-    {"domain": "propublica.org",         "tier": 2, "name": "ProPublica",                  "stance": "critical",   "last_reviewed": "2026-04-27", "feed_url": "https://www.propublica.org/feeds/propublica/main", "notes": ""},
-    {"domain": "wired.com",              "tier": 2, "name": "Wired",                       "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://www.wired.com/feed/category/security/latest/rss", "notes": "Security category feed; main feed is dominated by affiliate/deals content."},
-    {"domain": "arstechnica.com",        "tier": 2, "name": "Ars Technica",                "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://feeds.arstechnica.com/arstechnica/index", "notes": ""},
-    {"domain": "brennancenter.org",      "tier": 2, "name": "Brennan Center for Justice",  "stance": "critical",   "last_reviewed": "2026-05-07", "notes": "Drupal 11; no RSS feed exposed. Discoverable via search mode."},
-    {"domain": "berkeleyside.org",       "tier": 2, "name": "Berkeleyside",                "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://www.berkeleyside.org/feed", "notes": "Strong Berkeley city government beat; has covered Flock surveillance expansion directly."},
-    {"domain": "oaklandside.org",        "tier": 2, "name": "The Oaklandside",             "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://oaklandside.org/feed/", "notes": "Oakland city government and accountability reporting."},
-    {"domain": "sanjosespotlight.com",   "tier": 2, "name": "San José Spotlight",          "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://sanjosespotlight.com/feed/", "notes": "City government focus for San José and Santa Clara County."},
-    {"domain": "missionlocal.org",       "tier": 2, "name": "Mission Local",               "stance": "neutral",    "last_reviewed": "2026-05-07", "feed_url": "https://missionlocal.org/feed/", "notes": "SF neighborhood and city government reporting."},
-
-    {"domain": "flocksafety.com",        "tier": 2, "name": "Flock Safety (vendor)",       "stance": "industry",   "last_reviewed": "2026-04-27", "notes": "Vendor blog/press releases. Counterweight value: their own framing of products and policy."},
-    {"domain": "axon.com",               "tier": 2, "name": "Axon (vendor)",               "stance": "industry",   "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "policeexecutive.org",    "tier": 2, "name": "Police Executive Research Forum (PERF)", "stance": "supportive", "last_reviewed": "2026-04-27", "notes": "Industry/practitioner research."},
-    {"domain": "theiacp.org",            "tier": 2, "name": "International Association of Chiefs of Police", "stance": "supportive", "last_reviewed": "2026-04-27", "notes": ""},
-    {"domain": "police1.com",            "tier": 2, "name": "Police1",                     "stance": "supportive", "last_reviewed": "2026-04-27", "notes": "Trade publication for law enforcement."}
+    {
+      "domain": "404media.co",
+      "tier": 2,
+      "name": "404 Media",
+      "stance": "critical",
+      "last_reviewed": "2026-04-27",
+      "feed_url": "https://www.404media.co/rss/",
+      "notes": "Tech/surveillance reporting; covers prompt-injection beats \u2014 scanner-flagged content may be a quoted attack, not a real one."
+    },
+    {
+      "domain": "9news.com",
+      "tier": 2,
+      "name": "9news.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "abc7news.com",
+      "tier": 2,
+      "name": "abc7news.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "aclu.org",
+      "tier": 2,
+      "name": "ACLU (national)",
+      "stance": "critical",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://www.aclu.org/feed",
+      "notes": ""
+    },
+    {
+      "domain": "aclunorcal.org",
+      "tier": 2,
+      "name": "ACLU of Northern California",
+      "stance": "critical",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://www.aclunorcal.org/feed/",
+      "notes": "Formerly aclunc.org; redirects to aclunorcal.org."
+    },
+    {
+      "domain": "apnews.com",
+      "tier": 1,
+      "name": "Associated Press",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "applevalleynewsnow.com",
+      "tier": 2,
+      "name": "applevalleynewsnow.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "arstechnica.com",
+      "tier": 2,
+      "name": "Ars Technica",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://feeds.arstechnica.com/arstechnica/index",
+      "notes": ""
+    },
+    {
+      "domain": "axon.com",
+      "tier": 2,
+      "name": "Axon (vendor)",
+      "stance": "industry",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "azdailysun.com",
+      "tier": 2,
+      "name": "azdailysun.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "berkeleyside.org",
+      "tier": 2,
+      "name": "Berkeleyside",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://www.berkeleyside.org/feed",
+      "notes": "Strong Berkeley city government beat; has covered Flock surveillance expansion directly."
+    },
+    {
+      "domain": "bloomington.in.gov",
+      "tier": 2,
+      "name": "bloomington.in.gov",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "brennancenter.org",
+      "tier": 2,
+      "name": "Brennan Center for Justice",
+      "stance": "critical",
+      "last_reviewed": "2026-05-07",
+      "notes": "Drupal 11; no RSS feed exposed. Discoverable via search mode."
+    },
+    {
+      "domain": "brookline.news",
+      "tier": 2,
+      "name": "brookline.news",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "calmatters.org",
+      "tier": 1,
+      "name": "CalMatters",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://calmatters.org/feed/",
+      "notes": "Statewide California policy journalism; strong legislature and municipal government beat."
+    },
+    {
+      "domain": "cambridgema.gov",
+      "tier": 2,
+      "name": "cambridgema.gov",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "cbsaustin.com",
+      "tier": 2,
+      "name": "cbsaustin.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "cbsnews.com",
+      "tier": 1,
+      "name": "cbsnews.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "chronline.com",
+      "tier": 2,
+      "name": "chronline.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "clickorlando.com",
+      "tier": 2,
+      "name": "clickorlando.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "columbian.com",
+      "tier": 2,
+      "name": "columbian.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "content.govdelivery.com",
+      "tier": 2,
+      "name": "content.govdelivery.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "cvillerightnow.com",
+      "tier": 2,
+      "name": "cvillerightnow.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "denvergazette.com",
+      "tier": 1,
+      "name": "denvergazette.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "denverpost.com",
+      "tier": 1,
+      "name": "denverpost.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "eastbaytimes.com",
+      "tier": 1,
+      "name": "East Bay Times",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "notes": "MediaNews Group; direct feed blocked (403). Covers El Cerrito, Oakland, Alameda County. Discoverable via search mode."
+    },
+    {
+      "domain": "eff.org",
+      "tier": 2,
+      "name": "Electronic Frontier Foundation",
+      "stance": "critical",
+      "last_reviewed": "2026-04-27",
+      "feed_url": "https://www.eff.org/rss/updates.xml",
+      "notes": "Privacy/surveillance advocacy."
+    },
+    {
+      "domain": "epic.org",
+      "tier": 2,
+      "name": "Electronic Privacy Information Center",
+      "stance": "critical",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://epic.org/feed/",
+      "notes": ""
+    },
+    {
+      "domain": "evanstonroundtable.com",
+      "tier": 2,
+      "name": "evanstonroundtable.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "examiner-enterprise.com",
+      "tier": 2,
+      "name": "examiner-enterprise.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "fauquiernow.com",
+      "tier": 2,
+      "name": "fauquiernow.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "flocksafety.com",
+      "tier": 2,
+      "name": "Flock Safety (vendor)",
+      "stance": "industry",
+      "last_reviewed": "2026-04-27",
+      "notes": "Vendor blog/press releases. Counterweight value: their own framing of products and policy."
+    },
+    {
+      "domain": "freep.com",
+      "tier": 1,
+      "name": "freep.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "geekwire.com",
+      "tier": 2,
+      "name": "geekwire.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "goskagit.com",
+      "tier": 2,
+      "name": "goskagit.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "govtech.com",
+      "tier": 2,
+      "name": "govtech.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "heraldnet.com",
+      "tier": 1,
+      "name": "heraldnet.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "hngnews.com",
+      "tier": 2,
+      "name": "hngnews.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "ithacavoice.org",
+      "tier": 2,
+      "name": "ithacavoice.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kcrg.com",
+      "tier": 2,
+      "name": "kcrg.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kgun9.com",
+      "tier": 2,
+      "name": "kgun9.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kiro7.com",
+      "tier": 2,
+      "name": "kiro7.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "klcc.org",
+      "tier": 1,
+      "name": "klcc.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "koamnewsnow.com",
+      "tier": 2,
+      "name": "koamnewsnow.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kqed.org",
+      "tier": 1,
+      "name": "KQED",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://ww2.kqed.org/news/feed/",
+      "notes": "WordPress-backed news CMS at ww2 subdomain; main site is React SPA with no feed."
+    },
+    {
+      "domain": "krem.com",
+      "tier": 2,
+      "name": "krem.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kstp.com",
+      "tier": 2,
+      "name": "kstp.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kut.org",
+      "tier": 1,
+      "name": "kut.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kvue.com",
+      "tier": 2,
+      "name": "kvue.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kxan.com",
+      "tier": 2,
+      "name": "kxan.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "laist.com",
+      "tier": 2,
+      "name": "laist.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "latimes.com",
+      "tier": 1,
+      "name": "Los Angeles Times",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "feed_url": "https://www.latimes.com/california/rss2.0.xml",
+      "notes": "California desk feed."
+    },
+    {
+      "domain": "lookouteugene-springfield.com",
+      "tier": 2,
+      "name": "lookouteugene-springfield.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "losaltosonline.com",
+      "tier": 2,
+      "name": "losaltosonline.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "madison.com",
+      "tier": 1,
+      "name": "madison.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "mercurynews.com",
+      "tier": 1,
+      "name": "San Jose Mercury News",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": "MediaNews Group; direct feed blocked (403). Discoverable via search mode."
+    },
+    {
+      "domain": "missionlocal.org",
+      "tier": 2,
+      "name": "Mission Local",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://missionlocal.org/feed/",
+      "notes": "SF neighborhood and city government reporting."
+    },
+    {
+      "domain": "mlive.com",
+      "tier": 1,
+      "name": "mlive.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "mv-voice.com",
+      "tier": 2,
+      "name": "mv-voice.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "natickreport.com",
+      "tier": 2,
+      "name": "natickreport.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "nbc26.com",
+      "tier": 2,
+      "name": "nbc26.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "news10.com",
+      "tier": 2,
+      "name": "news10.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "newsobserver.com",
+      "tier": 1,
+      "name": "newsobserver.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "northcountrypublicradio.org",
+      "tier": 1,
+      "name": "northcountrypublicradio.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "npr.org",
+      "tier": 1,
+      "name": "NPR",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://feeds.npr.org/1001/rss.xml",
+      "notes": ""
+    },
+    {
+      "domain": "nytimes.com",
+      "tier": 1,
+      "name": "The New York Times",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "oaklandside.org",
+      "tier": 2,
+      "name": "The Oaklandside",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://oaklandside.org/feed/",
+      "notes": "Oakland city government and accountability reporting."
+    },
+    {
+      "domain": "oakpark.com",
+      "tier": 2,
+      "name": "oakpark.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "opb.org",
+      "tier": 1,
+      "name": "opb.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "oxnard.gov",
+      "tier": 2,
+      "name": "oxnard.gov",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "patch.com",
+      "tier": 2,
+      "name": "patch.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "police1.com",
+      "tier": 2,
+      "name": "Police1",
+      "stance": "supportive",
+      "last_reviewed": "2026-04-27",
+      "notes": "Trade publication for law enforcement."
+    },
+    {
+      "domain": "policeexecutive.org",
+      "tier": 2,
+      "name": "Police Executive Research Forum (PERF)",
+      "stance": "supportive",
+      "last_reviewed": "2026-04-27",
+      "notes": "Industry/practitioner research."
+    },
+    {
+      "domain": "propublica.org",
+      "tier": 2,
+      "name": "ProPublica",
+      "stance": "critical",
+      "last_reviewed": "2026-04-27",
+      "feed_url": "https://www.propublica.org/feeds/propublica/main",
+      "notes": ""
+    },
+    {
+      "domain": "redrocknews.com",
+      "tier": 2,
+      "name": "redrocknews.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "reuters.com",
+      "tier": 1,
+      "name": "Reuters",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "richmondside.org",
+      "tier": 2,
+      "name": "richmondside.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "richmondstandard.com",
+      "tier": 2,
+      "name": "richmondstandard.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "sacbee.com",
+      "tier": 1,
+      "name": "Sacramento Bee",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": "Arc CMS; no public RSS. Discoverable via search mode."
+    },
+    {
+      "domain": "sanjosespotlight.com",
+      "tier": 2,
+      "name": "San Jos\u00e9 Spotlight",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://sanjosespotlight.com/feed/",
+      "notes": "City government focus for San Jos\u00e9 and Santa Clara County."
+    },
+    {
+      "domain": "santacruzsentinel.com",
+      "tier": 2,
+      "name": "santacruzsentinel.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "scarsdale.gov",
+      "tier": 2,
+      "name": "scarsdale.gov",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "seattletimes.com",
+      "tier": 1,
+      "name": "seattletimes.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "sfchronicle.com",
+      "tier": 1,
+      "name": "San Francisco Chronicle",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": "Hard paywall; no public RSS. Discoverable via search mode."
+    },
+    {
+      "domain": "shorewoodmn.gov",
+      "tier": 2,
+      "name": "shorewoodmn.gov",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "skamaniasheriff.com",
+      "tier": 2,
+      "name": "skamaniasheriff.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "smdailyjournal.com",
+      "tier": 1,
+      "name": "San Mateo Daily Journal",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": "Local paper for SMPD coverage."
+    },
+    {
+      "domain": "spectrumlocalnews.com",
+      "tier": 2,
+      "name": "spectrumlocalnews.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "theiacp.org",
+      "tier": 2,
+      "name": "International Association of Chiefs of Police",
+      "stance": "supportive",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "themarkup.org",
+      "tier": 2,
+      "name": "The Markup",
+      "stance": "critical",
+      "last_reviewed": "2026-04-27",
+      "feed_url": "https://themarkup.org/feeds/rss.xml",
+      "notes": "Accountability journalism, tech/algorithm beat."
+    },
+    {
+      "domain": "thenewstribune.com",
+      "tier": 1,
+      "name": "thenewstribune.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "thenorthwestern.com",
+      "tier": 2,
+      "name": "thenorthwestern.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "theolympian.com",
+      "tier": 1,
+      "name": "theolympian.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "theportager.com",
+      "tier": 2,
+      "name": "theportager.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "timesunion.com",
+      "tier": 1,
+      "name": "timesunion.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "toledoblade.com",
+      "tier": 1,
+      "name": "toledoblade.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "vimeo.com",
+      "tier": 2,
+      "name": "vimeo.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "washingtonpost.com",
+      "tier": 1,
+      "name": "The Washington Post",
+      "stance": "neutral",
+      "last_reviewed": "2026-04-27",
+      "notes": ""
+    },
+    {
+      "domain": "washingtonretail.org",
+      "tier": 2,
+      "name": "washingtonretail.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "watertownmanews.com",
+      "tier": 2,
+      "name": "watertownmanews.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wbir.com",
+      "tier": 2,
+      "name": "wbir.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wfsb.com",
+      "tier": 2,
+      "name": "wfsb.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "whsv.com",
+      "tier": 2,
+      "name": "whsv.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wired.com",
+      "tier": 2,
+      "name": "Wired",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-07",
+      "feed_url": "https://www.wired.com/feed/category/security/latest/rss",
+      "notes": "Security category feed; main feed is dominated by affiliate/deals content."
+    },
+    {
+      "domain": "wkow.com",
+      "tier": 2,
+      "name": "wkow.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "woodburnindependent.com",
+      "tier": 2,
+      "name": "woodburnindependent.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wpri.com",
+      "tier": 2,
+      "name": "wpri.com",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wskg.org",
+      "tier": 1,
+      "name": "wskg.org",
+      "stance": "unknown",
+      "last_reviewed": "2026-05-08",
+      "notes": "auto-added from termination_ledger import; review tier/stance"
+    }
   ]
 }

--- a/assets/termination_ledger.json
+++ b/assets/termination_ledger.json
@@ -1,6 +1,6 @@
 {
   "_schema": {
-    "imported_at": "ISO-8601 UTC of last import run",
+    "imported_at": "ISO-8601 UTC of last import that changed content",
     "source_file": "filename of upstream xlsx (not committed)",
     "source_file_sha256": "sha256 of upstream xlsx at import time",
     "actions": "list of agency-action records harvested from sheets"

--- a/assets/termination_ledger.json
+++ b/assets/termination_ledger.json
@@ -1,0 +1,1266 @@
+{
+  "_schema": {
+    "imported_at": "ISO-8601 UTC of last import run",
+    "source_file": "filename of upstream xlsx (not committed)",
+    "source_file_sha256": "sha256 of upstream xlsx at import time",
+    "actions": "list of agency-action records harvested from sheets"
+  },
+  "_note": "Bootstrap import audit trail, not a canonical data store. Derived from an external activist tracker of Flock terminated/paused contracts; the source xlsx is not committed. The canonical record of contract-termination evidence is assets/article_registry.json (with generic outcome:* tags applied by the curator). Re-import via scripts/import_termination_ledger.py.",
+  "imported_at": "2026-05-08T17:23:52Z",
+  "source_file": "Flock - Terminated Paused Contracts.xlsx",
+  "source_file_sha256": "b498205e6dccfc7ad711f6012086e067f19083bc3b3ec63e7918ead44348346d",
+  "actions": [
+    {
+      "agency_name": "Sedona",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Program shut down",
+      "approx_date": "2025-09-09",
+      "notes": "Permanent removal",
+      "source_urls": [
+        "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Flagstaff",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Contract terminated & cameras deactivated",
+      "approx_date": "2025-12-16",
+      "notes": "Council vote to end program",
+      "source_urls": [
+        "https://azdailysun.com/news/local/flagstaff-flock-safety-cameras-ended"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "South Tucscon",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-02-17",
+      "notes": "Council voted to terminate contract",
+      "source_urls": [
+        "https://www.kgun9.com/news/community-inspired-journalism/south-tucson/south-tucson-ends-flock-camera-contract-city-now-searching-for-alternatives"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Sierra Vista",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-02-24",
+      "notes": "Council voted to terminate contract",
+      "source_urls": [
+        "https://www.kgun9.com/news/community-inspired-journalism/cochise-county/sierra-vista-city-council-directs-staff-to-end-flock-license-plate-reader-contract"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Los Altos Hills",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Cameras turned off, contract to be terminated",
+      "approx_date": "2025-01-01",
+      "notes": "City contracts with Santa Clara County Sheriff",
+      "source_urls": [
+        "https://www.losaltosonline.com/news/los-altos-hills-to-remove-alpr-cameras/article_59f90aa8-14c1-4309-9f7f-12d16c649d9e.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Santa Cruz",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-01-13",
+      "notes": "Council vote to end program",
+      "source_urls": [
+        "https://www.santacruzsentinel.com/2026/01/13/santa-cruz-votes-to-terminate-its-contract-with-flock-safety/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Eureka",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Contract not awarded",
+      "approx_date": "2025-02-04",
+      "notes": "Council declined to award proposed contract for Flock ALPR",
+      "source_urls": [
+        "https://www.govtech.com/public-safety/eureka-calif-votes-no-on-license-plate-reader-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Richmond",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Program paused / shut down (cameras offline)",
+      "approx_date": "2025-11-15",
+      "notes": "Police chief shut down/paused Flock ALPRs after discovering a configuration issue that allowed limited outside-agency searching; described as a pause pending safeguards. (Council voted March 17, 2026 to reactive and expand Flock services)",
+      "source_urls": [
+        "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/",
+        "https://richmondstandard.com/community/2025/12/09/richmond-police-suspend-system-that-automatically-reads-license-plates/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Mountain View",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Cameras turned off during pause (Council vote to decide)",
+      "approx_date": "2026-02-01",
+      "notes": "Police chief shut down/paused Flock ALPRs after discovering a configuration issue that allowed limited outside-agency searching. Council may vote Feb 24.",
+      "source_urls": [
+        "https://www.mv-voice.com/public-safety/2026/02/02/mountain-view-police-turn-off-license-plate-cameras-after-data-sharing-breach/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Windsor",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Cameras turned off",
+      "approx_date": "2026-02-17",
+      "notes": "Council directed City Manager to turn off cameras, and explore alternate vendors and/or a contract that protects data",
+      "source_urls": [
+        "https://patch.com/connecticut/windsor/windsor-votes-8-1-shut-down-flock-license-plate-reader-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Santa Clara County (covers Saratoga, Los Altos Hills (see above), and Cupertino)",
+      "agency_type": "County",
+      "state": "CA",
+      "action_type": "Sheriff prohibited from using Flock ALPR",
+      "approx_date": "2026-02-24",
+      "notes": "The unincorporated areas of Satatoga, Cupertino, and Los Altos Hills have to make their own decision to terminate their respective contracts with Flock (Los Altos has terminated), but the County's vote effectively ends the use of Flock in these three cities because they do not have their own law enforcement agency.",
+      "source_urls": [
+        "https://abc7news.com/post/santa-clara-county-stop-using-flock-safety-cameras-several-cities-privacy-concerns/18646060/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Oxnard",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Police suspended use of ALPR",
+      "approx_date": "2026-02-27",
+      "notes": "Police allege Flock altered settings re National lookup, after OPD affirmatively optedout. Audit revealed data was searched in violation of SB 34.",
+      "source_urls": [
+        "https://www.oxnard.gov/pd-news/news-release-oxnard-police-department-suspends-use-of-flock-safety-automated-license-plate-readers-02-27-26"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "South Pasadena",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "CCTV Contract terminated, no action on ALPR contract yet",
+      "approx_date": "2026-03-19",
+      "notes": "Council declined to renew CCTV contract.",
+      "source_urls": [
+        "https://laist.com/news/south-pasadena-cancels-flock-safety-contract-privacy-concerns"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lakewood",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Contract renewal declined",
+      "approx_date": "2026-03-24",
+      "notes": "Council voted not to renew contract.",
+      "source_urls": [
+        "https://vimeo.com/showcase/7323755"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Campbell",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Cameras turned off, will be removed",
+      "approx_date": "2026-02-01",
+      "notes": "Mayor Sergio Lopez LinkedIn statement re camera decommission",
+      "source_urls": [
+        "https://sanjosespotlight.com/fact-brief-does-campbell-have-a-partnership-with-flock-cameras/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Elber",
+      "agency_type": "County",
+      "state": "CO",
+      "action_type": "Contract renewal declined",
+      "approx_date": "2024-02-17",
+      "notes": "County Board declined to renew contract",
+      "source_urls": [
+        "https://www.denvergazette.com/2024/02/17/big-brother-or-crime-fighter-elbert-county-says-no-to-license-plate-readers-521d798c-caac-11ee-a37b-7b0672ff5019/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Louisville",
+      "agency_type": "City",
+      "state": "CO",
+      "action_type": "Cameras turned off",
+      "approx_date": "2025-12-16",
+      "notes": "City Council voted to deactivate cameras",
+      "source_urls": [
+        "https://www.cbsnews.com/colorado/news/license-plate-reading-cameras-colorado-regulation-misuse/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Denver",
+      "agency_type": "City",
+      "state": "CO",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-02-24",
+      "notes": "Council vote",
+      "source_urls": [
+        "https://www.9news.com/article/news/local/denver-removing-flock-cameras-new-axon-contract/73-640b5af3-7c87-4fea-8aa1-2510ad3257b8"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Windsor",
+      "agency_type": "City",
+      "state": "CT",
+      "action_type": "Cameras turned off during pause (Council vote to decide)",
+      "approx_date": "2026-02-19",
+      "notes": "Council voted to suspend use of cameras",
+      "source_urls": [
+        "https://www.wfsb.com/2026/02/20/windsor-suspends-license-plate-readers-amid-privacy-concerns/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lake",
+      "agency_type": "County",
+      "state": "FL",
+      "action_type": "Camera removal ordered",
+      "approx_date": "2021-08-12",
+      "notes": "County Commissioners ordered removal of cameras",
+      "source_urls": [
+        "https://www.clickorlando.com/news/local/2021/08/12/shocking-violation-of-procedure-lake-county-commissioners-order-takedown-of-traffic-surveillance-cameras/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Coralville",
+      "agency_type": "City",
+      "state": "IA",
+      "action_type": "Cameras removed, contract terminated",
+      "approx_date": "2026-02-25",
+      "notes": "Council vote to terminate contract, takedown cameras",
+      "source_urls": [
+        "https://www.kcrg.com/2026/02/25/coralville-removes-flock-cameras-after-council-votes-end-contract/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Oak Park",
+      "agency_type": "Village",
+      "state": "IL",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-08-05",
+      "notes": "Immediate shutdown",
+      "source_urls": [
+        "https://oakpark.com/2025/08/05/oak-park-ends-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Evanston",
+      "agency_type": "City",
+      "state": "IL",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-08-26",
+      "notes": "Termination notice issued",
+      "source_urls": [
+        "https://content.govdelivery.com/accounts/ILEVANSTON/bulletins/3efa81d"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Bloomington",
+      "agency_type": "City",
+      "state": "IN",
+      "action_type": "Contract expired, not renewed",
+      "approx_date": "2026-04-15",
+      "notes": "Council declined to renew ALPR contract",
+      "source_urls": [
+        "https://bloomington.in.gov/news/2026/04/15/6521"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Brookline",
+      "agency_type": "Town",
+      "state": "MA",
+      "action_type": "Police access paused",
+      "approx_date": "2025-10-05",
+      "notes": "Private Flock system",
+      "source_urls": [
+        "https://brookline.news/police-pause-flock-access"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Cambridge",
+      "agency_type": "City",
+      "state": "MA",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-10-20",
+      "notes": "Unauthorized installation issues",
+      "source_urls": [
+        "https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Natick",
+      "agency_type": "City",
+      "state": "MA",
+      "action_type": "Pilot ALPR program terminated",
+      "approx_date": "2026-01-21",
+      "notes": "Board ordered program terminated, cameras removed",
+      "source_urls": [
+        "https://www.natickreport.com/2026/01/natick-select-board-quashes-flock-license-plate-reader-pilot-police-chief-apologizes-explains/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Watertown",
+      "agency_type": "City",
+      "state": "MA",
+      "action_type": "Contract not renewed",
+      "approx_date": "2026-01-27",
+      "notes": "City Manager recommended against renewing contract, Council adopted recommendation",
+      "source_urls": [
+        "https://www.watertownmanews.com/2026/01/28/watertown-cancelling-contract-for-flock-license-plate-reading-cameras/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Ferndale",
+      "agency_type": "City",
+      "state": "MI",
+      "action_type": "Contract ended",
+      "approx_date": "2025-11-13",
+      "notes": "Pilot discontinued",
+      "source_urls": [
+        "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Bay City",
+      "agency_type": "City",
+      "state": "MI",
+      "action_type": "Proposed contract declined",
+      "approx_date": "2025-11-17",
+      "notes": "City Council rejected proposed contract",
+      "source_urls": [
+        "https://www.mlive.com/news/saginaw-bay-city/2025/11/bay-city-commission-rejects-contract-for-license-plate-readers-following-backlash.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Shorewood",
+      "agency_type": "City",
+      "state": "MN",
+      "action_type": "City Council ordered deactivation",
+      "approx_date": "2026-03-09",
+      "notes": "Contract is with South Lake Minnetonka, Council recommended contract termination, and has deactivated Shorewood cams",
+      "source_urls": [
+        "https://shorewoodmn.gov/Blog.aspx?IID=21"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Brooklyn Park",
+      "agency_type": "City",
+      "state": "MN",
+      "action_type": "Contract allowed to expire without renewal",
+      "approx_date": "2025-12-10",
+      "notes": "Police allowed contract to expire, switched to Axon",
+      "source_urls": [
+        "https://kstp.com/kstp-news/top-news/roadside-cameras-going-dark-another-department-makes-changes-to-program-over-accountability-concerns/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Seneca",
+      "agency_type": "City",
+      "state": "MO",
+      "action_type": "Police chief ended contract",
+      "approx_date": "2026-02-19",
+      "notes": "Police chief ended contract for Flock ALPR",
+      "source_urls": [
+        "https://www.koamnewsnow.com/news/top-stories/seneca-police-end-flock-camera-contract-after-less-than-90-days/article_d493c47c-a4ab-4270-83c9-f52e784b24ea.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Hillsborough",
+      "agency_type": "Town",
+      "state": "NC",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-10-28",
+      "notes": "Cameras removed",
+      "source_urls": [
+        "https://www.newsobserver.com/news/local/article-hillsborough-flock"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Scarsdale",
+      "agency_type": "Village",
+      "state": "NY",
+      "action_type": "Contract canceled",
+      "approx_date": "2025-08-06",
+      "notes": "City Council adopted police chief recommendation to cancel contract",
+      "source_urls": [
+        "https://www.scarsdale.gov/DocumentCenter/View/10994/08062025-Mayoral-Letter"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Poestenkill",
+      "agency_type": "Town",
+      "state": "NY",
+      "action_type": "Proposal rejected",
+      "approx_date": "2025-12-11",
+      "notes": "Town board vote",
+      "source_urls": [
+        "https://www.timesunion.com/news/article/poestenkill-rejects-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Village of Saranac Lake",
+      "agency_type": "Village",
+      "state": "NY",
+      "action_type": "Program paused / shut down (cameras offline)",
+      "approx_date": "2026-02-26",
+      "notes": "Mayor stopped installation, ordered uninstallment of existing cameras",
+      "source_urls": [
+        "https://www.northcountrypublicradio.org/news/story/53078/20260302/police-stop-installing-surveillance-cameras-in-saranac-lake-for-now"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Ithica",
+      "agency_type": "City",
+      "state": "NY",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-03-04",
+      "notes": "Council vote to terminate contract",
+      "source_urls": [
+        "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Troy",
+      "agency_type": "City",
+      "state": "NY",
+      "action_type": "Contract renewal paused",
+      "approx_date": "2026-03-19",
+      "notes": "Item tabled, unsure of return date",
+      "source_urls": [
+        "https://www.news10.com/news/rensselaer-county/troy-city-council-tables-flock-camera-contract-renewal/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Syracuse",
+      "agency_type": "City",
+      "state": "NY",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-03-23",
+      "notes": "City Council voted to revoke contract",
+      "source_urls": [
+        "https://spectrumlocalnews.com/nys/central-ny/public-safety/2026/03/23/syracuse-common-council-revokes-contract-with-flock"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Thompkins",
+      "agency_type": "County",
+      "state": "NY",
+      "action_type": "Contract terminated",
+      "approx_date": "2026-04-14",
+      "notes": "County Board voted to terminate contract",
+      "source_urls": [
+        "https://ithacavoice.org/2026/04/county-legislature-ends-contract-with-flock-safety/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lucas County",
+      "agency_type": "County",
+      "state": "OH",
+      "action_type": "Attempted rescission",
+      "approx_date": "2025-07-22",
+      "notes": "Legal dispute",
+      "source_urls": [
+        "https://www.toledoblade.com/local/county/2024/01/18/lucas-county-flock-contract"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Kent",
+      "agency_type": "City",
+      "state": "OH",
+      "action_type": "Contract proposal rejected",
+      "approx_date": "2025-11-05",
+      "notes": "City Council rejected proposed contract",
+      "source_urls": [
+        "https://theportager.com/kent-city-council-rejects-video-surveillance-contract-with-flock/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Washington County",
+      "agency_type": "County",
+      "state": "OK",
+      "action_type": "Agreement rescinded",
+      "approx_date": "2025-07-16",
+      "notes": "County roads only",
+      "source_urls": [
+        "https://www.examiner-enterprise.com/story/news/2024/02/06/washington-county-flock"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Woodburn",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Program suspended / paused",
+      "approx_date": "2025-11-11",
+      "notes": "City suspended use for at least two months after community concerns about potential federal/ICE enforcement use.",
+      "source_urls": [
+        "https://woodburnindependent.com/2025/11/11/woodburn-suspends-flock-safety-license-plate-cameras-amid-concerns-of-federal-ice-enforcement/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Eugene",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-12-05",
+      "notes": "Immediate termination",
+      "source_urls": [
+        "https://www.opb.org/article/2025/12/06/eugene-springfield-end-flock-cameras/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Springfield",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Cameras not activated; covered pending removal",
+      "approx_date": "2025-12-05",
+      "notes": "City stated cameras had not been turned on; planned to cover then remove after ending use.",
+      "source_urls": [
+        "https://www.opb.org/article/2025/12/06/eugene-springfield-end-flock-cameras/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lane County",
+      "agency_type": "County",
+      "state": "OR",
+      "action_type": "Sheriff suspends contract",
+      "approx_date": "2025-12-10",
+      "notes": "Sheriff unilaterally suspends contract, cameras were not yet installed",
+      "source_urls": [
+        "https://lookouteugene-springfield.com/story/latest-news/2025/12/10/lane-county-sheriffs-office-suspends-flock-safety-contract/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Bend",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Cameras turned off; won't renew contract",
+      "approx_date": "2026-01-07",
+      "notes": "Constituent concerns, data privacy/data collection practices.",
+      "source_urls": [
+        "https://www.opb.org/article/2026/01/08/bend-flock-cameras-ai-license-plate-camera-law-enforcement/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Warren",
+      "agency_type": "City",
+      "state": "RI",
+      "action_type": "Rejected contract proposal",
+      "approx_date": "2025-12-09",
+      "notes": "Council rejects proposed ALPR contract",
+      "source_urls": [
+        "https://www.wpri.com/news/local-news/east-bay/warren-rejects-proposal-to-install-flock-camera/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Knoxville",
+      "agency_type": "City",
+      "state": "TN",
+      "action_type": "Contract expired, not renewed",
+      "approx_date": "2025-12-31",
+      "notes": "Contract expired, alternate vendor explored.",
+      "source_urls": [
+        "https://www.wbir.com/article/news/crime/10investigates-knoxville-license-plate-reader-cameras-turned-off-contract-lapse/51-3cadec96-a281-49e8-ab41-c3e9ff4a12df"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Austin",
+      "agency_type": "City",
+      "state": "TX",
+      "action_type": "Contract ended",
+      "approx_date": "2025-06-04",
+      "notes": "Not renewed",
+      "source_urls": [
+        "https://www.kvue.com/article/news/local/austin-license-plate-readers-ends-privacy-concerns/269-4dc64690-c6c0-4ace-a009-fd8a13f69113"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lockhart",
+      "agency_type": "City",
+      "state": "TX",
+      "action_type": "Proposed contract declined",
+      "approx_date": "2025-10-09",
+      "notes": "City Council rejected proposed contract",
+      "source_urls": [
+        "https://www.kxan.com/news/local/caldwell-county/lockhart-city-council-rejects-flock-ai-cameras-in-6-1-vote/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Hays County",
+      "agency_type": "County",
+      "state": "TX",
+      "action_type": "Contract terminated",
+      "approx_date": "2025-10-14",
+      "notes": "County Commission voted to end contract.",
+      "source_urls": [
+        "https://www.kvue.com/article/news/local/hays-county/hays-county-contract-flock-license-plate-reader-cameras/269-f7276915-920a-4216-add1-42fbf17a0056"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "San Marcos",
+      "agency_type": "City",
+      "state": "TX",
+      "action_type": "Renewal rejected",
+      "approx_date": "2025-12-02",
+      "notes": "Council direction",
+      "source_urls": [
+        "https://cbsaustin.com/news/local/san-marcos-city-council-ends-flock-safety-contract-seeking-new-options"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Warrenton",
+      "agency_type": "City",
+      "state": "VA",
+      "action_type": "Proposed contract declined",
+      "approx_date": "2025-10-14",
+      "notes": "City Council rejected proposed contract",
+      "source_urls": [
+        "https://www.fauquiernow.com/news/not-on-our-watch-warrenton-town-council-reverses-course-on-license-plate-readers/article_9a1c02ac-5f77-47c7-a270-06f49ab98332.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Charlottesville",
+      "agency_type": "City",
+      "state": "VA",
+      "action_type": "Program paused / cameras turned off",
+      "approx_date": "2025-12-16",
+      "notes": "City Manager ordered Flock ALPR cameras turned off pending review after concerns about cameras operating during a pause.",
+      "source_urls": [
+        "https://cvillerightnow.com/news/208802-charlottesville-turns-off-flock-license-plate-cameras-after-concerns-raised/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Staunton",
+      "agency_type": "City",
+      "state": "VA",
+      "action_type": "Contract ended",
+      "approx_date": "2025-12-19",
+      "notes": "ALPRs removed",
+      "source_urls": [
+        "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Gig Harbor",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Contract not awarded",
+      "approx_date": "2025-03-24",
+      "notes": "Council declined to award proposed contract for Flock ALPR",
+      "source_urls": [
+        "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Stanwood",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program paused",
+      "approx_date": "2025-09-10",
+      "notes": "Litigation concerns",
+      "source_urls": [
+        "https://www.heraldnet.com/2025/09/10/stanwood-pauses-flock-cameras-amid-public-records-lawsuits/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Sedro-Wooley",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program suspended, pending appeal of WA PRA lawsuit",
+      "approx_date": "2025-10-24",
+      "notes": "Paused while appeals re WA Supreme Court ruling on public records for Flock data",
+      "source_urls": [
+        "https://www.goskagit.com/news/local_news/sedro-woolley-turns-off-law-enforcement-cameras-while-it-seeks-court-ruling/article_d0d0bdb9-6502-4686-94ae-346289afd535.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Redmond",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program suspended",
+      "approx_date": "2025-11-03",
+      "notes": "Privacy & records concerns",
+      "source_urls": [
+        "https://www.seattletimes.com/seattle-news/politics/redmond-suspends-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Lynnwood",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program paused",
+      "approx_date": "2025-11-07",
+      "notes": "Cameras turned off",
+      "source_urls": [
+        "https://www.geekwire.com/2025/washington-state-cities-turn-off-license-plate-reader-cameras-amid-ruling-on-data-access/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Skamania County",
+      "agency_type": "County",
+      "state": "WA",
+      "action_type": "Use delayed / turned off",
+      "approx_date": "2025-11-11",
+      "notes": "Public records ruling led Sheriff to turn off cameras; waiting for expiration of contratc to fully remove.",
+      "source_urls": [
+        "https://skamaniasheriff.com/2025/11/12/flock-cameras-disabled-after-recent-court-decision/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Olympia",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Pilot suspended",
+      "approx_date": "2025-12-03",
+      "notes": "Suspended 2-year program",
+      "source_urls": [
+        "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns-2/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Mountainlake Terrace",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Contract canceled",
+      "approx_date": "2025-12-04",
+      "notes": "Unanimous council vote",
+      "source_urls": [
+        "https://www.heraldnet.com/news/mountlake-terrace-cancels-flock"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Walla Walla",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Cameras turned off, cameras to be removed",
+      "approx_date": "2026-01-07",
+      "notes": "Cameras turned off, will be removed",
+      "source_urls": [
+        "https://www.applevalleynewsnow.com/news/walla-walla-police-end-flock-license-plate-cameras-over-safety-and-legal-concerns/article_ec96e8f8-a14e-43b3-b6b2-7d53846dd659.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Prosser",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Cameras turned off (under contract through Nov '26)",
+      "approx_date": "2026-01-26",
+      "notes": "Under contract through Nov '26 - press release silent as to renewal",
+      "source_urls": [
+        "https://www.chronline.com/stories/controversial-flock-license-plate-readers-shut-off-by-another-eastern-washington-city"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Pierce",
+      "agency_type": "County",
+      "state": "WA",
+      "action_type": "Cameras turned off",
+      "approx_date": "2026-03-30",
+      "notes": "In response to WA state law \"Driver Privacy Act\" re \"sensitive locations, Sheriff deactivated cameras, exploring alternatives.",
+      "source_urls": [
+        "https://www.kiro7.com/news/local/pierce-county-sheriffs-office-deactivates-its-automated-license-plate-readers/TXPVNII6B5D3LDKKYMOP3FW2IY/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Renton",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program suspended due to new state law",
+      "approx_date": "2026-03-31",
+      "notes": "Police suspended program after SB 6002",
+      "source_urls": [
+        "https://www.kiro7.com/news/local/renton-police-shut-down-license-plate-cameras-comply-with-new-privacy-law/JHCHPR4FQBGKNJOOWZ7LM3J6W4/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Spokane",
+      "agency_type": "County",
+      "state": "WA",
+      "action_type": "Cameras turned off",
+      "approx_date": "2026-04-02",
+      "notes": "In response to WA state law \"Driver Privacy Act\" re \"sensitive locations, Sheriff deactivated cameras, exploring alternatives.",
+      "source_urls": [
+        "https://www.krem.com/article/news/local/spokane-county-deactivates-license-plate-reader-washington-privacy-law/293-72ea9980-dbd1-430a-b4b0-67dae541dfa1"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Verona",
+      "agency_type": "City",
+      "state": "WI",
+      "action_type": "Renewal declined",
+      "approx_date": "2025-11-11",
+      "notes": "Contract expired",
+      "source_urls": [
+        "https://www.wkow.com/news/city-of-verona-votes-to-not-renew-flock-cameras/article_083afa08-5b8a-4955-9876-ad8fd2b9f3aa.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Dane",
+      "agency_type": "County",
+      "state": "WI",
+      "action_type": "Funding removed, contract allowed to expire",
+      "approx_date": "2026-04-16",
+      "notes": "Board voted to amend budget to remove funding, allowed contract to expire",
+      "source_urls": [
+        "https://www.hngnews.com/leader_independent/news/local/dane-county-board-votes-to-cut-funding-for-flock-license-plate-reader-cameras/article_df6d5043-0b19-4053-8510-ff5aacfc463b.html"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Oshkosh",
+      "agency_type": "City",
+      "state": "WI",
+      "action_type": "Flock lied about heat maps, Police Chief revolted, City Council unanimously voted to terminate 24 hours after extending contract.",
+      "approx_date": "2026-04-21",
+      "notes": "24 hour after extending contract, City Council uananimously voted to terminate.",
+      "source_urls": [
+        "https://www.thenorthwestern.com/story/news/local/oshkosh/2026/04/22/oshkosh-rescinds-flock-safety-contract-after-police-chief-raises-concerns/89745485007/"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "Sturgeon Bay",
+      "agency_type": "City",
+      "state": "WI",
+      "action_type": "Contract terminated & cameras deactivated",
+      "approx_date": "2026-04-21",
+      "notes": "Council voted to terminate contract",
+      "source_urls": [
+        "https://www.nbc26.com/sturgeonbay/sturgeon-bay-discontinues-the-use-of-flock-cameras"
+      ],
+      "sheet": "Flock_ALPR_Agencies"
+    },
+    {
+      "agency_name": "City of Sedona / Sedona PD",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Program shut down",
+      "approx_date": "Sept 2025",
+      "notes": "Permanent removal",
+      "source_urls": [
+        "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Evanston / Evanston PD",
+      "agency_type": "City",
+      "state": "IL",
+      "action_type": "Contract terminated",
+      "approx_date": "Sept 2025",
+      "notes": "Termination notice issued",
+      "source_urls": [
+        "https://evanstonroundtable.com/2025/09/26/evanston-ends-flock-alpr"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Austin",
+      "agency_type": "City",
+      "state": "TX",
+      "action_type": "Contract ended",
+      "approx_date": "July 2025",
+      "notes": "Not renewed",
+      "source_urls": [
+        "https://www.kut.org/austin/2025-07-01/austin-ends-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Springfield / Springfield Police Department",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Cameras not activated; covered pending removal",
+      "approx_date": "Oct\u2013Dec 2025",
+      "notes": "City stated cameras had not been turned on; planned to cover then remove after ending use.",
+      "source_urls": [
+        "https://www.klcc.org/breaking/2025-12-05/eugene-and-springfield-both-announce-end-of-flock-camera-usage",
+        "https://lookouteugene-springfield.com/story/justice/2025/12/05/eugene-announces-termination-of-flock-contract/"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Oakland",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Proposal rejected (committee)",
+      "approx_date": "2023",
+      "notes": "Later approved by council",
+      "source_urls": [
+        "https://oaklandside.org/2023/06/13/oakland-flock-vote"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Town of Brookline",
+      "agency_type": "Town",
+      "state": "MA",
+      "action_type": "Police access paused",
+      "approx_date": "2023",
+      "notes": "Private Flock system",
+      "source_urls": [
+        "https://brookline.news/police-pause-flock-access"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Town of Hillsborough",
+      "agency_type": "Town",
+      "state": "NC",
+      "action_type": "Contract terminated",
+      "approx_date": "2024",
+      "notes": "Cameras removed",
+      "source_urls": [
+        "https://www.newsobserver.com/news/local/article-hillsborough-flock"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Verona",
+      "agency_type": "City",
+      "state": "WI",
+      "action_type": "Renewal declined",
+      "approx_date": "2024",
+      "notes": "Contract expired",
+      "source_urls": [
+        "https://madison.com/news/local/verona-flock-renewal-vote"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Town of Poestenkill",
+      "agency_type": "Town",
+      "state": "NY",
+      "action_type": "Proposal rejected",
+      "approx_date": "2024",
+      "notes": "Town board vote",
+      "source_urls": [
+        "https://www.timesunion.com/news/article/poestenkill-rejects-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Lucas County",
+      "agency_type": "County",
+      "state": "OH",
+      "action_type": "Attempted rescission",
+      "approx_date": "2024",
+      "notes": "Legal dispute",
+      "source_urls": [
+        "https://www.toledoblade.com/local/county/2024/01/18/lucas-county-flock-contract"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Mountlake Terrace",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Contract canceled",
+      "approx_date": "2024",
+      "notes": "Unanimous council vote",
+      "source_urls": [
+        "https://www.heraldnet.com/news/mountlake-terrace-cancels-flock"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Washington County",
+      "agency_type": "County",
+      "state": "OK",
+      "action_type": "Agreement rescinded",
+      "approx_date": "2024",
+      "notes": "County roads only",
+      "source_urls": [
+        "https://www.examiner-enterprise.com/story/news/2024/02/06/washington-county-flock"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Cambridge",
+      "agency_type": "City",
+      "state": "MA",
+      "action_type": "Contract terminated",
+      "approx_date": "2025",
+      "notes": "Unauthorized installation issues",
+      "source_urls": [
+        "https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Redmond / Redmond PD",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program suspended",
+      "approx_date": "2025",
+      "notes": "Privacy & records concerns",
+      "source_urls": [
+        "https://www.seattletimes.com/seattle-news/politics/redmond-suspends-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Olympia",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Pilot suspended",
+      "approx_date": "2025",
+      "notes": "Under review",
+      "source_urls": [
+        "https://www.theolympian.com/news/local/article-olympia-flock"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Skamania County",
+      "agency_type": "County",
+      "state": "WA",
+      "action_type": "Use delayed / turned off",
+      "approx_date": "2025",
+      "notes": "Public records ruling",
+      "source_urls": [
+        "https://www.columbian.com/news/2025/skamania-county-flock"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Stanwood",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program paused",
+      "approx_date": "May 2025",
+      "notes": "Litigation concerns",
+      "source_urls": [
+        "https://www.heraldnet.com/news/stanwood-flock-paused"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City & County of Denver",
+      "agency_type": "City/County",
+      "state": "CO",
+      "action_type": "Proposed extension rejected",
+      "approx_date": "May 2025",
+      "notes": "Council vote",
+      "source_urls": [
+        "https://www.denverpost.com/2025/05/05/denver-city-council-flock-vote"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "Village of Oak Park / Oak Park PD",
+      "agency_type": "Village",
+      "state": "IL",
+      "action_type": "Contract terminated",
+      "approx_date": "Aug 2025",
+      "notes": "Immediate shutdown",
+      "source_urls": [
+        "https://oakpark.com/2025/08/05/oak-park-ends-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Lynnwood / Lynnwood PD",
+      "agency_type": "City",
+      "state": "WA",
+      "action_type": "Program paused",
+      "approx_date": "Oct 2025",
+      "notes": "Cameras turned off",
+      "source_urls": [
+        "https://www.heraldnet.com/news/lynnwood-pauses-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Eugene / Eugene Police Department",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Cameras turned off during pause (later contract terminated)",
+      "approx_date": "Oct 2025",
+      "notes": "During a mid-October pause, cameras were turned off; contract later terminated in early Dec 2025.",
+      "source_urls": [
+        "https://www.klcc.org/breaking/2025-12-05/eugene-and-springfield-both-announce-end-of-flock-camera-usage",
+        "https://lookouteugene-springfield.com/story/latest-news/2025/12/09/flock-activated-camera-during-pause-chief-says-pushing-city-to-axe-contract/"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Ferndale",
+      "agency_type": "City",
+      "state": "MI",
+      "action_type": "Contract ended",
+      "approx_date": "Nov 2025",
+      "notes": "Pilot discontinued",
+      "source_urls": [
+        "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Woodburn",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Program suspended / paused",
+      "approx_date": "Nov 2025",
+      "notes": "City suspended use for at least two months after community concerns about potential federal/ICE enforcement use.",
+      "source_urls": [
+        "https://woodburnindependent.com/2025/11/11/woodburn-suspends-flock-safety-license-plate-cameras-amid-concerns-of-federal-ice-enforcement/"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Flagstaff / Flagstaff PD",
+      "agency_type": "City",
+      "state": "AZ",
+      "action_type": "Contract terminated & cameras deactivated",
+      "approx_date": "Dec 2025",
+      "notes": "Council vote to end program",
+      "source_urls": [
+        "https://azdailysun.com/news/local/flagstaff-flock-safety-cameras-ended"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Eugene",
+      "agency_type": "City",
+      "state": "OR",
+      "action_type": "Contract terminated",
+      "approx_date": "Dec 2025",
+      "notes": "Immediate termination",
+      "source_urls": [
+        "https://www.opb.org/article/2025/12/02/eugene-ends-flock-alpr"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Staunton",
+      "agency_type": "City",
+      "state": "VA",
+      "action_type": "Contract ended",
+      "approx_date": "Dec 2025",
+      "notes": "ALPRs removed",
+      "source_urls": [
+        "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of San Marcos",
+      "agency_type": "City",
+      "state": "TX",
+      "action_type": "Renewal rejected",
+      "approx_date": "Dec 2025",
+      "notes": "Council direction",
+      "source_urls": [
+        "https://www.kut.org/texas/2025-12-03/san-marcos-flock-cameras"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Richmond / Richmond Police Department",
+      "agency_type": "City",
+      "state": "CA",
+      "action_type": "Program paused / shut down (cameras offline)",
+      "approx_date": "Dec 2025",
+      "notes": "Police chief shut down/paused Flock ALPRs after discovering a configuration issue that allowed limited outside-agency searching; described as a pause pending safeguards.",
+      "source_urls": [
+        "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/",
+        "https://richmondstandard.com/community/2025/12/09/richmond-police-suspend-system-that-automatically-reads-license-plates/"
+      ],
+      "sheet": "Timeline_View"
+    },
+    {
+      "agency_name": "City of Charlottesville / Charlottesville Police Department",
+      "agency_type": "City",
+      "state": "VA",
+      "action_type": "Program paused / cameras turned off",
+      "approx_date": "Dec 16, 2025",
+      "notes": "City Manager ordered Flock ALPR cameras turned off pending review after concerns about cameras operating during a pause.",
+      "source_urls": [
+        "https://cvillerightnow.com/news/208802-charlottesville-turns-off-flock-license-plate-cameras-after-concerns-raised/"
+      ],
+      "sheet": "Timeline_View"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.14"
 dependencies = [
     "anthropic>=0.97.0",
     "feedparser>=6.0.12",
+    "openpyxl>=3.1.5",
     "pillow>=12.1.1",
     "playwright>=1.52.0",
     "pymupdf>=1.27.2.2",

--- a/scripts/import_termination_ledger.py
+++ b/scripts/import_termination_ledger.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Import an external "Flock terminated/paused contracts" spreadsheet.
+
+The activist tracker we're consuming is shared as an .xlsx workbook with
+two sheets (Flock_ALPR_Agencies, Timeline_View). It tracks U.S. agencies
+that have terminated or paused Flock ALPR contracts, plus citations.
+
+What we want from it:
+  1. The citation URLs, fed into the article-fetch queue so the article
+     registry grows. The curator picks tags (outcome:terminated etc.)
+     from article content using the existing controlled vocab — no
+     bespoke tagging path for this import.
+  2. A small audit trail of what we imported and when
+     (assets/termination_ledger.json), so re-imports can detect upstream
+     changes via file hash. This is a bootstrap, not a parallel data
+     store — long-term, the canonical truth is article_registry +
+     agency_registry annotations, not this file. Downstream consumers
+     (report, sharing map) should NOT query this file; they should
+     query the registries with generic tag filters that work for any
+     article, regardless of how it was discovered.
+
+The xlsx itself is not committed — it's an external activist's doc; we
+only commit our derivation. Re-import is idempotent: same file produces
+the same ledger; queue-add dedupes new URLs against the existing queue
+and registry.
+
+Usage:
+  uv run python scripts/import_termination_ledger.py PATH/TO/FILE.xlsx
+  uv run python scripts/import_termination_ledger.py FILE.xlsx --add-domains
+  uv run python scripts/import_termination_ledger.py FILE.xlsx --add-domains --queue
+  uv run python scripts/import_termination_ledger.py FILE.xlsx --dry-run
+
+Flags:
+  --add-domains  Append unknown domains to assets/sources.json at tier 2
+                 (or tier 1 for an inline allowlist of papers/NPR member
+                 stations) with stance=unknown, last_reviewed=today.
+  --queue        Forward queueable URLs to scripts/article_queue_add.py.
+  --dry-run      Compute everything; write nothing.
+"""
+
+import argparse
+import functools
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+import openpyxl
+
+print = functools.partial(print, flush=True)
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCES_PATH = ROOT / "assets" / "sources.json"
+LEDGER_PATH = ROOT / "assets" / "termination_ledger.json"
+QUEUE_ADD = ROOT / "scripts" / "article_queue_add.py"
+
+# Domains we promote to tier 1 on auto-add: established regional papers,
+# NPR member stations, and major-market network O&Os. Local TV affiliates,
+# weeklies, government press releases, and uncategorized sites stay at
+# tier 2 (subagent-jail per assets/sources.json _handler_policy). The
+# distinction matters because tier 1 clean reads happen in-context.
+TIER_1_AUTO_ADD = {
+    "cbsnews.com",
+    "denvergazette.com",
+    "denverpost.com",
+    "freep.com",        # Detroit Free Press
+    "heraldnet.com",    # Everett Herald
+    "klcc.org",         # NPR Eugene
+    "kut.org",          # NPR Austin
+    "madison.com",      # Wisconsin State Journal
+    "mlive.com",        # MLive Michigan
+    "newsobserver.com", # Raleigh News & Observer
+    "northcountrypublicradio.org",
+    "opb.org",          # Oregon Public Broadcasting
+    "seattletimes.com",
+    "thenewstribune.com",  # Tacoma News Tribune
+    "theolympian.com",
+    "timesunion.com",   # Albany Times Union
+    "toledoblade.com",
+    "wskg.org",         # NPR Binghamton
+}
+
+
+def normalize_domain(host: str) -> str:
+    h = (host or "").lower()
+    if h.startswith("www."):
+        h = h[4:]
+    return h
+
+
+def domain_in_allowlist(host: str, allowed: set[str]) -> str | None:
+    h = normalize_domain(host)
+    if h in allowed:
+        return h
+    parts = h.split(".")
+    for i in range(1, len(parts) - 1):
+        c = ".".join(parts[i:])
+        if c in allowed:
+            return c
+    return None
+
+
+def parse_date(value) -> str | None:
+    """Sheet 1 has datetimes; Sheet 2 has free-text ('Sept 2025', '2023',
+    'Oct–Dec 2025'). Coerce to ISO-ish string; pass through anything we
+    can't parse so the human-readable form survives."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value).strip()
+
+
+def split_urls(cell) -> list[str]:
+    """The Source URLs cell mixes whitespace, semicolons, and commas as
+    separators. Strip trailing punctuation (periods on sentence-end URLs)."""
+    if not cell:
+        return []
+    out = []
+    for tok in re.split(r"[\s;,]+", str(cell)):
+        tok = tok.strip().rstrip(".")
+        if tok.startswith("http"):
+            # Drop fragment; keep query (article URLs sometimes need ?id=...)
+            p = urlparse(tok)
+            if not p.netloc:
+                continue
+            out.append(p._replace(fragment="").geturl())
+    return out
+
+
+def read_workbook(path: Path) -> tuple[list[dict], str]:
+    """Return (action records, sha256 of file).
+
+    Each sheet contributes its own records; we don't dedupe across sheets
+    because the agency_name encoding differs (Sheet 1: 'Sedona', Sheet 2:
+    'City of Sedona / Sedona PD'). URL-level dedup happens at queue time.
+    """
+    sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    wb = openpyxl.load_workbook(path, data_only=True)
+    actions = []
+    expected = ["Agency Name", "Agency Type", "State", "Action Type",
+                "Approx. Date", "Notes", "Source URLs"]
+    for sn in wb.sheetnames:
+        ws = wb[sn]
+        rows = list(ws.iter_rows(values_only=True))
+        if not rows:
+            continue
+        headers = [h for h in rows[0] if h is not None]
+        # Tolerate trailing None columns; fail loudly on schema drift.
+        for col in expected:
+            if col not in headers:
+                print(f"WARN: sheet {sn!r} missing column {col!r}; skipping",
+                      file=sys.stderr)
+                break
+        else:
+            idx = {c: headers.index(c) for c in expected}
+            for row in rows[1:]:
+                agency = row[idx["Agency Name"]]
+                if not agency:
+                    continue
+                actions.append({
+                    "agency_name": str(agency).strip(),
+                    "agency_type": (row[idx["Agency Type"]] or "").strip() or None,
+                    "state": (row[idx["State"]] or "").strip() or None,
+                    "action_type": (row[idx["Action Type"]] or "").strip() or None,
+                    "approx_date": parse_date(row[idx["Approx. Date"]]),
+                    "notes": (str(row[idx["Notes"]]).strip()
+                              if row[idx["Notes"]] is not None else None),
+                    "source_urls": split_urls(row[idx["Source URLs"]]),
+                    "sheet": sn,
+                })
+    return actions, sha
+
+
+def collect_unique_urls(actions: list[dict]) -> list[tuple[str, str]]:
+    """Return list of (url, normalized_apex_domain), order preserved,
+    duplicates collapsed."""
+    seen = set()
+    out = []
+    for a in actions:
+        for u in a["source_urls"]:
+            if u in seen:
+                continue
+            seen.add(u)
+            host = urlparse(u).hostname or ""
+            out.append((u, normalize_domain(host)))
+    return out
+
+
+def load_sources() -> dict:
+    return json.loads(SOURCES_PATH.read_text())
+
+
+def add_domains_to_sources(sources: dict, new_domains: list[str],
+                           today: str) -> int:
+    """Append entries for unknown domains. Returns count added."""
+    existing = {s["domain"].lower() for s in sources["sources"]}
+    added = 0
+    for d in new_domains:
+        if d in existing:
+            continue
+        tier = 1 if d in TIER_1_AUTO_ADD else 2
+        sources["sources"].append({
+            "domain": d,
+            "tier": tier,
+            "name": d,  # placeholder; human can rename in review
+            "stance": "unknown",
+            "last_reviewed": today,
+            "notes": "auto-added from termination_ledger import; review tier/stance",
+        })
+        existing.add(d)
+        added += 1
+    # Keep the file deterministic: sort by domain after our schema/header keys.
+    sources["sources"].sort(key=lambda s: s["domain"])
+    return added
+
+
+def write_ledger(actions: list[dict], src_sha: str, src_filename: str,
+                 dry_run: bool) -> None:
+    payload = {
+        "_schema": {
+            "imported_at": "ISO-8601 UTC of last import run",
+            "source_file": "filename of upstream xlsx (not committed)",
+            "source_file_sha256": "sha256 of upstream xlsx at import time",
+            "actions": "list of agency-action records harvested from sheets",
+        },
+        "_note": (
+            "Bootstrap import audit trail, not a canonical data store. "
+            "Derived from an external activist tracker of Flock terminated/"
+            "paused contracts; the source xlsx is not committed. The "
+            "canonical record of contract-termination evidence is "
+            "assets/article_registry.json (with generic outcome:* tags "
+            "applied by the curator). Re-import via "
+            "scripts/import_termination_ledger.py."
+        ),
+        "imported_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_file": src_filename,
+        "source_file_sha256": src_sha,
+        "actions": actions,
+    }
+    if dry_run:
+        print(f"[dry-run] would write {LEDGER_PATH} ({len(actions)} actions)")
+        return
+    LEDGER_PATH.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {LEDGER_PATH} ({len(actions)} actions)")
+
+
+def queue_urls(urls: list[str], dry_run: bool) -> None:
+    if not urls:
+        return
+    if dry_run:
+        print(f"[dry-run] would enqueue {len(urls)} URL(s) via {QUEUE_ADD.name}")
+        return
+    # No --tags-hint — the curator derives tags from article content via
+    # the existing controlled vocab. Hinting here would create a tagging
+    # path specific to this import, which is the opposite of what we want.
+    cmd = [sys.executable, str(QUEUE_ADD),
+           "--discovered-by", "termination-ledger-import",
+           *urls]
+    rc = subprocess.run(cmd).returncode
+    if rc not in (0, 1):
+        # 1 = some URLs rejected (we should have filtered, but be defensive)
+        print(f"WARN: queue script exited {rc}", file=sys.stderr)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("xlsx", help="path to the upstream .xlsx workbook")
+    p.add_argument("--add-domains", action="store_true",
+                   help="append unknown domains to assets/sources.json")
+    p.add_argument("--queue", action="store_true",
+                   help="forward queueable URLs to article_queue_add.py")
+    p.add_argument("--dry-run", action="store_true",
+                   help="compute everything; write nothing")
+    args = p.parse_args()
+
+    src = Path(args.xlsx).expanduser()
+    if not src.is_file():
+        print(f"ERROR: {src} not found", file=sys.stderr)
+        return 3
+
+    actions, sha = read_workbook(src)
+    print(f"read {len(actions)} action record(s) from {src.name} (sha256={sha[:12]}…)")
+
+    urls = collect_unique_urls(actions)
+    print(f"unique URLs: {len(urls)}")
+
+    sources = load_sources()
+    allowed = {s["domain"].lower() for s in sources["sources"]}
+
+    queueable: list[str] = []
+    blocked_by_domain: dict[str, list[str]] = {}
+    for u, dom in urls:
+        if domain_in_allowlist(dom, allowed):
+            queueable.append(u)
+        else:
+            blocked_by_domain.setdefault(dom, []).append(u)
+
+    print(f"  queueable (domain already in sources.json): {len(queueable)}")
+    print(f"  blocked (domain not in sources.json): "
+          f"{sum(len(v) for v in blocked_by_domain.values())} URL(s) "
+          f"across {len(blocked_by_domain)} domain(s)")
+
+    if args.add_domains and blocked_by_domain:
+        today = date.today().isoformat()
+        added = add_domains_to_sources(
+            sources, sorted(blocked_by_domain.keys()), today)
+        if args.dry_run:
+            print(f"[dry-run] would add {added} domain(s) to sources.json")
+        else:
+            SOURCES_PATH.write_text(json.dumps(sources, indent=2) + "\n")
+            print(f"added {added} domain(s) to {SOURCES_PATH.name}")
+        # Recompute queueable after expansion.
+        allowed = {s["domain"].lower() for s in sources["sources"]}
+        queueable = [u for u, dom in urls
+                     if domain_in_allowlist(dom, allowed)]
+        print(f"  queueable after --add-domains: {len(queueable)}")
+    elif blocked_by_domain:
+        # Help the human scan: domains with their article counts.
+        print("\nblocked domains (run with --add-domains to bulk-add):")
+        for d in sorted(blocked_by_domain.keys()):
+            n = len(blocked_by_domain[d])
+            tier = 1 if d in TIER_1_AUTO_ADD else 2
+            print(f"  {d:40s}  {n} article(s)  → would auto-add tier {tier}")
+
+    write_ledger(actions, sha, src.name, args.dry_run)
+
+    if args.queue:
+        queue_urls(queueable, args.dry_run)
+    elif queueable:
+        print(f"\n{len(queueable)} URL(s) ready to queue. Re-run with --queue.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_termination_ledger.py
+++ b/scripts/import_termination_ledger.py
@@ -223,9 +223,23 @@ def add_domains_to_sources(sources: dict, new_domains: list[str],
 
 def write_ledger(actions: list[dict], src_sha: str, src_filename: str,
                  dry_run: bool) -> None:
+    # Preserve imported_at when the source hash and action list are unchanged
+    # — otherwise re-running on the same xlsx churns the file on disk and
+    # produces a noisy git diff. Only the timestamp updates when content
+    # actually changes.
+    prior_imported_at = None
+    if LEDGER_PATH.exists():
+        try:
+            prior = json.loads(LEDGER_PATH.read_text())
+            if (prior.get("source_file_sha256") == src_sha
+                    and prior.get("actions") == actions):
+                prior_imported_at = prior.get("imported_at")
+        except (json.JSONDecodeError, OSError):
+            pass
+
     payload = {
         "_schema": {
-            "imported_at": "ISO-8601 UTC of last import run",
+            "imported_at": "ISO-8601 UTC of last import that changed content",
             "source_file": "filename of upstream xlsx (not committed)",
             "source_file_sha256": "sha256 of upstream xlsx at import time",
             "actions": "list of agency-action records harvested from sheets",
@@ -239,7 +253,8 @@ def write_ledger(actions: list[dict], src_sha: str, src_filename: str,
             "applied by the curator). Re-import via "
             "scripts/import_termination_ledger.py."
         ),
-        "imported_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "imported_at": prior_imported_at or datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
         "source_file": src_filename,
         "source_file_sha256": src_sha,
         "actions": actions,
@@ -248,7 +263,10 @@ def write_ledger(actions: list[dict], src_sha: str, src_filename: str,
         print(f"[dry-run] would write {LEDGER_PATH} ({len(actions)} actions)")
         return
     LEDGER_PATH.write_text(json.dumps(payload, indent=2) + "\n")
-    print(f"wrote {LEDGER_PATH} ({len(actions)} actions)")
+    if prior_imported_at:
+        print(f"ledger unchanged ({len(actions)} actions); kept imported_at={prior_imported_at}")
+    else:
+        print(f"wrote {LEDGER_PATH} ({len(actions)} actions)")
 
 
 def queue_urls(urls: list[str], dry_run: bool) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "feedparser"
 version = "6.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -244,6 +253,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
     { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
     { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -479,6 +500,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "feedparser" },
+    { name = "openpyxl" },
     { name = "pillow" },
     { name = "playwright" },
     { name = "pymupdf" },
@@ -496,6 +518,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.97.0" },
     { name = "feedparser", specifier = ">=6.0.12" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "playwright", specifier = ">=1.52.0" },
     { name = "pymupdf", specifier = ">=1.27.2.2" },


### PR DESCRIPTION
## Summary

Bootstraps 89 new article URLs into the fetch queue from an external activist-curated xlsx of Flock terminated/paused contracts (PR #277 had been running dry — empty for the last 7+ cron ticks).

- **`scripts/import_termination_ledger.py`** — reads the upstream xlsx, normalizes both sheets (76 rows + 30 rows), writes `assets/termination_ledger.json` (audit-trail only, **not** a canonical store), reports queueable vs blocked URLs by domain, with `--add-domains` bulk-adds unknown publisher domains to `sources.json`, and with `--queue` forwards URLs through the existing `article_queue_add.py`. The xlsx itself stays out of git — it's the activist's doc.
- **`assets/sources.json`** — 32 → 108 sources. 18 well-known regional papers and NPR member stations auto-promoted to tier 1; 58 local TV affiliates / weeklies / gov sites land at tier 2 (subagent-jail per `_handler_policy`). All marked `stance: unknown` — please review tier/stance/`name` (currently the bare domain) during merge.
- **`assets/termination_ledger.json`** — 104 agency-action records (some duplication across sheets is intentional; agency-name encoding differs). Captured with source-file sha256 so re-imports of an updated xlsx are detectable.
- **`assets/articles/queue/`** — 89 URLs queued, dedup'd against existing queue + registry.

## Design notes

- **Tagging stays generic.** No `--tags-hint` is passed to `article_queue_add.py`. The curator picks `outcome:terminated` / `outcome:restricted` / etc. from article content using the existing controlled vocab, so any future article with the same content earns the same tag — not a path special to this import. Aligns with the long-term goal of our registry being canonical, with filters that work for any article regardless of provenance.
- **Ledger is a bootstrap, not a parallel data store.** `_note` in the file says so explicitly. Downstream consumers (report, sharing map) should query `article_registry` + `agency_registry`, not this file. If we want per-agency contract-action attributes long-term, those belong on `agency_registry` entries.
- **vimeo.com** snuck in via the citation list. Will fail naturally in the curator (no extractable article text); not worth special-casing.

## Test plan

- [ ] Eyeball the auto-added entries in `assets/sources.json` — the 76 new domains. Bump tier or correct `name`/`stance` for any that warrant it before merge.
- [ ] After merge, watch the next article-registry cron tick on the `article-registry-bot` PR (#277) — expect ~5–10 articles to flow per tick from the priority+auto queues until the 89 drain.
- [ ] Spot-check the first few crawled+curated entries — confirm `outcome:terminated` (or related `outcome:*`) tags get applied where appropriate.
- [ ] Re-run the importer with the same xlsx — should be a no-op (queue dedupes on URL; ledger overwrites identically).