### PR TITLE
feat(crawl): real Chrome + playwright-stealth for bot bypass

### DIFF
--- a/.github/workflows/article-registry.yml
+++ b/.github/workflows/article-registry.yml
@@ -99,11 +99,16 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          key: playwright-chrome-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
-      - name: Install Chromium for Playwright (PDF render)
+      - name: Install real Chrome for Playwright
+        # `channel="chrome"` in the crawler launches the OS-installed
+        # real Chrome (not bundled Chromium) so its TLS handshake
+        # fingerprint matches the real-user population. `playwright
+        # install chrome` runs the OS package manager under the hood
+        # — needs --with-deps on a fresh runner for the system libs.
         if: ${{ inputs.phase2_only != 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
-        run: uv run playwright install chromium
+        run: uv run playwright install chrome --with-deps
 
       - name: Crawl queued URLs
         if: ${{ inputs.phase2_only != 'true' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pytesseract>=0.3.13",
     "reportlab>=4.4.10",
     "requests>=2.33.1",
+    "tf-playwright-stealth>=1.2.0",
 ]
 
 [dependency-groups]

--- a/scripts/article_crawl.py
+++ b/scripts/article_crawl.py
@@ -51,6 +51,7 @@ import requests
 # works even if Playwright isn't set up locally.
 try:
     from playwright.sync_api import sync_playwright
+    from playwright_stealth import stealth_sync
     _PLAYWRIGHT_AVAILABLE = True
 except ImportError:
     _PLAYWRIGHT_AVAILABLE = False
@@ -535,13 +536,27 @@ def fetch_and_render(url: str, pdf_path: Path | None,
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
+            # channel="chrome" launches the OS-installed real Chrome
+            # binary instead of Playwright's bundled Chromium. Real
+            # Chrome's TLS handshake fingerprint (JA3/JA4) blends with
+            # the real-user population; bundled Chromium's stands out
+            # and triggers HTTP/2 RST on JA3-fingerprinting sites
+            # (McClatchy properties — thenewstribune.com,
+            # theolympian.com — were emitting ERR_HTTP2_PROTOCOL_ERROR
+            # at the handshake before this).
+            browser = p.chromium.launch(channel="chrome", headless=True)
             try:
                 ctx = browser.new_context(
                     user_agent=USER_AGENT,
                     viewport={"width": 1280, "height": 1024},
                 )
                 page = ctx.new_page()
+                # tf-playwright-stealth patches the JS-layer detection
+                # signals (navigator.webdriver, plugin enumeration,
+                # WebGL vendor strings, Permissions API quirks). Stacks
+                # on top of the channel="chrome" TLS-layer fix above —
+                # together they cover most non-enterprise bot walls.
+                stealth_sync(page)
                 # `domcontentloaded` is faster than `networkidle` and
                 # good enough for static news pages; some sites (ad-
                 # heavy news, advocacy blogs with embeds) never reach

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,14 @@ wheels = [
 ]
 
 [[package]]
+name = "fake-http-header"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/0b/2849c87d9f13766e29c0a2f4d31681aa72e035016b251ab19d99bde7b592/fake_http_header-0.3.5-py3-none-any.whl", hash = "sha256:cd05f4bebf1b7e38b5f5c03d7fb820c0c17e87d9614fbee0afa39c32c7a2ad3c", size = 14938, upload-time = "2024-10-15T07:27:10.671Z" },
+]
+
+[[package]]
 name = "feedparser"
 version = "6.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -507,6 +515,7 @@ dependencies = [
     { name = "pytesseract" },
     { name = "reportlab" },
     { name = "requests" },
+    { name = "tf-playwright-stealth" },
 ]
 
 [package.dev-dependencies]
@@ -525,6 +534,7 @@ requires-dist = [
     { name = "pytesseract", specifier = ">=0.3.13" },
     { name = "reportlab", specifier = ">=4.4.10" },
     { name = "requests", specifier = ">=2.33.1" },
+    { name = "tf-playwright-stealth", specifier = ">=1.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -537,6 +547,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tf-playwright-stealth"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fake-http-header" },
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/6b/32bb58c65991f91aeaaf7473b650175d9d4af5dd383983d177d49ccba08d/tf_playwright_stealth-1.2.0.tar.gz", hash = "sha256:7bb8d32d3e60324fbf6b9eeae540b8cd9f3b9e07baeb33b025dbc98ad47658ba", size = 23362, upload-time = "2025-06-13T04:51:04.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/3d/2653f4cf49660bb44eeac8270617cc4c0287d61716f249f55053f0af0724/tf_playwright_stealth-1.2.0-py3-none-any.whl", hash = "sha256:26ee47ee89fa0f43c606fe37c188ea3ccd36f96ea90c01d167b768df457e7886", size = 33151, upload-time = "2025-06-13T04:51:03.769Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Article crawler was using bundled headless Chromium with no fingerprint patching, which hit two layers of bot detection:

- **TLS-fingerprint walls** (JA3/JA4) at handshake time. McClatchy properties (`thenewstribune.com`, `theolympian.com`) responded with HTTP/2 RST before any HTTP transaction, surfacing as Playwright `net::ERR_HTTP2_PROTOCOL_ERROR`. Bundled Chromium's TLS hello doesn't match the real-Chrome population, so it stood out.
- **JS-layer fingerprint walls** (Cloudflare-tier). Sites checking `navigator.webdriver`, plugin enumeration, WebGL vendor strings, Permissions API quirks. Many of the recent 403s were these.

Two changes, both no-downside:

1. **`channel="chrome"`** — launches the OS-installed real Chrome binary instead of bundled Chromium. Same engine, same capabilities; the only difference visible to sites is the TLS handshake fingerprint, which now matches a real-user browser.
2. **`stealth_sync(page)`** — applies `tf-playwright-stealth`'s JS-layer patches before navigation.

## Local verification

```
=== before (bundled chromium, no stealth) ===
  ERR_HTTP2_PROTOCOL_ERROR  thenewstribune.com
  ERR_HTTP2_PROTOCOL_ERROR  theolympian.com
  403                       oakpark.com
  403                       oaklandside.org

=== after (channel=chrome, no stealth) ===
  200  thenewstribune.com   ← unblocked
  200  theolympian.com      ← unblocked
  403  oakpark.com
  403  oaklandside.org

=== after (channel=chrome + stealth) ===
  (same — stealth made no difference for this set, but stays
   as cheap insurance against future fingerprint heuristics)
```

McClatchy is unblocked. Cloudflare-tier walls (`oakpark.com`, `oaklandside.org`) still 403 — those need a curl_cffi follow-up retry job. That's the next PR.

## Scope

Only `article-registry.yml` switches from `chromium` → `chrome` install. Other Playwright callers (`slug_probe.py`, `screenshot_pages.py`, Flock transparency scrapes) stay on bundled Chromium — they target known-friendly internal sources, no fingerprint problem to fix.

## Test plan
- [x] `article_crawl.py` parses + imports cleanly
- [x] Local fetch of previously-blocked McClatchy URLs returns 200
- [ ] CI Playwright cache rebuilds with new `playwright-chrome-` key (no stale Chromium cache hit)
- [ ] Next cron tick: queue drains thenewstribune/theolympian seeds successfully
- [ ] Next cron tick: 403 count drops on Cloudflare-tier sites *if* JS-stealth helps; if not, they roll into the curl_cffi retry job