### PR TITLE
feat(curate): bypass scanner gate for manually-seeded articles

### DIFF
--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -589,7 +589,14 @@ def run_phase2(registry: list[dict], *, tags_data: dict,
         if e.get("tier") not in PHASE2_ELIGIBLE_TIERS:
             continue
         verdict = (e.get("scanner_verdict") or "")
-        if not verdict.startswith(accepted_prefixes):
+        # Manually-seeded URLs (article_queue_add.py default discovered_by
+        # is "manual"; the seed-batch tool stamps "manual-seed-…") bypass
+        # the scanner gate. The user vouched for the source when they
+        # pasted the URL; Phase 2 still runs tool-less with json_schema
+        # output, so this only changes which articles get enriched, not
+        # what the model can do with them.
+        manual = (e.get("discovered_by") or "").startswith("manual")
+        if not manual and not verdict.startswith(accepted_prefixes):
             continue
         eligible.append(e)
     if reenrich:


### PR DESCRIPTION
## Summary
- Manually-seeded articles (`article_queue_add.py` default `discovered_by="manual"` and seed-batch tooling stamp like `manual-seed-…`) were getting stuck at `curation_status="mechanical"` because the prompt-injection scanner returns `REVIEW REQUIRED` on most modern news pages, and the cron's Phase 2 skips them.
- Result: no summary, no `key_quotes`, no `primary_subject_agency_id` → bare entries on articles.html with no map pin.
- This change: when `discovered_by` starts with `manual`, bypass the scanner-verdict gate. The user vouched for the source by pasting the URL into the queue tool. Phase 2 still runs tool-less with `json_schema`-constrained output regardless, so the scanner is defense-in-depth for unsolicited discovery, not a hard safety wall.
- Auto-discovered entries (`termination-ledger-import`, `search:…`, RSS, etc.) stay gated.

## Effect after merge
- 9 PR-#309 mechanical entries with `discovered_by="manual-seed-batch-2026-05-08"` become enrichment-eligible.
- They'll drain over the next ~2 cron ticks (5 per tick).
- 20 `termination-ledger-import`-discovered mechanical entries remain gated as designed.

## Test plan
- [ ] After merge, watch the next article-registry-bot run: PR body should show some of `art_094`, `art_097–099`, `art_100`, `art_104`, `art_109`, `art_110`, `art_116` flipping `mechanical` → `enriched`.
- [ ] No new `needs_review` entries from these (would indicate model refusal or schema validation issues).