### PR TITLE
feat(crawl): curl_cffi fallback for fingerprint-shaped Playwright failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "SMPD ALPR investigation — findings report and tooling"
 requires-python = ">=3.14"
 dependencies = [
     "anthropic>=0.97.0",
+    "curl-cffi>=0.15.0",
     "feedparser>=6.0.12",
     "openpyxl>=3.1.5",
     "pillow>=12.1.1",

--- a/scripts/article_crawl.py
+++ b/scripts/article_crawl.py
@@ -56,6 +56,18 @@ try:
 except ImportError:
     _PLAYWRIGHT_AVAILABLE = False
 
+# curl_cffi mimics Chrome's TLS handshake byte-for-byte and matches
+# its HTTP/2 SETTINGS frame ordering — the layer Cloudflare-tier
+# walls fingerprint on. Used as a fallback only, when Playwright
+# fetch hits a fingerprint-shaped error (HTTP 403 or
+# ERR_HTTP2_PROTOCOL_ERROR). No JS execution, so we lose in-session
+# PDF render on fallback; Wayback covers archival.
+try:
+    from curl_cffi import requests as _curl_cffi_requests
+    _CURL_CFFI_AVAILABLE = True
+except ImportError:
+    _CURL_CFFI_AVAILABLE = False
+
 print = functools.partial(print, flush=True)
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -502,11 +514,65 @@ def wayback_lookup_or_save(url: str) -> dict:
 # ───────────────────────── fetch + render ─────────────────────────
 
 
+def _is_fingerprint_failure(out: dict) -> bool:
+    """Does this Playwright result look like TLS/JS-fingerprint blocking?
+
+    Two patterns we know curl_cffi can recover:
+      - HTTP 403 — Cloudflare-tier walls reject the headless-Chrome JA3
+        plus header-shape combo even with channel='chrome' + stealth.
+      - ERR_HTTP2_PROTOCOL_ERROR — the stream gets RST'd at TLS
+        handshake before any HTTP transaction (McClatchy pattern).
+
+    Other failure modes — 404, 429, navigation timeouts, empty
+    responses — don't benefit from a fingerprint switch, so we don't
+    burn the fallback on them.
+    """
+    err = out.get("fetch_error") or ""
+    if out.get("status") == 403:
+        return True
+    if "ERR_HTTP2_PROTOCOL_ERROR" in err:
+        return True
+    return False
+
+
+def _fetch_curl_cffi(url: str) -> dict:
+    """Re-fetch with curl_cffi after a Playwright fingerprint failure.
+
+    impersonate='chrome' replays the latest Chrome's TLS+HTTP2 frame
+    fingerprint. No JS execution — we get the server-rendered HTML
+    only, no PDF render. pdf_status comes back as
+    'skipped-curl-fallback'; archival relies on the Wayback snapshot.
+    """
+    out = {
+        "fetch_error": None, "status": None, "body": None, "final_url": None,
+        "pdf_status": "skipped-curl-fallback",
+        "pdf_byte_size": None, "pdf_error": None,
+    }
+    if not _CURL_CFFI_AVAILABLE:
+        out["fetch_error"] = "curl_cffi not available"
+        return out
+    try:
+        r = _curl_cffi_requests.get(
+            url, impersonate="chrome",
+            timeout=30, allow_redirects=True,
+        )
+        out["status"] = r.status_code
+        out["final_url"] = str(r.url)
+        if r.status_code >= 400:
+            out["fetch_error"] = f"HTTP {r.status_code}"
+            return out
+        out["body"] = r.text
+    except Exception as e:
+        out["fetch_error"] = f"{type(e).__name__}: {str(e)[:300]}"
+    return out
+
+
 def fetch_and_render(url: str, pdf_path: Path | None,
                      *, skip_pdf: bool = False) -> dict:
     """Navigate to `url` with Playwright (real Chrome UA), capture HTML,
     and optionally render the loaded page to `pdf_path` in the same
-    browser session.
+    browser session. Falls back to curl_cffi on fingerprint-shaped
+    failures (HTTP 403, ERR_HTTP2_PROTOCOL_ERROR).
 
     One browser launch per URL covers both the HTML fetch and the PDF
     render — previously these were separate launches with a `requests`
@@ -519,13 +585,17 @@ def fetch_and_render(url: str, pdf_path: Path | None,
       status:        int | None — HTTP status from page.goto response
       body:          str | None — page.content() HTML, or None on error
       final_url:     str | None — page.url after redirects
-      pdf_status:    'rendered' | 'skipped' | 'failed' | None
+      pdf_status:    'rendered' | 'skipped' | 'skipped-curl-fallback' |
+                     'failed' | None
       pdf_byte_size: int | None
       pdf_error:     str | None
+      fetch_path:    'playwright-chrome' | 'curl_cffi' — which engine
+                     produced `body` (or attempted last on failure)
     """
     out = {
         "fetch_error": None, "status": None, "body": None, "final_url": None,
         "pdf_status": None, "pdf_byte_size": None, "pdf_error": None,
+        "fetch_path": "playwright-chrome",
     }
     if not _PLAYWRIGHT_AVAILABLE:
         out["fetch_error"] = "playwright not available"
@@ -565,39 +635,78 @@ def fetch_and_render(url: str, pdf_path: Path | None,
                                      timeout=45000)
                 if response is None:
                     out["fetch_error"] = "navigation returned no response"
-                    return out
-                out["status"] = response.status
-                out["final_url"] = page.url
-                if response.status >= 400:
-                    out["fetch_error"] = f"HTTP {response.status}"
-                    return out
-                out["body"] = page.content()
-
-                if skip_pdf or pdf_path is None:
-                    out["pdf_status"] = "skipped"
                 else:
-                    try:
-                        page.pdf(
-                            path=str(pdf_path),
-                            format="Letter",
-                            margin={"top": "0.5in", "bottom": "0.5in",
-                                    "left": "0.5in", "right": "0.5in"},
-                            print_background=False,
-                        )
-                        if pdf_path.exists():
-                            out["pdf_status"] = "rendered"
-                            out["pdf_byte_size"] = pdf_path.stat().st_size
+                    out["status"] = response.status
+                    out["final_url"] = page.url
+                    if response.status >= 400:
+                        out["fetch_error"] = f"HTTP {response.status}"
+                    else:
+                        out["body"] = page.content()
+                        if skip_pdf or pdf_path is None:
+                            out["pdf_status"] = "skipped"
                         else:
-                            out["pdf_status"] = "failed"
-                            out["pdf_error"] = "pdf not written"
-                    except Exception as e:
-                        out["pdf_status"] = "failed"
-                        out["pdf_error"] = f"{type(e).__name__}: {str(e)[:300]}"
+                            try:
+                                page.pdf(
+                                    path=str(pdf_path),
+                                    format="Letter",
+                                    margin={"top": "0.5in",
+                                            "bottom": "0.5in",
+                                            "left": "0.5in",
+                                            "right": "0.5in"},
+                                    print_background=False,
+                                )
+                                if pdf_path.exists():
+                                    out["pdf_status"] = "rendered"
+                                    out["pdf_byte_size"] = (
+                                        pdf_path.stat().st_size)
+                                else:
+                                    out["pdf_status"] = "failed"
+                                    out["pdf_error"] = "pdf not written"
+                            except Exception as e:
+                                out["pdf_status"] = "failed"
+                                out["pdf_error"] = (
+                                    f"{type(e).__name__}: {str(e)[:300]}")
             finally:
                 browser.close()
     except Exception as e:
         if out["fetch_error"] is None:
             out["fetch_error"] = f"{type(e).__name__}: {str(e)[:300]}"
+
+    # Inline fallback: if Playwright failed in a fingerprint-shaped
+    # way, retry with curl_cffi. Re-fetches over a different TLS
+    # stack, so 403/ERR_HTTP2 walls that fingerprint headless-Chrome
+    # let it through. Logged as fetch_path=curl_cffi so we can see
+    # which domains consistently need it.
+    if _is_fingerprint_failure(out):
+        primary_err = out["fetch_error"]
+        primary_status = out["status"]
+        print(f"  fingerprint-fallback: curl_cffi retry "
+              f"(playwright: status={primary_status} err={primary_err})")
+        fb = _fetch_curl_cffi(url)
+        if fb.get("body"):
+            # Promote the curl_cffi result to the primary record. PDF
+            # was already not rendered (fingerprint walls block earlier
+            # than the page.pdf step), so we just record the skip
+            # reason.
+            out["body"] = fb["body"]
+            out["status"] = fb["status"]
+            out["final_url"] = fb["final_url"]
+            out["fetch_error"] = None
+            out["pdf_status"] = "skipped-curl-fallback"
+            out["pdf_byte_size"] = None
+            out["pdf_error"] = None
+            out["fetch_path"] = "curl_cffi"
+        else:
+            # Fallback also failed; keep the original Playwright error
+            # for parity with prior behavior, but tag the path so the
+            # meta record shows we tried both.
+            out["fetch_path"] = "curl_cffi"
+            if fb.get("fetch_error"):
+                out["fetch_error"] = (
+                    f"playwright: {primary_err}; "
+                    f"curl_cffi: {fb['fetch_error']}"
+                )
+
     return out
 
 
@@ -726,6 +835,11 @@ def crawl_once(entry: dict, *, dry_run: bool,
         record["pdf_error"] = fetch_result["pdf_error"]
     if pdf_path.exists():
         record["paths"]["pdf"] = str(pdf_path.relative_to(ROOT))
+    # fetch_path tells us which engine produced the body — useful for
+    # spotting domains that consistently need the curl_cffi fallback,
+    # since those are candidates for "promote to curl_cffi-primary"
+    # to avoid showing CF a fail-then-success fingerprint switch.
+    record["fetch_path"] = fetch_result.get("fetch_path")
 
     save_json(meta_path, record)
     return record

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -99,6 +132,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]
@@ -264,6 +330,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -343,6 +430,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -496,6 +592,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -507,6 +616,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "curl-cffi" },
     { name = "feedparser" },
     { name = "openpyxl" },
     { name = "pillow" },
