### PR TITLE
fix(ci): set git identity before rebase in article-registry workflow

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -59,6 +59,13 @@ jobs:
 
       - name: Set up long-lived branch
         run: |
+          # Identity is needed BEFORE the rebase — `git rebase` rewrites
+          # the committer of every replayed commit, and dies with
+          # "fatal: empty ident name" if no user.name/user.email is set
+          # (which surfaces as a misleading "rebase against origin/main
+          # conflicts" in the abort branch below).
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin article-registry-bot || true
           if git rev-parse --verify origin/article-registry-bot >/dev/null 2>&1; then
             git checkout article-registry-bot
@@ -132,8 +139,6 @@ jobs:
       - name: Commit and push
         id: commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add \
             assets/article_registry.json \
             assets/articles/ \


### PR DESCRIPTION
## Summary

`git rebase` rewrites the committer of every replayed commit and dies with `fatal: empty ident name` when no `user.name`/`user.email` is configured. The article-registry workflow set the identity in the "Commit and push" step — too late, since rebase already runs in the earlier "Set up long-lived branch" step. The catch-all `||` branch then masked the real error as "rebase against origin/main conflicts."

Surfaced when workflow_dispatch was triggered (run [25573470760](https://github.com/none-below/sm-alpr/actions/runs/25573470760)) and `article-registry-bot` had 2 commits to replay onto current main — rebase failed instantly on the first replay, before reaching any actual conflict-detection logic.

## Fix

- Move `git config user.{name,email}` to the top of the "Set up long-lived branch" step.
- Drop the now-dead duplicate in "Commit and push".
- Add a comment explaining the ordering, since the failure mode is misleading.

## Test plan

- [ ] After merge, dispatch the workflow with `phase2_only=true` and confirm the rebase step completes (or surfaces a real conflict, not the identity error)
- [ ] Once #284's `phase2_reenrich` works end-to-end on CI, this is also the unblocker for any future hourly cron run that needs to rebase bot commits