### PR TITLE
ci: serialize the parallel build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,12 +172,11 @@ jobs:
           uv run python scripts/build_sharing_graph.py
           uv run python scripts/build_history.py
           uv run python scripts/build_audit_log.py
-          uv run python scripts/build_map.py &
-          uv run python scripts/build_scoreboard.py &
-          uv run python scripts/build_report_data.py &
-          uv run python scripts/build_justifications.py &
-          uv run python scripts/md_to_pdf.py &
-          wait
+          uv run python scripts/build_map.py
+          uv run python scripts/build_scoreboard.py
+          uv run python scripts/build_report_data.py
+          uv run python scripts/build_justifications.py
+          uv run python scripts/md_to_pdf.py
 
       - name: Run smoke tests
         run: uv run pytest tests/test_map_smoke.py -v


### PR DESCRIPTION
## Summary
- Drop shell `&` / `wait` from the CI build step; run the five build scripts sequentially.
- Five concurrent Python interpreters loading registry + audit + report data at once is the highest memory peak in the validate job, and it lands immediately before chromium fans out 31 helper processes for the smoke tests.
- PR #302 has been hanging at `TestLayout::test_ui_elements_and_overlays` with `The runner has received a shutdown signal` — host-level termination, not a test bug. Flattening the upstream memory profile is the cheapest first move.
- Cost: ~30 s of extra wall time in the build step.

## Test plan
- [ ] CI run on this PR completes without a runner shutdown.
- [ ] Smoke tests pass.
- [ ] Build step wall time stays reasonable (<2 min).