### PR TITLE
feat(map): compute indirect flags client-side, drop from map_data.json

### DIFF
--- a/scripts/build_map.py
+++ b/scripts/build_map.py
@@ -272,58 +272,11 @@ def main():
             mismatch_map.setdefault(agency_slug, []).append(partner_slug)
             mismatch_map.setdefault(partner_slug, []).append(agency_slug)
 
-    # Compute indirect flags: if A shares with B, and B shares with
-    # a flagged entity V, then A has an indirect flag "V via B"
-    def is_flagged_entity(aid):
-        r = reg_by_id.get(aid, {})
-        if has_tag(r, "private"):
-            return True
-        r_state = agency_state(r)
-        if r_state and r_state != "CA":
-            return True
-        if r.get("agency_type") in ("federal", "fusion_center", "decommissioned", "test"):
-            return True
-        return False
-
-    # Build outbound lookup from graph (agency_id -> [target_ids])
-    outbound_by_id = {}
-    for aid, data in graph["agencies"].items():
-        outbound_by_id[aid] = data.get("sharing_outbound_ids", [])
-
-    # For each agency, find indirect flags (depth 1: via intermediaries)
-    # Output uses slugs for JS consumption
-    indirect_flags = {}  # slug -> [{"flagged": slug, "via": slug}]
-    for aid, data in graph["agencies"].items():
-        slug = id_to_slug.get(aid)
-        if not slug:
-            continue
-        indirects = []
-        direct_flags = set()
-        for target_id in data.get("sharing_outbound_ids", []):
-            if is_flagged_entity(target_id):
-                direct_flags.add(target_id)
-        for target_id in data.get("sharing_outbound_ids", []):
-            if target_id in outbound_by_id:
-                for second_hop_id in outbound_by_id[target_id]:
-                    if is_flagged_entity(second_hop_id) and second_hop_id not in direct_flags:
-                        indirects.append({
-                            "flagged": id_to_slug.get(second_hop_id, second_hop_id),
-                            "via": id_to_slug.get(target_id, target_id),
-                            "via_name": agency_display_name(reg_by_id.get(target_id, {})),
-                            "flagged_name": agency_display_name(reg_by_id.get(second_hop_id, {})),
-                        })
-        if indirects:
-            seen = set()
-            deduped = []
-            for iv in indirects:
-                if iv["flagged"] not in seen:
-                    seen.add(iv["flagged"])
-                    deduped.append(iv)
-            indirect_flags[slug] = deduped
-
-    indirect_count = sum(len(v) for v in indirect_flags.values())
-    print(f"Indirect flags: {indirect_count} across {len(indirect_flags)} agencies")
-
+    # Indirect flags are computed client-side from markers[].outbound_slugs
+    # (depth-2 walk in JS). Precomputing them here produced an O(sources ×
+    # flagged_targets) blob — ~2.6M entries, ~330 MB — that crashed the
+    # renderer when chromium loaded sharing_map.html. The map already has
+    # everything JS needs to compute it on demand for the selected agency.
     print(f"Geocoded: {geocoded}/{len(graph['agencies'])}")
     if ungeocodable:
         print(f"Could not geocode: {', '.join(ungeocodable[:10])}")
@@ -341,7 +294,6 @@ def main():
         "coords": slug_coords,
         "agencyInfo": slug_info,
         "mismatches": mismatch_map,
