### PR TITLE
chore(articles): manual seed batch (134 URLs)

### DIFF
--- a/assets/articles/.failed_urls.json
+++ b/assets/articles/.failed_urls.json
@@ -34,21 +34,6 @@
     "error": "HTTP 403",
     "last_attempt": "2026-05-09T02:40:29Z"
   },
-  "https://richmondside.org/2025/12/09/richmond-license-plate-reader-data-breach/": {
-    "attempts": 2,
-    "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:39:22Z"
-  },
-  "https://richmondstandard.com/community/2025/12/09/richmond-police-suspend-system-that-automatically-reads-license-plates/": {
-    "attempts": 1,
-    "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:41:56Z"
-  },
-  "https://washingtonretail.org/olympia-and-redmond-halt-flock-safety-camera-use-amid-privacy-and-data-access-concerns-2/": {
-    "attempts": 2,
-    "error": "HTTP 403",
-    "last_attempt": "2026-05-09T02:39:29Z"
-  },
   "https://www.aclunc.org/blog/californians-fought-hard-driver-privacy-protections-why-are-police-refusing-follow-them": {
     "attempts": 3,
     "error": "HTTPError: 404 Client Error: Not Found for url: https://www.aclunorcal.org/blog/californians-fought-hard-driver-privacy-protections-why-are-police-refusing-follow-them",
@@ -68,11 +53,6 @@
     "attempts": 1,
     "error": "HTTP 404",
     "last_attempt": "2026-05-09T02:39:36Z"
-  },
-  "https://www.denverpost.com/2025/05/05/denver-city-council-flock-vote": {
-    "attempts": 1,
-    "error": "HTTP 404",
-    "last_attempt": "2026-05-09T02:42:52Z"
   },
   "https://www.freep.com/story/news/local/michigan/2025/11/13/ferndale-ends-flock-cameras": {
     "attempts": 3,
@@ -113,11 +93,6 @@
     "attempts": 3,
     "error": "HTTPError: 429 Client Error: Too Many Requests for url: https://www.smdailyjournal.com/opinion/guest_perspectives/why-both-privacy-and-public-safety-matter-with-license-plate-reader-data/article_bdbd7d8a-9bf8-11eb-85e4-53c51152eaf0.html",
     "last_attempt": "2026-05-05T20:15:18Z"
-  },
-  "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html": {
-    "attempts": 3,
-    "error": "Error: Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html\nCall log:\n  - navigating to \"https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html\", waiting until \"domcontentloaded\"\n",
-    "last_attempt": "2026-05-09T02:39:17Z"
   },
   "https://www.theolympian.com/news/local/article-olympia-flock": {
     "attempts": 3,

--- a/assets/articles/queue/06306994.json
+++ b/assets/articles/queue/06306994.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/09/02/river-forest-license-plate-cameras/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/07380291.json
+++ b/assets/articles/queue/07380291.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/state/washington/article315035181.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/0840ad52.json
+++ b/assets/articles/queue/0840ad52.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/south-san-francisco-council-oks-license-plate-reading-cameras/article_1e467e8e-8af7-11ec-81fc-87089d642110.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/09542cc5.json
+++ b/assets/articles/queue/09542cc5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/state/washington/article315683941.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/0b6a649c.json
+++ b/assets/articles/queue/0b6a649c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/politics-government/article314581905.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/0d709e9a.json
+++ b/assets/articles/queue/0d709e9a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/foster-city-adding-license-plate-monitoring-program/article_49c0eaba-903c-11eb-a162-d70f5231627a.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/0e2f68a3.json
+++ b/assets/articles/queue/0e2f68a3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondside.org/2026/03/04/richmond-residents-debate-flock-license-plate-readers/",
+  "source_domain": "richmondside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/0efd31d4.json
+++ b/assets/articles/queue/0efd31d4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://chronline.com/stories/flock-safety-cameras-in-centralia-are-here-to-stay-even-under-new-state-restrictions,400088",
+  "source_domain": "chronline.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/159fa2b6.json
+++ b/assets/articles/queue/159fa2b6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/south-san-francisco-launches-license-plate-reader-program/article_5d82c40e-6a21-11ed-b59f-bf892e6b7665.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/19402558.json
+++ b/assets/articles/queue/19402558.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/austin/around-20-of-license-plate-reader-database-searches-did-not-have-case-numbers/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/1e0022b4.json
+++ b/assets/articles/queue/1e0022b4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-city-ends-flock-pilot-program-over-federal-data-base-concerns/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/219d13d6.json
+++ b/assets/articles/queue/219d13d6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-new-license-plate-scanning-parking-garage-system-raises-city-councilor-concerns/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/22c73e6f.json
+++ b/assets/articles/queue/22c73e6f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/crime-justice/2025-07-23/kyle-tx-austin-texas-flock-safety-cameras-license-plate-readers",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/26e03746.json
+++ b/assets/articles/queue/26e03746.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/11/18/oakland-police-lawsuit-license-plate-camera-flock-safety/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/289c8764.json
+++ b/assets/articles/queue/289c8764.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2023/08/17/oaklands-license-plate-readers-have-been-off-for-months-so-why-does-the-city-want-more/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/2d1ad438.json
+++ b/assets/articles/queue/2d1ad438.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/11/19/oakland-council-committee-rejects-flock-surveillance-camera-expansion/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3034494c.json
+++ b/assets/articles/queue/3034494c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/05/20/police-oversight-committee-seeks-more-data-on-flock-camera-use/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/33d807d0.json
+++ b/assets/articles/queue/33d807d0.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/news/ice-using-driver-locations-vast-surveillance-database-target-immigrants/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3a535526.json
+++ b/assets/articles/queue/3a535526.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://chronline.com/stories/a-new-oregon-law-regulates-police-use-of-license-plate-readers-heres-how-it-works,400937",
+  "source_domain": "chronline.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3a7c3413.json
+++ b/assets/articles/queue/3a7c3413.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-cville-police-chief-kochis-presents-flock-safety-camera-pilot-project/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3bcc2ed4.json
+++ b/assets/articles/queue/3bcc2ed4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/01/06/more-license-plate-reading-cameras-coming-to-river-forest/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3ecff8a1.json
+++ b/assets/articles/queue/3ecff8a1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/news/local/flock-cameras-in-flagstaff-come-under-scrutiny/article_62556046-d721-43df-885a-14287fe8307e.html",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/3fe638ce.json
+++ b/assets/articles/queue/3fe638ce.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/crime/article315247938.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/404f3374.json
+++ b/assets/articles/queue/404f3374.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/06/16/foia-records-reveal-evanston-data-accessible-to-out-of-state-police-in-ice-searches/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/408f0b02.json
+++ b/assets/articles/queue/408f0b02.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-flock-ceo-includes-charlottesville-staunton-in-email-blaming-activists-for-cities-dropping-the-companys-services/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/426d65b1.json
+++ b/assets/articles/queue/426d65b1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/crime-justice/2026-02-12/austin-tx-apd-flock-cameras-license-plate-readers",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/43bb817b.json
+++ b/assets/articles/queue/43bb817b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-richmond-police-chief-apologizes-for-february-atf-access-grant-to-flock-system/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/475c51ce.json
+++ b/assets/articles/queue/475c51ce.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondside.org/2026/03/18/richmond-flock-cameras-license-plate-readers-on/",
+  "source_domain": "richmondside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/499129c8.json
+++ b/assets/articles/queue/499129c8.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302475774.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/4aaab474.json
+++ b/assets/articles/queue/4aaab474.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.freep.com/story/news/local/michigan/oakland/2026/04/09/oakland-county-flock-drone-program/89524548007/",
+  "source_domain": "freep.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/4ace507c.json
+++ b/assets/articles/queue/4ace507c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondstandard.com/richmond/2019/04/10/license-plate-reader-technology-pitched-for-richmond-bart-parking-areas/",
+  "source_domain": "richmondstandard.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/50856028.json
+++ b/assets/articles/queue/50856028.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/state/washington/article315379868.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/51f09ca4.json
+++ b/assets/articles/queue/51f09ca4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/news/license-plate-readers-alameda-need-strict-privacy-safeguards/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/5403b40c.json
+++ b/assets/articles/queue/5403b40c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/half-moon-bay-is-set-to-install-surveillance-cameras/article_46d428d2-82c6-11ef-8623-e7927b765967.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/569f9f6b.json
+++ b/assets/articles/queue/569f9f6b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://chronline.com/stories/chehalis-and-napavine-flock-cameras-still-effective-police-chiefs-say,400867",
+  "source_domain": "chronline.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/56aa7948.json
+++ b/assets/articles/queue/56aa7948.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/brookline-news-podcast-episode-8-flock-cameras-come-to-brookline-and-so-does-a-no-kings-rally/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/592adcdd.json
+++ b/assets/articles/queue/592adcdd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/09/24/flock-safety-reinstalls-evanston-cameras/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/5ab5f60f.json
+++ b/assets/articles/queue/5ab5f60f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/community/gateway/g-news/article302729359.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/5e918e05.json
+++ b/assets/articles/queue/5e918e05.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/state/washington/article315683941.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/5fea48fc.json
+++ b/assets/articles/queue/5fea48fc.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/podcasts/cpd-chief-michael-kochis-responds-to-the-removal-of-the-flock-camera-system/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/601b9ccd.json
+++ b/assets/articles/queue/601b9ccd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/south-san-francisco-considers-license-plate-reading-cameras/article_1782a3b6-4079-11ec-90bb-37eeee12c36b.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/6277e77d.json
+++ b/assets/articles/queue/6277e77d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/audit-of-austin-license-plate-camera-program-finds-general-accuracy-missing-data/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/660716c9.json
+++ b/assets/articles/queue/660716c9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/half-moon-bay-plans-for-license-plate-readers/article_b85b3a78-0084-11ef-bbbe-cf16b9ce6b8c.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/68a94df5.json
+++ b/assets/articles/queue/68a94df5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2024/01/02/new-year-new-laws-giannoulias-initiated-laws-take-effect/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/6a30cb76.json
+++ b/assets/articles/queue/6a30cb76.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/cases/lagleva-v-doyle-license-plate-surveillance/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/6b55ed94.json
+++ b/assets/articles/queue/6b55ed94.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2026/01/20/important-village-board-votes/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/6b7d035a.json
+++ b/assets/articles/queue/6b7d035a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/south-san-francisco-police-leverage-ai/article_98ae85ac-3282-41d1-aabe-00a0a5b2aa0e.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/704e99ce.json
+++ b/assets/articles/queue/704e99ce.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/border-report/border-report-live-california-attorney-general-rob-bonta/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/70a630ac.json
+++ b/assets/articles/queue/70a630ac.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/09/10/sedona-city-council-tells-staff-to-get-the-flock-out-of-town/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/78241e28.json
+++ b/assets/articles/queue/78241e28.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/09/02/why-i-voted-to-cancel-flock-cameras/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/78f847cd.json
+++ b/assets/articles/queue/78f847cd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2024/02/08/chp-to-control-oaklands-300-camera-vehicle-surveillance-network/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/7b61c80f.json
+++ b/assets/articles/queue/7b61c80f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/09/11/consultant-tells-oak-park-to-hire-full-time-police-oversight-staffer/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/7cd5c7f0.json
+++ b/assets/articles/queue/7cd5c7f0.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/press-releases/california-activists-sue-marin-county-sheriff-illegally-sharing-drivers-license-plate-data-ice/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/7d7ee43d.json
+++ b/assets/articles/queue/7d7ee43d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2025/10/22/denver-flock-contract-extension-council/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/7f439039.json
+++ b/assets/articles/queue/7f439039.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/12/17/oakland-flock-safety-council-approves-surveillance-cameras/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/806c8aa5.json
+++ b/assets/articles/queue/806c8aa5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/select-board-weighs-police-use-of-data-from-real-estate-companys-license-plate-readers/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/87254a67.json
+++ b/assets/articles/queue/87254a67.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/half-moon-bay-officials-weighing-automated-license-plate-readers/article_89833f94-d2c5-11ee-94af-4371e5ce797b.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/8b968137.json
+++ b/assets/articles/queue/8b968137.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2024/03/29/governor-gavin-newsom-announces-license-plate-reader-cameras-flock-safety-oakland/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/8d725685.json
+++ b/assets/articles/queue/8d725685.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/community/puyallup-herald/ph-news/article315257166.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/8f7ed101.json
+++ b/assets/articles/queue/8f7ed101.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/government-politics/article_69dc526f-e45c-582d-b4f0-b36d97716b53.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/909842f4.json
+++ b/assets/articles/queue/909842f4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/license-plate-readers-proposed-in-foster-city/article_53df79ee-0aae-11eb-bcb1-a3b8823e5655.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/91b0099c.json
+++ b/assets/articles/queue/91b0099c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/podcasts/city-flock-camera-program-discussion/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9492b462.json
+++ b/assets/articles/queue/9492b462.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-council-gives-verbal-support-for-flock-camera-continuation-after-charlottesville-police-chief-report/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/96f09804.json
+++ b/assets/articles/queue/96f09804.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/02/10/flock-cameras-privacy-debate-thornton-colorado-legislature/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9761e3c6.json
+++ b/assets/articles/queue/9761e3c6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2026/03/23/alameda-county-sheriff-flock-safety-license-plate-camera-thieves/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/987db862.json
+++ b/assets/articles/queue/987db862.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondstandard.com/community/2026/03/03/richmond-residents-businesses-urge-city-to-restore-public-safety-cameras/",
+  "source_domain": "richmondstandard.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9b83860a.json
+++ b/assets/articles/queue/9b83860a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/11/12/oakland-privacy-advisory-commission-resignation-brian-hofer-sean-everhart/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9cc6081c.json
+++ b/assets/articles/queue/9cc6081c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/austin/2025-09-25/austin-tx-city-park-safety-ai-liveview-technologies-cameras",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9dbc9d05.json
+++ b/assets/articles/queue/9dbc9d05.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/news/local/flagstaff-city-council-postpones-definitive-action-on-controversial-flock-cameras/article_10ad1680-ddaf-41af-9c31-e8d6a9ce2ed9.html",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/9eabd05b.json
+++ b/assets/articles/queue/9eabd05b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2026/03/31/spd-begins-strategic-plan/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/a275f6d9.json
+++ b/assets/articles/queue/a275f6d9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/news/local/flagstaff-city-council-attempts-to-find-middle-ground-in-use-of-flock-surveillance-cameras/article_3412588e-866c-437d-b46f-49fd3dea5772.html",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/aa0a797f.json
+++ b/assets/articles/queue/aa0a797f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/austin/safety-leaders-question-privacy-of-austin-license-plate-reader-data/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/aa329204.json
+++ b/assets/articles/queue/aa329204.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/state/washington/article314581905.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ab93296a.json
+++ b/assets/articles/queue/ab93296a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/press-releases/lawsuit-challenges-san-jose-s-warrantless-alpr-mass-surveillance/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ae4a06e1.json
+++ b/assets/articles/queue/ae4a06e1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/state/washington/article315379868.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/aeb09462.json
+++ b/assets/articles/queue/aeb09462.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/08/14/sedona-city-council-tells-spd-city-staff-to-turn-off-flock-cameras/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/af4b64db.json
+++ b/assets/articles/queue/af4b64db.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/state/washington/seattle/article314804119.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/b1c72e14.json
+++ b/assets/articles/queue/b1c72e14.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/belmont-debates-license-plate-cameras/article_c454f386-1977-11ee-99fb-eb7da9cb4b51.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/b355fa63.json
+++ b/assets/articles/queue/b355fa63.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/south-city-expands-surveillance/article_7b1f6d24-d18e-11ef-842a-3bdc6e80fad3.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/b68391ab.json
+++ b/assets/articles/queue/b68391ab.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/new-surveillance-cameras-on-hold-for-burlingame/article_45695412-991d-11ec-a41d-6f1ab5cd49c5.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/b850bee6.json
+++ b/assets/articles/queue/b850bee6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/08/21/sedona-city-council-was-right-to-shut-down-flock-spy-cameras/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/b91b7ce5.json
+++ b/assets/articles/queue/b91b7ce5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2026/02/11/flock-contract-alameda-county-ice-federal/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ba7da6e3.json
+++ b/assets/articles/queue/ba7da6e3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/08/12/a-missed-opportunity/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/bbe80258.json
+++ b/assets/articles/queue/bbe80258.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/08/30/city-manager-memo-to-council-accuses-sedona-mayor-jablow-of-manipulation-over-flock-cameras/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/bece916c.json
+++ b/assets/articles/queue/bece916c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://chronline.com/stories/centralia-police-chief-offers-testimony-on-state-bill-to-regulate-flock-safety-cameras,394939",
+  "source_domain": "chronline.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/bf7a7995.json
+++ b/assets/articles/queue/bf7a7995.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.cambridgema.gov/news/2025/12/statementontheflocksafetyalprcontracttermination",
+  "source_domain": "cambridgema.gov",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c044cbec.json
+++ b/assets/articles/queue/c044cbec.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/millbrae-council-approves-23-new-surveillance-cameras/article_2f3f8308-50f4-11ec-949a-dbef87a34dce.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c181d995.json
+++ b/assets/articles/queue/c181d995.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/half-moon-bay-weighs-license-plate-readers/article_2bba20c6-73a2-11e9-ab84-0f2d3fa76c2e.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c20d08cd.json
+++ b/assets/articles/queue/c20d08cd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/09/08/coconino-county-sheriffs-office-installs-flock-cameras/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c252f812.json
+++ b/assets/articles/queue/c252f812.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/surveillance-in-parks-expands-in-san-mateo/article_b3cad750-23cc-4d3c-8734-7fd41b8e54a1.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c5ad76c1.json
+++ b/assets/articles/queue/c5ad76c1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/state/california-sues-says-el-cajon-police-are-illegally-sharing-license-plate-info-with-other-agencies/article_ac686dbd-adab-4286-a09c-8dc5477fb707.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c8b60fda.json
+++ b/assets/articles/queue/c8b60fda.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2024/03/27/oakland-homeowner-groups-powerful-surveillance-cameras/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/c986dc04.json
+++ b/assets/articles/queue/c986dc04.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://washingtonretail.org/mayor-pauses-more-surveillance-cameras-and-pushes-for-more-housing-for-the-homeless/",
+  "source_domain": "washingtonretail.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ccb32b29.json
+++ b/assets/articles/queue/ccb32b29.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/article282855768.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/cfcc66a6.json
+++ b/assets/articles/queue/cfcc66a6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/06/24/evanston-alpr-network-access-restricted/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d1d84e2c.json
+++ b/assets/articles/queue/d1d84e2c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/03/30/denver-axon-contract-license-plate-cameras-council/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d1f3e6bc.json
+++ b/assets/articles/queue/d1f3e6bc.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/07/03/davis-proposes-24-hour-time-limit-for-holding-license-plate-camera-data/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d44f2c18.json
+++ b/assets/articles/queue/d44f2c18.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/04/02/denver-license-plate-readers-public-safety-letters/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d4ec8217.json
+++ b/assets/articles/queue/d4ec8217.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/03/23/denver-cameras-flock-safety-axon-johnston/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d5261ec4.json
+++ b/assets/articles/queue/d5261ec4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/nation-world/national/article315239095.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d6bb0b56.json
+++ b/assets/articles/queue/d6bb0b56.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondside.org/2026/03/13/richmond-primary-election-mayor-forum-marina-bay/",
+  "source_domain": "richmondside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d8e9e048.json
+++ b/assets/articles/queue/d8e9e048.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2026/02/27/on-the-issues-where-the-congressional-frontrunners-align-and-diverge/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d9638f09.json
+++ b/assets/articles/queue/d9638f09.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/11/20/flock-safety-cameras-oakland-license-plate-readers/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d997a542.json
+++ b/assets/articles/queue/d997a542.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/02/24/denver-flock-license-plate-cameras-contract-axon/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/d99b0a79.json
+++ b/assets/articles/queue/d99b0a79.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondstandard.com/community/2026/03/05/richmond-council-deadlocks-on-police-cameras-during-active-trafficking-search/",
+  "source_domain": "richmondstandard.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/da1e830c.json
+++ b/assets/articles/queue/da1e830c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/half-moon-bay-to-review-license-plate-readers-use/article_daa34f06-6353-4e2e-a4c4-2aa4f52cce66.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/db509d29.json
+++ b/assets/articles/queue/db509d29.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.redrocknews.com/2025/07/20/watchdog-eyes-sedonas-alpr-cameras/",
+  "source_domain": "redrocknews.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/db516f7b.json
+++ b/assets/articles/queue/db516f7b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/chestnut-hill-realty-pauses-its-plan-to-install-flock-license-plate-readers-after-community-backlash/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e11691c6.json
+++ b/assets/articles/queue/e11691c6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/09/03/fourth-ward-hears-citys-preparations-for-looming-federal-occupation-of-chicago/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e177baed.json
+++ b/assets/articles/queue/e177baed.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/nation-world/national/article315427268.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e5709dab.json
+++ b/assets/articles/queue/e5709dab.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.freep.com/story/news/local/michigan/wayne/2025/05/15/dearborn-police-contract-axon-fusus-access-surveillance-videos/83592148007/",
+  "source_domain": "freep.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e64ae603.json
+++ b/assets/articles/queue/e64ae603.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/state/washington/seattle/article314719001.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e66bf89a.json
+++ b/assets/articles/queue/e66bf89a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/events/event/privacy-is-power-fighting-the-surveillance-state-in-massachusetts/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e70c5097.json
+++ b/assets/articles/queue/e70c5097.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/city-approves-bill-to-expand-license-plate-readers/article_728784d0-2f0e-11ef-8f16-237253302dfe.html",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/e9fb9f27.json
+++ b/assets/articles/queue/e9fb9f27.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/02/16/denver-flock-cameras-license-plates-other-bidders/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/eb4877e7.json
+++ b/assets/articles/queue/eb4877e7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/here-are-the-central-texas-law-enforcement-agencies-with-flock-data-sharing-agreements-with-texas-dps/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/eb9e9dde.json
+++ b/assets/articles/queue/eb9e9dde.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/san-mateo-police-acquires-new-technology/article_9369744a-aeae-11ea-95ea-eb8f2d47b3a4.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ebaa491b.json
+++ b/assets/articles/queue/ebaa491b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/burlingame-council-supports-exploring-citywide-surveillance-technology-policy/article_72e78ed4-748c-410b-85bd-bb35f3ab661d.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ebd5bd33.json
+++ b/assets/articles/queue/ebd5bd33.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/chestnut-hill-realty-plans-to-install-ai-powered-license-plate-reader-cameras-in-south-brookline/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ec9615f5.json
+++ b/assets/articles/queue/ec9615f5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://richmondstandard.com/richmond/2023/11/08/richmond-to-exponentially-increase-number-of-public-safety-cameras-in-city/",
+  "source_domain": "richmondstandard.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/eca1ffd7.json
+++ b/assets/articles/queue/eca1ffd7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.smdailyjournal.com/news/local/belmont-moves-ahead-with-drone-program/article_4723b7c0-52d9-11ef-ac5e-efdc64cb5f0f.html",
+  "source_domain": "smdailyjournal.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f011c5e0.json
+++ b/assets/articles/queue/f011c5e0.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denverpost.com/2026/03/11/denver-axon-contract-flock-cameras/",
+  "source_domain": "denverpost.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f118b2c4.json
+++ b/assets/articles/queue/f118b2c4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/state-regional/wisconsin/article_d39d37b0-5ce5-5ea6-8e5a-4ac894928185.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f148d917.json
+++ b/assets/articles/queue/f148d917.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/podcasts/michael-payne-on-flock-budgets-and-audits/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f1cd9ba8.json
+++ b/assets/articles/queue/f1cd9ba8.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-chief-kochis-curtails-flock-and-peregrine-use/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f2cf4083.json
+++ b/assets/articles/queue/f2cf4083.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.theolympian.com/news/local/article312983261.html",
+  "source_domain": "theolympian.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f3b9c4d3.json
+++ b/assets/articles/queue/f3b9c4d3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://azdailysun.com/flaglive/features/beat/flagstaff-city-council-votes-to-cancel-flock-safety-camera-contract/article_435ca329-b3dc-45a8-8566-5df73ceb9835.html",
+  "source_domain": "azdailysun.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f5bfb1b3.json
+++ b/assets/articles/queue/f5bfb1b3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kut.org/austin/2025-06-04/austin-tx-automatic-license-reader-program-police-data-privacy-flock",
+  "source_domain": "kut.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f8911db7.json
+++ b/assets/articles/queue/f8911db7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2026/03/27/flock-removes-final-two-license-plate-cameras-from-evanston-after-roundtable-inquiry/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/f8c478c3.json
+++ b/assets/articles/queue/f8c478c3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://oaklandside.org/2025/07/15/oakland-police-ice-surveillance-camera-flock-safety-sfpd/",
+  "source_domain": "oaklandside.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/fa10a031.json
+++ b/assets/articles/queue/fa10a031.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/local/article315353591.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/fbfe9c71.json
+++ b/assets/articles/queue/fbfe9c71.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.thenewstribune.com/news/state/washington/article315285796.html",
+  "source_domain": "thenewstribune.com",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/fd871130.json
+++ b/assets/articles/queue/fd871130.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.aclunorcal.org/news/alameda-rejects-surveillance-deal-company-tied-ice/",
+  "source_domain": "aclunorcal.org",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}

