### PR TITLE
fix(geocode): disambiguate CO state code from Co. county abbreviation

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -27229,8 +27229,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "08005",
+      "name": "Arapahoe",
+      "state": "CO",
+      "lat": 39.644554,
+      "lng": -104.331706
     }
   },
   {
@@ -27442,8 +27446,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "place",
+      "fips": "0804000",
+      "name": "Aurora",
+      "state": "CO",
+      "lat": 39.703633,
+      "lng": -104.720088
     }
   },
   {

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -86,7 +86,12 @@ _CITY_OF = re.compile(r"^(City|Town|Village|Borough)\s+of\s+", re.IGNORECASE)
 _STATE_PREFIX = re.compile(r"^[A-Z]{2}\s*[-\u2013]\s*", re.IGNORECASE)
 # "Oxford PD - OH", "Harrah OK PD - original", "LaSalle Co. IL SO - New"
 _DASH_SUFFIX = re.compile(r"\s*-\s*(original|new|old|[A-Z]{2})$", re.IGNORECASE)
-_ABBREV_CO = re.compile(r"\bCo\b\.?", re.IGNORECASE)  # "Schuyler Co. IL SO" / "Gasconade Co MO SO"
+# "Co"/"Co." → "County" only when followed by another 2-letter token *and*
+# at least one more token after that. This distinguishes the County
+# abbreviation ("Schuyler Co. IL SO", "Gasconade Co MO SO" — "Co" then
+# state code then role) from the Colorado state code ("Aurora CO PD" —
+# "CO" then role with nothing after).
+_ABBREV_CO = re.compile(r"\bCo\.?(?=\s+[A-Z]{2}\b\s+\S)", re.IGNORECASE)
 _ABBREV_INTL = re.compile(r"\bIntl\b", re.IGNORECASE)  # "Nashville Intl Airport"
 # "Saint" → "St." anywhere in the name (Census uses "St."; Flock data
 # sometimes spells it out, e.g. "South Saint Paul MN PD").
@@ -344,14 +349,20 @@ def is_state_level_agency(name):
 _CO_COUNTY_STATE = re.compile(r"\b[A-Z][\w]+\s+CO\s+([A-Z]{2})\b")
 
 
+_ROLE_SUFFIX_TOKENS = frozenset(
+    {"PD", "SO", "DA", "DPS", "FD", "EMS", "OEM", "OES"}
+)
+
+
 def detect_county_co_state(name):
     """If name has 'X CO YY' pattern (CO=County), return YY.
-    Returns None when no match, or when YY is itself 'CO'."""
+    Returns None when no match, when YY is itself 'CO', or when YY is a
+    role suffix (e.g. 'Aurora CO PD' is Aurora, Colorado — not a county)."""
     m = _CO_COUNTY_STATE.search(name)
     if not m:
         return None
     code = m.group(1)
-    if code == "CO":
+    if code == "CO" or code in _ROLE_SUFFIX_TOKENS:
         return None
     return code
 

--- a/tests/test_geocode_co_disambiguation.py
+++ b/tests/test_geocode_co_disambiguation.py
@@ -1,0 +1,89 @@
+"""Regression tests for the "CO" state code vs "Co" County abbreviation
+ambiguity in geocode_agencies.
+
+Two distinct sites of confusion existed:
+
+1. `_ABBREV_CO` expanded any standalone "Co"/"CO" to "County", which
+   wrongly turned "Aurora CO PD" into "Aurora County PD".
+
+2. `detect_county_co_state` matched "X CO YY" and returned YY as the
+   actual state when CO was the County abbrev — but it accepted role
+   suffixes (PD/SO/...) as YY, so "Aurora CO PD" returned "PD" and
+   overrode the entry's state.
+
+Both cases now disambiguate by position: "Co" expands to "County" only
+when followed by *both* a 2-letter token and at least one more token,
+and the state-override only fires when the trailing 2-letter token
+isn't a known role suffix.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from geocode_agencies import (
+    detect_county_co_state,
+    extract_county_candidate,
+    extract_place_candidate,
+)
+
+
+class TestColoradoStateCode:
+    """'CO' as Colorado state code must not be expanded to 'County'."""
+
+    def test_colorado_city_pd_extracts_city(self):
+        assert extract_place_candidate("Aurora CO PD", "CO") == "Aurora"
+        assert extract_place_candidate("Avon CO PD", "CO") == "Avon"
+        assert extract_place_candidate("Brighton CO PD", "CO") == "Brighton"
+
+    def test_colorado_county_so_extracts_county(self):
+        assert extract_place_candidate("Arapahoe County CO SO", "CO") == "Arapahoe County"
+        assert extract_place_candidate("Chaffee County CO SO", "CO") == "Chaffee County"
+
+    def test_colorado_city_pd_does_not_match_county_extractor(self):
+        # "Aurora CO PD" must not look like a county once normalized
+        assert extract_county_candidate("Aurora CO PD") is None
+        assert extract_county_candidate("Avon CO PD") is None
+
+    def test_detect_county_co_state_ignores_role_suffix(self):
+        # "Aurora CO PD" — CO is the state code, PD is the role; no override
+        assert detect_county_co_state("Aurora CO PD") is None
+        assert detect_county_co_state("Avon CO PD") is None
+        # "Wagoner CO SO OK" — SO is role; override would otherwise return SO
+        assert detect_county_co_state("Wagoner CO SO OK") is None
+
+
+class TestCountyAbbreviation:
+    """'Co'/'Co.' as County abbreviation must still expand correctly."""
+
+    def test_co_dot_county_extracts_county(self):
+        assert extract_place_candidate("Schuyler Co. IL SO", "IL") == "Schuyler County"
+        assert extract_place_candidate("Bureau Co. IL SO", "IL") == "Bureau County"
+        assert extract_place_candidate("Florence Co. WI SO", "WI") == "Florence County"
+
+    def test_co_no_dot_county_extracts_county(self):
+        assert extract_place_candidate("Gasconade Co MO SO", "MO") == "Gasconade County"
+        assert extract_place_candidate("Morgan Co MO SO", "MO") == "Morgan County"
+        assert extract_place_candidate("Curry Co NM SO", "NM") == "Curry County"
+
+    def test_co_then_state_then_role_pattern(self):
+        # "Caldwell CO TX SO" — CO=County, TX=state, SO=role
+        # detect_county_co_state should return "TX" (the real state)
+        assert detect_county_co_state("Caldwell CO TX SO") == "TX"
+        assert detect_county_co_state("Reeves CO TX SO") == "TX"
+
+    def test_co_followed_by_dash_suffix(self):
+        # "LaSalle Co. IL SO - New" — _DASH_SUFFIX strips the trailing
+        # "- New", and Co. should still expand
+        assert extract_place_candidate("LaSalle Co. IL SO - New", "IL") == "LaSalle County"
+
+
+class TestNonAmbiguousCases:
+    """Names without 'Co'/'CO' shouldn't be affected by the disambiguation."""
+
+    def test_california_city(self):
+        assert extract_place_candidate("San Mateo CA PD", "CA") == "San Mateo"
+        assert extract_place_candidate("Foster City CA PD", "CA") == "Foster City"
+
+    def test_other_state_city(self):
+        assert extract_place_candidate("Akron OH PD", "OH") == "Akron"