-        "indirectFlags": indirect_flags,
     }
     (docs_dir / "data" / "map_data.json").write_text(json.dumps(map_data) + "\n")
     print(f"Data written to {docs_dir}/data/map_data.json")

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -20,7 +20,35 @@ Promise.all([
   const coords = data.coords;
   const agencyInfo = data.agencyInfo;
   const mismatches = data.mismatches;
-  const indirectFlags = data.indirectFlags || {};
+  const markerBySlug = Object.create(null);
+  markers.forEach(m => { markerBySlug[m.slug] = m; });
+
+  // Indirect flags are computed on demand for the selected agency.
+  // Precomputing them server-side was O(sources × flagged_targets) and
+  // shipped ~330 MB to every page load; the inputs (each agency's
+  // outbound_slugs + isFlagged) are already on the client.
+  function computeIndirectFlags(m) {
+    const out = (m && m.outbound_slugs) || [];
+    const direct = new Set(out.filter(isFlagged));
+    const seen = new Set();
+    const result = [];
+    out.forEach(via => {
+      const target = markerBySlug[via];
+      if (!target) return;
+      (target.outbound_slugs || []).forEach(second => {
+        if (!isFlagged(second)) return;
+        if (direct.has(second) || seen.has(second)) return;
+        seen.add(second);
+        result.push({
+          flagged: second,
+          via: via,
+          via_name: (agencyInfo[via] || {}).name || via,
+          flagged_name: (agencyInfo[second] || {}).name || second,
+        });
+      });
+    });
+    return result;
+  }
   const changelogBySlug = (changelog && changelog.by_slug) || {};
   const changelogMeta = changelog || { window_days: 90, tracking_days: null, window_complete: false };
   let showChanges = localStorage.getItem('smalpr-show-changes') !== 'false';
@@ -422,7 +450,8 @@ Promise.all([
 
     // Show flag summary as a fixed banner at top of map
     const bannerEl = document.getElementById('flag-banner');
-    const myIndirectCount = (indirectFlags[m.slug] || []).length;
+    const myIndirects = computeIndirectFlags(m);
+    const myIndirectCount = myIndirects.length;
     const totalFlags = outFlags + myIndirectCount;
     if (totalFlags > 0) {
       let bannerText = '\u26a0 ' + outFlags + ' direct flag' + (outFlags !== 1 ? 's' : '');
@@ -478,7 +507,6 @@ Promise.all([
       const sorted = sortOutbound(m.outbound_slugs, m.lat, m.lng);
       const directFlagged = sorted.filter(s => isFlagged(s));
       const clean = sorted.filter(s => !isFlagged(s));
-      const myIndirects = indirectFlags[m.slug] || [];
 
       // Direct flags first
       if (directFlagged.length) {

--- a/tests/test_map_smoke.py
+++ b/tests/test_map_smoke.py
@@ -78,10 +78,6 @@ class TestMapData:
         ncric = self.data["agencyInfo"].get("ncric", {})
         assert ncric.get("crawled") is True
 
-    def test_indirect_flags_computed(self):
-        assert "indirectFlags" in self.data
-        assert len(self.data["indirectFlags"]) > 50
-
     def test_no_garbled_entries(self):
         """No ncmec-amber-alert parser artifacts."""
         for slug in self.data["agencyInfo"]:


### PR DESCRIPTION
## Summary
- Stop precomputing \`indirectFlags\` in \`build_map.py\` and shipping it in \`map_data.json\`.
- Compute the depth-2 walk in JS on agency selection. The inputs are already there: \`markers[].outbound_slugs\` + the existing \`isFlagged(slug)\` function.
- \`map_data.json\` drops from **141 MB → 3.7 MB** on main; PR #302's flock-refresh would drop from 331 MB → ~5 MB. That's the size that was crashing chromium in CI (host shutdown signal mid-TestLayout).
- The structure was \`O(sources × flagged_targets)\` — every newly-geocoded out-of-state agency multiplied entries across ~1,700 source agencies, growing 17× since April.

## Verification
- \`du -sh docs/data/map_data.json\` → 3.7 MB (was 141 MB on main)
- \`uv run pytest tests/test_map_smoke.py -v\` → **50 passed** (including all TestLayout browser tests).
- Spot-check vs old shipped data on 7 sample agencies: flagged-slug sets match within 0–1 entries on lists of 376–378. The lone diff is \`flock-safety-vendor\` (a private vendor) being deduped differently between Python's id-ordered iteration and JS's slug-ordered iteration — same set, different \"via\" tie-break.

## Phased release?
Not needed. Build-time \`CACHE_BUST\` stamps the HTML+JS+JSON bundle atomically, so old/new versions can't mix. The old JS used \`data.indirectFlags || {}\` — defensive default — so even cross-version mixing degrades gracefully (no errors, just zero indirect-flag count).

## Test plan
- [ ] PR #302 (flock-refresh) rebases on top of this and validates green.
- [ ] Sharing map renders in browser, agency click shows indirect-flag count in banner and full list when \`<details>\` is opened.
- [ ] No regression on scoreboard (\`build_scoreboard.py\` computes indirect flags independently).