### PR TITLE
fix(crawl): sort article queue by fewest prior attempts first

### DIFF
--- a/scripts/article_crawl.py
+++ b/scripts/article_crawl.py
@@ -776,7 +776,17 @@ def main() -> int:
         candidates: list[dict] = [{"url": u, "discovered_by": "force"} for u in args.url]
         selected = [c for c in candidates if is_eligible(c)][: args.limit]
     else:
+        # Fewest-prior-attempts first, FIFO within each bucket. When most
+        # of the queue is 1–2-strike retries on dead URLs, fresh
+        # discoveries would otherwise wait behind them every tick.
+        # Python sort is stable, so the existing mtime order from
+        # load_queue_dir is preserved as the secondary key.
+        def attempts(entry: dict) -> int:
+            return failed.get(entry.get("url", ""), {}).get("attempts", 0)
+
         priority, auto = merge_queue()
+        priority.sort(key=attempts)
+        auto.sort(key=attempts)
         selected = round_robin(priority, args.limit)
         if len(selected) < args.limit:
             selected.extend(round_robin(auto, args.limit - len(selected)))


### PR DESCRIPTION
## Summary
- Round-robin walked the queue in mtime order (FIFO), which meant URLs that had already failed once or twice came up before fresh discoveries — their queue files have older mtimes.
- With ~14 of 47 queue entries currently 1–2-strike retries on guessed/templated URLs that 404 or 403, fresh URLs were waiting behind them every cron tick.
- Sort `priority` and `auto` pools by `.failed_urls.json` attempt count ascending before round-robin. Python's stable sort preserves the existing mtime FIFO as the tiebreak within each attempt bucket.

## Test plan
- [x] Dry-run on the current main queue: top 6 selected are all 0-attempt URLs (previously the 1-2-strike retries would have led).
- [ ] Watch the next cron tick to confirm fresh URLs progress and retries naturally drain over subsequent ticks.