### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -922,7 +922,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-10T11:36:24.950666+00:00",
+      "last_probed": "2026-05-10T18:40:07.681616+00:00",
       "tried": {
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -934,6 +934,7 @@
         "beverly-hills-po": "http_404",
         "beverly-hills-po-ca": "http_404",
         "beverly-hills-police-ca": "http_404",
+        "beverly-hills-police-department": "http_404",
         "beverly-hills-police-department-ca": "http_404",
         "beverly-hills-ps-ca": "http_404"
       }
@@ -1684,6 +1685,14 @@
         "pawnee-county-ks-so": "http_200"
       }
     },
+    "be5124a8-2b29-578f-b2d7-b63b9947b18f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-10T18:40:01.117147+00:00",
+      "tried": {
+        "albany-ny-pd-duplicate-no-not-use-ny-pd": "http_404"
+      }
+    },
     "bee385ab-4061-50f1-89f3-9a3a3c4b2f5e": {
       "exhausted": false,
       "found": null,
@@ -1825,6 +1834,14 @@
       "last_probed": "2026-05-08T23:41:08.500500+00:00",
       "tried": {
         "menominee-tribal-wi-pd": "http_404"
+      }
+    },
+    "d92dadc5-e837-5ff0-838d-33a9c4918bda": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-10T18:39:56.826670+00:00",
+      "tried": {
+        "pratt-county-ks-so": "http_404"
       }
     },
     "d9342287-962b-509a-9861-e44e0172394e": {
@@ -2159,6 +2176,6 @@
       }
     }
   },
-  "updated": "2026-05-10T17:38:22.109856+00:00",
+  "updated": "2026-05-10T18:40:07.720141+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -70,6 +70,14 @@
         "las-vegas-metro-nv-pd": "http_200"
       }
     },
+    "05d916bc-fcb0-5350-a670-3b2c5cd98fb3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-10T20:33:55.996715+00:00",
+      "tried": {
+        "benton-county-ar-so": "http_404"
+      }
+    },
     "0649c75b-a49d-5ec7-a240-18692dea2047": {
       "exhausted": false,
       "found": null,
@@ -414,9 +422,10 @@
     "33845531-5686-56e0-a3ff-371fae83d26b": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-27T07:57:12.706254+00:00",
+      "last_probed": "2026-05-10T20:33:51.802885+00:00",
       "tried": {
-        "albion-mi-dps-mi-pd": "http_404"
+        "albion-mi-dps-mi-pd": "http_404",
+        "albion-mi-dps-mi-po": "http_404"
       }
     },
     "339503d1-9389-51a0-a491-4d895d33e6be": {
@@ -1441,10 +1450,11 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-10T17:38:22.052899+00:00",
+      "last_probed": "2026-05-10T20:34:02.161509+00:00",
       "tried": {
         "-hollister-ca-pd": "http_404",
         "-hollister-ca-po": "http_404",
+        "-hollister-ca-police": "http_404",
         "-hollister-ca-police-department": "http_404",
         "hollister": "http_404",
         "hollister-ca": "http_404",
@@ -2193,6 +2203,6 @@
       }
     }
   },
-  "updated": "2026-05-10T19:47:49.364174+00:00",
+  "updated": "2026-05-10T20:34:02.199504+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -268,7 +268,7 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-10T15:38:37.873299+00:00",
+      "last_probed": "2026-05-10T19:47:49.325200+00:00",
       "tried": {
         "national-city": "http_404",
         "national-city-ca": "http_404",
@@ -288,7 +288,8 @@
         "national-city-police-department-ca": "http_404",
         "national-city-ps": "http_404",
         "national-city-ps-ca": "http_404",
-        "national-city-psca": "http_404"
+        "national-city-psca": "http_404",
+        "nationalcity-ca-pd": "http_404"
       }
     },
     "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
@@ -1051,6 +1052,14 @@
         "calhoun-county-mi-so": "http_404"
       }
     },
+    "77e04206-2f50-5e78-96a9-63fda0cc1c1a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-10T19:47:43.786315+00:00",
+      "tried": {
+        "gilbert-az-pd": "http_404"
+      }
+    },
     "7810622c-5cfd-5d8c-922a-9acd7e2ea391": {
       "exhausted": false,
       "found": null,
@@ -1725,6 +1734,14 @@
         "university-of-the-pacific-ca-pd": "http_404"
       }
     },
+    "c57c612b-30e6-57fd-a677-ab1b3f1ea095": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-10T19:47:39.260838+00:00",
+      "tried": {
+        "morgan-county-il-so": "http_404"
+      }
+    },
     "c7335eaf-bc00-59fa-bfff-e5992d32041d": {
       "exhausted": false,
       "found": null,
@@ -2176,6 +2193,6 @@
       }
     }
   },
-  "updated": "2026-05-10T18:40:07.720141+00:00",
+  "updated": "2026-05-10T19:47:49.364174+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.