### PR TITLE
fix(deploy): build articles_data.json so articles.html renders on Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           packages: tesseract-ocr
           version: 1.0
 
-      - name: Build sharing graph, audit log, map, scoreboard, report data, contracts map, justifications, and findings PDF
+      - name: Build sharing graph, audit log, map, scoreboard, report data, contracts map, justifications, articles, and findings PDF
         run: |
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
@@ -57,6 +57,7 @@ jobs:
           uv run python scripts/build_report_data.py &
           uv run python scripts/build_contract_map.py &
           uv run python scripts/build_justifications.py &
+          uv run python scripts/build_articles_data.py &
           uv run python scripts/md_to_pdf.py docs/SMPD_ALPR_Findings.md "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" &
           wait
 


### PR DESCRIPTION
## Summary
- `docs/data/articles_data.json` is gitignored, but the deploy workflow never built it, so `articles.js` got a 404 when fetching it on the published site.
- Added `build_articles_data.py` to the parallel build group in [deploy.yml](.github/workflows/deploy.yml) alongside the other `build_*.py` scripts.

## Test plan
- [ ] After merge, confirm `articles.html` on Pages renders the article list and tag filter chips (verified locally that `build_articles_data.py` produces the file `articles.js` expects: 62 articles, 32 tags, 10 sources).