### PR TITLE
ci: drop the alameda preview screenshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,11 +375,8 @@ jobs:
           ### scoreboard
           ![scoreboard](${RAW}/scoreboard.png)
 
-          ### per-agency report (SMPD — crawled)
+          ### per-agency report (SMPD)
           ![report_san-mateo-ca-pd](${RAW}/report_san-mateo-ca-pd.png)
-
-          ### per-agency report (Alameda — uncrawled)
-          ![report_alameda-ca-pd](${RAW}/report_alameda-ca-pd.png)
 
           *Updated $(date -u +%Y-%m-%dT%H:%M:%SZ)*
           EOF

--- a/scripts/screenshot_pages.py
+++ b/scripts/screenshot_pages.py
@@ -22,11 +22,8 @@ PAGES = [
     ("scoreboard.html", "scoreboard", {"width": 1280, "height": 900}),
     # Per-agency report renders client-side from report_data.json.
     # SMPD is the project's canonical subject so it's the natural
-    # example for PR previews. Alameda covers the non-crawled case —
-    # useful to eyeball that uncrawled reports still render sensibly
-    # (red "No" portal badge, inferred inbound, regional context).
+    # example for PR previews.
     ("report.html?agency=san-mateo-ca-pd", "report_san-mateo-ca-pd", {"width": 1000, "height": 1400}),
-    ("report.html?agency=alameda-ca-pd", "report_alameda-ca-pd", {"width": 1000, "height": 1400}),
 ]
 
 


### PR DESCRIPTION
## Summary
- Remove the second per-agency report screenshot (Alameda — uncrawled). The split was originally there to exercise the non-crawled rendering path; that path has converged with the crawled one enough that SMPD alone covers preview review.
- Trims one chromium page navigation per PR.

## Test plan
- [ ] PR preview comment renders with only the SMPD report card.
- [ ] No regression in screenshot step output.