### PR TITLE
fix(articles): OR within a tag namespace, AND across namespaces

### DIFF
--- a/docs/articles.html
+++ b/docs/articles.html
@@ -228,7 +228,7 @@
 
   <div class="filter-panel" id="filter-panel">
     <h2>Filter by tag</h2>
-    <div class="hint">Click a chip to require articles with that tag (green). Click again to exclude (red). Click a third time to clear.</div>
+    <div class="hint">Click a chip to require articles with that tag (green). Click again to exclude (red). Click a third time to clear. Within a row chips combine as OR; across rows as AND.</div>
     <div id="tag-groups"></div>
   </div>
 

--- a/docs/js/articles.js
+++ b/docs/js/articles.js
@@ -38,16 +38,42 @@ function clearFilters() {
   render();
 }
 
+function tagNamespace(tag) {
+  var i = tag.indexOf(':');
+  return i >= 0 ? tag.substring(0, i) : 'other';
+}
+
+// Filter semantics: OR within a namespace (selecting outcome:terminated and
+// outcome:rejected widens the result), AND across namespaces. Excludes always
+// drop matching articles regardless of grouping.
 function articleMatches(article) {
   var tags = article.tags || [];
   var tagSet = {};
   for (var i = 0; i < tags.length; i++) tagSet[tags[i]] = true;
   var srcKey = 'source:' + (article.source_domain || '');
+
+  function tagPresent(t) {
+    return t.indexOf('source:') === 0 ? (t === srcKey) : !!tagSet[t];
+  }
+
+  var includesByNs = {};
   for (var t in STATE.filters) {
     var mode = STATE.filters[t];
-    var present = t.indexOf('source:') === 0 ? (t === srcKey) : tagSet[t];
-    if (mode === 'include' && !present) return false;
-    if (mode === 'exclude' && present) return false;
+    if (mode === 'exclude' && tagPresent(t)) return false;
+    if (mode === 'include') {
+      var ns = tagNamespace(t);
+      if (!includesByNs[ns]) includesByNs[ns] = [];
+      includesByNs[ns].push(t);
+    }
+  }
+
+  for (var ns2 in includesByNs) {
+    var group = includesByNs[ns2];
+    var anyMatch = false;
+    for (var k = 0; k < group.length; k++) {
+      if (tagPresent(group[k])) { anyMatch = true; break; }
+    }
+    if (!anyMatch) return false;
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- Selecting two tags in the same namespace (e.g. `outcome:terminated` and `outcome:rejected`) used to AND them, shrinking the result. Users expect chips in the same row to widen the set.
- Group `include` filters by namespace prefix (the part before `:`, or `other`). Within a group: any tag may match. Across groups: every active group must have a match.
- `exclude` semantics unchanged — any matching exclude drops the article.
- Updated the hint line in [docs/articles.html](docs/articles.html) to spell out OR-within-row / AND-across-rows.

## Test plan
- [x] Local node-based sanity check on `articleMatches` covers: single include, OR within ns, AND across ns, OR-within-ns combined with cross-ns AND, and exclude.
- [ ] On the deployed site, confirm clicking two `outcome:` chips raises the article count and a cross-namespace combo (e.g. `outcome:terminated` + `vendor:flock`) still narrows.