### PR TITLE
feat(articles): allow multi-primary subject agencies on map

### DIFF
--- a/assets/article_registry.json
+++ b/assets/article_registry.json
@@ -4,12 +4,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock Safety\u2019s Feature Updates Cannot Make Automated License Plate Readers Safe",
+    "title": "Flock Safety’s Feature Updates Cannot Make Automated License Plate Readers Safe",
     "byline": "Sarah Hamid and Rindala Alajaji",
     "published_at": "2025-06-27T17:36:58-07:00",
     "fetched_at": "2026-05-04T21:19:38Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8d3e3bed2e66f066465931d75a59ad6eedc01e06827d442adb9559e4e4f66252",
     "paths": {
@@ -121,7 +121,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "978d5b81-63f1-5f5d-bf83-4f108c15abcb",
     "summary": "EFF criticizes Flock Safety's response to recent controversies, including a Texas sheriff using its ALPR network to track an abortion seeker and over 4,000 lookups linked to immigration enforcement. The piece argues Flock's proposed feature updates and reliance on local policy cannot fix systemic risks, and praises cities like Austin, Denver, and San Diego for pushing back.",
     "key_quotes": [
       {
@@ -139,7 +138,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:21:00Z",
-    "article_id": "art_001"
+    "article_id": "art_001",
+    "primary_subject_agency_ids": [
+      "978d5b81-63f1-5f5d-bf83-4f108c15abcb"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/11/washington-court-rules-data-captured-flock-safety-cameras-are-public-records",
@@ -151,7 +153,7 @@
     "published_at": "2025-11-12T15:00:00-08:00",
     "fetched_at": "2026-05-04T21:17:24Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "3a31d41980b484b54c531d8e6fd5e32e115d80a0a14be9255eda5225e031ecbd",
     "paths": {
@@ -273,7 +275,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "37330114-0b02-5b61-a889-2fc214849095",
     "summary": "A Skagit County Superior Court ruled that Flock Safety ALPR data collected for the cities of Stanwood and Sedro-Woolley are public records under Washington's Public Records Act, rejecting the cities' arguments that data stored on Flock's servers fell outside disclosure requirements. The cities had shut off their Flock cameras during the litigation, and the requester ultimately won't receive records because they were auto-deleted.",
     "key_quotes": [
       {
@@ -291,7 +292,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:21:10Z",
-    "article_id": "art_002"
+    "article_id": "art_002",
+    "primary_subject_agency_ids": [
+      "37330114-0b02-5b61-a889-2fc214849095"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/12/effs-investigations-expose-flock-safetys-surveillance-abuses-2025-review",
@@ -303,7 +307,7 @@
     "published_at": "2025-12-30T11:03:19-08:00",
     "fetched_at": "2026-05-04T21:21:16Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "be180c1f687d6f36f117956cb5bb77cbf831e3bb77364f2f1b74a5e5fbc37db6",
     "paths": {
@@ -423,7 +427,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "978d5b81-63f1-5f5d-bf83-4f108c15abcb",
     "summary": "EFF recaps its 2025 investigations into Flock Safety's ALPR network, documenting searches targeting protesters, Romani people, and a Texas abortion investigation, plus Flock's expansion into audio surveillance. The piece highlights resulting congressional and state investigations, an Illinois audit, an ACLU/EFF lawsuit against San Jose, and municipal cancellations.",
     "key_quotes": [
       {
@@ -445,19 +448,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:21:22Z",
-    "article_id": "art_003"
+    "article_id": "art_003",
+    "primary_subject_agency_ids": [
+      "978d5b81-63f1-5f5d-bf83-4f108c15abcb"
+    ]
   },
   {
     "url": "https://www.kqed.org/news/12066924/oaklands-license-plate-camera-contract-is-back-up-for-a-vote-critics-are-crying-foul",
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "Oakland\u2019s License Plate Camera Contract Is Back Up for a Vote. Critics Are Crying Foul | KQED",
+    "title": "Oakland’s License Plate Camera Contract Is Back Up for a Vote. Critics Are Crying Foul | KQED",
     "byline": "Katie DeBenedetti",
     "published_at": "2025-12-13T08:00:41-08:00",
     "fetched_at": "2026-05-04T23:08:16Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "6574373b7ee6709731eba54cc5afc63dd196654305ca284acb8769e981719170",
     "paths": {
@@ -578,7 +584,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "6f2b98a1-957a-5dc9-935c-7b8127a223d6",
     "summary": "Oakland's City Council is set to vote on a two-year, $2.25 million extension of its Flock Safety ALPR contract after the proposal failed in the Public Safety Committee but was revived by the Rules Committee with less than 24 hours' notice. Critics, including Councilmember Carroll Fife, the ACLU, and the city's Privacy Advisory Commission, oppose the extension citing data-sharing with federal agencies including ICE, a recent lawsuit by Secure Justice, and Oakland's sanctuary policies.",
     "key_quotes": [
       {
@@ -604,7 +609,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:21:38Z",
-    "article_id": "art_004"
+    "article_id": "art_004",
+    "primary_subject_agency_ids": [
+      "6f2b98a1-957a-5dc9-935c-7b8127a223d6"
+    ]
   },
   {
     "url": "https://www.kqed.org/news/12069705/santa-cruz-the-first-in-california-to-terminate-its-contract-with-flock-safety",
@@ -616,7 +624,7 @@
     "published_at": "2026-01-14T16:48:54-08:00",
     "fetched_at": "2026-05-04T23:06:29Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "00b8d1303383a6f722d78658d5ae11704fbfb532895b4ca2598000d89a03b16b",
     "paths": {
@@ -736,7 +744,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8e97dede-dc5e-518a-bd9c-ca1acce1757a",
     "summary": "The Santa Cruz City Council voted 6-1 to terminate its contract with Flock Safety, becoming the first California city to do so, after revelations that out-of-state agencies and federal law enforcement including ICE accessed the city's ALPR data in apparent violation of California's SB 34. Advocates documented roughly 4,000 such accesses between June and October 2025.",
     "key_quotes": [
       {
@@ -758,19 +765,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:21:51Z",
-    "article_id": "art_005"
+    "article_id": "art_005",
+    "primary_subject_agency_ids": [
+      "8e97dede-dc5e-518a-bd9c-ca1acce1757a"
+    ]
   },
   {
     "url": "https://www.kqed.org/news/12075999/san-jose-is-the-latest-bay-area-city-to-restrict-flock-license-plate-cameras",
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "San Jos\u00e9 Is the Latest Bay Area City to Restrict Flock License Plate Cameras | KQED",
+    "title": "San José Is the Latest Bay Area City to Restrict Flock License Plate Cameras | KQED",
     "byline": "Ayah Ali-Ahmad",
     "published_at": "2026-03-11T11:41:49-07:00",
     "fetched_at": "2026-05-04T23:09:34Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "3839d423ff9d03f5bcab1f7e15c867b0c83ec0b982f136e561dc877bb8ddb411",
     "paths": {
@@ -891,15 +901,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
-    "summary": "The San Jos\u00e9 City Council unanimously voted to tighten restrictions on its Flock Safety ALPR program, reducing data retention from one year to 30 days, prohibiting cameras near reproductive health facilities, places of worship, and gender-affirming care sites, and adding documentation requirements for data access. The council also directed the city manager to explore alternative vendors, while advocates and Councilmember Peter Ortiz pushed unsuccessfully to terminate the Flock contract entirely.",
+    "summary": "The San José City Council unanimously voted to tighten restrictions on its Flock Safety ALPR program, reducing data retention from one year to 30 days, prohibiting cameras near reproductive health facilities, places of worship, and gender-affirming care sites, and adding documentation requirements for data access. The council also directed the city manager to explore alternative vendors, while advocates and Councilmember Peter Ortiz pushed unsuccessfully to terminate the Flock contract entirely.",
     "key_quotes": [
       {
         "quote": "The city's changes reduce the default data retention period from one year to 30 days, prohibit placing cameras near reproductive health care facilities and places of worship, and add new documentation and authentication requirements for agencies requesting access to the data.",
         "paragraph_idx": 6
       },
       {
-        "quote": "San Jos\u00e9 has 474 Flock cameras administered by the police department's Real Time Intelligence Center.",
+        "quote": "San José has 474 Flock cameras administered by the police department's Real Time Intelligence Center.",
         "paragraph_idx": 10
       },
       {
@@ -913,7 +922,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:04Z",
-    "article_id": "art_006"
+    "article_id": "art_006",
+    "primary_subject_agency_ids": [
+      "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0"
+    ]
   },
   {
     "url": "https://www.404media.co/city-learns-flock-accessed-cameras-in-childrens-gymnastics-room-as-a-sales-pitch-demo-renews-contract-anyway/",
@@ -925,7 +937,7 @@
     "published_at": "2026-04-30T13:25:36.000Z",
     "fetched_at": "2026-05-05T08:29:47Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 30 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 30 pts, low/medium only",
     "scanner_score": 30,
     "content_hash": "bb1af747e113c28486c33be1c77caa94061b553a500b1d219d51df6f6258fc97",
     "paths": {
@@ -1027,8 +1039,7 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
-    "summary": "Public records obtained by a Dunwoody, Georgia resident revealed that Flock Safety employees accessed cameras in sensitive locations\u2014including a children's gymnastics room, playground, school, Jewish community center pool, and fitness studios\u2014as part of sales demonstrations under the city's 'demo partner' agreement. Flock confirmed the access but disputed characterizations of spying, agreed to stop using Dunwoody cameras for demos, and said employees will be trained to only demo in public locations like retail parking lots. Despite resident outrage, the city renewed its contract.",
+    "summary": "Public records obtained by a Dunwoody, Georgia resident revealed that Flock Safety employees accessed cameras in sensitive locations—including a children's gymnastics room, playground, school, Jewish community center pool, and fitness studios—as part of sales demonstrations under the city's 'demo partner' agreement. Flock confirmed the access but disputed characterizations of spying, agreed to stop using Dunwoody cameras for demos, and said employees will be trained to only demo in public locations like retail parking lots. Despite resident outrage, the city renewed its contract.",
     "key_quotes": [
       {
         "quote": "The cameras accessed have included surveillance tech in a children's gymnastics room, a playground, a school, a Jewish community center, and a pool.",
@@ -1049,7 +1060,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:14Z",
-    "article_id": "art_007"
+    "article_id": "art_007",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.404media.co/flock-removes-states-from-national-lookup-tool-after-ice-and-abortion-searches-revealed/",
@@ -1061,7 +1073,7 @@
     "published_at": "2025-06-25T15:08:13.000Z",
     "fetched_at": "2026-05-05T08:29:38Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 30 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 30 pts, low/medium only",
     "scanner_score": 30,
     "content_hash": "9ea04f46b04da6bef3c45897b18a30b85c75c08aae08e34f77b8f56f486e36c6",
     "paths": {
@@ -1106,7 +1118,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Flock has disabled out-of-state agency access to its ALPR cameras in California, Illinois, and Virginia following 404 Media reporting on ICE lookups and an abortion-related search, and after new Virginia legislation. The Illinois Secretary of State is investigating whether departments broke state law via the national lookup database.",
     "key_quotes": [
       {
@@ -1124,7 +1135,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:20Z",
-    "article_id": "art_008"
+    "article_id": "art_008",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/06/san-diegans-push-back-flock-alpr-surveillance",
@@ -1136,7 +1148,7 @@
     "published_at": "2025-06-03T13:13:25-07:00",
     "fetched_at": "2026-05-05T08:29:43Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "97e2a928c31e58617c0b6ac38cae48988fc0dbc57f9812c19ea05d423f5910f0",
     "paths": {
@@ -1250,11 +1262,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "ddca091b-bdea-5711-8eda-e1b175ebe7ad",
     "summary": "EFF reports that the TRUST Coalition is urging San Diego's city council, ahead of the first annual review of its Flock Safety ALPR contract, to end the program. The article cites concerns about data sharing with federal agencies (HSI, CBP), unauthorized deployments at Comic-Con and Pride, $3.5 million in costs, and a Privacy Board recommendation to reject the Surveillance Use Policy.",
     "key_quotes": [
       {
-        "quote": "Despite local and state restrictions barring the sharing of ALPR with federal and out of state agencies, San Diego Police have reportedly disclosed license plate data to federal agencies\u2014 including Homeland Security Investigations and Customs and Border Patrol.",
+        "quote": "Despite local and state restrictions barring the sharing of ALPR with federal and out of state agencies, San Diego Police have reportedly disclosed license plate data to federal agencies— including Homeland Security Investigations and Customs and Border Patrol.",
         "paragraph_idx": 7
       },
       {
@@ -1268,7 +1279,10 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_009",
-    "curated_at": "2026-05-08T18:28:13Z"
+    "curated_at": "2026-05-08T18:28:13Z",
+    "primary_subject_agency_ids": [
+      "ddca091b-bdea-5711-8eda-e1b175ebe7ad"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/06/victory-austin-organizers-cancel-citys-flock-alpr-contract",
@@ -1280,7 +1294,7 @@
     "published_at": "2025-06-06T15:38:32-07:00",
     "fetched_at": "2026-05-05T08:29:35Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "fe2c8e128d23190b3d007112c52b1bc5503b04bbc3c8470c76136c62785a7065",
     "paths": {
@@ -1376,7 +1390,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "summary": "Austin's city council, after pressure from a coalition of 30+ community groups, declined to renew the Austin Police Department's Flock Safety ALPR contract, ending the program at the end of June 2025. A recent audit found over 20% of ALPR searches lacked proper documentation and that contract terms allowed retention and sharing beyond council-mandated limits.",
     "key_quotes": [
       {
@@ -1394,7 +1407,10 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_010",
-    "curated_at": "2026-05-08T18:28:23Z"
+    "curated_at": "2026-05-08T18:28:23Z",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/02/effecting-change-get-flock-out-our-city",
@@ -1406,7 +1422,7 @@
     "published_at": "2026-02-09T14:31:43-08:00",
     "fetched_at": "2026-05-05T08:29:51Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "1293a51918013062322d5325408baa2344063ffd33b4d2c5fb0d6d0548d05575",
     "paths": {
@@ -1511,11 +1527,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF announces a February 2026 livestream event featuring speakers from EFF, Fight for the Future, and Rural Privacy Coalition discussing growing resistance to Flock ALPR contracts across U.S. cities. The post highlights privacy harms and notes jurisdictions like Austin and Cambridge have rejected Flock.",
     "key_quotes": [
       {
-        "quote": "From Austin to Cambridge to small towns across Texas, jurisdictions are rejecting Flock contracts altogether, proving that surveillance isn't inevitable\u2014it's a choice.",
+        "quote": "From Austin to Cambridge to small towns across Texas, jurisdictions are rejecting Flock contracts altogether, proving that surveillance isn't inevitable—it's a choice.",
         "paragraph_idx": 7
       },
       {
@@ -1525,7 +1540,8 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_011",
-    "curated_at": "2026-05-08T18:28:28Z"
+    "curated_at": "2026-05-08T18:28:28Z",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12072077/as-california-cities-grow-wary-of-flock-safety-cameras-mountain-views-shuts-its-off",
@@ -1537,7 +1553,7 @@
     "published_at": "2026-02-03T16:31:59-08:00",
     "fetched_at": "2026-05-05T08:29:29Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "728bfa59d43fd53e7004dfae1725038cf2d085f5df9cb7a0d2a877d64773fc74",
     "paths": {
@@ -1661,7 +1677,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
     "summary": "Mountain View Police Department turned off its Flock Safety ALPR cameras after an audit revealed federal agencies had accessed its data through a nationwide search tool and 29 of 30 cameras had been accessed by unauthorized California agencies, in violation of a 2015 state law. Chief Mike Canfield said community trust outweighed the tool's value, though the city may resume an ALPR program pending a council decision.",
     "key_quotes": [
       {
@@ -1683,7 +1698,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:33Z",
-    "article_id": "art_012"
+    "article_id": "art_012",
+    "primary_subject_agency_ids": [
+      "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0"
+    ]
   },
   {
     "url": "https://www.404media.co/ice-secret-service-navy-all-had-access-to-flocks-nationwide-network-of-cameras/",
@@ -1695,7 +1713,7 @@
     "published_at": "2025-10-16T13:00:05.000Z",
     "fetched_at": "2026-05-05T08:35:24Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 33 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 33 pts, low/medium only",
     "scanner_score": 33,
     "content_hash": "7a6f12f14c3dc21d792178b80b943235fad9355179aac92679bf44e450bdc7f1",
     "paths": {
@@ -1727,7 +1745,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Senator Ron Wyden disclosed in a letter to 404 Media that ICE's Homeland Security Investigations, the Secret Service, and the Navy's criminal investigation division all had access to Flock's nationwide network of ALPR cameras, with HSI conducting nearly 200 searches. Wyden urged local officials to remove Flock cameras, saying the company is uninterested in preventing abuse.",
     "key_quotes": [
       {
@@ -1745,19 +1762,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:39Z",
-    "article_id": "art_013"
+    "article_id": "art_013",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/02/free-surveillance-tech-still-comes-high-and-dangerous-cost",
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "\u201cFree\u201d Surveillance Tech Still Comes at a High and Dangerous Cost",
+    "title": "“Free” Surveillance Tech Still Comes at a High and Dangerous Cost",
     "byline": "Beryl Lipton and Sarah Hamid",
     "published_at": "2026-02-11T10:00:12-08:00",
     "fetched_at": "2026-05-05T08:35:13Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "73a85a61809f7bf940bf14b6442d6f6791eadf2b52a63aebdcaffa2a0c5d8d89",
     "paths": {
@@ -1886,15 +1904,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
-    "summary": "EFF argues that 'free' surveillance technology \u2014 provided through vendor trials, police foundation gifts, wealthy donors, and federal grants \u2014 bypasses local oversight and locks municipalities into long-term costs and federal data pipelines including ICE access. The piece surveys examples from Denver, Atlanta, San Francisco, Santa Cruz, Sumner WA, and Fall River MA, urging cities to refuse such offers and shut down existing systems.",
+    "summary": "EFF argues that 'free' surveillance technology — provided through vendor trials, police foundation gifts, wealthy donors, and federal grants — bypasses local oversight and locks municipalities into long-term costs and federal data pipelines including ICE access. The piece surveys examples from Denver, Atlanta, San Francisco, Santa Cruz, Sumner WA, and Fall River MA, urging cities to refuse such offers and shut down existing systems.",
     "key_quotes": [
       {
         "quote": "In May 2025, Denver's city council unanimously rejected a $666,000 contract extension for Flock Safety ALPR cameras after weeks of public outcry over mass surveillance data sharing with federal immigration enforcement.",
         "paragraph_idx": 17
       },
       {
-        "quote": "A recent report by the Surveillance Technology Oversight Project (S.T.O.P.) describes ICE agents using a Philadelphia\u2011area fusion center to query the city's ALPR network to track undocumented drivers in a self\u2011described sanctuary city.",
+        "quote": "A recent report by the Surveillance Technology Oversight Project (S.T.O.P.) describes ICE agents using a Philadelphia‑area fusion center to query the city's ALPR network to track undocumented drivers in a self‑described sanctuary city.",
         "paragraph_idx": 29
       },
       {
@@ -1904,7 +1921,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:22:53Z",
-    "article_id": "art_014"
+    "article_id": "art_014",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/04/print-blocking-wont-work-permission-print-part-2",
@@ -1916,7 +1934,7 @@
     "published_at": "2026-04-02T10:57:16-07:00",
     "fetched_at": "2026-05-05T08:35:19Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "0209abec89b3d186ab2ea850b9bffb6170fd61f6821867c5d06b31e31e711bb4",
     "paths": {
@@ -1969,25 +1987,25 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-05T08:36:16Z",
     "article_id": "art_015",
-    "curation_error": "refusal: Article is about 3D printer regulation, not ALPR or police surveillance."
+    "curation_error": "refusal: Article is about 3D printer regulation, not ALPR or police surveillance.",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12064587/civil-liberties-groups-sue-san-jose-over-license-plate-reader-use",
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "Civil Liberties Groups Sue San Jos\u00e9 Over License Plate Reader Use | KQED",
+    "title": "Civil Liberties Groups Sue San José Over License Plate Reader Use | KQED",
     "byline": "Joseph Geha",
     "published_at": "2025-11-18T16:16:38-08:00",
     "fetched_at": "2026-05-05T08:35:32Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "2b77def78e152046599817f53497d4ddebf1baf917ba262fa3414c913c2dc1c6",
     "paths": {
@@ -2110,15 +2128,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
-    "summary": "The ACLU of Northern California and EFF, on behalf of CAIR-CA and SIREN, sued San Jos\u00e9 over its ~500-camera Flock ALPR system, alleging the one-year retention and warrantless retrospective searches violate California privacy rights. The suit, filed the same day as a separate suit against Oakland, seeks to require warrants for searches of stored ALPR data.",
+    "summary": "The ACLU of Northern California and EFF, on behalf of CAIR-CA and SIREN, sued San José over its ~500-camera Flock ALPR system, alleging the one-year retention and warrantless retrospective searches violate California privacy rights. The suit, filed the same day as a separate suit against Oakland, seeks to require warrants for searches of stored ALPR data.",
     "key_quotes": [
       {
-        "quote": "a group of civil liberties and immigrant support organizations is suing San Jos\u00e9, alleging the city's widespread use of hundreds of automated license plate readers amounts to a 'deeply invasive' mass surveillance system",
+        "quote": "a group of civil liberties and immigrant support organizations is suing San José, alleging the city's widespread use of hundreds of automated license plate readers amounts to a 'deeply invasive' mass surveillance system",
         "paragraph_idx": 1
       },
       {
-        "quote": "the lawsuit asks a judge to require San Jos\u00e9 police officers and other law enforcement agencies to get a warrant when they want to search the vast troves of stored data",
+        "quote": "the lawsuit asks a judge to require San José police officers and other law enforcement agencies to get a warrant when they want to search the vast troves of stored data",
         "paragraph_idx": 11
       },
       {
@@ -2136,7 +2153,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:07Z",
-    "article_id": "art_016"
+    "article_id": "art_016",
+    "primary_subject_agency_ids": [
+      "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0"
+    ]
   },
   {
     "url": "https://www.404media.co/flock-exposed-its-ai-powered-cameras-to-the-internet-we-tracked-ourselves/",
@@ -2148,7 +2168,7 @@
     "published_at": "2025-12-22T16:05:19.000Z",
     "fetched_at": "2026-05-05T16:49:59Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "9ee8add536a274a36117bbc08f5f2354a400c823c4d055bc544307f92bd56922",
     "paths": {
@@ -2241,7 +2261,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "404 Media reports that Flock left at least 60 of its Condor PTZ cameras livestreaming and administratively accessible on the open internet without authentication, allowing anyone to view feeds, download 30 days of archived video, and alter settings. Researchers Benn Jordan and Jon Gaines discovered the exposure via Shodan, and the reporter verified it by watching himself on a livestream from a Bakersfield camera.",
     "key_quotes": [
       {
@@ -2255,7 +2274,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:14Z",
-    "article_id": "art_017"
+    "article_id": "art_017",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/alpr-against-op-ed-writer",
@@ -2267,7 +2287,7 @@
     "published_at": "2026-02-03T17:08:29+00:00",
     "fetched_at": "2026-05-05T16:54:39Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "e7d64ae9313aecde43441856924422a270bea0c68ec1cbe2bc332a25c81c9d3e",
     "paths": {
@@ -2332,7 +2352,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU describes how police in Lenexa, Kansas used ALPR technology to track Canyen Ashworth after he wrote an op-ed critical of local police cooperation with ICE, tying him to anonymous anti-ICE posters and issuing a 'make your own case' BOLO. The piece frames this as a textbook example of mass-surveillance misuse to target protected speech.",
     "key_quotes": [
       {
@@ -2350,7 +2369,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:21Z",
-    "article_id": "art_018"
+    "article_id": "art_018",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2019/06/victory-california-orders-state-audit-automated-license-plate-readers",
@@ -2362,7 +2382,7 @@
     "published_at": "2019-06-26T15:59:24-07:00",
     "fetched_at": "2026-05-05T16:51:33Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8f0a4d5232c571bb50531fd3347c34d7859b26127b9207b0bf210158511a9f10",
     "paths": {
@@ -2494,7 +2514,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "A California legislative committee voted to direct the State Auditor to conduct a statewide audit of law enforcement use of automated license plate readers, including deeper investigations of Fresno PD, Sacramento County Sheriff, LAPD, and the Marin County Sheriff/San Rafael PD shared system. EFF assisted Sen. Wiener in drafting the audit request to assess compliance with S.B. 34.",
     "key_quotes": [
       {
@@ -2512,7 +2531,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:30Z",
-    "article_id": "art_019"
+    "article_id": "art_019",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://epic.org/axon-ethics-board-no-license-plate-readers-without-public-input/",
@@ -2524,7 +2544,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T16:52:43Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "d04d6588d42d46a28dcdbed29b1ea9653e5ce67efa2115e8f06113eb48be350b",
     "paths": {
@@ -2594,7 +2614,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EPIC summarizes a 2019 report by the Axon AI and Policing Technology Ethics Board on automated license plate readers, which highlights disproportionate impacts on communities of color and recommends public review before deployment and that ALPR alerts alone should not justify vehicle stops. EPIC notes its parallel amicus position in Kansas v. Glover and prior FOIA work on DHS and FBI ALPR use.",
     "key_quotes": [
       {
@@ -2608,7 +2627,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:01Z",
-    "article_id": "art_020"
+    "article_id": "art_020",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12067461/oakland-council-expands-flock-license-plate-reader-network-despite-privacy-concerns",
@@ -2620,7 +2640,7 @@
     "published_at": "2025-12-17T12:59:42-08:00",
     "fetched_at": "2026-05-05T16:57:23Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "192e03fbb1e01be0397fb2291f4c8ad3fd168766697cc8744e00f4f0dc1dbf66",
     "paths": {
@@ -2753,7 +2773,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "6f2b98a1-957a-5dc9-935c-7b8127a223d6",
     "summary": "The Oakland City Council voted 7-1 to approve a new two-year, $2.25 million contract with Flock Safety, expanding its ALPR network from 291 cameras to add 40 new pan-tilt-zoom cameras, despite privacy advocates' objections about federal surveillance risks. The contract includes amendments restricting data sharing with federal immigration agencies and out-of-state investigators of reproductive/gender-affirming care, a two-key approval system for new data-sharing, quarterly independent audits, and an RFP requirement within 18 months.",
     "key_quotes": [
       {
@@ -2771,7 +2790,10 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_021",
-    "curated_at": "2026-05-08T18:28:41Z"
+    "curated_at": "2026-05-08T18:28:41Z",
+    "primary_subject_agency_ids": [
+      "6f2b98a1-957a-5dc9-935c-7b8127a223d6"
+    ]
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/flock-massachusetts-and-updates",
@@ -2783,7 +2805,7 @@
     "published_at": "2025-10-24T18:28:33+00:00",
     "fetched_at": "2026-05-05T18:24:30Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "a545fafd38e45088daf00d1deadce30d85984b6364a0231ec0a946100a3b0cce",
     "paths": {
@@ -2869,7 +2891,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "ACLU's Jay Stanley reports that Flock's default user agreement grants the company a perpetual license to share police ALPR data with federal and local agencies for 'investigative purposes' even when departments restrict access, per ACLU-MA's open-records project. The post also rounds up other Flock developments: Virginia's Warren County Sheriff sharing data with ICE, a Texas abortion-related search, a Flock-Ring partnership, and Flock's expansion of drone programs into the private sector.",
     "key_quotes": [
       {
@@ -2881,7 +2902,7 @@
         "paragraph_idx": 8
       },
       {
-        "quote": "one Virginia agency, the Warren County Sheriff's Office, performed more immigration searches than any other in the state \u2014 and confirmed that it did so because federal immigration agents asked them to.",
+        "quote": "one Virginia agency, the Warren County Sheriff's Office, performed more immigration searches than any other in the state — and confirmed that it did so because federal immigration agents asked them to.",
         "paragraph_idx": 8
       },
       {
@@ -2891,7 +2912,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:41Z",
-    "article_id": "art_022"
+    "article_id": "art_022",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/02/op-ed-san-jose-can-protect-immigrants-ending-flock-surveillance-system",
@@ -2903,7 +2925,7 @@
     "published_at": "2026-02-17T10:55:34-08:00",
     "fetched_at": "2026-05-05T18:21:26Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "372f7744aa98f199764f2890a4a3adcc9b1aa1a5a0b9d956d94d81f21b5a84d0",
     "paths": {
@@ -3033,7 +3055,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
     "summary": "An EFF op-ed urges San Jose to shut down its Flock ALPR system, arguing the technology endangers immigrants by enabling federal and ICE access to location data. It cites recent actions by Mountain View, Los Altos Hills, Santa Cruz, East Palo Alto, and Santa Clara County, and notes EFF/ACLU's pending lawsuit over San Jose's warrantless ALPR searches.",
     "key_quotes": [
       {
@@ -3051,7 +3072,10 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_023",
-    "curated_at": "2026-05-08T18:28:52Z"
+    "curated_at": "2026-05-08T18:28:52Z",
+    "primary_subject_agency_ids": [
+      "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0"
+    ]
   },
   {
     "url": "https://epic.org/supreme-court-to-hear-arguments-in-case-implicating-license-plate-readers/",
@@ -3063,7 +3087,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T18:29:55Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "8ea7a6aac7a1b58bd3931125f2d4bbef1deec71a5c7707355b050193fa511b07",
     "paths": {
@@ -3132,7 +3156,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EPIC announced it filed an amicus brief in Kansas v. Glover, a Supreme Court case on whether police can stop a vehicle based solely on the registered owner having a suspended license. EPIC argued that combined with ALPRs, such a rule could dramatically expand stops and disproportionately burden disadvantaged communities where ALPR use and car-sharing are more common.",
     "key_quotes": [
       {
@@ -3146,7 +3169,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:07Z",
-    "article_id": "art_024"
+    "article_id": "art_024",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://ww2.kqed.org/news/2026/02/25/santa-clara-county-leaders-cut-out-flock-safety-in-new-surveillance-policy/",
@@ -3158,7 +3182,7 @@
     "published_at": "2026-02-25T10:57:27-08:00",
     "fetched_at": "2026-05-05T18:26:06Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "9e9ce162da1cf6db70baa427b16f8fee127873df1062f2849da322dc75a228da",
     "paths": {
@@ -3288,7 +3312,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "1b719ab9-5230-5a7a-bcb4-a495a4e716eb",
     "summary": "Santa Clara County's Board of Supervisors voted 3-2 to amend its Surveillance Use Policy so the Sheriff's Office can no longer access or use Flock Safety ALPR data, effectively disabling Flock cameras in Cupertino, Saratoga, and Los Altos Hills. The move was driven by concerns about federal immigration agencies accessing Flock data, and joins a wave of California cities including Mountain View and Santa Cruz cutting ties with Flock. The new policy also mandates audits every four months and immediate reporting of unauthorized federal data sharing.",
     "key_quotes": [
       {
@@ -3314,19 +3337,22 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_025",
-    "curated_at": "2026-05-08T18:29:06Z"
+    "curated_at": "2026-05-08T18:29:06Z",
+    "primary_subject_agency_ids": [
+      "1b719ab9-5230-5a7a-bcb4-a495a4e716eb"
+    ]
   },
   {
     "url": "https://themarkup.org/privacy/2026/03/06/he-saw-an-abandoned-trailer-then-he-uncovered-a-surveillance-network-on-californias-border",
     "source_domain": "themarkup.org",
     "tier": 2,
     "stance": "critical",
-    "title": "He saw an abandoned trailer. Then, he uncovered a surveillance network on California's border \u2013 The Markup",
+    "title": "He saw an abandoned trailer. Then, he uncovered a surveillance network on California's border – The Markup",
     "byline": null,
     "published_at": "2026-03-06T08:00:00+00:00",
     "fetched_at": "2026-05-05T18:28:00Z",
     "discovered_by": "rss:themarkup.org",
-    "scanner_verdict": "CLEAN \u2014 no findings",
+    "scanner_verdict": "CLEAN — no findings",
     "scanner_score": 0,
     "content_hash": "d48b2dde44b79eb2f5cb471e6926388510a11d85b25148db3e44a78d0e18b5b5",
     "paths": {
@@ -3458,7 +3484,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Markup/CalMatters reports that Border Patrol and DEA have installed roughly 40 covert license plate readers, hidden in trailers and traffic equipment, along Southern California border highways under Caltrans permits. Privacy advocates including EFF say the cameras bypass California's 2016 ALPR law and feed data into federal deportation-related databases, while residents recount unusual CBP encounters apparently driven by plate-tracking analytics.",
     "key_quotes": [
       {
@@ -3480,7 +3505,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:23:53Z",
-    "article_id": "art_026"
+    "article_id": "art_026",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.404media.co/floridas-wildlife-cops-are-searching-thousands-of-flock-cameras-for-ice/",
@@ -3492,7 +3518,7 @@
     "published_at": "2026-04-06T13:53:56.000Z",
     "fetched_at": "2026-05-05T20:23:46Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "f6a1cead9da96b46c528e54df9c567e53fdb47c52ff78f14fac9aab06fd9c7df",
     "paths": {
@@ -3619,7 +3645,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Public records from a Ball State University Flock network audit show that Florida Fish and Wildlife Conservation Commission police performed dozens of license plate searches across thousands of Flock networks for immigration/ICE-related reasons, alongside similar searches by other state and local agencies. The article ties this to Florida's enrollment of nearly 800 FWC officers in the federal 287(g) program, arguing it provides ICE side-door access to Flock data despite Flock's claims it doesn't work with ICE.",
     "key_quotes": [
       {
@@ -3645,19 +3670,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:03Z",
-    "article_id": "art_027"
+    "article_id": "art_027",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/alpr-as-public-data",
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "License Plate Readings Shouldn\u2019t Be Public Data | ACLU",
+    "title": "License Plate Readings Shouldn’t Be Public Data | ACLU",
     "byline": "Jay Stanley, Chad Marlow",
     "published_at": "2026-02-25T14:52:09+00:00",
     "fetched_at": "2026-05-05T20:18:08Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "59dc1abf8d110303877c7f202d31ad6f384b576f63fc6c23ca41199bd480ed48",
     "paths": {
@@ -3724,7 +3750,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU argues that ALPR plate-read data released through open-records requests poses serious privacy risks, citing the HaveIBeenFlocked.com site that aggregates unredacted data from police departments. The authors propose a balance via their model state bill: audit/use logs should be public, but specific plate numbers and identifying vehicle features should be redacted, with individuals able to request their own data.",
     "key_quotes": [
       {
@@ -3738,7 +3763,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:10Z",
-    "article_id": "art_028"
+    "article_id": "art_028",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2020/09/flock-license-plate-reader-homeowners-association-safe-problems",
@@ -3750,7 +3776,7 @@
     "published_at": "2020-09-14T12:38:12-07:00",
     "fetched_at": "2026-05-05T20:16:50Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "d541f69af823e73340def8970bc8d81b158202bc4de7237d00b325734711d4e1",
     "paths": {
@@ -3875,7 +3901,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF advocacy article warning HOAs and neighborhood associations against installing ALPRs like Flock Safety, arguing they don't reduce crime, lack oversight, enable neighbor surveillance and abuse, produce dangerous false hits, and increasingly share data with police nationwide.",
     "key_quotes": [
       {
@@ -3897,7 +3922,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:21Z",
-    "article_id": "art_029"
+    "article_id": "art_029",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://epic.org/vehicle-fingerprinting-through-pervasive-camera-surveillance-likely-violates-fourth-amendment-court-finds/",
@@ -3909,7 +3935,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T20:19:56Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "5b0b71f3e5e6aa6c870b349eba4aafb0a201daa0308f05d0ea705fa6c0d7d4e1",
     "paths": {
@@ -3988,8 +4014,7 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
-    "summary": "EPIC reports on a federal court ruling in the Eastern District of Virginia denying Norfolk's motion to dismiss a \u00a71983 suit challenging the city's use of Flock ALPR cameras under the Fourth Amendment. The court found plaintiffs plausibly alleged a reasonable expectation of privacy in their long-term movements under Carpenter v. United States and that warrantless querying of Flock's database likely constitutes an unconstitutional search.",
+    "summary": "EPIC reports on a federal court ruling in the Eastern District of Virginia denying Norfolk's motion to dismiss a §1983 suit challenging the city's use of Flock ALPR cameras under the Fourth Amendment. The court found plaintiffs plausibly alleged a reasonable expectation of privacy in their long-term movements under Carpenter v. United States and that warrantless querying of Flock's database likely constitutes an unconstitutional search.",
     "key_quotes": [
       {
         "quote": "the city's tracking of individuals through the use of Flock was \"notably similar to [the facts] in Carpenter.\"",
@@ -4006,7 +4031,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:17Z",
-    "article_id": "art_030"
+    "article_id": "art_030",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12066989/california-cities-double-down-on-license-plate-readers-as-federal-surveillance-grows",
@@ -4018,7 +4044,7 @@
     "published_at": "2025-12-18T09:00:09-08:00",
     "fetched_at": "2026-05-05T20:21:57Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "dd48c36986d52ec0883f30238fbe47b4eacced27d91207184597b90edc9e4a4a",
     "paths": {
@@ -4152,7 +4178,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "6f2b98a1-957a-5dc9-935c-7b8127a223d6",
     "summary": "KQED reports that despite mounting evidence ALPR data feeds federal surveillance used against immigrants, most California cities are pressing ahead with Flock Safety contracts, exemplified by Oakland's 7-1 council vote to renew and expand its $2.25M contract with new audit and 'two-key' data-sharing safeguards. The article contrasts Oakland's renewal with Richmond PD's recent shutdown of its ALPR system after a Flock configuration error and Santa Cruz's temporary limits on outside-agency access.",
     "key_quotes": [
       {
@@ -4178,7 +4203,10 @@
     ],
     "curation_status": "enriched",
     "article_id": "art_031",
-    "curated_at": "2026-05-08T18:29:27Z"
+    "curated_at": "2026-05-08T18:29:27Z",
+    "primary_subject_agency_ids": [
+      "6f2b98a1-957a-5dc9-935c-7b8127a223d6"
+    ]
   },
   {
     "url": "https://www.404media.co/ice-taps-into-nationwide-ai-enabled-camera-network-data-shows/",
@@ -4190,7 +4218,7 @@
     "published_at": "2025-05-27T13:36:43.000Z",
     "fetched_at": "2026-05-06T00:03:36Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "7dfaeb1fab6b09b6dfaf47d33a57108834b3cac28b17ea44c2598867411dfdd6",
     "paths": {
@@ -4226,7 +4254,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "4a1c911b-5e90-53fd-805e-3b55f344434d",
     "summary": "404 Media obtained Flock ALPR search logs via a public records request to the Danville, Illinois Police Department showing more than 4,000 nationwide and statewide lookups by local police citing immigration-related reasons such as 'ICE' and 'ICE+ERO.' The data indicates ICE is sourcing Flock data through informal requests to local law enforcement despite lacking its own contract with Flock.",
     "key_quotes": [
       {
@@ -4240,19 +4267,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:28Z",
-    "article_id": "art_032"
+    "article_id": "art_032",
+    "primary_subject_agency_ids": [
+      "4a1c911b-5e90-53fd-805e-3b55f344434d"
+    ]
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/how-to-pump-the-brakes-on-your-police-departments-use-of-flocks-mass-surveillance-license-plate-readers",
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "How to Pump the Brakes on Your Police Department\u2019s Use of Flock\u2019s Mass Surveillance License Plate Readers | ACLU",
+    "title": "How to Pump the Brakes on Your Police Department’s Use of Flock’s Mass Surveillance License Plate Readers | ACLU",
     "byline": "Chad Marlow, Jay Stanley",
     "published_at": "2023-02-13T21:30:27+00:00",
     "fetched_at": "2026-05-06T00:00:20Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 12 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 12 pts, low/medium only",
     "scanner_score": 12,
     "content_hash": "426c659b5c145150e29ef44e3508b94d3724a9cb4f04014c17aecd6deac391c1",
     "paths": {
@@ -4338,11 +4368,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU urges communities to oppose Flock Safety's nationwide ALPR mass-surveillance network, and provides advocacy guidance and suggested contract language for limiting data retention, data sharing, and database use where adoption can't be stopped outright.",
     "key_quotes": [
       {
-        "quote": "Flock is the first to create a nationwide mass-surveillance system out of its customers\u2019 cameras.",
+        "quote": "Flock is the first to create a nationwide mass-surveillance system out of its customers’ cameras.",
         "paragraph_idx": 3
       },
       {
@@ -4354,29 +4383,30 @@
         "paragraph_idx": 15
       },
       {
-        "quote": "Flock\u2019s default provisions give the company a \u201cworldwide\u201d license to use its customers\u2019 APLR data",
+        "quote": "Flock’s default provisions give the company a “worldwide” license to use its customers’ APLR data",
         "paragraph_idx": 17
       },
       {
-        "quote": "the National Crime Information Center (NCIC) database \u2014 does not even comply with the 1974 United States Privacy Act\u2019s basic accuracy, reliability, and completeness requirements.",
+        "quote": "the National Crime Information Center (NCIC) database — does not even comply with the 1974 United States Privacy Act’s basic accuracy, reliability, and completeness requirements.",
         "paragraph_idx": 19
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:35Z",
-    "article_id": "art_033"
+    "article_id": "art_033",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/10/flocks-gunshot-detection-microphones-will-start-listening-human-voices",
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock\u2019s Gunshot Detection Microphones Will Start Listening for Human Voices",
+    "title": "Flock’s Gunshot Detection Microphones Will Start Listening for Human Voices",
     "byline": "Matthew Guariglia",
     "published_at": "2025-10-02T08:45:18-07:00",
     "fetched_at": "2026-05-05T23:58:57Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8265d3690aa93919405fb9e4c8821c829f8a735408d8840edb1d7146644dbebd",
     "paths": {
@@ -4460,15 +4490,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF warns that Flock Safety is expanding its Raven acoustic gunshot detection product to also alert police to human sounds like screaming or 'distress,' raising civil liberties and eavesdropping-law concerns. The post urges cities to cancel Flock contracts and references controversies including ICE data access in Illinois, a North Carolina licensing halt, and Evanston's contract cancellation dispute.",
     "key_quotes": [
       {
-        "quote": "Flock has been touting new features to their Raven product\u2014including the ability of the device to alert police based on sounds, including \u201cdistress.\u201d",
+        "quote": "Flock has been touting new features to their Raven product—including the ability of the device to alert police based on sounds, including “distress.”",
         "paragraph_idx": 6
       },
       {
-        "quote": "When the city of Evanston, Illinois recently canceled its contract with Flock, it ordered the company to take down their license plate readers\u2013only for Flock to mysteriously reinstall them a few days later.",
+        "quote": "When the city of Evanston, Illinois recently canceled its contract with Flock, it ordered the company to take down their license plate readers–only for Flock to mysteriously reinstall them a few days later.",
         "paragraph_idx": 8
       },
       {
@@ -4478,19 +4507,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:45Z",
-    "article_id": "art_034"
+    "article_id": "art_034",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://epic.org/epic-files-amicus-brief-arguing-citys-use-of-flock-alprs-violated-fourth-amendment/",
     "source_domain": "epic.org",
     "tier": 2,
     "stance": "critical",
-    "title": "EPIC Files Amicus Brief Arguing City\u2019s Use of Flock ALPRs Violated Fourth Amendment",
+    "title": "EPIC Files Amicus Brief Arguing City’s Use of Flock ALPRs Violated Fourth Amendment",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-06T00:05:01Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "740227f44ae12a76bc974bff9e6f43fcd7e5d0ea218b92ea3e793e9ef87734fe",
     "paths": {
@@ -4523,7 +4553,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EPIC filed an amicus brief with the Fourth Circuit in Schmidt v. City of Norfolk, supporting plaintiffs' argument that Norfolk, Virginia's use of Flock ALPR cameras constitutes warrantless mass surveillance violating the Fourth Amendment. The brief argues ALPRs expose the 'privacies of life,' enable predictive policing built on biased data, and urges reversal of the district court's January dismissal.",
     "key_quotes": [
       {
@@ -4537,7 +4566,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:23Z",
-    "article_id": "art_035"
+    "article_id": "art_035",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12068738/privacy-advocates-have-growing-concerns-over-use-of-automated-license-plate-readers",
@@ -4549,7 +4579,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T00:02:05Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "32144f2716c5407777cada012e0d62e116401214de3cc2e15cc3ea2e1c2a0886",
     "paths": {
@@ -4667,7 +4697,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "KQED's California Report segment reports that ALPRs are now used by more than 200 California law enforcement agencies, and privacy advocates warn that local databases are feeding federal surveillance used against immigrants and others. Privacy advocate Brian Hofer calls many local oversight efforts 'performative,' echoing a state AG audit finding that few agencies have adequate ALPR usage and privacy policies, and notes federal warrants supersede state protections.",
     "key_quotes": [
       {
@@ -4685,7 +4714,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:24:56Z",
-    "article_id": "art_036"
+    "article_id": "art_036",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.smdailyjournal.com/news/local/license-plate-readers-to-increase-throughout-county/article_3af96c58-f0da-11ee-91f1-8b4e10075b4d.html",
@@ -4697,7 +4727,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T00:06:43Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 233 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 233 pts, HIGH/CRITICAL findings",
     "scanner_score": 233,
     "content_hash": "da8579564d6fed6d8fa049736ef84c9a38f33edbb8217550853257cad7e05f38",
     "paths": {
@@ -4826,7 +4856,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "847ce8af-3e88-59ca-90f3-d621db6f31f6",
     "summary": "San Mateo County cities including San Bruno, San Mateo, Daly City, and Belmont are expanding or adopting ALPR programs, citing retail theft and other crimes. The article notes ongoing concerns about data-sharing violations, with EFF's Jennifer Pinsof saying 73+ California agencies have shared ALPR data improperly with out-of-state and federal agencies including ICE.",
     "key_quotes": [
       {
@@ -4838,25 +4867,28 @@
         "paragraph_idx": 10
       },
       {
-        "quote": "data would be stored only for 30 days \u2014 unless particular license plates are part of ongoing investigations",
+        "quote": "data would be stored only for 30 days — unless particular license plates are part of ongoing investigations",
         "paragraph_idx": 8
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:35Z",
-    "article_id": "art_037"
+    "article_id": "art_037",
+    "primary_subject_agency_ids": [
+      "847ce8af-3e88-59ca-90f3-d621db6f31f6"
+    ]
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/flocks-terms-and-conditions",
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Municipalities: Beware of Changes in Flock\u2019s Legal Terms if You\u2019re Using or Considering License Plate Readers | ACLU",
+    "title": "Municipalities: Beware of Changes in Flock’s Legal Terms if You’re Using or Considering License Plate Readers | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2026-04-16T18:48:54+00:00",
     "fetched_at": "2026-05-06T06:42:17Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "377998b9f05c5762eddee6c34a73920fd6bb078e9582d793d904e20d9cb0c6ea",
     "paths": {
@@ -4921,7 +4953,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU warns municipalities that Flock Safety has made several changes to its standard terms and conditions that shift power from customer agencies to the company, including removing a no-sale-of-data clause, granting Flock exclusive control over data access, adding a perpetual license to use customer data, and expanding liability protections and arbitration requirements. The post urges current and prospective customers to review the contract changes carefully with counsel.",
     "key_quotes": [
       {
@@ -4929,7 +4960,7 @@
         "paragraph_idx": 5
       },
       {
-        "quote": "The T&C now add a \"perpetual\" right for Flock to use customer data to \"support and improve\" its services \u2014 allowing the company to keep using driver surveillance data even after a town, city, or other customer has terminated its relationship with Flock",
+        "quote": "The T&C now add a \"perpetual\" right for Flock to use customer data to \"support and improve\" its services — allowing the company to keep using driver surveillance data even after a town, city, or other customer has terminated its relationship with Flock",
         "paragraph_idx": 7
       },
       {
@@ -4939,7 +4970,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:07Z",
-    "article_id": "art_038"
+    "article_id": "art_038",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.brennancenter.org/our-work/research-reports/automatic-license-plate-readers-legal-status-and-policy-recommendations",
@@ -4951,7 +4983,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T06:46:33Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "962f31949b926e068611e62833634559ee1a445e3cea19538942108fb4b71ee9",
     "paths": {
@@ -5098,7 +5130,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "A Brennan Center research report explaining how automatic license plate readers work, surveying Fourth Amendment and state-law doctrine (including Carpenter, Jones, Glover, Yang, McCarthy, and Neal v. Fairfax County), and detailing policy concerns such as error rates, data sharing with ICE, disparate impact, and First Amendment chilling effects. It concludes with recommendations for retention limits, warrants for historical searches, audit logs, community input, and disparate-impact audits.",
     "key_quotes": [
       {
@@ -5120,19 +5151,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:22Z",
-    "article_id": "art_039"
+    "article_id": "art_039",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2020/02/california-auditor-releases-damning-report-about-law-enforcements-use-automated",
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "California Auditor Releases Damning Report About Law Enforcement\u2019s Use of Automated License Plate Readers",
+    "title": "California Auditor Releases Damning Report About Law Enforcement’s Use of Automated License Plate Readers",
     "byline": "Dave Maass and Hayley Tsukayama",
     "published_at": "2020-02-13T12:58:11-08:00",
     "fetched_at": "2026-05-06T06:40:57Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "cbd3b075eb3561209d91ea420ba2069e2f220086a8676eefa1f90b76f61a47ef",
     "paths": {
@@ -5269,7 +5301,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF summarizes a California State Auditor report finding that LAPD, Fresno PD, Sacramento County SO, and Marin County SO have inadequate ALPR policies, insufficient auditing, overlong retention, weak data security, and broad data sharing in violation of SB 34's intent. EFF calls for legislative reforms including a moratorium and stricter hotlist, retention, and sharing rules.",
     "key_quotes": [
       {
@@ -5277,7 +5308,7 @@
         "paragraph_idx": 3
       },
       {
-        "quote": "the three agencies storing ALPR data in Vigilant's cloud\u2014Fresno, Marin, and Sacramento\u2014do not have sufficient data security safeguards in their contracts.",
+        "quote": "the three agencies storing ALPR data in Vigilant's cloud—Fresno, Marin, and Sacramento—do not have sufficient data security safeguards in their contracts.",
         "paragraph_idx": 7
       },
       {
@@ -5291,7 +5322,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:33Z",
-    "article_id": "art_040"
+    "article_id": "art_040",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://epic.org/license-plate-recognition-systems/",
@@ -5303,7 +5335,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T06:47:45Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 23 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 23 pts, HIGH/CRITICAL findings",
     "scanner_score": 23,
     "content_hash": "c1fcafcc90d59aedbbdcba9005a595471573b49f1e9adf0408aa5643277cb258",
     "paths": {
@@ -5419,7 +5451,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EPIC's overview page on License Plate Recognition systems explains how LPR works, surveys uses by US law enforcement, and raises informational-privacy concerns. It discusses state privacy laws, court cases on location tracking, and notes Maine and New Hampshire as the only states restricting LPR use.",
     "key_quotes": [
       {
@@ -5437,7 +5468,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:42Z",
-    "article_id": "art_041"
+    "article_id": "art_041",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.npr.org/2025/11/07/nx-s1-5587724/some-sanctuary-states-discover-feds-mining-local-license-plate-data",
@@ -5451,7 +5483,7 @@
     "published_at": "2025-11-07",
     "fetched_at": "2026-05-06T06:43:32Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 20 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 20 pts, low/medium only",
     "scanner_score": 20,
     "content_hash": "0d43e1b88566bb20dcda69fffd9d15170c3537ba15ce0e5bd98bff2bbc2f8a42",
     "paths": {
@@ -5508,7 +5540,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "NPR reports that federal agencies, including Border Patrol, have sharply increased searches of local ALPR data stored by Flock Safety, raising concerns in sanctuary states like Washington and California where such sharing may violate state law. California AG Rob Bonta warned 20 departments and is suing El Cajon, which refused to restrict sharing; a clarification notes Flock admitted at least one case (San Diego) where data was mistakenly shared.",
     "key_quotes": [
       {
@@ -5530,7 +5561,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:42Z",
-    "article_id": "art_042"
+    "article_id": "art_042",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/dozens-of-police-agencies-in-california-are-still-sharing-driver-locations-with-anti-abortion-states-were-fighting-back",
@@ -5542,7 +5574,7 @@
     "published_at": "2024-02-13T20:37:08+00:00",
     "fetched_at": "2026-05-06T09:41:54Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "a8b7185512a5de6c756208f9f8e5f06d818991c7171deb2a39bbd320742f9101",
     "paths": {
@@ -5608,7 +5640,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU of Northern California describes its ongoing effort to enforce SB 34, which bars California police from sharing ALPR data with out-of-state and federal agencies. It notes that 35 California police agencies remain noncompliant despite AG Bonta's guidance, and urges the AG to take stronger enforcement action, citing risks to abortion-seekers and immigrants.",
     "key_quotes": [
       {
@@ -5626,7 +5657,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:49Z",
-    "article_id": "art_043"
+    "article_id": "art_043",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/report/fast-growing-company-flock-building-new-ai-driven-mass-surveillance-system",
@@ -5638,7 +5670,7 @@
     "published_at": "2022-03-01T18:37:50+00:00",
     "fetched_at": "2026-05-06T09:35:45Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "f3105ca3ba673458ce12f0907fcaa060e4bcd7a9160a9fcbc126f3ebe931d87d",
     "paths": {
@@ -5660,7 +5692,6 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "The ACLU publishes a report by Jay Stanley warning that Flock Safety is building a nationwide mass-surveillance network by selling ALPR cameras to HOAs, private parties, and police while centralizing data, and is expanding into AI-driven video surveillance.",
     "key_quotes": [
       {
@@ -5674,7 +5705,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:25:54Z",
-    "article_id": "art_044"
+    "article_id": "art_044",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/09/eff-aclu-sfpd-stop-illegally-sharing-data-ice-and-anti-abortion-states",
@@ -5686,7 +5718,7 @@
     "published_at": "2025-09-18T12:44:15-07:00",
     "fetched_at": "2026-05-06T09:40:34Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "df347ae05725680b474cf5caf7f5314b9a36a751ec6a550d810a2752d02bf677",
     "paths": {
@@ -5765,7 +5797,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "14b510e3-7bde-5474-8249-6ef49a16cfc5",
     "summary": "EFF and ACLU of Northern California sent SFPD a demand letter and Sunshine Ordinance records request after reporting revealed SFPD shared ALPR data with out-of-state and federal agencies, including searches flagged as ICE-related and queries from Georgia and Texas. The groups argue this violates California's SB 34 and SB 54 and urge SFPD to audit its Flock ALPR database, adopt compliance protocols, and sanction violators.",
     "key_quotes": [
       {
@@ -5773,7 +5804,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "Since 2016, sharing ALPR data with out-of-state or federal agencies\u2014for any reason\u2014violates California law ( SB 34 ). If this data is shared for the purpose of assisting with immigration enforcement, agencies violate an additional California law ( SB 54 ).",
+        "quote": "Since 2016, sharing ALPR data with out-of-state or federal agencies—for any reason—violates California law ( SB 34 ). If this data is shared for the purpose of assisting with immigration enforcement, agencies violate an additional California law ( SB 54 ).",
         "paragraph_idx": 8
       },
       {
@@ -5783,7 +5814,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:05Z",
-    "article_id": "art_045"
+    "article_id": "art_045",
+    "primary_subject_agency_ids": [
+      "14b510e3-7bde-5474-8249-6ef49a16cfc5"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/04/hot-press-effs-updated-guide-tech-us-mexico-border",
@@ -5795,7 +5829,7 @@
     "published_at": "2026-04-13T10:35:21-07:00",
     "fetched_at": "2026-05-06T09:34:05Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "4ebe1cb6077afdb72fb0b0e7ed23f5e7a3c6f1bc9ef3b9ecaf16136e85976fa2",
     "paths": {
@@ -5867,7 +5901,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF announces a major update to its zine 'Surveillance Technology at the U.S.-Mexico Border,' a 40-page guide cataloging surveillance towers, military tech, disguised trail cameras, and automated license plate readers deployed along the border. The update is the first since the second Trump administration began and is aimed at journalists, humanitarian workers, and advocates.",
     "key_quotes": [
       {
@@ -5877,7 +5910,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:11Z",
-    "article_id": "art_046"
+    "article_id": "art_046",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.npr.org/2026/02/17/nx-s1-5612825/flock-contracts-canceled-immigration-survillance-concerns",
@@ -5891,7 +5925,7 @@
     "published_at": "2026-02-17",
     "fetched_at": "2026-05-06T09:38:54Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 20 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 20 pts, low/medium only",
     "scanner_score": 20,
     "content_hash": "e4cdb80fba67d6909cb7db3903c2ab9f29c28b8b96d573d8d25cb74e1bb107fc",
     "paths": {
@@ -6015,7 +6049,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "NPR reports that at least 30 localities have deactivated or canceled Flock Safety license plate reader contracts since early 2025, driven by concerns about federal immigration enforcement access and data sharing. The piece details decisions in Flagstaff, Santa Cruz, Hillsborough NC, and Staunton VA, along with Flock's acknowledgment of past pilot programs with CBP and HSI and CEO Garrett Langley's combative remarks about activists.",
     "key_quotes": [
       {
@@ -6033,19 +6066,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:20Z",
-    "article_id": "art_047"
+    "article_id": "art_047",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/flock-pushback",
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "I\u2019m Hearing About More Pushback Against Flock, Fueled by Concern Over Anti-Immigrant Uses | ACLU",
+    "title": "I’m Hearing About More Pushback Against Flock, Fueled by Concern Over Anti-Immigrant Uses | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2025-08-21T15:03:29+00:00",
     "fetched_at": "2026-05-06T12:03:00Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "278782b4ebd7eb85c2928a39b5fdbca2be12aaae2328384f06424557e2bc82da",
     "paths": {
@@ -6152,7 +6186,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "ACLU's Jay Stanley argues that growing awareness of ICE's use of Flock ALPR data is fueling local pushback against the technology nationwide. He cites examples in Gig Harbor, Syracuse, Evanston, Austin, Denver, and Richmond (VA) where officials have questioned, restricted, or cancelled Flock contracts.",
     "key_quotes": [
       {
@@ -6174,19 +6207,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:28Z",
-    "article_id": "art_048"
+    "article_id": "art_048",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclu.org/news/privacy-technology/flock-roundup",
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock\u2019s Aggressive Expansions Go Far Beyond Simple Driver Surveillance | ACLU",
+    "title": "Flock’s Aggressive Expansions Go Far Beyond Simple Driver Surveillance | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2025-08-18T16:48:27+00:00",
     "fetched_at": "2026-05-06T12:07:26Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "c9200fd77433de7bd46dec41054735e75fa49694c73e8522040ffd5d295dab2d",
     "paths": {
@@ -6234,7 +6268,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "ACLU's Jay Stanley surveys multiple ways Flock's ALPR system is expanding: ICE accessing the data, a Texas officer searching for an abortion seeker, integration with data brokers, video and AI-powered natural-language search, a 'Flock Business Network' for private-sector hotlists, and AI analytics that generate suspicion. The piece argues these expansions justify strong state and local privacy legislation.",
     "key_quotes": [
       {
@@ -6260,7 +6293,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:38Z",
-    "article_id": "art_049"
+    "article_id": "art_049",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2023/10/victory-california-department-justice-declares-out-state-sharing-license-plate",
@@ -6272,7 +6306,7 @@
     "published_at": "2023-10-31T13:53:13-07:00",
     "fetched_at": "2026-05-06T12:09:09Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "dfb93f83ad9203cce900c12056fcfca47029f7805d4603b66f53bba40ec11585",
     "paths": {
@@ -6340,7 +6374,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "California AG Rob Bonta issued legal guidance declaring that sharing ALPR data with out-of-state and federal agencies violates SB 34. EFF celebrates the bulletin as vindication of years of advocacy and litigation, including its settled suit against the Marin County Sheriff for sharing data with ICE and CBP.",
     "key_quotes": [
       {
@@ -6358,7 +6391,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:46Z",
-    "article_id": "art_050"
+    "article_id": "art_050",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2024/11/human-toll-alpr-errors",
@@ -6370,7 +6404,7 @@
     "published_at": "2024-11-01T20:17:28-07:00",
     "fetched_at": "2026-05-06T12:01:04Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "69b07e348f4e5bd8dd3f84eaf7cdb121f4be9101a06583f3e7b56a716a844ecd",
     "paths": {
@@ -6426,7 +6460,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF surveys multiple cases in which ALPR misreads or outdated hot-list data led police to wrongfully detain innocent drivers at gunpoint, including Black motorists and children. The piece argues ALPR errors, police over-reliance, and database mismanagement cause serious harm and have resulted in significant lawsuit settlements.",
     "key_quotes": [
       {
@@ -6444,7 +6477,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:26:55Z",
-    "article_id": "art_051"
+    "article_id": "art_051",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/02/anti-surveillance-mapmaker-refuses-flock-safetys-cease-and-desist-demand",
@@ -6456,7 +6490,7 @@
     "published_at": "2025-02-26T10:08:13-08:00",
     "fetched_at": "2026-05-06T12:05:50Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "486051ed042acfaa530ed1ea709a3aeef89c0511472dd01d3d41d2ac053a5386",
     "paths": {
@@ -6508,7 +6542,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF, representing DeFlock.me creator Will Freeman, publicly rejected a cease-and-desist letter from Flock Safety claiming the anti-ALPR mapping site dilutes its trademark. EFF argues the project is protected noncommercial criticism under the First Amendment and federal trademark law's carve-outs.",
     "key_quotes": [
       {
@@ -6526,7 +6559,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:03Z",
-    "article_id": "art_052"
+    "article_id": "art_052",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2021/01/eff-joins-effort-restrict-automated-license-plate-readers-california",
@@ -6538,7 +6572,7 @@
     "published_at": "2021-03-19T15:59:53-07:00",
     "fetched_at": "2026-05-06T14:43:44Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "3a0bbf39d8d92e8e7fd759fd14272afe4f5a35c43810b12132445eacd7a80381",
     "paths": {
@@ -6669,11 +6703,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF announces co-sponsorship of California S.B. 210 (License Plate Privacy Act), introduced by State Sen. Scott Wiener, which would strengthen S.B. 34 by requiring 24-hour data deletion for non-hotlist plates, annual audits, an AG model policy, and restrictions on accessing older ALPR data. The post cites the 2020 California State Auditor report finding LAPD, Fresno, Sacramento County, and Marin County noncompliant with existing ALPR law.",
     "key_quotes": [
       {
-        "quote": "While the auditor only conducted a deep-dive into four jurisdictions\u2014Los Angeles, Fresno, Sacramento County and Marin County\u2014all were found to be noncompliant.",
+        "quote": "While the auditor only conducted a deep-dive into four jurisdictions—Los Angeles, Fresno, Sacramento County and Marin County—all were found to be noncompliant.",
         "paragraph_idx": 4
       },
       {
@@ -6687,7 +6720,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:12Z",
-    "article_id": "art_053"
+    "article_id": "art_053",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/10/flock-safety-and-texas-sheriff-claimed-license-plate-search-was-missing-person-it",
@@ -6699,7 +6733,7 @@
     "published_at": "2025-10-07T06:00:08-07:00",
     "fetched_at": "2026-05-06T14:40:53Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "576e3ba7cdd925e8447a1bf08320ed819a70d05f70b426c63106ce1047df816d",
     "paths": {
@@ -6831,7 +6865,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "ba107933-2f9d-5af5-836f-72a35dd288ba",
     "summary": "EFF reports that newly obtained records contradict claims by Flock Safety and the Johnson County, Texas Sheriff's Office that a nationwide Flock ALPR search of 83,000+ cameras logged as 'had an abortion, search for female' was a welfare check for a missing person. The documents show deputies opened a 'death investigation' into a non-viable fetus following a self-managed abortion, collected evidence, consulted prosecutors about charges, and conducted searches that may have violated Illinois and Washington laws restricting cross-state ALPR data sharing.",
     "key_quotes": [
       {
@@ -6843,7 +6876,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "The first search, which has not been previously reported, probed 1,295 Flock Safety networks\u2013composed of 17,684 different cameras\u2013going back one week. The second search... was expanded to a full month of data across 6,809 networks, including 83,345 cameras.",
+        "quote": "The first search, which has not been previously reported, probed 1,295 Flock Safety networks–composed of 17,684 different cameras–going back one week. The second search... was expanded to a full month of data across 6,809 networks, including 83,345 cameras.",
         "paragraph_idx": 14
       },
       {
@@ -6853,7 +6886,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:26Z",
-    "article_id": "art_054"
+    "article_id": "art_054",
+    "primary_subject_agency_ids": [
+      "ba107933-2f9d-5af5-836f-72a35dd288ba"
+    ]
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/10/victory-california-requires-transparency-ai-police-reports",
@@ -6865,7 +6901,7 @@
     "published_at": "2025-10-14T10:44:24-07:00",
     "fetched_at": "2026-05-06T14:42:18Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "a3414944ddb32661da48021e9ca35454c22f11600436e197328b572468d225b4",
     "paths": {
@@ -6921,7 +6957,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF celebrates California Governor Newsom signing S.B. 524, which requires police to disclose AI use in writing reports, retain first drafts, and bans vendors from selling agency-provided data. The post highlights compliance challenges for Axon's Draft One product, which doesn't retain edit logs.",
     "key_quotes": [
       {
@@ -6935,7 +6970,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:34Z",
-    "article_id": "art_055"
+    "article_id": "art_055",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/04/claw-back",
@@ -6947,7 +6983,7 @@
     "published_at": "2026-05-05T00:11:54-07:00",
     "fetched_at": "2026-05-06T14:49:15Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "13dc83fee51aa1ad2af039f5fb1b92a6e3fe584d3e7108e9065554a6c66d3b3f",
     "paths": {
@@ -6967,7 +7003,6 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "An EFF membership fundraising post framed around William Binney's 'turnkey totalitarian state,' touting EFF's work including a lawsuit against warrantless ALPR searches and tools like Rayhunter, while pitching new member gear.",
     "key_quotes": [
       {
@@ -6977,19 +7012,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:39Z",
-    "article_id": "art_056"
+    "article_id": "art_056",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/04/open-records-laws-reveal-alprs-sprawling-surveillance-now-states-want-block-what",
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Open Records Laws Reveal ALPRs\u2019 Sprawling Surveillance. Now States Want to Block What the Public Sees.",
+    "title": "Open Records Laws Reveal ALPRs’ Sprawling Surveillance. Now States Want to Block What the Public Sees.",
     "byline": "Beryl Lipton, Aaron Mackey, and Adam Schwartz",
     "published_at": "2026-04-30T09:54:10-07:00",
     "fetched_at": "2026-05-06T14:45:50Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "050a92619fa848c915f7522d3118b381a58782d1387c022fd61354bdf156efc9",
     "paths": {
@@ -7013,7 +7049,6 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "EFF criticizes a wave of state laws and pending bills (in Connecticut, Arizona, Washington, Illinois, Georgia, Maryland, and Oklahoma) that exempt ALPR data from public records laws, arguing this blocks vital oversight of police surveillance. The article advocates instead for case-by-case privacy balancing, redaction, and disclosure of aggregated/deidentified data.",
     "key_quotes": [
       {
@@ -7035,19 +7070,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:49Z",
-    "article_id": "art_057"
+    "article_id": "art_057",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2026/04/selling-mass-surveillance-effector-387",
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "\ud83d\udc41 Selling Mass Surveillance | EFFector 38.7",
+    "title": "👁 Selling Mass Surveillance | EFFector 38.7",
     "byline": "Christian Romero",
     "published_at": "2026-04-08T09:24:35-07:00",
     "fetched_at": "2026-05-06T14:47:38Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "e144bbf0f2b6f1c9ae804547b7738be56208d2e3419eb17a31251b8b258704e0",
     "paths": {
@@ -7068,11 +7104,10 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "EFF's EFFector 38.7 newsletter promotes its latest issue and podcast episode focused on police surveillance 'mission creep,' including how license plate readers normalize mass surveillance, NSA spying reform, and a Supreme Court internet access victory.",
     "key_quotes": [
       {
-        "quote": "police surveillance suffer from 'mission creep'\u2014technology sold as a way to prevent heinous crimes ends up enforcing traffic violations, tracking protestors, and more.",
+        "quote": "police surveillance suffer from 'mission creep'—technology sold as a way to prevent heinous crimes ends up enforcing traffic violations, tracking protestors, and more.",
         "paragraph_idx": 3
       },
       {
@@ -7082,7 +7117,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:27:53Z",
-    "article_id": "art_058"
+    "article_id": "art_058",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.eff.org/deeplinks/2025/11/how-cops-are-using-flock-safetys-alpr-network-surveil-protesters-and-activists",
@@ -7094,7 +7130,7 @@
     "published_at": "2025-11-20T15:58:40-08:00",
     "fetched_at": "2026-05-06T16:51:31Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "9d51ae3af133787f82c4fc0cbf6d44b87bb3be7bd0060b031752bd7420582615",
     "paths": {
@@ -7240,7 +7276,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EFF analyzed 12 million Flock Safety ALPR searches from public records and found more than 50 federal, state, and local agencies ran hundreds of searches related to protests in 2025, including No Kings rallies, 50501 protests, and actions by animal-rights group DxE. The article details specific agencies' searches, Border Patrol's use of the system, and argues ALPR networks chill First Amendment activity.",
     "key_quotes": [
       {
@@ -7262,7 +7297,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T18:28:03Z",
-    "article_id": "art_059"
+    "article_id": "art_059",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.berkeleyside.org/2026/05/06/berkeley-flock-surveillance-contract-memo-confidential",
@@ -7274,7 +7310,7 @@
     "published_at": "2026-05-07T00:12:30+00:00",
     "fetched_at": "2026-05-07T17:59:25Z",
     "discovered_by": "rss:berkeleyside.org",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 173 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 173 pts, HIGH/CRITICAL findings",
     "scanner_score": 173,
     "content_hash": "f083884c4c81487083e3c0e3f73a0a31334531b04f18d03cbfb1c81272a2ee3d",
     "paths": {
@@ -7365,7 +7401,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "eca5a0e5-4ab4-5868-a688-c03da1dff9b1",
     "summary": "A leaked confidential memo from Berkeley city attorneys warns of significant legal risks in the police department's proposed $2 million expansion of its Flock Safety surveillance contract, including data-sharing vulnerabilities, weak enforceability of contract terms, and possible litigation exposure. The Police Accountability Board separately alleges BPD bypassed competitive bidding rules. The City Council is set to vote on the expansion.",
     "key_quotes": [
       {
@@ -7387,7 +7422,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:01:52Z",
-    "article_id": "art_060"
+    "article_id": "art_060",
+    "primary_subject_agency_ids": [
+      "eca5a0e5-4ab4-5868-a688-c03da1dff9b1"
+    ]
   },
   {
     "url": "https://www.berkeleyside.org/2026/05/06/opinion-berkeley-does-not-need-flock-surveillance-tech-to-stay-safe",
@@ -7399,7 +7437,7 @@
     "published_at": "2026-05-06T22:25:27+00:00",
     "fetched_at": "2026-05-07T17:59:42Z",
     "discovered_by": "rss:berkeleyside.org",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 169 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 169 pts, HIGH/CRITICAL findings",
     "scanner_score": 169,
     "content_hash": "21fab13a2506c1f1a6931062d7ab3deb1f2ed743545844c95a14d219e6e404c0",
     "paths": {
@@ -7478,11 +7516,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "eca5a0e5-4ab4-5868-a688-c03da1dff9b1",
     "summary": "The chair and vice chair of Berkeley's Police Accountability Board argue against the City Council's proposed expansion of its Flock Safety surveillance contract, citing data-sharing with federal immigration authorities, lack of competitive procurement, and BPD's failure to consider alternatives. They urge the council to reject the expansion ahead of a May 7 vote.",
     "key_quotes": [
       {
-        "quote": "Flock Safety \u2014 a vendor that over 75 jurisdictions have deemed untrustworthy, has facilitated data-sharing with federal immigration authorities, and has not demonstrated either the technical capacity or will to adhere to Berkeley's data privacy standards.",
+        "quote": "Flock Safety — a vendor that over 75 jurisdictions have deemed untrustworthy, has facilitated data-sharing with federal immigration authorities, and has not demonstrated either the technical capacity or will to adhere to Berkeley's data privacy standards.",
         "paragraph_idx": 11
       },
       {
@@ -7496,7 +7533,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:02Z",
-    "article_id": "art_061"
+    "article_id": "art_061",
+    "primary_subject_agency_ids": [
+      "eca5a0e5-4ab4-5868-a688-c03da1dff9b1"
+    ]
   },
   {
     "url": "https://epic.org/texas-observer-as-license-plate-readers-expand-in-texas-privacy-advocates-are-fighting-back/",
@@ -7508,7 +7548,7 @@
     "published_at": null,
     "fetched_at": "2026-05-07T17:59:34Z",
     "discovered_by": "rss:epic.org",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "4581ba3dd101cf6a7e4c29108d12105242cf82b30da0dff543eeae49d75cb81a",
     "paths": {
@@ -7540,7 +7580,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "EPIC links to a Texas Observer article on the expansion of license plate readers in Texas and privacy advocates' pushback, quoting EPIC fellow Kabbas Azhar who says Flock's use is largely unregulated and runs on an honor system.",
     "key_quotes": [
       {
@@ -7554,7 +7593,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:06Z",
-    "article_id": "art_062"
+    "article_id": "art_062",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.hngnews.com/leader_independent/news/local/dane-county-board-votes-to-cut-funding-for-flock-license-plate-reader-cameras/article_df6d5043-0b19-4053-8510-ff5aacfc463b.html",
@@ -7566,7 +7606,7 @@
     "published_at": null,
     "fetched_at": "2026-05-08T19:06:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "e2ed0076fc5f789a2531770383e626e552bda66d3139e74517e872e321d6e53a",
     "paths": {
@@ -7694,7 +7734,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "48841a6b-f280-54eb-ba5d-cb57962ad687",
     "summary": "The Dane County (WI) Board voted 32-1 to remove $80,000 in 2026 budget funding for the Sheriff's Office Flock Safety ALPR subscription, ending the contract that runs through May 31. Supervisors cited concerns about Flock's data-sharing with more than 140 outside agencies and federal entities, while Board Chair Patrick Miles said the county remains open to alternative ALPR vendors. Sheriff Kalvin Barrett criticized the decision as also a cut to his office's funding.",
     "key_quotes": [
       {
@@ -7716,7 +7755,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:20Z",
-    "article_id": "art_063"
+    "article_id": "art_063",
+    "primary_subject_agency_ids": [
+      "48841a6b-f280-54eb-ba5d-cb57962ad687"
+    ]
   },
   {
     "url": "https://www.kcrg.com/2026/02/25/coralville-removes-flock-cameras-after-council-votes-end-contract/",
@@ -7728,7 +7770,7 @@
     "published_at": "2026-02-25T22:02:49.129Z",
     "fetched_at": "2026-05-08T19:06:57Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "7cf211fea6e786b47a3bfbc76ce836563bac58a5a02a6fca5e20656d6cf84fb3",
     "paths": {
@@ -7776,8 +7818,7 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "40521632-8a29-5e5d-a064-1b57410743b5",
-    "summary": "Coralville, Iowa removed its Flock license plate reader cameras after the city council voted 3-1 to terminate the contract. The vote followed an Iowa Attorney General letter declaring the city's policy\u2014which barred using Flock data for immigration enforcement\u2014in violation of state law; rather than amend the policy, the council ended the program.",
+    "summary": "Coralville, Iowa removed its Flock license plate reader cameras after the city council voted 3-1 to terminate the contract. The vote followed an Iowa Attorney General letter declaring the city's policy—which barred using Flock data for immigration enforcement—in violation of state law; rather than amend the policy, the council ended the program.",
     "key_quotes": [
       {
         "quote": "The city of Coralville removed its Flock license plate reader cameras Wednesday morning, one day after the city council voted to terminate its contract with the surveillance company.",
@@ -7794,7 +7835,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T19:10:03Z",
-    "article_id": "art_064"
+    "article_id": "art_064",
+    "primary_subject_agency_ids": [
+      "40521632-8a29-5e5d-a064-1b57410743b5"
+    ]
   },
   {
     "url": "https://www.kgun9.com/news/community-inspired-journalism/cochise-county/sierra-vista-city-council-directs-staff-to-end-flock-license-plate-reader-contract",
@@ -7806,7 +7850,7 @@
     "published_at": "2026-02-25T01:12:23.544",
     "fetched_at": "2026-05-08T19:06:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 66 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 66 pts, HIGH/CRITICAL findings",
     "scanner_score": 66,
     "content_hash": "c8a237971554b4ddbd084e01517bda8ea6d8c47f6934ccdd15bb306ada8c6646",
     "paths": {
@@ -7860,7 +7904,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "3b3aa3f2-1a52-5fa4-9b7d-e6e940a39991",
     "summary": "Sierra Vista City Council directed staff to terminate the city's contract with Flock for license plate readers following a work session where residents and officials raised concerns about Flock's ownership of captured images, potential data sales, and use of AI. The council also asked staff to explore alternative ALPR vendors.",
     "key_quotes": [
       {
@@ -7878,7 +7921,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:26Z",
-    "article_id": "art_065"
+    "article_id": "art_065",
+    "primary_subject_agency_ids": [
+      "3b3aa3f2-1a52-5fa4-9b7d-e6e940a39991"
+    ]
   },
   {
     "url": "https://www.klcc.org/breaking/2025-12-05/eugene-and-springfield-both-announce-end-of-flock-camera-usage",
@@ -7890,7 +7936,7 @@
     "published_at": "2025-12-06T04:48:15.362",
     "fetched_at": "2026-05-08T19:07:37Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 23 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 23 pts, low/medium only",
     "scanner_score": 23,
     "content_hash": "be49d4ac86df9fa6912c390e5668386f4df18ff8e708340f82e38d1ec5ffd417",
     "paths": {
@@ -7990,7 +8036,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
     "summary": "Eugene and Springfield, Oregon both announced on Dec. 5, 2025 that they are ending their contracts with Flock Safety for ALPR cameras, citing vulnerabilities, data security concerns, and community pushback. Springfield's cameras had never been activated and will be removed; Eugene had paused use in October. Springfield indicated it may seek alternative ALPR vendors.",
     "key_quotes": [
       {
@@ -8012,7 +8057,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T19:10:12Z",
-    "article_id": "art_066"
+    "article_id": "art_066",
+    "primary_subject_agency_ids": [
+      "68f11e4a-7a56-5692-a0a2-558de9117210"
+    ]
   },
   {
     "url": "https://www.kvue.com/article/news/local/austin-license-plate-readers-ends-privacy-concerns/269-4dc64690-c6c0-4ace-a009-fd8a13f69113",
@@ -8024,7 +8072,7 @@
     "published_at": "6/4/2025 5:52:18 PM",
     "fetched_at": "2026-05-08T19:06:52Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 116 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 116 pts, HIGH/CRITICAL findings",
     "scanner_score": 116,
     "content_hash": "12c2931c36b1a977f26eec9d42993ca3094f35137572c7f99b9166e628bb6cb4",
     "paths": {
@@ -8061,7 +8109,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "summary": "Austin's city manager pulled an item to extend the city's ALPR contracts with Flock Safety and Axon, ending the program at month's end amid privacy concerns about data collection and potential tracking of people seeking abortions or gender-affirming care. Council members and advocates praised the decision, while APD said it supports the pause and Flock cited arrests enabled by the cameras.",
     "key_quotes": [
       {
@@ -8079,19 +8126,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:34Z",
-    "article_id": "art_067"
+    "article_id": "art_067",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ]
   },
   {
     "url": "https://lookouteugene-springfield.com/story/latest-news/2025/12/09/flock-activated-camera-during-pause-chief-says-pushing-city-to-axe-contract/",
     "source_domain": "lookouteugene-springfield.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock activated camera during \u2018pause,\u2019 chief says, pushing city to axe contract",
+    "title": "Flock activated camera during ‘pause,’ chief says, pushing city to axe contract",
     "byline": "Jaime Adame",
     "published_at": "2025-12-10T02:25:55+00:00",
     "fetched_at": "2026-05-08T19:07:32Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 185 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 185 pts, HIGH/CRITICAL findings",
     "scanner_score": 185,
     "content_hash": "4b728fa9f6e4a95b230f8b97b604e1613e988c0a624e009975600ccb5d1c28e7",
     "paths": {
@@ -8167,7 +8217,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
     "summary": "Eugene Police Chief Chris Skinner ended the city's contract with Flock Safety after learning that a license-plate reader camera was reactivated and collected data during a citywide pause on the technology. Flock attributed the reactivation to an automated maintenance work order and said it has changed protocols; Springfield, OR also canceled its Flock contract amid similar concerns. Eugene has requested removal of the 57 cameras.",
     "key_quotes": [
       {
@@ -8189,7 +8238,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:02:48Z",
-    "article_id": "art_068"
+    "article_id": "art_068",
+    "primary_subject_agency_ids": [
+      "68f11e4a-7a56-5692-a0a2-558de9117210"
+    ]
   },
   {
     "url": "https://www.mv-voice.com/public-safety/2026/02/02/mountain-view-police-turn-off-license-plate-cameras-after-data-sharing-breach/",
@@ -8201,7 +8253,7 @@
     "published_at": "2026-02-03T00:09:01+00:00",
     "fetched_at": "2026-05-08T19:06:14Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 131 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 131 pts, HIGH/CRITICAL findings",
     "scanner_score": 131,
     "content_hash": "311daa517137890a2a27e7b986789476ba126ea484d371cec4fdf76e3b9701ef",
     "paths": {
@@ -8332,7 +8384,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
     "summary": "Mountain View Police Chief Mike Canfield disabled all 30 of the city's Flock Safety license plate cameras after disclosures that over 250 California agencies, and briefly federal entities, accessed the data without authorization in violation of city policy and state law. The cameras will remain off pending City Council discussion on Feb. 24, and Canfield said he no longer has confidence in Flock as a vendor.",
     "key_quotes": [
       {
@@ -8354,7 +8405,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:03:01Z",
-    "article_id": "art_069"
+    "article_id": "art_069",
+    "primary_subject_agency_ids": [
+      "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0"
+    ]
   },
   {
     "url": "https://www.opb.org/article/2025/12/06/eugene-springfield-end-flock-cameras/",
@@ -8366,7 +8420,7 @@
     "published_at": "2025-12-06",
     "fetched_at": "2026-05-08T19:06:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "52ce71b135890a2550154c2b1db4bc510a35568fe2c95ba7632e8dc5132edc08",
     "paths": {
@@ -8452,7 +8506,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "68f11e4a-7a56-5692-a0a2-558de9117210",
     "summary": "Eugene and Springfield, Oregon announced on Dec. 5, 2025 that they are ending their contracts with Flock Safety for ALPR cameras, citing unspecified vulnerabilities, data security concerns, and community trust issues. Eugene had already asked Flock to turn off its cameras in October; Springfield's cameras were never activated and will be removed, though the department says it may seek other ALPR vendors.",
     "key_quotes": [
       {
@@ -8474,19 +8527,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T19:10:20Z",
-    "article_id": "art_070"
+    "article_id": "art_070",
+    "primary_subject_agency_ids": [
+      "68f11e4a-7a56-5692-a0a2-558de9117210"
+    ]
   },
   {
     "url": "https://skamaniasheriff.com/2025/11/12/flock-cameras-disabled-after-recent-court-decision/",
     "source_domain": "skamaniasheriff.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock Cameras Disabled After Recent Court Decision \u2013 Skamania County Sheriff",
+    "title": "Flock Cameras Disabled After Recent Court Decision – Skamania County Sheriff",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-08T19:07:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "b7ddd987c48d594c79256ede23c209f925e3dba9836fa2afdb6a9d7efe8ccbe6",
     "paths": {
@@ -8509,7 +8565,6 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "The Skamania County Sheriff's Office announced it is disabling its six Flock cameras following a recent court decision regarding public-records access to Flock-generated footage. The Flock contract runs through December 2026 and the infrastructure will remain in place, but the cameras and license plate reader technology will be turned off.",
     "key_quotes": [
       {
@@ -8527,7 +8582,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:03:06Z",
-    "article_id": "art_071"
+    "article_id": "art_071",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenorthwestern.com/story/news/local/oshkosh/2026/04/22/oshkosh-rescinds-flock-safety-contract-after-police-chief-raises-concerns/89745485007/",
@@ -8539,7 +8595,7 @@
     "published_at": "2026-04-23T04:00:58.295131947Z",
     "fetched_at": "2026-05-08T19:06:20Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 71 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 71 pts, HIGH/CRITICAL findings",
     "scanner_score": 71,
     "content_hash": "083eb425ae85cabf02ff0955ab964bc650bbda4a96682e40086d94ad6a411400",
     "paths": {
@@ -8616,7 +8672,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712",
     "summary": "Oshkosh, WI rescinded its Flock Safety ALPR contract after Police Chief Dean Smith told the Common Council that Flock had misrepresented the cameras' capabilities, including claims about heat maps and federal access to data. The unanimous reversal came less than 24 hours after council had approved a one-year renewal, and OPD is powering off all 26 cameras and revoking outside-agency access.",
     "key_quotes": [
       {
@@ -8624,7 +8679,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "Smith said he was immediately advised by officers that Flock cameras create a \u201cheat map,\u201d directly refuting claims to the contrary from Flock Chief Information Security Officer Chris Castaldo.",
+        "quote": "Smith said he was immediately advised by officers that Flock cameras create a “heat map,” directly refuting claims to the contrary from Flock Chief Information Security Officer Chris Castaldo.",
         "paragraph_idx": 9
       },
       {
@@ -8638,7 +8693,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T20:03:18Z",
-    "article_id": "art_072"
+    "article_id": "art_072",
+    "primary_subject_agency_ids": [
+      "25a4e15f-c0b8-5fc4-9aea-4990fdb4a712"
+    ]
   },
   {
     "url": "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety",
@@ -8650,7 +8708,7 @@
     "published_at": "2026-03-05T04:24:56.349",
     "fetched_at": "2026-05-08T19:07:25Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 24 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 24 pts, low/medium only",
     "scanner_score": 24,
     "content_hash": "0035688abceac22795e60710c31c695ad0219becbd22e08d5d3c28e7705193ef",
     "paths": {
@@ -8758,7 +8816,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d22f3264-52b5-5139-ad7c-849564e02eb1",
     "summary": "The Ithaca Common Council voted to end the city's contract with Flock Safety, citing privacy concerns, data-sharing practices, and conflicts with Ithaca's sanctuary city policies. Activists rallied before the vote, while the police chief defended the ALPR cameras as a valuable tool.",
     "key_quotes": [
       {
@@ -8780,7 +8837,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T19:10:27Z",
-    "article_id": "art_073"
+    "article_id": "art_073",
+    "primary_subject_agency_ids": [
+      "d22f3264-52b5-5139-ad7c-849564e02eb1"
+    ]
   },
   {
     "url": "https://www.kvue.com/article/news/local/hays-county/hays-county-contract-flock-license-plate-reader-cameras/269-f7276915-920a-4216-add1-42fbf17a0056",
@@ -8792,7 +8852,7 @@
     "published_at": "10/14/2025 6:56:33 PM",
     "fetched_at": "2026-05-08T20:21:51Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 116 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 116 pts, HIGH/CRITICAL findings",
     "scanner_score": 116,
     "content_hash": "7b0deaf45a1cbd285e2442932aed4f442f981d4e65664d7f1cc7597c1427862d",
     "paths": {
@@ -8834,12 +8894,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-08T20:22:17Z",
-    "article_id": "art_074"
+    "article_id": "art_074",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.opb.org/article/2026/01/08/bend-flock-cameras-ai-license-plate-camera-law-enforcement/",
@@ -8847,11 +8907,11 @@
     "tier": 1,
     "stance": "unknown",
     "title": "Bend is the latest Oregon city to turn off Flock cameras",
-    "byline": "Kathryn Styer Mart\u00ednez",
+    "byline": "Kathryn Styer Martínez",
     "published_at": "2026-01-08",
     "fetched_at": "2026-05-08T22:16:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "587463a2dd5c765809a70856aca1ce04de780973e9cc0dac4d71cb68d37254fe",
     "paths": {
@@ -8896,7 +8956,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Bend, Oregon's city council voted not to renew its Flock Safety ALPR contract and turned off four cameras after public concerns about privacy and potential federal immigration surveillance use. Bend joins Eugene, Springfield, Woodburn, and Skamania County in deactivating Flock cameras, though Bend police say they'll seek an alternate ALPR vendor.",
     "key_quotes": [
       {
@@ -8918,19 +8977,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-08T22:17:03Z",
-    "article_id": "art_075"
+    "article_id": "art_075",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.clickorlando.com/news/local/2021/08/12/shocking-violation-of-procedure-lake-county-commissioners-order-takedown-of-traffic-surveillance-cameras/",
     "source_domain": "clickorlando.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "\u2018Shocking violation:\u2019 Lake County commissioners order takedown of secret surveillance cameras",
+    "title": "‘Shocking violation:’ Lake County commissioners order takedown of secret surveillance cameras",
     "byline": "Brian Didlake",
     "published_at": "2021-08-12T22:17:14.497Z",
     "fetched_at": "2026-05-09T00:13:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 104 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 104 pts, HIGH/CRITICAL findings",
     "scanner_score": 104,
     "content_hash": "bd920221837590e48d76be12de3afcdc1db2d0429c249ba99def4b1b2b3eb96d",
     "paths": {
@@ -9030,12 +9090,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T00:15:03Z",
-    "article_id": "art_076"
+    "article_id": "art_076",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.goskagit.com/news/local_news/sedro-woolley-turns-off-law-enforcement-cameras-while-it-seeks-court-ruling/article_d0d0bdb9-6502-4686-94ae-346289afd535.html",
@@ -9047,7 +9107,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:22:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 223 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 223 pts, HIGH/CRITICAL findings",
     "scanner_score": 223,
     "content_hash": "e50f07bb3a8c1b5b34772520721e263ddd1d63a8131218bb51102060e22072c5",
     "paths": {
@@ -9175,24 +9235,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:22:43Z",
-    "article_id": "art_077"
+    "article_id": "art_077",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://shorewoodmn.gov/Blog.aspx?IID=21",
     "source_domain": "shorewoodmn.gov",
     "tier": 2,
     "stance": "unknown",
-    "title": "Blog \u2022 Flock Safety Camera Turned Off",
+    "title": "Blog • Flock Safety Camera Turned Off",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T02:22:17Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 34 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 34 pts, HIGH/CRITICAL findings",
     "scanner_score": 34,
     "content_hash": "f6de9b7c0d6031d0e0f2dc113b2fc08aa375d6aafec0a37da069f5ec95665fb0",
     "paths": {
@@ -9224,12 +9284,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:22:43Z",
-    "article_id": "art_078"
+    "article_id": "art_078",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://abc7news.com/post/santa-clara-county-stop-using-flock-safety-cameras-several-cities-privacy-concerns/18646060/",
@@ -9241,7 +9301,7 @@
     "published_at": "2026-02-25T05:50:59Z",
     "fetched_at": "2026-05-09T02:42:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "148744b9158e8ffa4756584380c183ff92d48a1e588ee0e474ec1e4105b6c734",
     "paths": {
@@ -9356,7 +9416,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "1b719ab9-5230-5a7a-bcb4-a495a4e716eb",
     "summary": "The Santa Clara County Board of Supervisors voted to stop using Flock Safety as the vendor for license plate readers in Cupertino, Saratoga, and Los Altos Hills, where the sheriff's office provides policing. The decision follows revelations that federal agencies accessed Flock data from Mountain View without consent, prompting a county review of surveillance policies.",
     "key_quotes": [
       {
@@ -9374,7 +9433,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T02:45:34Z",
-    "article_id": "art_079"
+    "article_id": "art_079",
+    "primary_subject_agency_ids": [
+      "1b719ab9-5230-5a7a-bcb4-a495a4e716eb"
+    ]
   },
   {
     "url": "https://bloomington.in.gov/news/2026/04/15/6521",
@@ -9386,7 +9448,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:41:13Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "7cfd9247f1207df4bb4a14610a219b763934126816b6045e55703c1906a909f8",
     "paths": {
@@ -9435,7 +9497,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "97f69d1e-5db1-5a4d-a95a-7314e28d0ad1",
     "summary": "Bloomington, Indiana Mayor Kerry Thomson announced the city did not renew its Flock ALPR contract, which expired March 5, 2026, following a months-long evaluation. During the transition, data access is restricted to BPD personnel and outside data sharing is discontinued; the city will evaluate alternative technologies.",
     "key_quotes": [
       {
@@ -9453,7 +9514,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T02:45:43Z",
-    "article_id": "art_080"
+    "article_id": "art_080",
+    "primary_subject_agency_ids": [
+      "97f69d1e-5db1-5a4d-a95a-7314e28d0ad1"
+    ]
   },
   {
     "url": "https://www.cbsnews.com/colorado/news/license-plate-reading-cameras-colorado-regulation-misuse/",
@@ -9465,7 +9529,7 @@
     "published_at": "2025-09-19T22:12:00-0600",
     "fetched_at": "2026-05-09T02:41:42Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 303 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 303 pts, HIGH/CRITICAL findings",
     "scanner_score": 303,
     "content_hash": "b29d1ac250656c643008ea46d68b2365ad28f24d32f26d9fa6935a7bf2c006ea",
     "paths": {
@@ -9586,24 +9650,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:08Z",
-    "article_id": "art_081"
+    "article_id": "art_081",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.denvergazette.com/2024/02/17/big-brother-or-crime-fighter-elbert-county-says-no-to-license-plate-readers-521d798c-caac-11ee-a37b-7b0672ff5019/",
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Big Brother or crime fighter? Elbert County says \u2018no\u2019 to license plate readers",
+    "title": "Big Brother or crime fighter? Elbert County says ‘no’ to license plate readers",
     "byline": null,
     "published_at": "2024-02-17T19:00:00+00:00",
     "fetched_at": "2026-05-09T02:40:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 197 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 197 pts, HIGH/CRITICAL findings",
     "scanner_score": 197,
     "content_hash": "951a1b348e70cf0f08a386f85c5c2ff464479cbb45a3dc6f28961e97cd0efd6f",
     "paths": {
@@ -9719,12 +9783,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:11Z",
-    "article_id": "art_082"
+    "article_id": "art_082",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.heraldnet.com/news/mountlake-terrace-cancels-flock",
@@ -9736,7 +9800,7 @@
     "published_at": "2025-12-05T18:26:00+00:00",
     "fetched_at": "2026-05-09T02:39:50Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "76ef6c18065fce5a634431ef5a929f9e0b99adefc0c5b726009cac0d45bb17ca",
     "paths": {
@@ -9846,12 +9910,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:13Z",
-    "article_id": "art_083"
+    "article_id": "art_083",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.koamnewsnow.com/news/top-stories/seneca-police-end-flock-camera-contract-after-less-than-90-days/article_d493c47c-a4ab-4270-83c9-f52e784b24ea.html",
@@ -9863,7 +9927,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:41:04Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 153 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 153 pts, HIGH/CRITICAL findings",
     "scanner_score": 153,
     "content_hash": "0f57e35a4c10640f246cdb97bd63c8639f27a716c4ae91e5e59585f7095162e9",
     "paths": {
@@ -9945,12 +10009,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:14Z",
-    "article_id": "art_084"
+    "article_id": "art_084",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://kstp.com/kstp-news/top-news/roadside-cameras-going-dark-another-department-makes-changes-to-program-over-accountability-concerns/",
@@ -9962,7 +10026,7 @@
     "published_at": "2026-02-03T23:53:37+00:00",
     "fetched_at": "2026-05-09T02:40:51Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 134 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 134 pts, HIGH/CRITICAL findings",
     "scanner_score": 134,
     "content_hash": "11b26c6f4f5350b098aeda9d1ff0ed4fa035e477ed571bdf05b70fe69ecf8beb",
     "paths": {
@@ -10003,12 +10067,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:15Z",
-    "article_id": "art_085"
+    "article_id": "art_085",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://laist.com/news/south-pasadena-cancels-flock-safety-contract-privacy-concerns",
@@ -10020,7 +10084,7 @@
     "published_at": "2026-03-19T20:49:46.5",
     "fetched_at": "2026-05-09T02:41:27Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 30 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 30 pts, HIGH/CRITICAL findings",
     "scanner_score": 30,
     "content_hash": "8f3d617890984fc6e4ce78e9fd365a2c60843a95f830a76c05dfc19ad87f54b1",
     "paths": {
@@ -10123,12 +10187,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:17Z",
-    "article_id": "art_086"
+    "article_id": "art_086",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.northcountrypublicradio.org/news/story/53078/20260302/police-stop-installing-surveillance-cameras-in-saranac-lake-for-now",
@@ -10140,7 +10204,7 @@
     "published_at": "2026-03-02T00:00:00Z",
     "fetched_at": "2026-05-09T02:43:40Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 16 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 16 pts, low/medium only",
     "scanner_score": 16,
     "content_hash": "0577836126816b47dbe6816e7f25299ada8e58dd6d9a6dee1058ba229a64b672",
     "paths": {
@@ -10173,7 +10237,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Village of Saranac Lake has paused installation of Flock Safety license plate reader cameras after community concerns, with the mayor saying a final decision will be made with the Village Board, police, and public once the police chief returns from an FBI academy trip. Three of six planned cameras had already been installed.",
     "key_quotes": [
       {
@@ -10187,19 +10250,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T02:45:48Z",
-    "article_id": "art_087"
+    "article_id": "art_087",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://sanjosespotlight.com/fact-brief-does-campbell-have-a-partnership-with-flock-cameras/",
     "source_domain": "sanjosespotlight.com",
     "tier": 2,
     "stance": "neutral",
-    "title": "Fact Brief: Does Campbell have a partnership with Flock cameras? - San Jos\u00e9 Spotlight",
+    "title": "Fact Brief: Does Campbell have a partnership with Flock cameras? - San José Spotlight",
     "byline": "Donovan Farnham",
     "published_at": "2026-04-15T17:00:28+00:00",
     "fetched_at": "2026-05-09T02:41:50Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 88 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 88 pts, HIGH/CRITICAL findings",
     "scanner_score": 88,
     "content_hash": "f39bdd86ece9a4a2a86aafb6b7999813ae61fd6f820b3bfce7ed7f3a177ead46",
     "paths": {
@@ -10254,12 +10318,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:20Z",
-    "article_id": "art_088"
+    "article_id": "art_088",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://spectrumlocalnews.com/nys/central-ny/public-safety/2026/03/23/syracuse-common-council-revokes-contract-with-flock",
@@ -10271,7 +10335,7 @@
     "published_at": "2026-03-23T17:48:00.000-04:00",
     "fetched_at": "2026-05-09T02:43:19Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 73 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 73 pts, HIGH/CRITICAL findings",
     "scanner_score": 73,
     "content_hash": "bb2ae1d22d4ca1fb61ac50f91e925388a4373ea3fb76c862d1132a21ba3c1d90",
     "paths": {
@@ -10302,12 +10366,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:21Z",
-    "article_id": "art_089"
+    "article_id": "art_089",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://vimeo.com/showcase/7323755",
@@ -10319,7 +10383,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:40:18Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 38 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 38 pts, HIGH/CRITICAL findings",
     "scanner_score": 38,
     "content_hash": "e61245e1c15580c6bd3811ec43111a41339336cde579cf76bff0ab7e77b51fd8",
     "paths": {
@@ -10335,12 +10399,12 @@
     "tags": [],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:21Z",
-    "article_id": "art_090"
+    "article_id": "art_090",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.watertownmanews.com/2026/01/28/watertown-cancelling-contract-for-flock-license-plate-reading-cameras/",
@@ -10352,7 +10416,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:42:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 50 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 50 pts, HIGH/CRITICAL findings",
     "scanner_score": 50,
     "content_hash": "29a4c288464130e0c26073d268ed7754fa2da869cea4fbf967f4832b1457186a",
     "paths": {
@@ -10382,12 +10446,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:23Z",
-    "article_id": "art_091"
+    "article_id": "art_091",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.wbir.com/article/news/crime/10investigates-knoxville-license-plate-reader-cameras-turned-off-contract-lapse/51-3cadec96-a281-49e8-ab41-c3e9ff4a12df",
@@ -10399,7 +10463,7 @@
     "published_at": "2/4/2026 6:27:08 PM",
     "fetched_at": "2026-05-09T02:40:03Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "2bee96e18e062257740b4f42d5b6549b20263f86130a21a4e780925fb6e9c1c1",
     "paths": {
@@ -10440,12 +10504,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:25Z",
-    "article_id": "art_092"
+    "article_id": "art_092",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://woodburnindependent.com/2025/11/11/woodburn-suspends-flock-safety-license-plate-cameras-amid-concerns-of-federal-ice-enforcement/",
@@ -10457,7 +10521,7 @@
     "published_at": "2025-11-12T00:30:09+00:00",
     "fetched_at": "2026-05-09T02:42:59Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 65 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 65 pts, HIGH/CRITICAL findings",
     "scanner_score": 65,
     "content_hash": "0f3f2c6986e5ed12cae94703e9ac38f9de527709c32292c60228c140b88ef7d3",
     "paths": {
@@ -10475,12 +10539,12 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T02:45:26Z",
-    "article_id": "art_093"
+    "article_id": "art_093",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/news/208802-city-ends-flock-pilot-program-over-federal-data-base-concerns/",
@@ -10492,7 +10556,7 @@
     "published_at": "2025-12-16T15:44:05+00:00",
     "fetched_at": "2026-05-09T08:53:03Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 64 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 64 pts, HIGH/CRITICAL findings",
     "scanner_score": 64,
     "content_hash": "2f20b37a770145b63313fbbc13626504b714fe98f53bc22c7223b4de256071a7",
     "paths": {
@@ -10529,7 +10593,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville City Manager Sam Sanders announced the city will not resume its Flock ALPR pilot program after it expired in October, citing councilor concerns about data potentially feeding federal databases via Palantir/Peregrine-style aggregation. Police Chief Michael Kochis noted the program had the most restrictive policy in Virginia and that the Police Civilian Oversight Board's audits found no misuse.",
     "key_quotes": [
       {
@@ -10555,7 +10618,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:48:45Z",
-    "article_id": "art_094"
+    "article_id": "art_094",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.kut.org/crime-justice/2025-07-23/kyle-tx-austin-texas-flock-safety-cameras-license-plate-readers",
@@ -10567,7 +10633,7 @@
     "published_at": "2025-07-23T09:00:00",
     "fetched_at": "2026-05-09T08:54:51Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 34 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 34 pts, low/medium only",
     "scanner_score": 34,
     "content_hash": "579a991d62ece6c8e79f2c99d14e8d4f070f45e15fb011ac15a337f91518cd9c",
     "paths": {
@@ -10625,7 +10691,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "2a642c83-7602-5269-9be4-550b7632c36d",
     "summary": "Advocates in Kyle, Texas are urging the City Council to reject an expansion of its Flock Safety license plate reader program and reduce the 25 ALPRs and three live-view cameras currently deployed. The push follows Austin's recent decision to end its Flock contract and San Marcos's rejection of an expansion proposal, with advocates citing concerns about false positives, privacy, and potential ICE access.",
     "key_quotes": [
       {
@@ -10647,7 +10712,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T08:56:28Z",
-    "article_id": "art_095"
+    "article_id": "art_095",
+    "primary_subject_agency_ids": [
+      "2a642c83-7602-5269-9be4-550b7632c36d"
+    ]
   },
   {
     "url": "https://www.aclunorcal.org/news/ice-using-driver-locations-vast-surveillance-database-target-immigrants/",
@@ -10659,7 +10727,7 @@
     "published_at": "2019-03-13T16:00:00+00:00",
     "fetched_at": "2026-05-09T10:22:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "5cc7d115b125a4e16e74cad4efff9d7f5794cc4d70822648d8e068117ad1f5a1",
     "paths": {
@@ -10736,8 +10804,7 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
-    "summary": "The ACLU of Northern California reports on FOIA records revealing that ICE has access to Vigilant Solutions' ALPR database under a $6.1M contract, with over 80 local agencies sharing license plate data\u2014including California sanctuary jurisdictions like Union City and Merced. The piece argues such sharing violates California's SB 34 and SB 54 and urges local agencies to halt sharing.",
+    "summary": "The ACLU of Northern California reports on FOIA records revealing that ICE has access to Vigilant Solutions' ALPR database under a $6.1M contract, with over 80 local agencies sharing license plate data—including California sanctuary jurisdictions like Union City and Merced. The piece argues such sharing violates California's SB 34 and SB 54 and urges local agencies to halt sharing.",
     "key_quotes": [
       {
         "quote": "Over 9,000 ICE officers have gained access to the Vigilant system under a $6.1 million contract",
@@ -10748,17 +10815,18 @@
         "paragraph_idx": 15
       },
       {
-        "quote": "Senate Bill 34 and the California Values Act (SB 54) \u2014 passed to protect privacy and immigrant safety \u2014 prohibit local law enforcement agencies from sharing license plate information and personal information for immigration enforcement or with out-of-state or federal agencies.",
+        "quote": "Senate Bill 34 and the California Values Act (SB 54) — passed to protect privacy and immigrant safety — prohibit local law enforcement agencies from sharing license plate information and personal information for immigration enforcement or with out-of-state or federal agencies.",
         "paragraph_idx": 21
       },
       {
-        "quote": "Some have already rejected contracts for license plate surveillance \u2014 like Alameda and Culver City in California.",
+        "quote": "Some have already rejected contracts for license plate surveillance — like Alameda and Culver City in California.",
         "paragraph_idx": 22
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T10:23:44Z",
-    "article_id": "art_096"
+    "article_id": "art_096",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/news/208802-new-license-plate-scanning-parking-garage-system-raises-city-councilor-concerns/",
@@ -10770,7 +10838,7 @@
     "published_at": "2026-01-07T17:42:40+00:00",
     "fetched_at": "2026-05-09T10:17:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "e74581adf4e471948c97f730f2df2b31dfe9de462aa70abc88830c45da9799a9",
     "paths": {
@@ -10803,7 +10871,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Charlottesville City Council spent nearly an hour debating concerns about a new license-plate-scanning parking garage payment system operated by Metropolis, which replaced ticket-based kiosks on Dec. 16. Councilors raised concerns about data retention, surveillance, and vendor practices, while city staff defended the modernization on cost and reliability grounds and acknowledged a poor rollout.",
     "key_quotes": [
       {
@@ -10825,7 +10892,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:48:56Z",
-    "article_id": "art_097"
+    "article_id": "art_097",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/news/208802-cville-police-chief-kochis-presents-flock-safety-camera-pilot-project/",
@@ -10837,7 +10905,7 @@
     "published_at": "2024-04-02T17:50:04+00:00",
     "fetched_at": "2026-05-09T11:59:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "3bd5b6345d41767019a072baea7262a5255595e885733a9e50981c5a4bce893b",
     "paths": {
@@ -10869,7 +10937,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville Police Chief Michael Kochis presented a proposal to City Council for a one-year Flock Safety ALPR pilot program, funded by the Police Foundation, involving 10 cameras at city entryways. Kochis cited use cases including Amber/Silver/Blue alerts and solving shootings, robberies, and stolen vehicle cases.",
     "key_quotes": [
       {
@@ -10881,25 +10948,28 @@
         "paragraph_idx": 7
       },
       {
-        "quote": "no one can be pulled on a Flock hit alone\u2026 there must be other ample evidence for that to happen.",
+        "quote": "no one can be pulled on a Flock hit alone… there must be other ample evidence for that to happen.",
         "paragraph_idx": 8
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:49:02Z",
-    "article_id": "art_098"
+    "article_id": "art_098",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/news/208802-flock-ceo-includes-charlottesville-staunton-in-email-blaming-activists-for-cities-dropping-the-companys-services/",
     "source_domain": "cvillerightnow.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock CEO includes Charlottesville, Staunton in email blaming activists for cities dropping the company\u2019s services - Cville Right Now",
+    "title": "Flock CEO includes Charlottesville, Staunton in email blaming activists for cities dropping the company’s services - Cville Right Now",
     "byline": "Dori Zook",
     "published_at": "2025-12-30T14:58:23+00:00",
     "fetched_at": "2026-05-09T13:46:57Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "703e115f7c18b08a329cafbfe469a8dc38862f48df87c6711ac0e3806ca6cc31",
     "paths": {
@@ -11023,7 +11093,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Charlottesville Police Chief Michael Kochis criticized as 'unprofessional' an email from Flock Safety CEO Garrett Langley that blamed activists for cities cancelling Flock contracts. The article recounts Charlottesville's and Staunton's recent decisions to end their Flock programs and lists other cities (Flagstaff, Cambridge, Eugene, Springfield) that have terminated contracts amid broader controversies.",
     "key_quotes": [
       {
@@ -11041,7 +11110,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:49:09Z",
-    "article_id": "art_099"
+    "article_id": "art_099",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.freep.com/story/news/local/michigan/oakland/2026/04/09/oakland-county-flock-drone-program/89524548007/",
@@ -11053,7 +11123,7 @@
     "published_at": "2026-04-09T13:34:14Z",
     "fetched_at": "2026-05-09T13:53:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 46 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 46 pts, HIGH/CRITICAL findings",
     "scanner_score": 46,
     "content_hash": "fef40cd91f9c9c0032849fac774a618a5646f88036b4b03b87d95167329b155e",
     "paths": {
@@ -11086,7 +11156,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Oakland County (Michigan) Board of Commissioners voted 13-4 on April 8, 2026 to approve a 9-month pilot of Flock surveillance drones for the Sheriff's Office. The decision came after a contentious meeting featuring hours of public comment opposing the program over privacy and cost concerns.",
     "key_quotes": [
       {
@@ -11100,7 +11169,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:49:14Z",
-    "article_id": "art_100"
+    "article_id": "art_100",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kut.org/crime-justice/2026-02-12/austin-tx-apd-flock-cameras-license-plate-readers",
@@ -11112,7 +11182,7 @@
     "published_at": "2026-02-12T20:07:58.472",
     "fetched_at": "2026-05-09T13:48:55Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 34 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 34 pts, low/medium only",
     "scanner_score": 34,
     "content_hash": "f730b17a1c902605c2bcf553874b1e236eacb5a780959c27cc34e9908f193fd9",
     "paths": {
@@ -11190,7 +11260,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "summary": "After the Austin City Council ended APD's Flock license plate reader contract in June 2025 over privacy concerns, a KUT investigation found APD has continued accessing Flock data through neighboring agencies including Round Rock and Sunset Valley. Council members and advocates call it a loophole that violates the intent of the new TRUST Act surveillance ordinance, and APD says it is reviewing its policy.",
     "key_quotes": [
       {
@@ -11208,7 +11277,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T13:55:03Z",
-    "article_id": "art_101"
+    "article_id": "art_101",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ]
   },
   {
     "url": "https://www.aclunorcal.org/news/license-plate-readers-alameda-need-strict-privacy-safeguards/",
@@ -11220,7 +11292,7 @@
     "published_at": "2014-01-29T20:46:32+00:00",
     "fetched_at": "2026-05-09T15:09:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "fd7fc74cde661891815e76c85899a3be96e33c93419891a0cb1fa8184ad2f01c",
     "paths": {
@@ -11254,7 +11326,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "aeee2f0f-6386-5a1a-b93a-30babdede4f9",
     "summary": "The ACLU of Northern California submitted an analysis of Alameda's draft ALPR policies ahead of a city council public forum, warning that the policies lack safeguards on data collection, use, and retention. The ACLU urges Alameda not to adopt ALPR technology until stronger, enforceable safeguards are adopted through public input.",
     "key_quotes": [
       {
@@ -11268,7 +11339,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T15:15:05Z",
-    "article_id": "art_102"
+    "article_id": "art_102",
+    "primary_subject_agency_ids": [
+      "aeee2f0f-6386-5a1a-b93a-30babdede4f9"
+    ]
   },
   {
     "url": "https://chronline.com/stories/chehalis-and-napavine-flock-cameras-still-effective-police-chiefs-say,400867",
@@ -11280,7 +11354,7 @@
     "published_at": "2026-04-22",
     "fetched_at": "2026-05-09T15:13:04Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "62e0848ad6c7483712917da3a0df594ac217d5ebcdb95fd754821982d286e433",
     "paths": {
@@ -11365,7 +11439,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "624117fb-8cba-5612-8f6f-0ebbfc512ae9",
     "summary": "Chehalis and Napavine police chiefs say their Flock Safety ALPR systems remain effective under Washington's new SB 6002 regulations, requiring only minor policy changes and camera relocations. Chehalis has paused use of its self-entered license plate watch list until it can meet the new 24-hour review requirement, while Napavine's chief is considering expanding his three-camera deployment.",
     "key_quotes": [
       {
@@ -11383,7 +11456,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T15:15:12Z",
-    "article_id": "art_103"
+    "article_id": "art_103",
+    "primary_subject_agency_ids": [
+      "624117fb-8cba-5612-8f6f-0ebbfc512ae9"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/news/208802-richmond-police-chief-apologizes-for-february-atf-access-grant-to-flock-system/",
@@ -11395,7 +11471,7 @@
     "published_at": "2025-07-09T17:15:55+00:00",
     "fetched_at": "2026-05-09T15:06:09Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 86 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 86 pts, HIGH/CRITICAL findings",
     "scanner_score": 86,
     "content_hash": "0570dd6fb73f082022e0aee06e467886348cac130c7cdd25c7e4f9e8524f9a94",
     "paths": {
@@ -11478,7 +11554,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "7b9dbf06-a73b-532d-ba54-751ba8d15fe8",
     "summary": "Richmond (VA) Police Chief Rick Edwards apologized after discovering an ATF analyst had been granted access to RPD's Flock license plate reader system in February and used it for immigration-related queries in violation of department policy. RPD terminated the analyst's access and announced no federal agencies will have access to its ALPR program going forward; the article also recaps Charlottesville PD's earlier move to isolate its Flock system from outside access.",
     "key_quotes": [
       {
@@ -11490,13 +11565,16 @@
         "paragraph_idx": 5
       },
       {
-        "quote": "In one instance, a potential residency violation may have prompted the use of 'ICE' in a search field \u2014 but all queries were related to criminal activity, not civil immigration enforcement.",
+        "quote": "In one instance, a potential residency violation may have prompted the use of 'ICE' in a search field — but all queries were related to criminal activity, not civil immigration enforcement.",
         "paragraph_idx": 10
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:05:46Z",
-    "article_id": "art_104"
+    "article_id": "art_104",
+    "primary_subject_agency_ids": [
+      "7b9dbf06-a73b-532d-ba54-751ba8d15fe8"
+    ]
   },
   {
     "url": "https://www.aclunorcal.org/cases/lagleva-v-doyle-license-plate-surveillance/",
@@ -11508,7 +11586,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:01:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "49de7effba0b3ce72fee0f86c23dcad61c4db20bbb7da60fd1b37dac3b0780c0",
     "paths": {
@@ -11554,11 +11632,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1922365-80e2-5ec7-8580-95245cdad7f8",
     "summary": "ACLU of Northern California case page describing Lagleva v. Doyle, a 2021 lawsuit against Marin County Sheriff Robert Doyle for sharing ALPR data with ICE, CBP, and out-of-state agencies in violation of SB 34 and SB 54. A May 2022 settlement requires the Sheriff to stop sharing license plate data outside California, binding on successors.",
     "key_quotes": [
       {
-        "quote": "Since at least 2014, the Marin County Sheriff's Office has shared and transferred the sensitive location information of its residents and people who travel through its boundaries with these agencies\u2014a practice that violates two California laws",
+        "quote": "Since at least 2014, the Marin County Sheriff's Office has shared and transferred the sensitive location information of its residents and people who travel through its boundaries with these agencies—a practice that violates two California laws",
         "paragraph_idx": 4
       },
       {
@@ -11568,7 +11645,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:06:43Z",
-    "article_id": "art_105"
+    "article_id": "art_105",
+    "primary_subject_agency_ids": [
+      "e1922365-80e2-5ec7-8580-95245cdad7f8"
+    ]
   },
   {
     "url": "https://www.cambridgema.gov/news/2025/12/statementontheflocksafetyalprcontracttermination",
@@ -11580,7 +11660,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:03:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "473e4a42de2435afb51eb73b1446d679a2cb518b121655dfc057e79d6f7b17b4",
     "paths": {
@@ -11613,7 +11693,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "a6ee05fe-842e-512c-9cae-13bb118682c0",
     "summary": "The City of Cambridge announced termination of its Flock Safety ALPR contract after Flock technicians installed two cameras in late November 2025 without the City's awareness, following the City's October deactivation and removal of 16 Flock ALPRs. Cambridge cited the unauthorized installation as a material breach and plans further evaluation of ALPR technology.",
     "key_quotes": [
       {
@@ -11631,7 +11710,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:06:52Z",
-    "article_id": "art_106"
+    "article_id": "art_106",
+    "primary_subject_agency_ids": [
+      "a6ee05fe-842e-512c-9cae-13bb118682c0"
+    ]
   },
   {
     "url": "https://cbsaustin.com/news/local/san-marcos-city-council-ends-flock-safety-contract-seeking-new-options",
@@ -11643,7 +11725,7 @@
     "published_at": "2025-12-05T18:01:14.000Z",
     "fetched_at": "2026-05-09T16:03:21Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "dfe10cc5e9d2fe6257c1544d600390d835501370b33657930f530c227d7f80f5",
     "paths": {
@@ -11748,7 +11830,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The San Marcos (TX) City Council directed staff to discontinue the city's Flock Safety license plate reader contract and explore alternative camera vendors, ending a program in place since 2022. Mayor Jane Hughson said the council lacked the four votes needed to renew, while the police chief defended the cameras' role in solving a recent homicide.",
     "key_quotes": [
       {
@@ -11766,7 +11847,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:06:59Z",
-    "article_id": "art_107"
+    "article_id": "art_107",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://chronline.com/stories/centralia-police-chief-offers-testimony-on-state-bill-to-regulate-flock-safety-cameras,394939",
@@ -11778,7 +11860,7 @@
     "published_at": "2026-01-21",
     "fetched_at": "2026-05-09T16:02:59Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "28bde6b1ace02c03739a36f4cb76cb5312af45c0a5c59af28f3e15db79018b97",
     "paths": {
@@ -11910,7 +11992,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "b47e37ee-b687-5be5-a284-a153da743c03",
     "summary": "Centralia Police Chief Andy Caldwell testified before the Washington Senate Committee on Law and Justice on SB 6002, which would regulate automated license plate readers like Flock Safety cameras. Caldwell signed in as 'other,' supporting regulation but seeking to preserve features useful to law enforcement, while ACLU-WA and civil liberties groups pushed for shorter retention, tighter sharing limits, and PRA access.",
     "key_quotes": [
       {
@@ -11928,7 +12009,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:07:08Z",
-    "article_id": "art_108"
+    "article_id": "art_108",
+    "primary_subject_agency_ids": [
+      "b47e37ee-b687-5be5-a284-a153da743c03"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/podcasts/cpd-chief-michael-kochis-responds-to-the-removal-of-the-flock-camera-system/",
@@ -11940,7 +12024,7 @@
     "published_at": "2025-12-16T12:42:29+00:00",
     "fetched_at": "2026-05-09T16:01:26Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 54 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 54 pts, HIGH/CRITICAL findings",
     "scanner_score": 54,
     "content_hash": "0f6d48eb35b83f6bcd8bd99f438cd6bf758bf276f97687a4acc8617161f72328",
     "paths": {
@@ -11973,7 +12057,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville Police Chief Michael Kochis discusses the city council's decision to remove the Flock ALPR camera system, expressing respect for the council's view and sharing community feedback he received.",
     "key_quotes": [
       {
@@ -11983,19 +12066,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:05:50Z",
-    "article_id": "art_109"
+    "article_id": "art_109",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2025/10/22/denver-flock-contract-extension-council/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Mayor extends Denver\u2019s contract with Flock license-plate readers without council approval",
+    "title": "Mayor extends Denver’s contract with Flock license-plate readers without council approval",
     "byline": "Elliott Wenzler",
     "published_at": "2025-10-22T16:11:37+00:00",
     "fetched_at": "2026-05-09T16:02:16Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "a767b7a117c60cb69338c42d7e678f4fd833a67923f072bda9062099fae5e9aa",
     "paths": {
@@ -12107,11 +12193,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver Mayor Mike Johnston's office extended the city's Flock ALPR contract for five months without City Council approval, after the council unanimously rejected a longer extension in May. The new extension adds restrictions including a $100,000 penalty for any sharing of Denver's data with federal agencies, limits on search terms (excluding immigration and reproductive health), and requirements that other agencies accessing the data not share it with federal immigration authorities.",
     "key_quotes": [
       {
-        "quote": "Mayor Mike Johnston's office is extending Denver's contract with Flock \u2014 a company that operates AI-powered license-plate readers throughout the city \u2014 for five months without any additional cost, circumventing the need for a vote by the City Council.",
+        "quote": "Mayor Mike Johnston's office is extending Denver's contract with Flock — a company that operates AI-powered license-plate readers throughout the city — for five months without any additional cost, circumventing the need for a vote by the City Council.",
         "paragraph_idx": 17
       },
       {
@@ -12125,19 +12210,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:01Z",
-    "article_id": "art_110"
+    "article_id": "art_110",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.fauquiernow.com/news/not-on-our-watch-warrenton-town-council-reverses-course-on-license-plate-readers/article_9a1c02ac-5f77-47c7-a270-06f49ab98332.html",
     "source_domain": "fauquiernow.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "\u2018Not on our watch\u2019: Warrenton Town Council reverses course on license plate readers",
+    "title": "‘Not on our watch’: Warrenton Town Council reverses course on license plate readers",
     "byline": "Grace Schumacher | FauquierNow",
     "published_at": null,
     "fetched_at": "2026-05-09T16:03:39Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 137 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 137 pts, HIGH/CRITICAL findings",
     "scanner_score": 137,
     "content_hash": "c1a4dc6f22c90b58c993137a84b097691cfac0d785bc8f79b17735b0d3c9c344",
     "paths": {
@@ -12155,12 +12243,12 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:06:22Z",
-    "article_id": "art_111"
+    "article_id": "art_111",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.heraldnet.com/2025/09/10/stanwood-pauses-flock-cameras-amid-public-records-lawsuits/",
@@ -12172,7 +12260,7 @@
     "published_at": "2025-09-10T21:13:00+00:00",
     "fetched_at": "2026-05-09T16:02:29Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "61af71c73b329132b1f582d0890584b667a4cce054839b9a2d48b255354ae242",
     "paths": {
@@ -12190,12 +12278,12 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:06:24Z",
-    "article_id": "art_112"
+    "article_id": "art_112",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kgun9.com/news/community-inspired-journalism/south-tucson/south-tucson-ends-flock-camera-contract-city-now-searching-for-alternatives",
@@ -12207,7 +12295,7 @@
     "published_at": "2026-02-23T21:41:09.756",
     "fetched_at": "2026-05-09T16:03:05Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 70 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 70 pts, HIGH/CRITICAL findings",
     "scanner_score": 70,
     "content_hash": "ec1c8bcda6385070ef659943b7b08a6fa45015d0a2b9f04fd0a1464f87d69764",
     "paths": {
@@ -12268,12 +12356,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:06:25Z",
-    "article_id": "art_113"
+    "article_id": "art_113",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kiro7.com/news/local/renton-police-shut-down-license-plate-cameras-comply-with-new-privacy-law/JHCHPR4FQBGKNJOOWZ7LM3J6W4/",
@@ -12285,7 +12373,7 @@
     "published_at": "2026-04-07T18:08:01.363Z",
     "fetched_at": "2026-05-09T16:04:35Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "515d322bd0533966f0d03c1719fba90a01a7454aac7a611556b93effbf880be9",
     "paths": {
@@ -12353,7 +12441,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Renton Police Department temporarily shut down its Flock Safety ALPR cameras on March 31 to comply with Washington's new SB 6002 privacy law, while it rewrites policies and updates software. The article notes Renton joins Seattle, Redmond, Lynnwood, and Pierce County in pausing or terminating ALPR programs under the new law.",
     "key_quotes": [
       {
@@ -12367,7 +12454,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:07:18Z",
-    "article_id": "art_114"
+    "article_id": "art_114",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kut.org/austin/2025-09-25/austin-tx-city-park-safety-ai-liveview-technologies-cameras",
@@ -12379,7 +12467,7 @@
     "published_at": "2025-09-25T15:21:17.387",
     "fetched_at": "2026-05-09T16:02:47Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 37 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 37 pts, low/medium only",
     "scanner_score": 37,
     "content_hash": "81b160ab3e413fc51573565a42cf44a6e02f7423c5bd352e8cb196cc11e82729",
     "paths": {
@@ -12411,7 +12499,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
     "summary": "Austin withdrew a proposed $2 million contract with LiveView Technologies for AI-enabled surveillance cameras at city parks before an August city council vote, amid resident concerns about privacy and data handling. The withdrawal came shortly after Austin ended its automatic license plate reader program over similar privacy concerns. It is unclear if the contract will return to council.",
     "key_quotes": [
       {
@@ -12429,7 +12516,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T16:07:25Z",
-    "article_id": "art_115"
+    "article_id": "art_115",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ]
   },
   {
     "url": "https://www.redrocknews.com/2025/09/10/sedona-city-council-tells-staff-to-get-the-flock-out-of-town/",
@@ -12441,7 +12531,7 @@
     "published_at": "2025-09-10T17:08:18+00:00",
     "fetched_at": "2026-05-09T16:02:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "6c222090701019ef7f74f7ff29157659befb7e3a2784ef5d0ceca0c404b00e4f",
     "paths": {
@@ -12477,7 +12567,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Sedona City Council voted unanimously on Sept. 9, 2025 to cancel its Flock Safety contract and remove all 11 ALPR cameras, citing revelations that Flock had allowed federal agencies including CBP to access ALPR data despite assurances to council that data would not be shared. Mayor Scott Jablow reversed his prior support, and council members called Flock dishonorable as a vendor.",
     "key_quotes": [
       {
@@ -12499,7 +12588,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:11Z",
-    "article_id": "art_116"
+    "article_id": "art_116",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.toledoblade.com/local/county/2024/01/18/lucas-county-flock-contract",
@@ -12511,7 +12601,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:04:11Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 25 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 25 pts, low/medium only",
     "scanner_score": 25,
     "content_hash": "84ab7704a7a5fc55be244beae596f6dbc4a4bd61b0cbc1280b8b1323a26db52a",
     "paths": {
@@ -12539,13 +12629,13 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-09T16:06:33Z",
     "article_id": "art_117",
-    "curation_error": "refusal: 404 page not found; no article content available."
+    "curation_error": "refusal: 404 page not found; no article content available.",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.wfsb.com/2026/02/20/windsor-suspends-license-plate-readers-amid-privacy-concerns/",
@@ -12557,7 +12647,7 @@
     "published_at": "2026-02-20T04:19:25.74Z",
     "fetched_at": "2026-05-09T16:03:49Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "abf93cb7ae5d5cab6a0ba63f9c3e46c54b0854ad5c73612c29eea0013faba507",
     "paths": {
@@ -12633,12 +12723,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:06:34Z",
-    "article_id": "art_118"
+    "article_id": "art_118",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.hngnews.com/leader_independent/news/local/monona-police-suspend-use-of-flock-cameras/article_08a572d3-9d1e-41a0-8bed-2b0680b4b1c4.html",
@@ -12650,7 +12740,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:47:23Z",
     "discovered_by": "bing:alpr",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 197 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 197 pts, HIGH/CRITICAL findings",
     "scanner_score": 197,
     "content_hash": "2c49a6ef589f70cb5d4abe065be702067bd62834d60f12cc87c308c87cc9f59e",
     "paths": {
@@ -12774,12 +12864,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:48:28Z",
-    "article_id": "art_119"
+    "article_id": "art_119",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://ww2.kqed.org/news/2026/05/08/berkeley-extends-surveillance-contract-with-flock-safety-but-rejects-major-expansion/",
@@ -12791,7 +12881,7 @@
     "published_at": "2026-05-08T16:14:26-07:00",
     "fetched_at": "2026-05-09T16:47:02Z",
     "discovered_by": "rss:kqed.org",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 103 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 103 pts, HIGH/CRITICAL findings",
     "scanner_score": 103,
     "content_hash": "2a203f67929ca7390d870304c67e248b531654e3f79786b540b614ca59f1c4c4",
     "paths": {
@@ -12892,12 +12982,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:48:31Z",
-    "article_id": "art_120"
+    "article_id": "art_120",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.nbc26.com/oshkosh/oshkosh-ends-flock-safety-contract-but-will-keep-license-plate-readers",
@@ -12909,7 +12999,7 @@
     "published_at": "2026-04-29T23:31:41.164",
     "fetched_at": "2026-05-09T16:46:48Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 79 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 79 pts, HIGH/CRITICAL findings",
     "scanner_score": 79,
     "content_hash": "b2b3d241757ae3d1f588c5e89c8187e81c6c1ec212d86cbaa3369f941a79befd",
     "paths": {
@@ -12991,24 +13081,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T16:48:32Z",
-    "article_id": "art_121"
+    "article_id": "art_121",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclunorcal.org/press-releases/california-activists-sue-marin-county-sheriff-illegally-sharing-drivers-license-plate-data-ice/",
     "source_domain": "aclunorcal.org",
     "tier": 2,
     "stance": "critical",
-    "title": "California Activists Sue Marin County Sheriff for Illegally Sharing Drivers\u2019 License Plate Data With ICE, CBP and Other Out-of-State Agencies - ACLU of Northern California",
+    "title": "California Activists Sue Marin County Sheriff for Illegally Sharing Drivers’ License Plate Data With ICE, CBP and Other Out-of-State Agencies - ACLU of Northern California",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T17:01:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "68b6e6e70b7837d84ad7df28c3d5c6f96b4a03470d01a8952854e68d58e4aecc",
     "paths": {
@@ -13083,7 +13173,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1922365-80e2-5ec7-8580-95245cdad7f8",
     "summary": "The ACLU of Northern California, EFF, and co-counsel sued Marin County Sheriff Robert Doyle, alleging his office illegally shares ALPR data with ICE, CBP, and over 400 out-of-state agencies in violation of California's S.B. 34 and S.B. 54. The suit, filed on behalf of three Marin community activists, seeks to end the data-sharing practice.",
     "key_quotes": [
       {
@@ -13101,7 +13190,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:19Z",
-    "article_id": "art_122"
+    "article_id": "art_122",
+    "primary_subject_agency_ids": [
+      "e1922365-80e2-5ec7-8580-95245cdad7f8"
+    ]
   },
   {
     "url": "https://www.cbsnews.com/atlanta/news/atlanta-protest-targets-flock-safety-as-debate-over-surveillance-ice-fears-and-public-safety-intensifies/",
@@ -13113,7 +13205,7 @@
     "published_at": "2026-04-16T17:50:00-0400",
     "fetched_at": "2026-05-09T17:03:18Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 196 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 196 pts, HIGH/CRITICAL findings",
     "scanner_score": 196,
     "content_hash": "fbf386517006f5d6d8a8fe012d8588c214faed35585b1083f3996f5ea708b7d4",
     "paths": {
@@ -13233,12 +13325,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T17:05:09Z",
-    "article_id": "art_123"
+    "article_id": "art_123",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/podcasts/city-flock-camera-program-discussion/",
@@ -13250,7 +13342,7 @@
     "published_at": "2025-02-05T13:36:03+00:00",
     "fetched_at": "2026-05-09T17:02:12Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 54 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 54 pts, HIGH/CRITICAL findings",
     "scanner_score": 54,
     "content_hash": "d6234f895af8512b63673a42dc93dcab858cd578be18653904354833875d0684",
     "paths": {
@@ -13283,7 +13375,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "A brief podcast item noting that the hosts discussed the Charlottesville City Council's deliberations over whether to continue the city's FLOCK camera program.",
     "key_quotes": [
       {
@@ -13293,19 +13384,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:23Z",
-    "article_id": "art_124"
+    "article_id": "art_124",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2026/02/10/flock-cameras-privacy-debate-thornton-colorado-legislature/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Pushback against Flock cameras comes to Denver suburb \u2014 the latest Colorado city to enter debate",
+    "title": "Pushback against Flock cameras comes to Denver suburb — the latest Colorado city to enter debate",
     "byline": "John Aguilar",
     "published_at": "2026-02-10T13:00:31+00:00",
     "fetched_at": "2026-05-09T17:02:35Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 148 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 148 pts, HIGH/CRITICAL findings",
     "scanner_score": 148,
     "content_hash": "5b0c892b967ef0cb7189027156bed45b16586530b9c6845a7a5c3f126c5e9837",
     "paths": {
@@ -13415,7 +13509,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "cf1e330c-8a42-5cd9-813d-cfe383b83802",
     "summary": "Thornton, Colorado residents are pushing back against the city's 16 Flock Safety ALPR cameras, raising privacy and Fourth Amendment concerns at community and council meetings, while Thornton police defend the system as a vital crime-fighting tool. The article situates the local debate alongside actions in Denver, Longmont, and Louisville and pending Colorado bills (SB 70, SB 71) that would restrict surveillance data sharing and retention.",
     "key_quotes": [
       {
@@ -13423,7 +13516,7 @@
         "paragraph_idx": 12
       },
       {
-        "quote": "Any situation I feel uncomfortable about or that might be in conflict with our policies or with Colorado law, I will revoke their access \u2014 no problem,",
+        "quote": "Any situation I feel uncomfortable about or that might be in conflict with our policies or with Colorado law, I will revoke their access — no problem,",
         "paragraph_idx": 29
       },
       {
@@ -13437,7 +13530,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:35Z",
-    "article_id": "art_125"
+    "article_id": "art_125",
+    "primary_subject_agency_ids": [
+      "cf1e330c-8a42-5cd9-813d-cfe383b83802"
+    ]
   },
   {
     "url": "https://www.govtech.com/biz/under-scrutiny-flock-safety-debuts-automatic-auditing-tool",
@@ -13449,7 +13545,7 @@
     "published_at": "2026-04-24T21:45:04.85",
     "fetched_at": "2026-05-09T17:02:26Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "89346712f67ada4ca73a04c295c2f271145ebd42b01b57bc78d8d2a181f8f347",
     "paths": {
@@ -13479,12 +13575,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T17:05:16Z",
-    "article_id": "art_126"
+    "article_id": "art_126",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.latimes.com/socal/daily-pilot/news/story/2026-04-24/costa-mesa-to-audit-of-license-plate-reader-program-after-misuse-case",
@@ -13496,7 +13592,7 @@
     "published_at": "2026-04-25T00:40:48.123",
     "fetched_at": "2026-05-09T17:02:51Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 139 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 139 pts, HIGH/CRITICAL findings",
     "scanner_score": 139,
     "content_hash": "a1978b9f6038fc7cd5d93069f409c9b41705ecccc2edbf6f557e8a03fd55e706",
     "paths": {
@@ -13618,12 +13714,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T17:05:18Z",
-    "article_id": "art_127"
+    "article_id": "art_127",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.nbc26.com/oshkosh/appleton-mayor-calls-to-remove-flock-cameras",
@@ -13635,7 +13731,7 @@
     "published_at": "2026-05-08T16:33:38.326",
     "fetched_at": "2026-05-09T17:01:25Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 79 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 79 pts, HIGH/CRITICAL findings",
     "scanner_score": 79,
     "content_hash": "2a072e37084a3b5117574a19396f1096a3ae3892cebe191182ebdfdbbf854ef3",
     "paths": {
@@ -13706,12 +13802,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-09T17:05:19Z",
-    "article_id": "art_128"
+    "article_id": "art_128",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.redrocknews.com/2026/03/31/spd-begins-strategic-plan/",
@@ -13723,7 +13819,7 @@
     "published_at": "2026-04-01T00:07:35+00:00",
     "fetched_at": "2026-05-09T17:02:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 112 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 112 pts, HIGH/CRITICAL findings",
     "scanner_score": 112,
     "content_hash": "b621ac19b43a80e688ba22d02400d915e324f866a44d90cf0e929cdc06f180ed",
     "paths": {
@@ -13831,13 +13927,13 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-09T17:05:25Z",
     "article_id": "art_129",
-    "curation_error": "refusal: Article is about Sedona PD strategic planning; not about ALPR or related surveillance technology."
+    "curation_error": "refusal: Article is about Sedona PD strategic planning; not about ALPR or related surveillance technology.",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/local/community/puyallup-herald/ph-news/article315257166.html",
@@ -13849,7 +13945,7 @@
     "published_at": "2026-04-08T05:00:00-07:00",
     "fetched_at": "2026-05-09T17:02:03Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "62b24cd9122ee41f35025256e635f4f4c4af1f8b307748cea18c8ac557cc682c",
     "paths": {
@@ -13985,7 +14081,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "b111be54-e0b4-5bc2-83c9-ad2285eccaaf",
     "summary": "Puyallup's two-year Flock Safety ALPR contract has expired and the city is deciding whether to renew amid Washington's new Driver's Privacy Act (SB 6002), which limits retention, sharing, and camera placement. Police Chief Scott Engle says PPD has turned off its in-car Axon ALPR system and is reviewing three of 39 Flock cameras for compliance, while crediting the cameras with significant crime drops; critics like former officer Jeff Bennett raise transparency and data-sharing concerns, including past national lookup access by federal agencies revealed in a UW study.",
     "key_quotes": [
       {
@@ -14007,7 +14102,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:06:54Z",
-    "article_id": "art_130"
+    "article_id": "art_130",
+    "primary_subject_agency_ids": [
+      "b111be54-e0b4-5bc2-83c9-ad2285eccaaf"
+    ]
   },
   {
     "url": "https://www.theolympian.com/news/state/washington/seattle/article314804119.html",
@@ -14015,11 +14113,11 @@
     "tier": 1,
     "stance": "unknown",
     "title": "What to know about controversial automated license plate readers in WA",
-    "byline": "Catalina Gait\u00e1n, The Seattle Times",
+    "byline": "Catalina Gaitán, The Seattle Times",
     "published_at": "2026-02-23T06:37:48-08:00",
     "fetched_at": "2026-05-09T17:03:37Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "eaaac27aa29b914560a609b1a9bbe09d25ac813c733e7a344edcc76ba0738a36",
     "paths": {
@@ -14143,7 +14241,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "A statewide explainer on ALPRs in Washington, covering how the technology works, its rapid expansion via state grants, controversies including federal data access and a Skagit County public-records ruling, and pending state legislation that would impose the first ALPR regulations in Washington.",
     "key_quotes": [
       {
@@ -14161,19 +14258,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T17:07:01Z",
-    "article_id": "art_131"
+    "article_id": "art_131",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclunorcal.org/press-releases/lawsuit-challenges-san-jose-s-warrantless-alpr-mass-surveillance/",
     "source_domain": "aclunorcal.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Lawsuit Challenges San Jose\u2019s Warrantless ALPR Mass Surveillance - ACLU of Northern California",
+    "title": "Lawsuit Challenges San Jose’s Warrantless ALPR Mass Surveillance - ACLU of Northern California",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T19:25:43Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "eb18af576c7b2088c08f4fd770c528ed033c34e61c8165309795304fbcf3311b",
     "paths": {
@@ -14240,11 +14338,10 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
     "summary": "The EFF and ACLU of Northern California filed a lawsuit in Santa Clara County Superior Court against San Jose, its police chief, and mayor, alleging that SJPD's warrantless searches of ALPR data violate the California Constitution. The suit, on behalf of SIREN and CAIR-CA, challenges the city's nearly 500 ALPR cameras and one-year retention policy, seeking a warrant requirement for searches.",
     "key_quotes": [
       {
-        "quote": "The San Jose Police Department has blanketed the city's roadways with nearly 500 ALPRs \u2013 indiscriminately collecting millions of records per month about people's movements \u2013 and keeps this data for an entire year.",
+        "quote": "The San Jose Police Department has blanketed the city's roadways with nearly 500 ALPRs – indiscriminately collecting millions of records per month about people's movements – and keeps this data for an entire year.",
         "paragraph_idx": 6
       },
       {
@@ -14258,7 +14355,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T19:26:13Z",
-    "article_id": "art_132"
+    "article_id": "art_132",
+    "primary_subject_agency_ids": [
+      "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/news/208802-council-gives-verbal-support-for-flock-camera-continuation-after-charlottesville-police-chief-report/",
@@ -14270,7 +14370,7 @@
     "published_at": "2025-02-04T18:22:57+00:00",
     "fetched_at": "2026-05-09T19:22:40Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 64 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 64 pts, HIGH/CRITICAL findings",
     "scanner_score": 64,
     "content_hash": "a88e8e889a46c9355226bd6cd12dfb668994d1d0acc55ec54400b924daec6793",
     "paths": {
@@ -14306,7 +14406,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville City Council informally signaled support for continuing the city's Flock ALPR camera program after Police Chief Mike Kochis presented a six-month update citing successes in solving stolen vehicle, shooting, and missing person cases. Kochis highlighted the city's restrictive policies, including 7-day data retention and monthly audits by CPD and the Police Civilian Oversight Board.",
     "key_quotes": [
       {
@@ -14324,7 +14423,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T19:26:21Z",
-    "article_id": "art_133"
+    "article_id": "art_133",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.thenewstribune.com/news/state/washington/article314581905.html",
@@ -14336,7 +14438,7 @@
     "published_at": "2026-02-05T05:00:00-08:00",
     "fetched_at": "2026-05-09T19:24:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "e817d0f7aff5362a061108867f5cfab6563054101f2d450d80aeb158c39ba188",
     "paths": {
@@ -14423,7 +14525,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Washington state Senate passed SB 6002 on a 40-9 vote, limiting ALPR data retention to 21 days and barring use for immigration enforcement, protest tracking, and near sensitive sites like schools and places of worship. The bill, sponsored by Sen. Yasmin Trudeau with Republican co-sponsor Sen. Jeff Holy, now moves to the state House.",
     "key_quotes": [
       {
@@ -14445,7 +14546,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T19:26:29Z",
-    "article_id": "art_134"
+    "article_id": "art_134",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.redrocknews.com/2025/08/14/sedona-city-council-tells-spd-city-staff-to-turn-off-flock-cameras/",
@@ -14457,7 +14559,7 @@
     "published_at": "2025-08-14T21:46:35+00:00",
     "fetched_at": "2026-05-09T21:02:41Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "1bdfc4547e989ad64ce0d8eec4f0b42f42685d82c9cb250f3f7402e0c6aba0f7",
     "paths": {
@@ -14480,7 +14582,6 @@
     ],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": "The Sedona City Council, by majority consensus at an Aug. 13 special meeting, directed Sedona Police Department and city staff to indefinitely shut off the city's 11 installed Flock ALPR cameras. The council also ordered staff to provide a timeline of prior discussions, form a citizen work group, and return with a pilot program proposal.",
     "key_quotes": [
       {
@@ -14498,7 +14599,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T21:06:01Z",
-    "article_id": "art_135"
+    "article_id": "art_135",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/state/washington/article315379868.html",
@@ -14510,7 +14612,7 @@
     "published_at": "2026-04-11T11:28:11-07:00",
     "fetched_at": "2026-05-09T21:01:00Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "41c55965b6527703634194e2da630010f3e238665d57eb612bfd7cb1aa64acba",
     "paths": {
@@ -14599,7 +14701,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "b47e37ee-b687-5be5-a284-a153da743c03",
     "summary": "After Washington Gov. Bob Ferguson signed SB 6002 imposing new restrictions on ALPRs, Centralia Police Chief Andy Caldwell says the department will keep using its Flock Safety cameras, though three cameras near a school, library, and Planned Parenthood will be shut off to comply with the law's 500-foot exclusion zones. The bill also limits ALPR use to felonies and gross misdemeanors, shortens retention from 30 to 21 days, and ends NCIC watchlist notifications, while peer agencies in Seattle, Kent, and Pierce County have temporarily shut off systems.",
     "key_quotes": [
       {
@@ -14621,19 +14722,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T21:06:10Z",
-    "article_id": "art_136"
+    "article_id": "art_136",
+    "primary_subject_agency_ids": [
+      "b47e37ee-b687-5be5-a284-a153da743c03"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2026/03/30/denver-axon-contract-license-plate-cameras-council/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for \u2018this whole Flock era\u2019",
+    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for ‘this whole Flock era’",
     "byline": "Elliott Wenzler",
     "published_at": "2026-03-30T12:00:52+00:00",
     "fetched_at": "2026-05-09T22:05:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "184bdb1f578f7231e8af66286f32294b317bc114c5f85605698badc701d8ef98",
     "paths": {
@@ -14681,7 +14785,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver City Council is set to vote on a one-year, $150,000 contract with Axon Enterprise to replace its expiring Flock Safety ALPR contract, which would cut camera count roughly in half. Several council members signaled they may reject the deal over surveillance concerns, including past ICE access to Denver's Flock data; if rejected, the city's ALPR program will end.",
     "key_quotes": [
       {
@@ -14699,7 +14802,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T22:06:34Z",
-    "article_id": "art_137"
+    "article_id": "art_137",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.redrocknews.com/2025/08/21/sedona-city-council-was-right-to-shut-down-flock-spy-cameras/",
@@ -14711,7 +14817,7 @@
     "published_at": "2025-08-21T19:58:36+00:00",
     "fetched_at": "2026-05-09T22:00:37Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 112 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 112 pts, HIGH/CRITICAL findings",
     "scanner_score": 112,
     "content_hash": "78dbe690ad6e7cafd08fbec49215e2619e4507133c9bb9c3b7600bc00c3d598f",
     "paths": {
@@ -14757,7 +14863,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "A Sedona Red Rock News editorial praises five Sedona City Council members for directing staff to shut down 11 newly installed Flock Safety automated license plate readers, citing bipartisan public opposition and lack of prior public debate. The piece criticizes Mayor Scott Jablow's dissent and questions data retention, ICE access, and oversight of the for-profit vendor.",
     "key_quotes": [
       {
@@ -14775,7 +14880,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T22:06:42Z",
-    "article_id": "art_138"
+    "article_id": "art_138",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/local/article282855768.html",
@@ -14787,7 +14893,7 @@
     "published_at": "2023-12-15T05:30:00-08:00",
     "fetched_at": "2026-05-09T22:03:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "4447f49030005c79e4d205893608da5e04f4f4bcd1e6dbfc3098898c648b539e",
     "paths": {
@@ -14919,7 +15025,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The News Tribune reports on the spread of Flock Safety automated license plate readers across Pierce County, Washington, with Lakewood, Eatonville, and Puyallup having adopted the cameras, often via consent-agenda approvals. The article details how the technology works, early results cited by police, ACLU concerns about mass surveillance and privacy, and the lack of Washington state regulation governing ALPR use and retention.",
     "key_quotes": [
       {
@@ -14941,7 +15046,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-09T22:06:53Z",
-    "article_id": "art_139"
+    "article_id": "art_139",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.denverpost.com/2026/04/02/denver-license-plate-readers-public-safety-letters/",
@@ -14953,7 +15059,7 @@
     "published_at": "2026-04-02T11:03:42+00:00",
     "fetched_at": "2026-05-10T00:06:16Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "3976c87bc76780f1cf4b2471b354146b4a3b206798ec7c5b51e3389c6bd02952",
     "paths": {
@@ -15008,7 +15114,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Letters to the editor in the Denver Post react to the Denver City Council's narrow 7-6 vote approving a new Axon ALPR contract. Writers support the cameras as a public-safety tool while urging vigilance that data not be misused beyond contract terms.",
     "key_quotes": [
       {
@@ -15022,7 +15127,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T00:08:50Z",
-    "article_id": "art_140"
+    "article_id": "art_140",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.redrocknews.com/2025/08/30/city-manager-memo-to-council-accuses-sedona-mayor-jablow-of-manipulation-over-flock-cameras/",
@@ -15034,7 +15142,7 @@
     "published_at": "2025-08-30T07:02:00+00:00",
     "fetched_at": "2026-05-10T00:02:48Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 114 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 114 pts, HIGH/CRITICAL findings",
     "scanner_score": 114,
     "content_hash": "f3505b1c3f70c480627e125f2b9dd496ae60109d47b2b45743fe3972123b5811",
     "paths": {
@@ -15090,7 +15198,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Sedona City Manager Anette Spickard's 30-page memo accuses Mayor Scott Jablow of manipulating the process to install Flock ALPR cameras without council direction or public outreach, then leaving her as the 'fall guy' during public backlash. On Aug. 13, council voted 5-1 to indefinitely pause the ALPR program, order a timeline, and form a citizen working group to consider a pilot.",
     "key_quotes": [
       {
@@ -15098,7 +15205,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "You continue to pursue this unilater\u00adally without ever having discussed it with council",
+        "quote": "You continue to pursue this unilater­ally without ever having discussed it with council",
         "paragraph_idx": 10
       },
       {
@@ -15112,19 +15219,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T00:08:58Z",
-    "article_id": "art_141"
+    "article_id": "art_141",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/nation-world/national/article315239095.html",
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for \u2018this whole Flock era'",
+    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for ‘this whole Flock era'",
     "byline": " Elliott Wenzler, The Denver Post ",
     "published_at": "2026-03-30T11:35:59-07:00",
     "fetched_at": "2026-05-10T00:08:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "9e2c72c341ccb151044ecae6c165dcd325902b21debcc327e058a2104f697461",
     "paths": {
@@ -15172,7 +15280,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver City Council is set to vote on a new one-year, $150,000 contract with Axon to replace its expiring Flock Safety ALPR contract, with several council members signaling opposition amid concerns over ICE access to data and broader surveillance integration. If rejected, the mayor's office says the ALPR program will shut down.",
     "key_quotes": [
       {
@@ -15194,19 +15301,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T00:09:08Z",
-    "article_id": "art_142"
+    "article_id": "art_142",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2026/03/23/denver-cameras-flock-safety-axon-johnston/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver\u2019s City Council rejected Flock surveilance, but Axon is just as bad (Opinion)",
+    "title": "Denver’s City Council rejected Flock surveilance, but Axon is just as bad (Opinion)",
     "byline": "Jennifer Piper",
     "published_at": "2026-03-23T15:36:37+00:00",
     "fetched_at": "2026-05-10T04:14:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "4705cf1fb8d69a338bac3be284a38551b819c2ed795370e1afe265ebd4581d0b",
     "paths": {
@@ -15251,7 +15361,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "In an opinion column, AFSC's Jennifer Piper urges Denver City Council to reject Mayor Mike Johnston's proposed Axon license-plate-reader contract, arguing Axon poses the same surveillance and ICE-cooperation risks that led activists to end Denver's Flock contract. She cites Axon's $370M ICE/DHS contract and its hiring of former ICE acting director Ronald Vitiello.",
     "key_quotes": [
       {
@@ -15269,19 +15378,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T04:18:41Z",
-    "article_id": "art_143"
+    "article_id": "art_143",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.redrocknews.com/2025/09/08/coconino-county-sheriffs-office-installs-flock-cameras/",
     "source_domain": "redrocknews.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Coconino County Sheriff\u2019s Office installs Flock Cameras - Sedona Red Rock News",
+    "title": "Coconino County Sheriff’s Office installs Flock Cameras - Sedona Red Rock News",
     "byline": "Joseph K Giddens",
     "published_at": "2025-09-08T13:37:00+00:00",
     "fetched_at": "2026-05-10T04:11:02Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "205325432128bf381204113b65491494b780cfb95c96261695692580b52c741e",
     "paths": {
@@ -15409,7 +15521,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Coconino County Sheriff's Office installed 18 Flock ALPR cameras across the county under a $64,627 first-year lease approved 4-0 by the Board of Supervisors in April. CCSO retains data 30 days, has 95 data-sharing agreements with other law enforcement agencies but none with ICE or federal agencies, and has no plans for additional cameras.",
     "key_quotes": [
       {
@@ -15421,13 +15532,14 @@
         "paragraph_idx": 13
       },
       {
-        "quote": "In order to generate that list of vehicles based on \"a vague vehicle descrip\u00adtion,\" ALPRs scan and document every single vehicle that enters its field of view, leading to privacy advocates to cite ALPR programs as mass surveillance.",
+        "quote": "In order to generate that list of vehicles based on \"a vague vehicle descrip­tion,\" ALPRs scan and document every single vehicle that enters its field of view, leading to privacy advocates to cite ALPR programs as mass surveillance.",
         "paragraph_idx": 16
       }
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T04:18:49Z",
-    "article_id": "art_144"
+    "article_id": "art_144",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.smdailyjournal.com/news/local/south-city-expands-surveillance/article_7b1f6d24-d18e-11ef-842a-3bdc6e80fad3.html",
@@ -15439,7 +15551,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T04:09:02Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 245 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 245 pts, HIGH/CRITICAL findings",
     "scanner_score": 245,
     "content_hash": "d8044a3c92980dc29f05f9c0880b1c74744b4b890db1c227d49813b561790d40",
     "paths": {
@@ -15566,7 +15678,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "South San Francisco approved a two-year, ~$120,000/year contract with Flock Safety to expand its ALPR program from 28 to 44 cameras, and launched a drone program for police and fire. Police Chief Scott Campbell cited 555 Flock-related incidents and 147 arrests since 2022; the article also notes EFF findings that 70+ California departments violated ALPR data-sharing rules and references AG Bonta's 2023 memo.",
     "key_quotes": [
       {
@@ -15584,7 +15695,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T04:19:01Z",
-    "article_id": "art_145"
+    "article_id": "art_145",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.9news.com/article/news/local/denver-removing-flock-cameras-new-axon-contract/73-640b5af3-7c87-4fea-8aa1-2510ad3257b8",
@@ -15596,7 +15708,7 @@
     "published_at": "2/24/2026 10:12:32 AM",
     "fetched_at": "2026-05-10T07:39:56Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "f1c7432dc58a48aeeaf650ab2a4755bf45c0d523d267ad588992b50530baf1dc",
     "paths": {
@@ -15628,12 +15740,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T07:40:22Z",
-    "article_id": "art_146"
+    "article_id": "art_146",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.denverpost.com/2026/02/24/denver-flock-license-plate-cameras-contract-axon/",
@@ -15645,7 +15757,7 @@
     "published_at": "2026-02-24T17:12:04+00:00",
     "fetched_at": "2026-05-10T07:35:27Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "8c51667ad06da13fdd7f0933cd11b035ee98018811d0d28d885c03437894e2ca",
     "paths": {
@@ -15694,7 +15806,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver Mayor Mike Johnston announced the city will end its contract with Flock Safety on March 31, 2026, and proposed a one-year, $150,000 contract with Axon for license plate readers. The new deal includes a 21-day retention policy, no national database, no ICE access, and ends data-sharing with other police departments by default.",
     "key_quotes": [
       {
@@ -15702,7 +15813,7 @@
         "paragraph_idx": 17
       },
       {
-        "quote": "The new deal will also have a shorter retention policy for the photos the cameras snap \u2014 21 days instead of 30 days under Flock.",
+        "quote": "The new deal will also have a shorter retention policy for the photos the cameras snap — 21 days instead of 30 days under Flock.",
         "paragraph_idx": 22
       },
       {
@@ -15716,19 +15827,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T07:40:37Z",
-    "article_id": "art_147"
+    "article_id": "art_147",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.redrocknews.com/2025/07/20/watchdog-eyes-sedonas-alpr-cameras/",
     "source_domain": "redrocknews.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Watchdog eyes Sedona\u2019s ALPR cameras - Sedona Red Rock News",
+    "title": "Watchdog eyes Sedona’s ALPR cameras - Sedona Red Rock News",
     "byline": "Christopher Fox Graham",
     "published_at": "2025-07-20T13:54:00+00:00",
     "fetched_at": "2026-05-10T07:37:18Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 114 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 114 pts, HIGH/CRITICAL findings",
     "scanner_score": 114,
     "content_hash": "c25d2252f2c9e28db266e6dbd6b8b60b9338b413ba65685bbb8ed0996989115f",
     "paths": {
@@ -15783,7 +15897,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Judicial Watch filed a public records request with the city of Sedona seeking documents on its installation of 12 Flock Safety ALPR cameras, citing concerns about lack of public notice and transparency. The Sedona City Council scheduled an Aug. 13 work session on the ALPRs, and the system will not be activated until after that meeting.",
     "key_quotes": [
       {
@@ -15801,7 +15914,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T07:40:47Z",
-    "article_id": "art_148"
+    "article_id": "art_148",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://content.govdelivery.com/accounts/ILEVANSTON/bulletins/3efa81d",
@@ -15813,7 +15927,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T09:54:15Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 16 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 16 pts, HIGH/CRITICAL findings",
     "scanner_score": 16,
     "content_hash": "0d4c4bd4c7a1ad6dc17ecc9ee2692ef6bea6eb25a4d7950576b8f25392e4acb7",
     "paths": {
@@ -15855,12 +15969,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T09:54:32Z",
-    "article_id": "art_149"
+    "article_id": "art_149",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.santacruzsentinel.com/2026/01/13/santa-cruz-votes-to-terminate-its-contract-with-flock-safety/",
@@ -15872,7 +15986,7 @@
     "published_at": "2026-01-14T03:15:19+00:00",
     "fetched_at": "2026-05-10T09:47:37Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 139 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 139 pts, HIGH/CRITICAL findings",
     "scanner_score": 139,
     "content_hash": "1246e23fc82cb654f6aa6153847de4a106016c551e4bdb390aa82eb4b056d846",
     "paths": {
@@ -15964,12 +16078,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T09:54:35Z",
-    "article_id": "art_150"
+    "article_id": "art_150",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.smdailyjournal.com/news/local/millbrae-council-approves-23-new-surveillance-cameras/article_2f3f8308-50f4-11ec-949a-dbef87a34dce.html",
@@ -15981,7 +16095,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T09:46:18Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 239 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 239 pts, HIGH/CRITICAL findings",
     "scanner_score": 239,
     "content_hash": "8cb4be3952abb172e4a1a54697f85dcbe9cf76f93cec0822cb627c78c92ba647",
     "paths": {
@@ -16108,7 +16222,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Millbrae City Council approved a five-year, $293,000 contract with Flock Safety to install 23 automated license plate readers around the city's transit arteries. Police Chief Christina Corpus cited regional organized crime and rising burglaries as justification, while the article notes ongoing state-level concerns about ALPR data sharing and retention.",
     "key_quotes": [
       {
@@ -16126,7 +16239,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T09:55:00Z",
-    "article_id": "art_151"
+    "article_id": "art_151",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/nation-world/national/article315427268.html",
@@ -16138,7 +16252,7 @@
     "published_at": "2026-04-15T16:47:03-07:00",
     "fetched_at": "2026-05-10T09:51:19Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "fe050ab331b27823178ee4410331977a6aafcc97ae504a768cccdd63ebf384e0",
     "paths": {
@@ -16256,7 +16370,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
     "summary": "Three San Jose residents, represented by the Institute for Justice, filed a federal lawsuit alleging the city's 474 Flock ALPR cameras violate the Fourth Amendment, seeking 24-hour data deletion absent a warrant. The suit parallels a November state lawsuit by EFF and ACLU-NC; San Jose officials defend the program as lawful and effective.",
     "key_quotes": [
       {
@@ -16278,7 +16391,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T09:55:12Z",
-    "article_id": "art_152"
+    "article_id": "art_152",
+    "primary_subject_agency_ids": [
+      "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0"
+    ]
   },
   {
     "url": "https://www.freep.com/story/news/local/michigan/wayne/2025/05/15/dearborn-police-contract-axon-fusus-access-surveillance-videos/83592148007/",
@@ -16290,7 +16406,7 @@
     "published_at": "2025-05-15T10:04:08Z",
     "fetched_at": "2026-05-10T11:11:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 73 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 73 pts, HIGH/CRITICAL findings",
     "scanner_score": 73,
     "content_hash": "3d5749d3871987c2ad9d3a695ea15d14db36e8f85fb597f5c951d132e3ff76f1",
     "paths": {
@@ -16404,7 +16520,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "a64727cf-9798-595e-9bf4-72f177cdd221",
     "summary": "Dearborn City Council unanimously approved a $720,000 five-year contract with Axon's Fusus to give police access to private camera feeds, drawing concern from civil liberties groups about potential targeting of protesters and immigrants. Officials stressed the system lacks facial recognition and that data policies protect privacy, while noting Dearborn also recently installed license plate readers.",
     "key_quotes": [
       {
@@ -16422,7 +16537,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T11:19:16Z",
-    "article_id": "art_153"
+    "article_id": "art_153",
+    "primary_subject_agency_ids": [
+      "a64727cf-9798-595e-9bf4-72f177cdd221"
+    ]
   },
   {
     "url": "https://www.scarsdale.gov/DocumentCenter/View/10994/08062025-Mayoral-Letter",
@@ -16434,7 +16552,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T11:15:08Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "CLEAN \u2014 no findings",
+    "scanner_verdict": "CLEAN — no findings",
     "scanner_score": 0,
     "content_hash": "e8845dd235ccba766afddb67a1c5641d2fcb5bd8e6816c3e7ed9129af53bbebd",
     "paths": {
@@ -16450,13 +16568,13 @@
     "tags": [],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-10T11:19:02Z",
     "article_id": "art_154",
-    "curation_error": "refusal: No article text provided"
+    "curation_error": "refusal: No article text provided",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.theolympian.com/news/state/washington/seattle/article314719001.html",
@@ -16468,7 +16586,7 @@
     "published_at": "2026-02-16T09:55:38-08:00",
     "fetched_at": "2026-05-10T11:17:08Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "43d01e36684821ba17b9786eb4ef64de283fa245ab5bc2d7e16ec60cf462d728",
     "paths": {
@@ -16516,7 +16634,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The article surveys surveillance technologies ICE and CBP use to track immigrants and citizens, including phone hacking, spyware, facial recognition, and Palantir data integration. It also highlights UW research showing Flock ALPR data from Washington agencies was shared with Border Patrol, discusses Washington's SB 6002 to restrict ALPR sharing, and notes federal access to state licensing data.",
     "key_quotes": [
       {
@@ -16534,19 +16651,20 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T11:19:40Z",
-    "article_id": "art_155"
+    "article_id": "art_155",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.denverpost.com/2026/02/16/denver-flock-cameras-license-plates-other-bidders/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver considers kicking out Flock \u2014 but still using license plate cameras",
+    "title": "Denver considers kicking out Flock — but still using license plate cameras",
     "byline": "Elliott Wenzler",
     "published_at": "2026-02-16T20:39:03+00:00",
     "fetched_at": "2026-05-10T13:55:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 146 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 146 pts, HIGH/CRITICAL findings",
     "scanner_score": 146,
     "content_hash": "19cf8f6b63d64b134060f8c4d614c8a89ee0ff9a7910a80a70da7cedee696689",
     "paths": {
@@ -16594,7 +16712,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver is soliciting bids for license-plate reader services as its current Flock contract expires March 31, with the mayor's office planning to submit a new contract to council in coming weeks. Flock is among bidders but faces criticism over data sharing including 1,400+ immigration-related searches of Denver data, and the council previously rejected a Flock renewal.",
     "key_quotes": [
       {
@@ -16616,7 +16733,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T13:58:52Z",
-    "article_id": "art_156"
+    "article_id": "art_156",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.geekwire.com/2025/washington-state-cities-turn-off-license-plate-reader-cameras-amid-ruling-on-data-access/",
@@ -16628,7 +16748,7 @@
     "published_at": "2025-11-18T17:25:51+00:00",
     "fetched_at": "2026-05-10T13:53:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "caa6cf9f54281a13addb37cbc2ebad97a492f4f19e3ada43dbdc77849c997e14",
     "paths": {
@@ -16747,12 +16867,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T13:58:39Z",
-    "article_id": "art_157"
+    "article_id": "art_157",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://patch.com/connecticut/windsor/windsor-votes-8-1-shut-down-flock-license-plate-reader-cameras",
@@ -16764,7 +16884,7 @@
     "published_at": "2026-02-19T00:00:02Z",
     "fetched_at": "2026-05-10T13:56:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 141 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 141 pts, HIGH/CRITICAL findings",
     "scanner_score": 141,
     "content_hash": "29105c459dc612c875a20de5aa6d1d8c5d22ce9539c09c42f877b533d2c164f9",
     "paths": {
@@ -16822,12 +16942,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T13:58:41Z",
-    "article_id": "art_158"
+    "article_id": "art_158",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.applevalleynewsnow.com/news/walla-walla-police-end-flock-license-plate-cameras-over-safety-and-legal-concerns/article_ec96e8f8-a14e-43b3-b6b2-7d53846dd659.html",
@@ -16839,7 +16959,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T15:11:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 185 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 185 pts, HIGH/CRITICAL findings",
     "scanner_score": 185,
     "content_hash": "485ddec34b8bf0e8a9c8eebf04b72d4e1f906f9b48e766587e8231efd28e3f06",
     "paths": {
@@ -16961,24 +17081,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T15:14:35Z",
-    "article_id": "art_159"
+    "article_id": "art_159",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.denverpost.com/2026/03/11/denver-axon-contract-flock-cameras/",
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver\u2019s new license plate reader deal is for 50 cameras \u2014 less than half as many as Flock has now",
+    "title": "Denver’s new license plate reader deal is for 50 cameras — less than half as many as Flock has now",
     "byline": "Elliott Wenzler",
     "published_at": "2026-03-11T22:45:10+00:00",
     "fetched_at": "2026-05-10T15:12:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "cee454f7963c1ce1de989f38ca08d7e8d1e0b3afd398b826a508911b16bd7733",
     "paths": {
@@ -17026,7 +17146,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
     "summary": "Denver City Council began considering a $150,000 one-year contract with Axon for 50 license-plate-reading cameras to replace its expiring Flock Safety system, which currently has 111 cameras. The proposed Axon system would have a shorter 21-day retention period, no national database, and an invite-only sharing arrangement, following months of controversy including ICE access to Denver's Flock data nearly 1,400 times.",
     "key_quotes": [
       {
@@ -17044,7 +17163,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T15:14:50Z",
-    "article_id": "art_160"
+    "article_id": "art_160",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.krem.com/article/news/local/spokane-county-deactivates-license-plate-reader-washington-privacy-law/293-72ea9980-dbd1-430a-b4b0-67dae541dfa1",
@@ -17056,7 +17178,7 @@
     "published_at": "4/1/2026 5:24:20 PM",
     "fetched_at": "2026-05-10T15:14:16Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 158 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 158 pts, HIGH/CRITICAL findings",
     "scanner_score": 158,
     "content_hash": "8d165b1d113b037acce426a8b7a332d9d30792855fd027c9b10f6cd4227eb29c",
     "paths": {
@@ -17098,12 +17220,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T15:14:40Z",
-    "article_id": "art_161"
+    "article_id": "art_161",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/podcasts/michael-payne-on-flock-budgets-and-audits/",
@@ -17115,7 +17237,7 @@
     "published_at": "2025-12-16T22:04:50+00:00",
     "fetched_at": "2026-05-10T16:09:47Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 35 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 35 pts, HIGH/CRITICAL findings",
     "scanner_score": 35,
     "content_hash": "580587fae693aef658a7ded1b871846853609dada697c0b6e32d0f7cd0779322",
     "paths": {
@@ -17149,7 +17271,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville City Councilor Michael Payne appears on a podcast to discuss the removal of FLOCK cameras, the FY25 audit, and recent budget meetings.",
     "key_quotes": [
       {
@@ -17159,19 +17280,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T16:15:05Z",
-    "article_id": "art_162"
+    "article_id": "art_162",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.kiro7.com/news/local/pierce-county-sheriffs-office-deactivates-its-automated-license-plate-readers/TXPVNII6B5D3LDKKYMOP3FW2IY/",
     "source_domain": "kiro7.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Pierce County Sheriff\u2019s Office deactivates its automated license plate readers",
+    "title": "Pierce County Sheriff’s Office deactivates its automated license plate readers",
     "byline": "KIRO 7 News Staff",
     "published_at": "2026-03-31T02:02:59.261Z",
     "fetched_at": "2026-05-10T16:14:22Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "8e1a0e8123b70a3ec8a132549a5824ad1b30554089d7290b3054d4b9c0223dcd",
     "paths": {
@@ -17215,7 +17339,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Pierce County Sheriff's Office deactivated its Flock ALPR system in response to Washington's newly signed Driver Privacy Act, which restricts ALPR use near hospitals, schools, and other protected locations and makes violations a gross misdemeanor. The Sheriff said no technology currently allows the cameras to reliably distinguish restricted from permitted areas, putting deputies at legal risk.",
     "key_quotes": [
       {
@@ -17233,7 +17356,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T16:15:13Z",
-    "article_id": "art_163"
+    "article_id": "art_163",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://madison.com/news/state-regional/wisconsin/article_d39d37b0-5ce5-5ea6-8e5a-4ac894928185.html",
@@ -17245,7 +17369,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T16:08:09Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 189 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 189 pts, HIGH/CRITICAL findings",
     "scanner_score": 189,
     "content_hash": "b3e424063c94f2dce0954349d8f7898244c356272ca3b6715a402b8296b4a5e5",
     "paths": {
@@ -17365,14 +17489,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-10T16:14:56Z",
     "article_id": "art_164",
     "curation_error": "schema parse failed or refusal",
-    "curation_raw": "[model refusal]"
+    "curation_raw": "[model refusal]",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.nbc26.com/sturgeonbay/sturgeon-bay-discontinues-the-use-of-flock-cameras",
@@ -17384,7 +17508,7 @@
     "published_at": "2026-04-21T23:13:30.215",
     "fetched_at": "2026-05-10T16:12:43Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 104 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 104 pts, HIGH/CRITICAL findings",
     "scanner_score": 104,
     "content_hash": "a9f8dcc8ce760071a0a4ecdbb94e8fc8e19223f9f97ef946f7c96e0f7c436b03",
     "paths": {
@@ -17454,24 +17578,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T16:14:57Z",
-    "article_id": "art_165"
+    "article_id": "art_165",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.theolympian.com/news/local/article312983261.html",
     "source_domain": "theolympian.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Olympia council hears privacy concerns about license plate cameras. What\u2019s next?",
+    "title": "Olympia council hears privacy concerns about license plate cameras. What’s next?",
     "byline": "Ty Vinson",
     "published_at": "2025-11-24T08:38:44-08:00",
     "fetched_at": "2026-05-10T16:11:11Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "c4763988dfdcfc0d6af3405abfaddb04c773728f652e6f79a1582ac106bb3209",
     "paths": {
@@ -17599,7 +17723,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "80fc5e77-78d4-5499-abf4-9cda8cfb284d",
     "summary": "At a Nov. 18 Olympia City Council meeting, about a dozen residents urged the city to end its Flock Safety ALPR contract, citing privacy, public-records, and immigration-enforcement concerns following a Skagit County court ruling that Flock data is a public record. Interim Chief Shelby Parker will brief the council on Dec. 2; no decision meeting is scheduled, and the current contract runs through July 2026.",
     "key_quotes": [
       {
@@ -17617,7 +17740,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T16:15:25Z",
-    "article_id": "art_166"
+    "article_id": "art_166",
+    "primary_subject_agency_ids": [
+      "80fc5e77-78d4-5499-abf4-9cda8cfb284d"
+    ]
   },
   {
     "url": "https://azdailysun.com/flaglive/features/beat/flagstaff-city-council-votes-to-cancel-flock-safety-camera-contract/article_435ca329-b3dc-45a8-8566-5df73ceb9835.html",
@@ -17629,7 +17755,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T17:13:39Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "fd39d235d89dc9b1c331f67aca98dfd1665b0a5fa0bbc7863f18278d04c39c3c",
     "paths": {
@@ -17749,14 +17875,14 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-10T17:19:38Z",
     "article_id": "art_167",
     "curation_error": "schema parse failed or refusal",
-    "curation_raw": "[model refusal]"
+    "curation_raw": "[model refusal]",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://cvillerightnow.com/news/208802-chief-kochis-curtails-flock-and-peregrine-use/",
@@ -17768,7 +17894,7 @@
     "published_at": "2025-06-18T17:55:13+00:00",
     "fetched_at": "2026-05-10T17:11:43Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 83 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 83 pts, HIGH/CRITICAL findings",
     "scanner_score": 83,
     "content_hash": "2c39c0f1a77ba81080c4fd82cd152e4a5bd0f2b84cc5fbd3d1a9e58c743dd311",
     "paths": {
@@ -17803,7 +17929,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3",
     "summary": "Charlottesville Police Chief Mike Kochis told City Council he is pausing use of the Peregrine data integration system and has restricted Flock ALPR data to local personnel only, citing citizen concerns. Flock cameras remain in use but data can no longer be shared with or accessed from outside agencies.",
     "key_quotes": [
       {
@@ -17817,7 +17942,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T17:20:00Z",
-    "article_id": "art_168"
+    "article_id": "art_168",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ]
   },
   {
     "url": "https://www.govtech.com/public-safety/eureka-calif-votes-no-on-license-plate-reader-cameras",
@@ -17829,7 +17957,7 @@
     "published_at": "2025-02-06T18:55:19.431",
     "fetched_at": "2026-05-10T17:19:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "065c7d03cd3b78f9d565877e4ad5dd5b413a3af57f04fc8a91bd9c2272cbc7c3",
     "paths": {
@@ -17900,12 +18028,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T17:19:42Z",
-    "article_id": "art_169"
+    "article_id": "art_169",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kut.org/austin/2025-06-04/austin-tx-automatic-license-reader-program-police-data-privacy-flock",
@@ -17917,7 +18045,7 @@
     "published_at": "2025-06-04T14:45:48.039",
     "fetched_at": "2026-05-10T17:17:19Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 22 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 22 pts, low/medium only",
     "scanner_score": 22,
     "content_hash": "140d383370d48dd488f8f6238d693014d94f61e01dfc8dc08ec0ee156263aa8a",
     "paths": {
@@ -17957,8 +18085,7 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58",
-    "summary": "Austin City Manager T.C. Broadnax announced the City Council will not vote on renewing the city's ALPR program, effectively ending it at the end of June 2025 amid community concerns about data sharing with ICE and other agencies. A city audit found 75 million scans led to 165 arrests, but also that 10\u201320% of searches lacked a clear case reason. Officials said the program could return for reconsideration in 5\u20136 months.",
+    "summary": "Austin City Manager T.C. Broadnax announced the City Council will not vote on renewing the city's ALPR program, effectively ending it at the end of June 2025 amid community concerns about data sharing with ICE and other agencies. A city audit found 75 million scans led to 165 arrests, but also that 10–20% of searches lacked a clear case reason. Officials said the program could return for reconsideration in 5–6 months.",
     "key_quotes": [
       {
         "quote": "The city of Austin's automatic license plate reader program will come to a close at the end of the month.",
@@ -17975,7 +18102,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T17:20:10Z",
-    "article_id": "art_170"
+    "article_id": "art_170",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ]
   },
   {
     "url": "https://www.timesunion.com/news/article/poestenkill-rejects-flock-cameras",
@@ -17987,7 +18117,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T17:15:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 8 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 8 pts, HIGH/CRITICAL findings",
     "scanner_score": 8,
     "content_hash": "9b8bf4dd3102caa40045b3fb539bb30b72c13c474186e76f9fa84c9b6b7f8bff",
     "paths": {
@@ -18003,24 +18133,24 @@
     "tags": [],
     "agencies": [],
     "agency_candidates": [],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T17:19:45Z",
-    "article_id": "art_171"
+    "article_id": "art_171",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.heraldnet.com/2026/03/12/automated-license-plate-reader-bill-heads-to-governors-desk/",
     "source_domain": "heraldnet.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Automated license plate reader bill heads to governor\u2019s desk - HeraldNet.com",
+    "title": "Automated license plate reader bill heads to governor’s desk - HeraldNet.com",
     "byline": "Jenna Peterson",
     "published_at": "2026-03-12T08:30:00+00:00",
     "fetched_at": "2026-05-10T19:20:40Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "08a9226dc21e28148257309c4aebcfb2739bc148179256bb7157588f9f2225e6",
     "paths": {
@@ -18110,12 +18240,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T19:27:15Z",
-    "article_id": "art_172"
+    "article_id": "art_172",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.kqed.org/news/12082887/berkeley-extends-surveillance-contract-with-flock-safety-but-rejects-major-expansion",
@@ -18127,7 +18257,7 @@
     "published_at": "2026-05-08T16:14:26-07:00",
     "fetched_at": "2026-05-10T19:19:22Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 102 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 102 pts, HIGH/CRITICAL findings",
     "scanner_score": 102,
     "content_hash": "752f0fb089231bd92d653f077ca3d02865ca1aa8b95db22effe1bdce287a9b90",
     "paths": {
@@ -18228,24 +18358,24 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T19:27:18Z",
-    "article_id": "art_173"
+    "article_id": "art_173",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/local/article315353591.html",
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Did new law shut down Pierce County license-plate readers? Here\u2019s what we know",
+    "title": "Did new law shut down Pierce County license-plate readers? Here’s what we know",
     "byline": "Shea Johnson",
     "published_at": "2026-04-10T05:00:00-07:00",
     "fetched_at": "2026-05-10T19:26:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "f8b43b19a2d45b72c3416123f68bb2d071cca9137bf12a2f994d576fec68d3fb",
     "paths": {
@@ -18352,7 +18482,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "After Washington Gov. Bob Ferguson signed SB 6002 (the Driver Privacy Act), Pierce County Sheriff's Office, Tacoma PD, and Puyallup PD deactivated their mobile/dash-cam ALPRs, citing inability to comply with the law's geographic restrictions near sensitive locations. The bill's sponsor Sen. Yasmin Trudeau said the law allows ALPR use with guardrails and commended agencies pausing to ensure compliance; agencies are working with Axon on technical fixes.",
     "key_quotes": [
       {
@@ -18374,7 +18503,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T19:27:31Z",
-    "article_id": "art_174"
+    "article_id": "art_174",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.aclunorcal.org/news/alameda-rejects-surveillance-deal-company-tied-ice/",
@@ -18386,7 +18516,7 @@
     "published_at": "2018-02-07T22:31:46+00:00",
     "fetched_at": "2026-05-10T21:09:15Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "1ba8b22490b3ef26adc63c178d51d1209b2d17b8979b6c9004d787908253ee19",
     "paths": {
@@ -18431,7 +18561,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "aeee2f0f-6386-5a1a-b93a-30babdede4f9",
     "summary": "Alameda's city council unanimously rejected a proposed $500,000 contract with Vigilant Solutions for license plate reader technology, citing the vendor's data-sharing arrangement with ICE. The ACLU frames the vote as a win and urges other cities to adopt surveillance oversight ordinances like Oakland's.",
     "key_quotes": [
       {
@@ -18449,7 +18578,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T21:09:51Z",
-    "article_id": "art_175"
+    "article_id": "art_175",
+    "primary_subject_agency_ids": [
+      "aeee2f0f-6386-5a1a-b93a-30babdede4f9"
+    ]
   },
   {
     "url": "https://www.losaltosonline.com/news/los-altos-hills-to-remove-alpr-cameras/article_59f90aa8-14c1-4309-9f7f-12d16c649d9e.html",
@@ -18461,7 +18593,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T21:02:39Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 161 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 161 pts, HIGH/CRITICAL findings",
     "scanner_score": 161,
     "content_hash": "9cc096a68d63172bf1caca734d30cf353c130ed27442c6144296a469fdcc4c51",
     "paths": {
@@ -18542,12 +18674,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T21:09:41Z",
-    "article_id": "art_176"
+    "article_id": "art_176",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.thenewstribune.com/news/state/washington/article315285796.html",
@@ -18559,7 +18691,7 @@
     "published_at": "2026-04-02T23:41:27-07:00",
     "fetched_at": "2026-05-10T21:05:55Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "0c03259893a4839894595724615f48a4ed30ec97328612d84c9a4539c130a69e",
     "paths": {
@@ -18656,7 +18788,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "ae292ffc-510d-5af1-b78d-7c026bfe1754",
     "summary": "The Spokane County Sheriff's Office disabled its automated license plate readers after Washington Gov. Bob Ferguson signed new legislation restricting ALPR use, including prohibiting NCIC database searches and barring use near sensitive locations like schools and churches. Sheriff John Nowels criticized the law as overly restrictive, and other agencies including Pierce County and Richland PD also suspended use.",
     "key_quotes": [
       {
@@ -18674,7 +18805,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T21:09:58Z",
-    "article_id": "art_177"
+    "article_id": "art_177",
+    "primary_subject_agency_ids": [
+      "ae292ffc-510d-5af1-b78d-7c026bfe1754"
+    ]
   },
   {
     "url": "https://theportager.com/kent-city-council-rejects-video-surveillance-contract-with-flock/",
@@ -18686,7 +18820,7 @@
     "published_at": "2025-11-10T04:59:45",
     "fetched_at": "2026-05-10T21:03:59Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "0bcda0ac93e94e1d00b2861bd6342bedb84aee3ee68cb78697c49e9c066fbcc2",
     "paths": {
@@ -18720,7 +18854,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Kent (Ohio) City Council voted on Nov. 5, 2025 against allowing the Kent Police Department to enter into a contract with Flock Safety, a license-plate-reader surveillance vendor used by over 5,000 law enforcement agencies.",
     "key_quotes": [
       {
@@ -18730,7 +18863,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T21:10:01Z",
-    "article_id": "art_178"
+    "article_id": "art_178",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.oxnard.gov/pd-news/news-release-oxnard-police-department-suspends-use-of-flock-safety-automated-license-plate-readers-02-27-26",
@@ -18742,7 +18876,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T22:02:30Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 49 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 49 pts, HIGH/CRITICAL findings",
     "scanner_score": 49,
     "content_hash": "d2db2e949556dd98b2390b21132dbd755fabee9f6c15299d1bf6f11a74c96391",
     "paths": {
@@ -18784,12 +18918,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T22:08:40Z",
-    "article_id": "art_179"
+    "article_id": "art_179",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.wkow.com/news/city-of-verona-votes-to-not-renew-flock-cameras/article_083afa08-5b8a-4955-9876-ad8fd2b9f3aa.html",
@@ -18801,7 +18935,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T22:01:08Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 169 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 169 pts, HIGH/CRITICAL findings",
     "scanner_score": 169,
     "content_hash": "a14afb9fa705ee26922ddead237216820a85e9c06c09de95dc322c7427ffffec",
     "paths": {
@@ -18861,12 +18995,12 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "mechanical",
     "curated_at": "2026-05-10T22:08:42Z",
-    "article_id": "art_180"
+    "article_id": "art_180",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://chronline.com/stories/flock-safety-cameras-in-centralia-are-here-to-stay-even-under-new-state-restrictions,400088",
@@ -18878,7 +19012,7 @@
     "published_at": "2026-04-10",
     "fetched_at": "2026-05-10T23:09:49Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "402a76d8eb5f47a277c41c867ff0d3ab7f0f49e7bc72f601a0dcf1663d14cef3",
     "paths": {
@@ -18988,7 +19122,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "b47e37ee-b687-5be5-a284-a153da743c03",
     "summary": "Centralia, WA Police Chief Andy Caldwell says the department will continue using Flock Safety ALPR cameras despite new state restrictions under SB 6002, which limits use to felonies/gross misdemeanors, reduces retention from 30 to 21 days, and bars cameras within 500 feet of schools, places of worship, reproductive health facilities, and courthouses. Centralia is shutting off three cameras that violate the proximity rule but otherwise maintaining its system, in contrast to agencies like Seattle, Kent, and Pierce County that paused their programs.",
     "key_quotes": [
       {
@@ -19006,7 +19139,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T23:11:20Z",
-    "article_id": "art_181"
+    "article_id": "art_181",
+    "primary_subject_agency_ids": [
+      "b47e37ee-b687-5be5-a284-a153da743c03"
+    ]
   },
   {
     "url": "https://www.thenewstribune.com/news/state/washington/article315035181.html",
@@ -19018,7 +19154,7 @@
     "published_at": "2026-03-13T05:15:00-07:00",
     "fetched_at": "2026-05-10T23:02:23Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "cdeff918b506ce97d534a7d9d60044a99a4bf5f764cdd67e0182dd1f98439238",
     "paths": {
@@ -19117,7 +19253,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Washington's 2026 legislative session passed SB 6002, which regulates ALPR systems like Flock and generally requires data deletion within three weeks, alongside a millionaire income tax and other measures. The ALPR bill, by Sen. Yasmin Trudeau, keeps data in-state and limits use to solving listed serious crimes, amid concerns about misuse by stalkers and immigration data-sharing.",
     "key_quotes": [
       {
@@ -19131,7 +19266,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T23:11:25Z",
-    "article_id": "art_182"
+    "article_id": "art_182",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.theolympian.com/news/politics-government/article314581905.html",
@@ -19143,7 +19279,7 @@
     "published_at": "2026-02-05T05:00:00-08:00",
     "fetched_at": "2026-05-10T23:06:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "a8eef2a5cb44b38b9eaf30f0d2fff7d320a4157713c817e4d7be5cd3783498c3",
     "paths": {
@@ -19220,7 +19356,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Washington's Senate passed SB 6002 on a 40-9 vote, imposing limits on automatic license plate reader data collection and retention, including a 21-day retention cap (amended up from 72 hours), prohibitions on use for immigration enforcement, protest tracking, and near sensitive sites like schools and places of worship. The bill now heads to the state House.",
     "key_quotes": [
       {
@@ -19238,7 +19373,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-10T23:11:30Z",
-    "article_id": "art_183"
+    "article_id": "art_183",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://azdailysun.com/news/local/flock-cameras-in-flagstaff-come-under-scrutiny/article_62556046-d721-43df-885a-14287fe8307e.html",
@@ -19250,7 +19386,7 @@
     "published_at": null,
     "fetched_at": "2026-05-11T00:11:40Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 239 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 239 pts, HIGH/CRITICAL findings",
     "scanner_score": 239,
     "content_hash": "40a0c43fe6626caedeb1bc620101a0d66e1e93291a7f53ebe78c2245450d1c34",
     "paths": {
@@ -19372,26 +19508,26 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": null,
     "key_quotes": [],
     "curation_status": "needs_review",
     "curated_at": "2026-05-11T00:12:45Z",
     "article_id": "art_184",
     "curation_error": "schema parse failed or refusal",
-    "curation_raw": "[model refusal]"
+    "curation_raw": "[model refusal]",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://chronline.com/stories/a-new-oregon-law-regulates-police-use-of-license-plate-readers-heres-how-it-works,400937",
     "source_domain": "chronline.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "A new Oregon law regulates police use of license plate readers. Here\u2019s how it works - The Daily Chronicle",
+    "title": "A new Oregon law regulates police use of license plate readers. Here’s how it works - The Daily Chronicle",
     "byline": "Shaanth Nanguneri / Oregon Capital Chronicle",
     "published_at": "2026-04-23",
     "fetched_at": "2026-05-11T00:10:22Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "327df261f3243fe4731a456542a6094a8dbae19b44e73437f4815d01cfa7cba1",
     "paths": {
@@ -19516,7 +19652,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "Oregon's SB 1516, signed by Gov. Tina Kotek in March 2026, establishes the state's first comprehensive ALPR framework, limiting data retention to 30 days, requiring search logging and public audits, barring use that violates sanctuary laws, and allowing Oregonians to sue vendors that improperly share data. Advocates praised transparency provisions but criticized reliance on private rights of action and the lack of a definition for required end-to-end encryption.",
     "key_quotes": [
       {
@@ -19538,7 +19673,8 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-11T00:13:10Z",
-    "article_id": "art_185"
+    "article_id": "art_185",
+    "primary_subject_agency_ids": []
   },
   {
     "url": "https://www.smdailyjournal.com/news/local/foster-city-adding-license-plate-monitoring-program/article_49c0eaba-903c-11eb-a162-d70f5231627a.html",
@@ -19550,7 +19686,7 @@
     "published_at": null,
     "fetched_at": "2026-05-11T00:05:17Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "8dd7b55318f4ee6e1bc476a78e461281b24eefd09d396cc172c17c867a20f4ab",
     "paths": {
@@ -19675,7 +19811,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "c7534013-784e-5c7b-8acb-b88b2ad8dfbe",
     "summary": "Foster City Council approved an Automated License Plate Reader program with Flock, installing 20 cameras at city entry/exit points to address rising vehicle thefts and burglaries. The contract costs $13,334 for the initial two months and $50,000 annually thereafter, with a 30-day data retention policy. The motion passed 4-1.",
     "key_quotes": [
       {
@@ -19697,7 +19832,10 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-11T00:13:19Z",
-    "article_id": "art_186"
+    "article_id": "art_186",
+    "primary_subject_agency_ids": [
+      "c7534013-784e-5c7b-8acb-b88b2ad8dfbe"
+    ]
   },
   {
     "url": "https://www.thenewstribune.com/news/state/washington/article315683941.html",
@@ -19709,7 +19847,7 @@
     "published_at": "2026-05-08T07:06:02-07:00",
     "fetched_at": "2026-05-11T00:03:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "864d666dc146c8b232eafbf856160423a1b681be108766f9eb3f7d6d48c98ad4",
     "paths": {
@@ -19776,7 +19914,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": "f9528ae9-97e1-555d-8dd3-f842543cb473",
     "summary": "The Sedro-Woolley City Council voted to reactivate its seven Flock ALPR cameras, expected back online by June 1, after they were disabled in June 2025 amid a public records dispute. New Washington state legislation signed by Gov. Ferguson restricts access to authorized law enforcement and bars federal/immigration use, prompting the reversal. The chief negotiated a prorated discount on the contract.",
     "key_quotes": [
       {
@@ -19798,19 +19935,22 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-11T00:13:26Z",
-    "article_id": "art_187"
+    "article_id": "art_187",
+    "primary_subject_agency_ids": [
+      "f9528ae9-97e1-555d-8dd3-f842543cb473"
+    ]
   },
   {
     "url": "https://www.thenewstribune.com/news/local/crime/article315247938.html",
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Pierce County Sheriff\u2019s Office to deactivate its license-plate reader cameras",
+    "title": "Pierce County Sheriff’s Office to deactivate its license-plate reader cameras",
     "byline": "Puneet Bsanti",
     "published_at": "2026-03-31T09:55:29-07:00",
     "fetched_at": "2026-05-11T04:24:48Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "73f671dd4adfa4b1671fbcce5e38041f123e85cce3d3ac9551a0e3e0ca4c3b67",
     "paths": {
@@ -19847,7 +19987,6 @@
         ]
       }
     ],
-    "primary_subject_agency_id": null,
     "summary": "The Pierce County Sheriff's Office announced it will deactivate its Flock ALPR cameras following Washington Gov. Bob Ferguson's signing of SB 6002, the Driver Privacy Act, which restricts ALPR use near sensitive locations, limits data retention, and bars use for immigration enforcement. Sheriff Keith Swank said the office cannot reliably ensure compliance with the geographic restrictions and warned the loss of the technology will hurt investigations.",
     "key_quotes": [
       {
@@ -19869,6 +20008,7 @@
     ],
     "curation_status": "enriched",
     "curated_at": "2026-05-11T04:27:50Z",
-    "article_id": "art_188"
+    "article_id": "art_188",
+    "primary_subject_agency_ids": []
   }
 ]

--- a/docs/js/articles.js
+++ b/docs/js/articles.js
@@ -278,27 +278,39 @@ function renderMap(matched) {
   STATE.markerLayer.clearLayers();
   STATE.vendorLayer.clearLayers();
 
-  // Plot each article at its primary subject agency only — mentions of
-  // other agencies (Flock HQ, peer cities) would otherwise scatter the
-  // article across the map. Vendor-primary articles (no real subject
-  // city) get bucketed into a single off-coast pip.
+  // Plot one pin per agency the article is substantively about
+  // (primary_subject_agencies). An article about three cities gets
+  // three pins; an article that merely name-checks them gets zero
+  // (the curator filters those out). Vendor-primary entries (no real
+  // subject city) get bucketed into a single off-coast pip.
+  // Dedupe per agency so a single article never adds two pins at the
+  // same agency, even if the curator returned a duplicate.
   var byAgency = {};
   var vendorBucket = { articles: [], names: {} };
   for (var i = 0; i < matched.length; i++) {
     var a = matched[i];
-    var ag = a.primary_subject_agency;
-    if (!ag) continue;
-    if (ag.is_vendor) {
-      vendorBucket.articles.push(a);
-      vendorBucket.names[ag.name] = true;
-      continue;
+    var subjects = a.primary_subject_agencies || [];
+    var seenForArticle = {};
+    var vendorAddedForArticle = false;
+    for (var s = 0; s < subjects.length; s++) {
+      var ag = subjects[s];
+      if (!ag) continue;
+      if (ag.is_vendor) {
+        if (vendorAddedForArticle) continue;
+        vendorBucket.articles.push(a);
+        vendorBucket.names[ag.name] = true;
+        vendorAddedForArticle = true;
+        continue;
+      }
+      if (ag.lat == null || ag.lng == null) continue;
+      var key = ag.agency_id;
+      if (seenForArticle[key]) continue;
+      seenForArticle[key] = true;
+      if (!byAgency[key]) {
+        byAgency[key] = { agency: ag, articles: [] };
+      }
+      byAgency[key].articles.push(a);
     }
-    if (ag.lat == null || ag.lng == null) continue;
-    var key = ag.agency_id;
-    if (!byAgency[key]) {
-      byAgency[key] = { agency: ag, articles: [] };
-    }
-    byAgency[key].articles.push(a);
   }
 
   var bounds = [];

--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -17,7 +17,7 @@ Two phases:
     Anthropic API with NO tools and a strict json_schema output
     constraint — model can only return structured fields, can't take
     actions. Fills in summary, key_quotes, genre, refined topic_tags,
-    primary_subject_agency_id. Marks curation_status="enriched".
+    primary_subject_agency_ids. Marks curation_status="enriched".
 
     Skips entirely if ANTHROPIC_API_KEY isn't set.
 
@@ -288,7 +288,7 @@ def mechanical_curate_one(meta_path: Path, *, tags_data: dict,
         "tags": auto_tag_vendors(text, tags_data),
         "agencies": agencies,
         "agency_candidates": candidates,
-        "primary_subject_agency_id": None,
+        "primary_subject_agency_ids": [],
         "summary": None,
         "key_quotes": [],
         "curation_status": "mechanical",
@@ -355,11 +355,14 @@ CURATION_SCHEMA = {
             "enum": ["investigative", "explainer", "opinion",
                      "press-release", "analysis"],
         },
-        "primary_subject_agency_id": {"type": ["string", "null"]},
+        "primary_subject_agency_ids": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
     },
     "required": [
         "refusal", "refusal_reason", "summary", "key_quotes",
-        "topic_tags", "genre", "primary_subject_agency_id",
+        "topic_tags", "genre", "primary_subject_agency_ids",
     ],
     "additionalProperties": False,
 }
@@ -459,10 +462,27 @@ fields are:
   apply outcome:*.
 - genre: investigative | explainer | opinion | press-release | analysis.
   Pick exactly one based on what the piece is, not what it covers.
-- primary_subject_agency_id: the agency_id of the agency the article is
-  primarily about, chosen from the candidate list provided in the user
-  message. Use null if the article is national/multi-subject and not
-  primarily about any one agency.
+- primary_subject_agency_ids: the agency_ids of every agency this
+  article is substantively about, chosen from the candidate list in
+  the user message. The map viewer plots one pin per id in this list,
+  so the test is "would a reader expect a map pin here?"
+
+  Include an agency when the article reports on its specific actions,
+  decisions, incidents, contracts, audits, or policies — i.e. the
+  story would lose meaning without it. A piece may have one subject
+  (most local news), several (an investigation naming multiple
+  agencies whose cameras were exposed; a roundup of cities that turned
+  Flock off), or none (national/vendor/legal pieces not anchored to
+  specific agencies).
+
+  Exclude agencies that are merely name-checked: "as in [City], where
+  cameras were also installed last year" is a side mention, not a
+  subject. Likewise exclude agencies that appear only in lists, asides,
+  or quote attributions ("a spokesperson for [Dept] said..."). When in
+  doubt, leave the agency out — false positives scatter the map.
+
+  Return an empty list for national, vendor-focused, or legal-doctrine
+  pieces with no specific agency subjects.
 
 If you cannot complete the task — paywalled stub, language you can't
 read, content that turned out not to be about ALPR — set refusal=true
@@ -493,7 +513,8 @@ stance (publisher's posture, denormalized): {entry.get('stance')}
 
 [AGENCY CANDIDATES]
 The fuzzy matcher proposed these agency_ids based on names appearing in
-the text. Pick primary_subject_agency_id from this list, or null:
+the text. Pick primary_subject_agency_ids from this list (zero, one, or
+many — see the system instructions for the inclusion test):
 {candidates_block}
 
 [ARTICLE TEXT]
@@ -510,9 +531,12 @@ def validate_curation_output(data: dict, entry: dict, tags_data: dict) -> tuple[
     if bogus:
         return False, f"topic_tags not in vocabulary: {sorted(bogus)}"
     valid_agency_ids = {c["agency_id"] for c in entry.get("agency_candidates", [])}
-    psa = data.get("primary_subject_agency_id")
-    if psa is not None and psa not in valid_agency_ids:
-        return False, f"primary_subject_agency_id {psa!r} not in candidate set"
+    psa_ids = data.get("primary_subject_agency_ids") or []
+    bogus_psa = [p for p in psa_ids if p not in valid_agency_ids]
+    if bogus_psa:
+        return False, f"primary_subject_agency_ids not in candidate set: {bogus_psa}"
+    if len(set(psa_ids)) != len(psa_ids):
+        return False, f"primary_subject_agency_ids has duplicates: {psa_ids}"
     return True, None
 
 
@@ -656,7 +680,7 @@ def run_phase2(registry: list[dict], *, tags_data: dict,
         existing_tags.update(data["topic_tags"])
         existing_tags.add(f"genre:{data['genre']}")
         entry["tags"] = sorted(existing_tags)
-        entry["primary_subject_agency_id"] = data["primary_subject_agency_id"]
+        entry["primary_subject_agency_ids"] = data["primary_subject_agency_ids"]
         entry["curation_status"] = "enriched"
         entry["curated_at"] = now_iso()
         entry.pop("curation_error", None)

--- a/scripts/article_pr_body.py
+++ b/scripts/article_pr_body.py
@@ -106,9 +106,10 @@ def render_article(a: dict) -> list[str]:
     tags = a.get("tags") or []
     if tags:
         lines.append("Tags: " + ", ".join(f"`{t}`" for t in tags))
-    psa = a.get("primary_subject_agency_id")
-    if psa:
-        lines.append(f"Primary subject agency_id: `{psa}`")
+    psa_ids = a.get("primary_subject_agency_ids") or []
+    if psa_ids:
+        label = "Primary subject agency_id" + ("s" if len(psa_ids) != 1 else "")
+        lines.append(f"{label}: " + ", ".join(f"`{p}`" for p in psa_ids))
     return lines
 
 

--- a/scripts/build_articles_data.py
+++ b/scripts/build_articles_data.py
@@ -58,24 +58,24 @@ def main() -> int:
                 "lng": lng,
             })
 
-        primary_id = entry.get("primary_subject_agency_id")
-        primary = None
-        if primary_id:
+        # Each id in primary_subject_agency_ids gets a map pin. Vendor-
+        # primary entries (e.g. Flock Safety year-in-review pieces) get
+        # bucketed off-coast in the viewer instead of at the vendor HQ
+        # to avoid misleading geographic clustering.
+        primary_subjects = []
+        for primary_id in entry.get("primary_subject_agency_ids") or []:
             ag = reg_by_id.get(primary_id)
-            if ag:
-                lat, lng = agency_coords(ag)
-                primary = {
-                    "agency_id": primary_id,
-                    "name": agency_display_name(ag, fallback=primary_id),
-                    "state": agency_state(ag),
-                    "lat": lat,
-                    "lng": lng,
-                    # Vendor-primary articles (e.g. Flock Safety year-in-
-                    # review pieces) aren't really *about* a place; the
-                    # viewer plots them in the ocean instead of at the
-                    # vendor HQ to avoid misleading geographic clustering.
-                    "is_vendor": ag.get("agency_role") == "vendor",
-                }
+            if not ag:
+                continue
+            lat, lng = agency_coords(ag)
+            primary_subjects.append({
+                "agency_id": primary_id,
+                "name": agency_display_name(ag, fallback=primary_id),
+                "state": agency_state(ag),
+                "lat": lat,
+                "lng": lng,
+                "is_vendor": ag.get("agency_role") == "vendor",
+            })
 
         tags = sorted(entry.get("tags") or [])
         for t in tags:
@@ -94,7 +94,7 @@ def main() -> int:
             "key_quotes": entry.get("key_quotes") or [],
             "tags": tags,
             "agencies": agencies,
-            "primary_subject_agency": primary,
+            "primary_subject_agencies": primary_subjects,
             "stance": entry.get("stance"),
             "tier": entry.get("tier"),
             "wayback_url": entry.get("wayback_url"),

--- a/scripts/lint_articles.py
+++ b/scripts/lint_articles.py
@@ -11,7 +11,8 @@ Checks (errors — exit 1):
   - URL uniqueness
   - source_domain present and listed in assets/sources.json
   - agencies[] entries resolve to assets/agency_registry.json agency_ids
-  - primary_subject_agency_id (if set) appears in this entry's agencies[]
+  - primary_subject_agency_ids entries each appear in this entry's agencies[]
+    (and are unique within the list)
   - tags appear in assets/tags.json (topics + editorial vocabulary)
   - curation_status in known set
   - paths.{html,txt,meta} relative paths exist on disk
@@ -161,15 +162,23 @@ def main() -> int:
                     f"{prefix}: agencies[] references unknown agency_id {aid_ref!r}"
                 )
 
-        psa = entry.get("primary_subject_agency_id")
-        if psa is not None:
+        psa_ids = entry.get("primary_subject_agency_ids") or []
+        agencies_set = set(entry.get("agencies") or [])
+        seen_psa: set[str] = set()
+        for psa in psa_ids:
+            if psa in seen_psa:
+                errors.append(
+                    f"{prefix}: primary_subject_agency_ids has duplicate {psa!r}"
+                )
+                continue
+            seen_psa.add(psa)
             if valid_agency_ids and psa not in valid_agency_ids:
                 errors.append(
-                    f"{prefix}: primary_subject_agency_id {psa!r} not in agency registry"
+                    f"{prefix}: primary_subject_agency_ids entry {psa!r} not in agency registry"
                 )
-            elif psa not in (entry.get("agencies") or []):
+            elif psa not in agencies_set:
                 errors.append(
-                    f"{prefix}: primary_subject_agency_id {psa!r} not in this entry's agencies[]"
+                    f"{prefix}: primary_subject_agency_ids entry {psa!r} not in this entry's agencies[]"
                 )
 
         status = entry.get("curation_status")

--- a/tests/test_lint_articles.py
+++ b/tests/test_lint_articles.py
@@ -2,9 +2,9 @@
 
 The lint enforces: article_id format + uniqueness, URL uniqueness,
 source_domain in allowlist, agencies[] entries resolve to
-agency_registry, primary_subject_agency_id appears in this entry's
-agencies[], tags appear in tags.json, curation_status in known set,
-paths.{html,txt,meta} exist.
+agency_registry, primary_subject_agency_ids entries each appear in
+this entry's agencies[] (and are unique), tags appear in tags.json,
+curation_status in known set, paths.{html,txt,meta} exist.
 
 We test by running the script as a subprocess against a temp repo
 laid out in tmp_path.
@@ -152,14 +152,42 @@ def test_lint_rejects_unknown_tag(tmp_path):
 
 
 def test_lint_rejects_primary_subject_not_in_agencies(tmp_path):
-    """primary_subject_agency_id must appear in this entry's agencies[]."""
+    """Every primary_subject_agency_ids entry must appear in agencies[]."""
     repo, _ = _make_repo(tmp_path, registry=[_good_entry(
         agencies=["agency-1"],
-        primary_subject_agency_id="agency-2",  # not in agencies[]
+        primary_subject_agency_ids=["agency-2"],  # not in agencies[]
     )])
     rc, out, err = _run(repo)
     assert rc == 1
-    assert "primary_subject_agency_id" in err
+    assert "primary_subject_agency_ids" in err
+
+
+def test_lint_rejects_primary_subject_duplicate(tmp_path):
+    """primary_subject_agency_ids entries must be unique."""
+    repo, _ = _make_repo(tmp_path, registry=[_good_entry(
+        agencies=["agency-1"],
+        primary_subject_agency_ids=["agency-1", "agency-1"],
+    )])
+    rc, out, err = _run(repo)
+    assert rc == 1
+    assert "duplicate" in err
+
+
+def test_lint_accepts_multiple_primary_subjects(tmp_path):
+    """Multiple distinct primary subjects, all in agencies[], passes."""
+    repo, _ = _make_repo(
+        tmp_path,
+        registry=[_good_entry(
+            agencies=["agency-1", "agency-2"],
+            primary_subject_agency_ids=["agency-1", "agency-2"],
+        )],
+        agencies=[
+            {"agency_id": "agency-1", "geo": {"name": "X"}},
+            {"agency_id": "agency-2", "geo": {"name": "Y"}},
+        ],
+    )
+    rc, out, err = _run(repo)
+    assert rc == 0, err
 
 
 def test_lint_rejects_unknown_curation_status(tmp_path):


### PR DESCRIPTION
## Summary

- Articles substantively about multiple cities now plot one pin per subject. The singular `primary_subject_agency_id` field forced multi-subject pieces to either pick one (lossy) or be set to null (and disappear from the map). On the current registry ~63% of curated articles had a null primary and were dropped from the article map entirely.
- Schema: `primary_subject_agency_id` (string|null) → `primary_subject_agency_ids` (string[]).
- Curator prompt rewritten with the "would a reader expect a map pin here?" test, plus include/exclude examples (substantive subject vs. name-check, list aside, quote attribution).
- Lint, build script, viewer JS, PR-body generator, and tests updated to match.
- Existing 188 entries migrated 1:1 (singular value → single-element list, null → empty list). The new multi-element lists will be populated when Phase 2 re-runs with `--reenrich` — the `article-registry.yml` workflow already supports this via `workflow_dispatch` (set `phase2_only=true`, `phase2_reenrich=true`, raise `phase2_limit`).

## Test plan

- [x] `python3 scripts/lint_articles.py` passes on the migrated registry (188 entries, 0 errors)
- [x] `pytest tests/test_lint_articles.py` — 13 passed (adds two new cases: multiple distinct primaries, duplicate primary rejected)
- [x] `python3 scripts/build_articles_data.py` rebuilds cleanly
- [ ] Eyeball the rendered article map after the GH Pages rebuild — pin count should match pre-merge (singular migrated 1:1) until `--reenrich` runs
- [ ] After merge, kick `article-registry.yml` with `phase2_only=true, phase2_reenrich=true, phase2_limit=50` and confirm the next Pages build shows additional pins for genuinely multi-subject pieces