### PR TITLE
test(playwright): launch chromium with --disable-dev-shm-usage --no-sandbox

### DIFF
--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -355,7 +355,12 @@ class TestLayout:
     def browser(self, request):
         from playwright.sync_api import sync_playwright
         pw = sync_playwright().start()
-        b = pw.chromium.launch()
+        # GH Actions stock runners (4c/16G) intermittently kill the runner
+        # the moment Chromium starts rendering map_data.json (~8MB and
+        # growing). --disable-dev-shm-usage routes shared-memory writes to
+        # /tmp instead of the small /dev/shm partition; --no-sandbox skips
+        # the user-namespace setup that costs memory on launch.
+        b = pw.chromium.launch(args=["--disable-dev-shm-usage", "--no-sandbox"])
         request.cls._pw = pw
         request.cls._browser = b
         yield b


### PR DESCRIPTION
## Summary
- The validate job (CI) and the refresh-flock-data job have both been dying the moment Chromium starts rendering \`sharing_map.html\` — same pattern (~5s fixture setup, runner gets SIGKILL/shutdown).
- \`map_data.json\` is now ~8 MB and the bot adds hundreds of agencies per refresh; Chromium's default \`/dev/shm\` allocation on Actions stock runners is small enough that page render spikes can exhaust it.
- \`--disable-dev-shm-usage\` is the well-known fix (route shared-memory writes to \`/tmp\`). \`--no-sandbox\` skips user-namespace setup that costs memory at launch and adds nothing on single-tenant Actions runners.

## Test plan
- [ ] CI on this PR passes \`TestLayout::test_ui_elements_and_overlays\` and the rest of \`TestLayout\`.
- [ ] Stays green for at least a couple subsequent merges (the failure was intermittent before, so one pass isn't proof).