### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -87,6 +87,14 @@
         "san-luis-obispo-county-ca-so": "http_404"
       }
     },
+    "08514a25-077d-52d1-a7e3-5bcc3ef1be56": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T04:56:34.817669+00:00",
+      "tried": {
+        "colorado-state-parks-co-pd": "http_404"
+      }
+    },
     "08bd5589-6ad6-5be4-bea5-60bd90bf6883": {
       "exhausted": false,
       "found": null,
@@ -228,7 +236,7 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T14:27:33.050516+00:00",
+      "last_probed": "2026-05-09T04:56:46.676945+00:00",
       "tried": {
         "national-city-ca": "http_404",
         "national-city-ca-po": "http_404",
@@ -243,6 +251,7 @@
         "national-city-police-ca": "http_404",
         "national-city-police-department": "http_404",
         "national-city-police-department-ca": "http_404",
+        "national-city-ps": "http_404",
         "national-city-ps-ca": "http_404"
       }
     },
@@ -1626,6 +1635,14 @@
         "sierra-madre-ca-po": "http_404"
       }
     },
+    "e0905266-5997-5468-a68a-55abc5e49065": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T04:56:40.521697+00:00",
+      "tried": {
+        "tupelo-regional-airport-ms-pd": "http_404"
+      }
+    },
     "e35b094f-0435-50b5-a03c-e644ad6144be": {
       "exhausted": false,
       "found": null,
@@ -1840,6 +1857,6 @@
       }
     }
   },
-  "updated": "2026-05-09T01:24:50.471762+00:00",
+  "updated": "2026-05-09T04:56:46.717215+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.