### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -77,5 +77,5 @@
     "https://www.opb.org/article/2026/01/08/bend-flock-cameras-ai-license-plate-camera-law-enforcement/",
     "https://www.clickorlando.com/news/local/2021/08/12/shocking-violation-of-procedure-lake-county-commissioners-order-takedown-of-traffic-surveillance-cameras/"
   ],
-  "last_run": "2026-05-09T00:15:00Z"
+  "last_run": "2026-05-09T02:15:11Z"
 }

--- a/assets/articles/.failed_urls.json
+++ b/assets/articles/.failed_urls.json
@@ -25,24 +25,24 @@
     "last_attempt": "2026-05-06T12:04:13Z"
   },
   "https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated": {
-    "attempts": 2,
-    "error": "HTTPError: 404 Client Error: Not Found for url: https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated",
-    "last_attempt": "2026-05-09T00:06:35Z"
+    "attempts": 3,
+    "error": "HTTP 404",
+    "last_attempt": "2026-05-09T02:14:41Z"
   },
   "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras": {
-    "attempts": 2,
-    "error": "HTTPError: 404 Client Error: Not Found for url: https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras/",
-    "last_attempt": "2026-05-09T00:10:13Z"
+    "attempts": 3,
+    "error": "HTTP 404",
+    "last_attempt": "2026-05-09T02:14:52Z"
   },
   "https://www.kut.org/austin/2025-07-01/austin-ends-flock-cameras": {
-    "attempts": 1,
-    "error": "HTTPError: 404 Client Error: Not Found for url: https://www.kut.org/austin/2025-07-01/austin-ends-flock-cameras",
-    "last_attempt": "2026-05-09T00:15:00Z"
+    "attempts": 2,
+    "error": "HTTP 404",
+    "last_attempt": "2026-05-09T02:15:04Z"
   },
   "https://www.kxan.com/news/local/caldwell-county/lockhart-city-council-rejects-flock-ai-cameras-in-6-1-vote/": {
-    "attempts": 2,
-    "error": "HTTPError: 403 Client Error: Forbidden for url: https://www.kxan.com/news/local/caldwell-county/lockhart-city-council-rejects-flock-ai-cameras-in-6-1-vote/",
-    "last_attempt": "2026-05-09T00:11:56Z"
+    "attempts": 3,
+    "error": "HTTP 403",
+    "last_attempt": "2026-05-09T02:14:59Z"
   },
   "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras": {
     "attempts": 3,
@@ -54,9 +54,14 @@
     "error": "HTTPError: 429 Client Error: Too Many Requests for url: https://www.smdailyjournal.com/opinion/guest_perspectives/why-both-privacy-and-public-safety-matter-with-license-plate-reader-data/article_bdbd7d8a-9bf8-11eb-85e4-53c51152eaf0.html",
     "last_attempt": "2026-05-05T20:15:18Z"
   },
+  "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html": {
+    "attempts": 1,
+    "error": "Error: Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html\nCall log:\n  - navigating to \"https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html\", waiting until \"domcontentloaded\"\n",
+    "last_attempt": "2026-05-09T02:15:11Z"
+  },
   "https://www.theolympian.com/news/local/article-olympia-flock": {
-    "attempts": 2,
-    "error": "ReadTimeout: HTTPSConnectionPool(host='www.theolympian.com', port=443): Read timed out. (read timeout=30)",
-    "last_attempt": "2026-05-09T00:08:43Z"
+    "attempts": 3,
+    "error": "Error: Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://www.theolympian.com/news/local/article-olympia-flock\nCall log:\n  - navigating to \"https://www.theolympian.com/news/local/article-olympia-flock\", waiting until \"domcontentloaded\"\n",
+    "last_attempt": "2026-05-09T02:14:47Z"
   }
 }

--- a/assets/articles/queue/4ac4fa5c.json
+++ b/assets/articles/queue/4ac4fa5c.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.cambridgema.gov/Departments/citymanagersoffice/news/2025/flock-contract-terminated",
-  "source_domain": "cambridgema.gov",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/4add73e6.json
+++ b/assets/articles/queue/4add73e6.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.theolympian.com/news/local/article-olympia-flock",
-  "source_domain": "theolympian.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/51caefc6.json
+++ b/assets/articles/queue/51caefc6.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras",
-  "source_domain": "freep.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/5643b6a9.json
+++ b/assets/articles/queue/5643b6a9.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.kxan.com/news/local/caldwell-county/lockhart-city-council-rejects-flock-ai-cameras-in-6-1-vote/",
-  "source_domain": "kxan.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 76
- Curation: enriched: 57 · mechanical: 18 · needs_review: 1
- Scanner: WARNINGS: 57 · REVIEW REQUIRED: 18 · CLEAN: 1
- Wayback: poll-failed: 33 · submit-failed: 23 · saved: 17 · existing: 2 · save-failed: 1
- PDF: rendered: 76
- Top sources: eff.org (25), kqed.org (9), aclu.org (9), 404media.co (6), epic.org (6), npr.org (2), berkeleyside.org (2), kvue.com (2)
- Queue remaining: 0 priority + 66 auto = 66

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
