### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -798,7 +798,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-08T23:41:20.185295+00:00",
+      "last_probed": "2026-05-09T15:37:26.979821+00:00",
       "tried": {
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -806,7 +806,8 @@
         "beverly-hills-ca-police-department": "http_404",
         "beverly-hills-ca-ps": "http_404",
         "beverly-hills-pd-ca": "http_404",
-        "beverly-hills-po-ca": "http_404"
+        "beverly-hills-po-ca": "http_404",
+        "beverly-hills-police-department-ca": "http_404"
       }
     },
     "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd": {
@@ -1537,6 +1538,14 @@
         "gustine-ca-police-department": "http_404"
       }
     },
+    "d2086e22-c382-5fc5-96ac-173e64e0946d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T15:37:17.761205+00:00",
+      "tried": {
+        "royse-city-tx-pd": "http_404"
+      }
+    },
     "d30c1555-ff35-55be-8226-4d5f62612e97": {
       "exhausted": false,
       "found": null,
@@ -1641,6 +1650,14 @@
       "last_probed": "2026-05-09T04:56:40.521697+00:00",
       "tried": {
         "tupelo-regional-airport-ms-pd": "http_404"
+      }
+    },
+    "e1f96571-a743-54f4-872f-9ca305d4ee9f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-09T15:37:22.082096+00:00",
+      "tried": {
+        "parker-az-pd": "http_404"
       }
     },
     "e35b094f-0435-50b5-a03c-e644ad6144be": {
@@ -1857,6 +1874,6 @@
       }
     }
   },
-  "updated": "2026-05-09T04:56:46.717215+00:00",
+  "updated": "2026-05-09T15:37:27.021852+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.