### PR TITLE
ci: bust playwright cache in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}-v2
 
       - name: Install Chromium for Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Mirror `9105b33` (which only touched `refresh-flock-data.yml`) into `ci.yml`.
- PR validate has been hitting a stale playwright cache keyed on `pyproject.toml` hash, which rarely changes. The cached chromium binary on hosted runners can drift out of sync with the wheel uv resolves.
- Switch to `uv.lock`-keyed + a manual `-v2` suffix to force one fresh install.
- This is the next thing to try after build-step serialization (#307), which didn't move PR #302's TestLayout off its hang at 82%.

## Test plan
- [ ] Run picks up the `Install Chromium for Playwright` step on first hit (cache miss expected on the new key).
- [ ] Smoke tests progress past `test_has_cache_bust_on_data` without the runner taking a shutdown signal.