### PR DESCRIPTION
## Summary

Two regexes confused **CO** (Colorado USPS code) with **Co**/**Co.** (County abbreviation) in agency names. Result: every Colorado entry that arrived without manual coords stayed in the off-map ocean cluster.

- `_ABBREV_CO`: case-insensitive `\bCo\b\.?` — turned `Aurora CO PD` → `Aurora County PD` → false county lookup.
- `detect_county_co_state`: matched `X CO YY` and returned `YY` as the real state, but accepted role suffixes as `YY` — so `Aurora CO PD` overrode the entry's state to "PD".

Both now require disambiguating context:
- `Co`/`Co.` → `County` only when followed by a 2-letter token *and* at least one more token (i.e. role-suffix-only context like `Aurora CO PD` no longer matches; legit `Schuyler Co. IL SO` still does).
- The `X CO YY` state override only fires when `YY` isn't a known role suffix (`PD/SO/DA/DPS/FD/EMS/OEM/OES`).

## Impact

Resolves 2 of the 111 ungeocoded recipients in the live ocean cluster:

- `aurora-co-pd` → place Aurora, CO
- `arapahoe-county-co-so` → county Arapahoe, CO

(Most other CO city PDs are already manually geocoded — Avon, Brighton, Durango, Fountain, etc. — so the surface impact is small, but the bug would resurface every time a new CO entry got crawled.)

## Out of scope (follow-ups visible in the same cluster)

- ~50 entries mistyped `agency_type: "federal"` that are actually state/county (e.g. `summit-county-sheriffs-office-co`, `indiana-state-police-in-pd`). Needs a registry-side classification pass.
- ~10 university entries (`elon-university-nc-pd`, `app-state-university-nc-pd`, `university-of-notre-dame-pd-in`) that need `STATE_CITY_ALIASES` rows.
- ~11 junk slugs (`delete`, `old`, `dnu`, `duplicate-please-delete`) that should be filtered out of `markers[].outbound_slugs` upstream.

## Test plan

- [x] `tests/test_geocode_co_disambiguation.py` — 10 cases covering both directions (CO state vs Co County) and edge cases (`Caldwell CO TX SO`, `Wagoner CO SO OK`, `LaSalle Co. IL SO - New`).
- [x] `tests/test_geo_cache.py` still passes (cached registry coords still match the gazetteer).
- [x] Full geocoder dry-run confirms only the 2 intended entries change.