### PR TITLE
fix(ci): bust Playwright cache to force fresh chromium install

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -74,7 +74,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}-v2
 
       - name: Install Chromium for Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

Run [25571177638](https://github.com/none-below/sm-alpr/actions/runs/25571177638) used the test fix from #279 but still failed at `TestLayout::test_ui_elements_and_overlays`. The test prints, then 50ms later the runner gets cancelled with `cancelled_at: null`. No timeout set, no concurrency cancel.

That test is the first in `TestLayout` — its class-scoped `browser` fixture launches Chromium. Best hypothesis: the cached chromium binaries are stale/corrupt and the launch crashes the runner.

Switch cache key from `hashFiles('**/pyproject.toml')` (rarely changes — last edit 4/14) to `hashFiles('**/uv.lock')` (changes on any dep update) plus a manual `-v2` suffix to force one fresh install.

## Test plan

- [ ] Next scheduled `refresh-flock-data` run shows `Install Chromium for Playwright` actually running (not skipped from cache)
- [ ] Validate step completes through `TestLayout` without cancellation
- [ ] If still fails, the failure mode is something other than chromium launch