### PR TITLE
ci(refresh): drop pytest from validate step

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -153,7 +153,6 @@ jobs:
           uv run python scripts/build_justifications.py &
           uv run python scripts/md_to_pdf.py &
           wait
-          uv run pytest tests/test_map_smoke.py -v
 
       - name: Check recipient coordinates
         env:


### PR DESCRIPTION
## Summary
- Refresh runs were dying mid-test (or with explicit *hosted runner lost communication* on older runs) at the moment `TestLayout::test_ui_elements_and_overlays` launched Chromium — a second browser on top of the crawl's Playwright session and four parallel `build_*.py` processes.
- CI runs the same smoke suite on every push to main and passes there. Running it again in the refresh job adds no coverage on top of CI.
- This drops `pytest tests/test_map_smoke.py` from the refresh-flock-data validate step.

## Test plan
- [ ] Manually trigger refresh-flock-data via workflow_dispatch and confirm the job reaches *Commit and push* / *Create or update PR*.
- [ ] Confirm CI on this PR still runs the smoke tests as before.