### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -127,6 +127,14 @@
         "california-state-parks-ca-pd": "http_404"
       }
     },
+    "132bc98f-aebb-52c5-b98b-6dbbec94ad46": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T17:59:36.808169+00:00",
+      "tried": {
+        "sumner-county-tn-so": "http_404"
+      }
+    },
     "13422e46-1750-5a1f-865c-a7219949a2ef": {
       "exhausted": false,
       "found": null,
@@ -1201,7 +1209,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T16:04:20.428407+00:00",
+      "last_probed": "2026-05-08T17:59:46.428569+00:00",
       "tried": {
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
@@ -1210,6 +1218,7 @@
         "hollister-ca-ps": "http_404",
         "hollister-pd-ca": "http_404",
         "hollister-po-ca": "http_404",
+        "hollister-police-ca": "http_404",
         "hollister-police-department-ca": "http_404"
       }
     },
@@ -1382,6 +1391,14 @@
       "last_probed": "2026-05-07T21:40:27.116284+00:00",
       "tried": {
         "markle-in-pd": "http_404"
+      }
+    },
+    "bc17b741-df64-54cc-a3cc-62bd3fa08f65": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T17:59:40.722298+00:00",
+      "tried": {
+        "sedgwick-ks-pd": "http_404"
       }
     },
     "bee385ab-4061-50f1-89f3-9a3a3c4b2f5e": {
@@ -1755,6 +1772,6 @@
       }
     }
   },
-  "updated": "2026-05-08T16:04:20.461589+00:00",
+  "updated": "2026-05-08T17:59:46.465829+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.