--- a/assets/articles/queue/ff2a0300.json
+++ b/assets/articles/queue/ff2a0300.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://brookline.news/re-chestnut-hill-realty-plans-to-install-ai-powered-license-plate-reader-cameras-in-south-brookline-3/",
+  "source_domain": "brookline.news",
+  "discovered_at": "2026-05-09T07:00:26Z",
+  "discovered_by": "manual-seed-batch-2026-05-08"
+}


### PR DESCRIPTION
## Summary
- 134 manual URLs queued via `article_queue_add.py` covering domains where discovery had been generating fabricated URL paths (denverpost, freep, kut, kxan) plus bot-walled real-article URLs the user pulled by hand (thenewstribune, theolympian, oaklandside, oakpark, richmondside/standard, washingtonretail, chronline, brookline.news, evanstonroundtable, cvillerightnow, cambridgema, azdailysun, redrocknews, smdailyjournal, aclunorcal, madison.com).
- Cleared 5 overlapping entries from `.failed_urls.json` so seeds get a fresh retry budget instead of starting at 1–3 strikes.
- McClatchy URLs (thenewstribune, theolympian) will still hit TLS-fingerprint blocking in Playwright — re-queueing alone doesn't fix that — but the seeds are recorded for when a fingerprint workaround lands.

## Test plan
- [ ] Cron tick confirms queue draining at the configured rate (check `.crawl_state.json`).
- [ ] Spot-check a few seeded URLs land in `assets/articles/<domain>/` after their tick.