### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -94,5 +94,5 @@
     "https://spectrumlocalnews.com/nys/central-ny/public-safety/2026/03/23/syracuse-common-council-revokes-contract-with-flock",
     "https://www.northcountrypublicradio.org/news/story/53078/20260302/police-stop-installing-surveillance-cameras-in-saranac-lake-for-now"
   ],
-  "last_run": "2026-05-09T04:01:20Z"
+  "last_run": "2026-05-09T06:33:23Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -94,5 +94,5 @@
     "https://spectrumlocalnews.com/nys/central-ny/public-safety/2026/03/23/syracuse-common-council-revokes-contract-with-flock",
     "https://www.northcountrypublicradio.org/news/story/53078/20260302/police-stop-installing-surveillance-cameras-in-saranac-lake-for-now"
   ],
-  "last_run": "2026-05-09T02:45:04Z"
+  "last_run": "2026-05-09T04:01:20Z"
 }

--- a/assets/articles/.failed_urls.json
+++ b/assets/articles/.failed_urls.json
@@ -35,9 +35,9 @@
     "last_attempt": "2026-05-09T02:40:29Z"
   },
   "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/": {
-    "attempts": 2,
+    "attempts": 3,
     "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:39:22Z"
+    "last_attempt": "2026-05-09T03:53:20Z"
   },
   "https://richmondstandard.com/community/2025/12/09/richmond-police-suspend-system-that-automatically-reads-license-plates/": {
     "attempts": 1,
@@ -45,9 +45,9 @@
     "last_attempt": "2026-05-09T02:41:56Z"
   },
   "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns-2/": {
-    "attempts": 2,
+    "attempts": 3,
     "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:39:29Z"
+    "last_attempt": "2026-05-09T03:54:57Z"
   },
   "https://www.aclunc.org/blog/californians-fought-hard-driver-privacy-protections-why-are-police-refusing-follow-them": {
     "attempts": 3,
@@ -60,14 +60,14 @@
     "last_attempt": "2026-05-09T02:14:41Z"
   },
   "https://www.chronline.com/stories/controversial-flock-license-plate-readers-shut-off-by-another-eastern-washington-city": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:39:56Z"
+    "last_attempt": "2026-05-09T03:59:33Z"
   },
   "https://www.columbian.com/news/2025/skamania-county-flock": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T02:39:36Z"
+    "last_attempt": "2026-05-09T03:56:19Z"
   },
   "https://www.denverpost.com/2025/05/05/denver-city-council-flock-vote": {
     "attempts": 1,
@@ -95,9 +95,9 @@
     "last_attempt": "2026-05-09T02:41:21Z"
   },
   "https://www.opb.org/article/2025/12/02/eugene-ends-flock-alpr": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T02:39:43Z"
+    "last_attempt": "2026-05-09T03:58:00Z"
   },
   "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras": {
     "attempts": 3,
@@ -125,9 +125,9 @@
     "last_attempt": "2026-05-09T02:14:47Z"
   },
   "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T02:40:25Z"
+    "last_attempt": "2026-05-09T04:01:20Z"
   },
   "https://www.wpri.com/news/local-news/east-bay/warren-rejects-proposal-to-install-flock-camera/": {
     "attempts": 1,

--- a/assets/articles/.failed_urls.json
+++ b/assets/articles/.failed_urls.json
@@ -30,9 +30,9 @@
     "last_attempt": "2026-05-09T02:42:01Z"
   },
   "https://oakpark.com/2025/08/05/oak-park-ends-flock-cameras": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:40:29Z"
+    "last_attempt": "2026-05-09T06:31:43Z"
   },
   "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/": {
     "attempts": 3,
@@ -60,14 +60,14 @@
     "last_attempt": "2026-05-09T02:14:41Z"
   },
   "https://www.chronline.com/stories/controversial-flock-license-plate-readers-shut-off-by-another-eastern-washington-city": {
-    "attempts": 2,
-    "error": "HTTP 403",
-    "last_attempt": "2026-05-09T03:59:33Z"
+    "attempts": 3,
+    "error": "HTTP 404",
+    "last_attempt": "2026-05-09T06:28:56Z"
   },
   "https://www.columbian.com/news/2025/skamania-county-flock": {
-    "attempts": 2,
+    "attempts": 3,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T03:56:19Z"
+    "last_attempt": "2026-05-09T06:25:42Z"
   },
   "https://www.denverpost.com/2025/05/05/denver-city-council-flock-vote": {
     "attempts": 1,
@@ -95,9 +95,9 @@
     "last_attempt": "2026-05-09T02:41:21Z"
   },
   "https://www.opb.org/article/2025/12/02/eugene-ends-flock-alpr": {
-    "attempts": 2,
+    "attempts": 3,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T03:58:00Z"
+    "last_attempt": "2026-05-09T06:27:18Z"
   },
   "https://www.redrocknews.com/2025/09/09/sedona-ends-flock-license-plate-cameras": {
     "attempts": 3,
@@ -125,13 +125,13 @@
     "last_attempt": "2026-05-09T02:14:47Z"
   },
   "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras": {
-    "attempts": 2,
+    "attempts": 3,
     "error": "HTTP 404",
-    "last_attempt": "2026-05-09T04:01:20Z"
+    "last_attempt": "2026-05-09T06:30:07Z"
   },
   "https://www.wpri.com/news/local-news/east-bay/warren-rejects-proposal-to-install-flock-camera/": {
-    "attempts": 1,
+    "attempts": 2,
     "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:40:36Z"
+    "last_attempt": "2026-05-09T06:33:23Z"
   }
 }

--- a/assets/articles/queue/5b0224ea.json
+++ b/assets/articles/queue/5b0224ea.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/",
-  "source_domain": "richmondside.org",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/5cf82328.json
+++ b/assets/articles/queue/5cf82328.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns-2/",
-  "source_domain": "washingtonretail.org",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/608f063d.json
+++ b/assets/articles/queue/608f063d.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.columbian.com/news/2025/skamania-county-flock",
-  "source_domain": "columbian.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/67034313.json
+++ b/assets/articles/queue/67034313.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.opb.org/article/2025/12/02/eugene-ends-flock-alpr",
-  "source_domain": "opb.org",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/6876fea4.json
+++ b/assets/articles/queue/6876fea4.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.chronline.com/stories/controversial-flock-license-plate-readers-shut-off-by-another-eastern-washington-city",
-  "source_domain": "chronline.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}

--- a/assets/articles/queue/6ab24183.json
+++ b/assets/articles/queue/6ab24183.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://www.whsv.com/2025/12/10/staunton-ends-flock-cameras",
-  "source_domain": "whsv.com",
-  "discovered_at": "2026-05-08T17:23:52Z",
-  "discovered_by": "termination-ledger-import"
-}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 93
- Curation: enriched: 76 · mechanical: 16 · needs_review: 1
- Scanner: WARNINGS: 60 · REVIEW REQUIRED: 32 · CLEAN: 1
- Wayback: poll-failed: 38 · submit-failed: 31 · saved: 21 · existing: 2 · save-failed: 1
- PDF: rendered: 93
- Top sources: eff.org (25), kqed.org (9), aclu.org (9), 404media.co (6), epic.org (6), npr.org (2), berkeleyside.org (2), kvue.com (2)
- Queue remaining: 0 priority + 41 auto = 41

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