@@ -526,6 +636,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.97.0" },
+    { name = "curl-cffi", specifier = ">=0.15.0" },
     { name = "feedparser", specifier = ">=6.0.12" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pillow", specifier = ">=12.1.1" },


### PR DESCRIPTION
## Summary
Chrome+stealth (PR #315) handled McClatchy TLS-fingerprint walls, but Cloudflare-tier walls (`oaklandside.org`, `oakpark.com`, `richmondside.org`, `richmondstandard.com`, `natickreport.com`, `kxan.com`) still 403 — they fingerprint the TLS handshake **plus** HTTP/2 SETTINGS frame ordering at a layer Playwright can't change.

`curl_cffi` (`impersonate="chrome"`) replays Chrome's TLS hello and HTTP/2 frame layout byte-for-byte. Local test: 5/5 of the previously-403'd URLs return 200.

## Plumbing
Inline fallback at the end of `fetch_and_render`. After the Playwright attempt, if the result looks fingerprint-shaped (`HTTP 403` or `ERR_HTTP2_PROTOCOL_ERROR`), retry with `curl_cffi` and promote the result to the primary record. New `fetch_path` field on the meta sidecar records which engine produced the body: `playwright-chrome` for the fast path, `curl_cffi` for the fallback.

## Trade-offs
- **PDF loss on fallback.** `curl_cffi` can't execute JS, so no in-session PDF render on the fallback path. `pdf_status="skipped-curl-fallback"`. Archival still works — the crawler submits a Wayback save independently.
- **Same-IP fingerprint switch.** Theoretically detectable if CF correlates JA3-A-fails with JA3-B-succeeds on the same IP. GHA runners rotate IPs per job though, so the pattern is bounded to ~5 switches per IP before that IP is gone forever. If a domain consistently needs the fallback, `fetch_path` makes it observable — we can later promote those to a "curl_cffi-first" allowlist that never exposes the failed Playwright fingerprint at all.

## Verification
```
--- oaklandside.org/.../oakland-flock-safety-council-approves-... ---
  fingerprint-fallback: curl_cffi retry (playwright: status=403 err=HTTP 403)
  status=200  fetch_path=curl_cffi  err=None
  body_size=585076  pdf_status=skipped-curl-fallback

--- eff.org/deeplinks/2024/11/human-toll-alpr-errors  (control) ---
  status=200  fetch_path=playwright-chrome  err=None
  body_size=102425  pdf_status=skipped
```

## Test plan
- [x] `article_crawl.py` parses + imports
- [x] Local fetch: previously-403 oaklandside URL recovers via fallback; eff.org control uses primary path
- [ ] CI run: `fetch_path=curl_cffi` appears in meta sidecars for the expected domains
- [ ] Body sizes for fallback paths are non-trivial (>50KB; matches local test)