### PR TITLE
fix(ci): set git identity before rebase in bot-branch workflows

### DIFF
--- a/.github/workflows/discover-articles.yml
+++ b/.github/workflows/discover-articles.yml
@@ -41,6 +41,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.REFRESH_PAT || github.token }}
 
+      - name: Configure git identity
+        # Required before any step that may write commits (rebase replay,
+        # not just `git commit`). See article-registry.yml for the full
+        # incident — `fatal: empty ident name` masked as a "conflicts"
+        # error when the rebase wrapper trapped it.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Set up long-lived branch
         run: |
           git fetch origin article-registry-bot || true
@@ -80,8 +89,6 @@ jobs:
       - name: Commit and push
         id: commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add assets/articles/queue 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No new URLs discovered"

--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -38,19 +38,35 @@ jobs:
           # Need full history so the rebase below can find a common ancestor
           # with origin/slug-probe. With the default shallow clone, rebase
           # replays slug-probe's entire history (back to the initial commit)
-          # onto main and conflicts on every binary file added since then;
-          # the fallback `reset --hard` then wipes accumulated probe state.
+          # onto main and conflicts on every binary file added since then.
           fetch-depth: 0
           # PAT (if configured) attributes the resulting PR to a human so
           # CI doesn't require approval-for-bots on every run.
           token: ${{ secrets.REFRESH_PAT || github.token }}
+
+      - name: Configure git identity
+        # Required before any step that may write commits (rebase replay,
+        # not just `git commit`). See article-registry.yml for the full
+        # incident — `fatal: empty ident name` masked as a "conflicts"
+        # error when the rebase wrapper trapped it.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up probe branch
         run: |
           git fetch origin slug-probe || true
           if git rev-parse --verify origin/slug-probe >/dev/null 2>&1; then
             git checkout slug-probe
-            git rebase origin/main || { git rebase --abort; git reset --hard origin/main; }
+            # See article-registry.yml — never auto-reset to main on
+            # rebase failure. It silently destroys accumulated probe work
+            # (registry hits, failed_slugs state). Abort and fail loudly;
+            # a human resolves and force-pushes.
+            git rebase origin/main || {
+              git rebase --abort
+              echo "::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually. NOT auto-resetting (would destroy unmerged work)."
+              exit 1
+            }
           else
             git checkout -b slug-probe
           fi
@@ -87,8 +103,6 @@ jobs:
       - name: Commit and push
         id: commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           # On a hit, slug_probe also runs archive_agency to save the
           # captured page (.txt/.html/.json/.pdf) under the new slug's
           # directory, and updates .content_hashes.json. Stage the whole

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -44,6 +44,16 @@ jobs:
           # "approval required for non-committers" setting on every run.
           token: ${{ secrets.REFRESH_PAT || github.token }}
 
+      - name: Configure git identity
+        # Required before any step that may write commits (rebase replay,
+        # not just `git commit`). Setting this only in the commit step
+        # caused real rebases to fail with `fatal: empty ident name`,
+        # which the rebase wrapper masked as a misleading "conflicts"
+        # error. Set early so the whole workflow can write commits.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Set up refresh branch
         run: |
           git fetch origin flock-refresh || true
@@ -192,8 +202,6 @@ jobs:
       - name: Commit and push
         id: commit
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add assets/transparency.flocksafety.com/ assets/agency_registry.json
           if git diff --cached --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary

The flock refresh workflow has been failing repeatedly (e.g. [run 25605590413](https://github.com/none-below/sm-alpr/actions/runs/25605590413/job/75166795713)) with what looked like rebase conflicts. The actual error was `fatal: empty ident name` — `git rebase` rewrites the committer of every replayed commit, so it needs `user.name`/`user.email` set, not just `git commit`. The rebase wrapper trapped the failure and emitted a "conflicts" error that hid the cause.

Three workflows had `git config` only in the later "Commit and push" step:
- `refresh-flock-data.yml` — failing every real rebase
- `discover-articles.yml` — same pattern, hadn't tripped yet
- `probe-slugs.yml` — same pattern, plus a destructive `git reset --hard origin/main` fallback that the other workflows already removed (silently nukes accumulated probe state on conflict)

`article-registry.yml` already had this fix in [d22e743](https://github.com/none-below/sm-alpr/commit/d22e743). This PR brings the other three in line.

**Why intermittent:** rebase only writes new commits when the bot branch has commits ahead of main. Fast-forward / no-op rebases pass without needing identity. So failures correlate with main moving forward while the bot branch holds unmerged work.

## Test plan

- [ ] Wait for the next scheduled run of refresh-flock-data (or trigger via workflow_dispatch) and confirm "Set up refresh branch" succeeds when there are accumulated bot commits to replay
- [ ] Verify probe-slugs and discover-articles still run cleanly on next schedule