### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -489,6 +489,14 @@
         "irvine-ca-po": "http_404"
       }
     },
+    "4354a2c5-174d-57b3-9c1d-bfe102433c1b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T23:41:14.603134+00:00",
+      "tried": {
+        "thomas-county-ga-so": "http_404"
+      }
+    },
     "439b73b5-4c09-5c34-9fb8-388f9be01140": {
       "exhausted": false,
       "found": null,
@@ -773,14 +781,15 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T12:00:22.015532+00:00",
+      "last_probed": "2026-05-08T23:41:20.185295+00:00",
       "tried": {
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
         "beverly-hills-ca-police": "http_404",
         "beverly-hills-ca-police-department": "http_404",
         "beverly-hills-ca-ps": "http_404",
-        "beverly-hills-pd-ca": "http_404"
+        "beverly-hills-pd-ca": "http_404",
+        "beverly-hills-po-ca": "http_404"
       }
     },
     "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd": {
@@ -1530,6 +1539,14 @@
         "wheatland-ca-police-department": "http_404"
       }
     },
+    "d8ef6f92-49dd-5bd5-90f6-eb9c9a5e4989": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T23:41:08.500500+00:00",
+      "tried": {
+        "menominee-tribal-wi-pd": "http_404"
+      }
+    },
     "d9342287-962b-509a-9861-e44e0172394e": {
       "exhausted": false,
       "found": null,
@@ -1806,6 +1823,6 @@
       }
     }
   },
-  "updated": "2026-05-08T22:40:07.546645+00:00",
+  "updated": "2026-05-08T23:41:20.218644+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -927,6 +927,14 @@
         "amarillo-tx-po": "http_404"
       }
     },
+    "7cb7b666-5f1d-59c0-8b4b-6c4b3b0cab69": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T21:43:48.419051+00:00",
+      "tried": {
+        "radcliff-ky-pd": "http_404"
+      }
+    },
     "7d2b8047-a15b-524a-bc77-627e8eeab00a": {
       "exhausted": false,
       "found": null,
@@ -977,6 +985,14 @@
       "tried": {
         "salinas-ca-po": "http_404",
         "salinas-ca-police-department": "http_404"
+      }
+    },
+    "848b8f45-0a97-5955-9f47-2d88cb03666d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T21:43:42.173586+00:00",
+      "tried": {
+        "ozark-ar-pd": "http_404"
       }
     },
     "862d352e-a1e3-5445-b9ad-abb1a479b8bf": {
@@ -1209,7 +1225,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T17:59:46.428569+00:00",
+      "last_probed": "2026-05-08T21:43:53.510856+00:00",
       "tried": {
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
@@ -1219,7 +1235,8 @@
         "hollister-pd-ca": "http_404",
         "hollister-po-ca": "http_404",
         "hollister-police-ca": "http_404",
-        "hollister-police-department-ca": "http_404"
+        "hollister-police-department-ca": "http_404",
+        "hollister-ps-ca": "http_404"
       }
     },
     "a5b59684-abcc-5a43-949d-3aec089d30a4": {
@@ -1772,6 +1789,6 @@
       }
     }
   },
-  "updated": "2026-05-08T17:59:46.465829+00:00",
+  "updated": "2026-05-08T21:43:53.539510+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -556,6 +556,14 @@
         "atwater-ca-police-department": "http_404"
       }
     },
+    "4bd9591a-0e56-5370-a6a0-49133f75f44d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T01:24:46.296104+00:00",
+      "tried": {
+        "lebanon-tn-pd": "http_404"
+      }
+    },
     "4cc1fd23-7711-52b8-be07-9d6e1ad7b364": {
       "exhausted": false,
       "found": null,
@@ -1039,6 +1047,14 @@
         "california-city-ca-pd": "http_404"
       }
     },
+    "8b9c5e7f-8229-52dd-9cb7-4adb28eeaea7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T01:24:42.413509+00:00",
+      "tried": {
+        "kingman-county-ks-so": "http_404"
+      }
+    },
     "8bbdbc6d-a0cb-51af-bdbe-f3fef9a95cb5": {
       "exhausted": false,
       "found": null,
@@ -1250,7 +1266,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T22:40:07.512061+00:00",
+      "last_probed": "2026-05-09T01:24:50.437930+00:00",
       "tried": {
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
@@ -1259,6 +1275,7 @@
         "hollister-ca-ps": "http_404",
         "hollister-pd": "http_404",
         "hollister-pd-ca": "http_404",
+        "hollister-po": "http_404",
         "hollister-po-ca": "http_404",
         "hollister-police-ca": "http_404",
         "hollister-police-department-ca": "http_404",
@@ -1823,6 +1840,6 @@
       }
     }
   },
-  "updated": "2026-05-08T23:41:20.218644+00:00",
+  "updated": "2026-05-09T01:24:50.471762+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -111,6 +111,14 @@
         "san-francisco-district-attorney-ca-da": "http_404"
       }
     },
+    "0ee67a83-d9c3-55bd-97cc-7c4b9e78a0ae": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T22:40:02.291226+00:00",
+      "tried": {
+        "northport-al-pd": "http_404"
+      }
+    },
     "11949eb7-26df-5b98-a23d-ac249879ec01": {
       "exhausted": false,
       "found": null,
@@ -1189,6 +1197,14 @@
         "tustin-ca-police-department": "http_404"
       }
     },
+    "9ed4c651-7990-5386-9a36-cd90c7aa329e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-08T22:39:56.843730+00:00",
+      "tried": {
+        "rose-hill-ks-pd": "http_404"
+      }
+    },
     "9efcc0a0-e7e2-5f1c-be61-21cd6e468e2f": {
       "exhausted": false,
       "found": null,
@@ -1225,13 +1241,14 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T21:43:53.510856+00:00",
+      "last_probed": "2026-05-08T22:40:07.512061+00:00",
       "tried": {
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
         "hollister-ca-police": "http_404",
         "hollister-ca-police-department": "http_404",
         "hollister-ca-ps": "http_404",
+        "hollister-pd": "http_404",
         "hollister-pd-ca": "http_404",
         "hollister-po-ca": "http_404",
         "hollister-police-ca": "http_404",
@@ -1789,6 +1806,6 @@
       }
     }
   },
-  "updated": "2026-05-08T21:43:53.539510+00:00",
+  "updated": "2026-05-08T22:40:07.546645+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.