### PR TITLE
fix(crawl): stage scrape artifacts in temp dir; never commit partial sets

### DIFF
--- a/.github/workflows/probe-slugs.yml
+++ b/.github/workflows/probe-slugs.yml
@@ -27,6 +27,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   probe:
@@ -98,7 +99,46 @@ jobs:
             ARGS="$ARGS --agency ${{ inputs.agency }}"
           fi
           # shellcheck disable=SC2086
-          uv run python scripts/slug_probe.py $ARGS
+          uv run python scripts/slug_probe.py $ARGS | tee /tmp/probe.log
+
+      - name: Surface parser failures as an issue
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # archive_agency logs `PARSE_ERROR: <slug> <date> :: <error>`
+          # whenever a probe hit lands on a Flock portal whose bold
+          # headings aren't in _HEADING_MAP. Nothing was committed to
+          # the asset tree (archive_agency stages and only commits on
+          # full success), so the parser fix is the only follow-up —
+          # the next refresh-flock-data crawl will re-capture once
+          # the parser is updated.
+          if [ ! -f /tmp/probe.log ]; then exit 0; fi
+          ERRORS=$(grep -E "PARSE_ERROR: " /tmp/probe.log | sort -u || true)
+          if [ -z "$ERRORS" ]; then exit 0; fi
+          {
+            echo "slug_probe captured one or more Flock portals the parser"
+            echo "couldn't read. No partial artifact set was written to the"
+            echo "asset tree. Add the unrecognized bold headings to"
+            echo "_HEADING_MAP / _DYNAMIC_HEADINGS in scripts/flock_transparency.py;"
+            echo "the next crawl will re-capture cleanly."
+            echo
+            echo '```'
+            echo "$ERRORS"
+            echo '```'
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > /tmp/parse-issue-body.md
+          EXISTING=$(gh issue list --label parser --state open --json number -q '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file /tmp/parse-issue-body.md
+          else
+            gh issue create \
+              --title "Parser tripped on a new Flock portal variant" \
+              --label parser \
+              --body-file /tmp/parse-issue-body.md
+          fi
 
       - name: Commit and push
         id: commit

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -37,9 +37,9 @@ import hashlib
 import html.parser
 import io
 import json
-import os
 import random
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -292,7 +292,9 @@ _HEADING_MAP = {
     # ── other structural fields ──
     "Additional Info":                       "additional_info",
     "Additional Information":                "additional_info",
+    "Additional Flock Safety Information":   "additional_info",
     "Community Safeguards":                  "additional_info",
+    "LPR and other Cameras":                 "additional_info",
     "Download CSV":                          "download_csv",
     "Public Search Audit":                   "search_audit",
     "Search Audit":                          "search_audit",
@@ -368,8 +370,10 @@ _DYNAMIC_HEADINGS = [
     # generic policy-link variant.
     (re.compile(r"^.+(?:Police Department|Sheriff(?:'s)?(?: Office)?|Police Bureau) Policy$", re.IGNORECASE), "policy_info"),
     # Success-story subheadings — agencies post titled excerpts under
-    # "Success Stories" (e.g. "Yuba County SO - Facebook Post - …").
+    # "Success Stories" (e.g. "Yuba County SO - Facebook Post - …",
+    # "Credit Card Skimming Ring - Success story").
     (re.compile(r"^.+ - Facebook Post - .+$", re.IGNORECASE), "success_stories"),
+    (re.compile(r"^.+ - Success Stor(?:y|ies)$", re.IGNORECASE), "success_stories"),
     # Sentence-style link blurbs, e.g. "Auburn PD's Policies and
     # Procedures can be found at the following link:" — same role as
     # the "Policy Documents" / "Policy Link" exact headings. Placed
@@ -387,6 +391,8 @@ _DYNAMIC_HEADINGS = [
     # Empty-state placeholder for sharing fields, e.g.
     # "None: Alameda does not share with outside agencies".
     (re.compile(r"^None:\s", re.IGNORECASE), None),
+    # Documentation chrome some portals add (durango-co-pd 2026-05-11).
+    (re.compile(r"^Glossary$", re.IGNORECASE), None),
 ]
 
 _MAX_HEADING_LEN = 120
@@ -865,16 +871,21 @@ def extract_csvs_from_html(html_text):
 def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
     """Returns (status, discovered_slugs).
 
-    status: Path (saved), "unchanged", "rate_limited", or None (failed).
+    status: Path (saved), "unchanged", "rate_limited", or ("failed", reason).
+
+    Artifact-set integrity: a slug-dir capture is the four-tuple
+    .txt/.html/.json/.pdf. The whole set is staged in a `mktemp -d`
+    directory and only moved into `assets/transparency.flocksafety.com/<slug>/`
+    after all four artifacts validate. Parser failure on a new heading
+    variant returns ("failed", "parse_error") and writes nothing to the
+    asset tree — the PARSE_ERROR log line is surfaced as a tracking issue
+    by the workflows, and the next crawl will re-capture once the parser
+    is updated. (Earlier behavior left .txt + .html on disk with no .json,
+    which polluted diff/build logic that assumes html ↔ json parity per date.)
     """
     url = f"{BASE_URL}/{slug}"
     datestamp = date.today().isoformat()
     slug_dir = data_dir / slug
-    slug_dir.mkdir(parents=True, exist_ok=True)
-
-    txt_path = slug_dir / f"{datestamp}.txt"
-    json_path = slug_dir / f"{datestamp}.json"
-    pdf_path = slug_dir / f"{datestamp}.pdf"
 
     prefix = f"  {progress} " if progress else "  "
     print(f"{prefix}{slug} -> {url}")
@@ -906,31 +917,16 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
     page_html = page.content()
     crawled_at = datetime.now(timezone.utc).isoformat()
 
-    # Save source-of-truth files BEFORE parsing — if the parser fails
-    # (e.g. Flock added a new heading variant), we still have the .txt
-    # and .html on disk to debug from and to re-parse later via
-    # `parse --force`. Otherwise a parser failure means we lose the
-    # captured page entirely and have to wait for the next crawl.
-    if force or prev_hash != current_hash:
-        txt_path.write_text(page_text, encoding="utf-8")
-        html_path = slug_dir / f"{datestamp}.html"
-        html_path.write_text(page_html, encoding="utf-8")
-
-    # Parse for sharing names (needed for recursive crawling even if unchanged)
+    # Parse in memory before writing anything. discovered_slugs is needed
+    # for depth crawling even when content is unchanged, so we parse on
+    # every successful fetch.
     bold_headings = extract_bold_headings(page_html)
     discovered_slugs = []
     try:
         portal_data = parse_portal_text(page_text, slug, datestamp, bold_headings=bold_headings)
     except ValueError as e:
-        # Parser hit a new format variant. The .txt and .html were saved
-        # above so latest_capture_attempt_date sees today's date and the
-        # slug ages out of tier 0 in the crawl queue (no stub JSON
-        # needed — that would pollute downstream consumers like
-        # build_history with bogus zeroed-out fields). The stub-free
-        # design lets `parse --force --slug <slug>` produce a correct
-        # JSON later once the parser is fixed.
-        # Structured marker line so the workflow can grep crawl logs
-        # and surface PARSE_ERROR: <slug> as a GitHub issue.
+        # PARSE_ERROR marker line is grepped by the refresh-flock-data
+        # and probe-slugs workflows to surface a tracking issue.
         print(f"    PARSE_ERROR: {slug} {datestamp} :: {e}")
         if not force and prev_hash == current_hash:
             return "unchanged", []
@@ -952,16 +948,11 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
         print(f"    unchanged since last capture, skipping")
         return "unchanged", discovered_slugs
 
-    # 1c. Extract embedded CSVs from HTML
     for csv_name, csv_rows in extract_csvs_from_html(page_html):
         field = csv_name.replace(".csv", "").replace("-", "_") + "_csv"
         portal_data[field] = csv_rows
         print(f"    extracted {csv_name}: {len(csv_rows)} rows")
 
-    # 2. Parsed JSON (derived from .txt + html)
-    json_path.write_text(json.dumps(portal_data, indent=2) + "\n")
-
-    # 3. PDF visual archive
     cdp = page.context.new_cdp_session(page)
     result = cdp.send("Page.printToPDF", {
         "printBackground": True, "preferCSSPageSize": False,
@@ -972,16 +963,25 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
     cdp.detach()
     pdf_data = base64.b64decode(result["data"])
 
-    fd, tmp_path = tempfile.mkstemp(suffix=".pdf", dir=str(slug_dir))
-    try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(pdf_data)
-        Path(tmp_path).replace(pdf_path)
-    except Exception:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
+    # Stage the four-artifact set in a fresh temp dir, then mv into
+    # slug_dir only after all four write successfully. mktemp -d (not
+    # a fixed staging path) so retries/parallel batches can't collide.
+    with tempfile.TemporaryDirectory(prefix=f"flock-{slug}-") as staging_str:
+        staging = Path(staging_str)
+        (staging / f"{datestamp}.txt").write_text(page_text, encoding="utf-8")
+        (staging / f"{datestamp}.html").write_text(page_html, encoding="utf-8")
+        (staging / f"{datestamp}.json").write_text(json.dumps(portal_data, indent=2) + "\n")
+        (staging / f"{datestamp}.pdf").write_bytes(pdf_data)
 
-    print(f"    saved {slug}/{datestamp}.{{txt,json,pdf}}")
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = slug_dir / f"{datestamp}.pdf"
+        for ext in ("txt", "html", "json", "pdf"):
+            shutil.move(
+                str(staging / f"{datestamp}.{ext}"),
+                str(slug_dir / f"{datestamp}.{ext}"),
+            )
+
+    print(f"    saved {slug}/{datestamp}.{{txt,html,json,pdf}}")
 
     if hashes is not None:
         hashes[slug] = current_hash
@@ -1037,10 +1037,12 @@ def run_crawl_batch(page, slugs, data_dir, force, delay, hashes, failed_slugs,
             discovered.extend(discovered_slugs)
         if isinstance(status, tuple) and status[0] == "failed":
             # parse_error means we got the page but the parser tripped on
-            # a new format variant. The .txt/.html were saved by archive_agency,
-            # so re-parsing locally fixes it without re-crawling. Don't
-            # permanently quarantine these — let the next crawl retry, so
-            # if the parser is updated meanwhile the slug self-heals.
+            # a new format variant — nothing was written to the asset tree
+            # (archive_agency stages and only commits on full success).
+            # Don't permanently quarantine these: leave them out of
+            # failed_slugs so the next crawl re-fetches and re-parses
+            # against an updated parser. The PARSE_ERROR log line is
+            # surfaced as a tracking issue by the workflow.
             if status[1] != "parse_error":
                 failed_slugs[slug] = {"reason": status[1], "date": date.today().isoformat()}
 

--- a/tests/test_archive_agency_staging.py
+++ b/tests/test_archive_agency_staging.py
@@ -1,0 +1,104 @@
+"""Pin the temp-dir staging behavior in archive_agency.
+
+Invariant: a slug-dir capture is the four-tuple .txt/.html/.json/.pdf.
+Either all four land together, or none do. A parse failure (new heading
+variant) must NOT leave .txt/.html on disk without a matching .json —
+that pollutes downstream consumers that assume html ↔ json parity per
+date.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import flock_transparency as ft
+
+
+def _make_page(body_text, html):
+    """Build a MagicMock that quacks like a Playwright Page just enough
+    for archive_agency. Returns http 200 with the given body/html.
+    """
+    page = MagicMock()
+    response = MagicMock()
+    response.status = 200
+    page.goto.return_value = response
+    page.inner_text.return_value = body_text
+    page.content.return_value = html
+
+    cdp = MagicMock()
+    # archive_agency b64-decodes result["data"]; "AAAA" decodes to 3 NULs.
+    cdp.send.return_value = {"data": "AAAA"}
+    page.context.new_cdp_session.return_value = cdp
+    return page
+
+
+def test_parse_failure_leaves_slug_dir_empty(tmp_path):
+    """Probe lands on a Flock portal with an unknown bold heading. The
+    parser raises ValueError; archive_agency must return parse_error
+    and write nothing under <data_dir>/<slug>/. Earlier behavior left
+    .txt + .html on disk with no .json (PR #252 / PR #333 incident).
+    """
+    body = "\n".join([
+        "Some Agency PD",
+        "Brand New Mystery Heading",
+        "",
+        "body content under the mystery heading",
+        "",
+        "What's Detected",
+        "",
+        "License Plates",
+        "",
+    ])
+    html = (
+        '<p style="font-weight:700">Brand New Mystery Heading</p>'
+        '<p style="font-weight:700">What\'s Detected</p>'
+    )
+    page = _make_page(body, html)
+
+    slug = "fake-mystery-pd"
+    status, discovered = ft.archive_agency(page, slug, tmp_path, force=True)
+
+    assert status == ("failed", "parse_error"), status
+    assert discovered == []
+    slug_dir = tmp_path / slug
+    if slug_dir.exists():
+        files = sorted(p.name for p in slug_dir.iterdir())
+        assert files == [], (
+            f"slug dir must be empty on parse_error, got {files}"
+        )
+
+
+def test_parse_success_writes_full_four_tuple(tmp_path):
+    """Happy path: parser succeeds, all four artifacts land together."""
+    body = "\n".join([
+        "Foo PD",
+        "Overview",
+        "",
+        "Foo PD uses Flock Safety LPR technology to capture evidence.",
+        "",
+        "Policies",
+        "",
+        "What's Detected",
+        "",
+        "License Plates",
+        "",
+    ])
+    html = (
+        '<p style="font-weight:700">Overview</p>'
+        '<p style="font-weight:700">Policies</p>'
+        '<p style="font-weight:700">What\'s Detected</p>'
+    )
+    page = _make_page(body, html)
+
+    slug = "fake-foo-pd"
+    status, _ = ft.archive_agency(page, slug, tmp_path, force=True)
+
+    assert not (isinstance(status, tuple) and status[0] == "failed"), status
+    slug_dir = tmp_path / slug
+    files = sorted(p.name for p in slug_dir.iterdir())
+    from datetime import date
+    today = date.today().isoformat()
+    assert files == [
+        f"{today}.html", f"{today}.json", f"{today}.pdf", f"{today}.txt",
+    ], files

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -489,6 +489,55 @@ def test_alpr_acronym_in_parens_classifies_as_alpr_policy():
     assert field == "alpr_policy"
 
 
+def test_titled_success_story_subheading_classifies_as_success_stories():
+    """Blue Springs (2026-05-10) posts titled success-story excerpts as
+    bold subheadings like "Credit Card Skimming Ring - Success story".
+    The dynamic pattern parallels the existing "X - Facebook Post - …"
+    rule and routes them to success_stories so they don't trip the
+    unrecognized-bold-heading check."""
+    from flock_transparency import _match_heading_kind
+    for h in (
+        "Credit Card Skimming Ring - Success story",
+        "Domestic Assault - Success Story",
+        "Ulta Beauty Burglary - Success story",
+        "Some Long Multi-Word Title - Success Stories",
+    ):
+        field, kind = _match_heading_kind(h)
+        assert (field, kind) == ("success_stories", "dynamic"), (
+            f"expected success_stories/dynamic for {h!r}, got {(field, kind)}"
+        )
+
+
+def test_additional_flock_safety_information_maps_to_additional_info():
+    """Blue Springs (2026-05-10) uses "Additional Flock Safety
+    Information" as a section heading — same role as the existing
+    "Additional Info" / "Additional Information" aliases."""
+    assert _match_heading("Additional Flock Safety Information") == "additional_info"
+
+
+def test_lpr_and_other_cameras_heading_maps_to_additional_info():
+    """Durango (2026-05-11) bolds "LPR and other Cameras" as a
+    section heading (distinct from the existing "Number of LPR and
+    other cameras" count). Conservative routing: additional_info,
+    so the body is captured as text without an integer-parse attempt."""
+    assert _match_heading("LPR and other Cameras") == "additional_info"
+    # The count heading must still route to camera_count.
+    assert _match_heading("Number of LPR and other cameras") == "camera_count"
+
+
+def test_glossary_bold_heading_does_not_raise():
+    """Durango (2026-05-11) bolds "Glossary" as documentation chrome —
+    not a field heading. The dynamic noise pattern should swallow it."""
+    from flock_transparency import _match_heading_kind
+    field, kind = _match_heading_kind("Glossary")
+    assert (field, kind) == (None, "dynamic")
+    text = "What's Detected\n\nLicense Plates\n\n"
+    parse_portal_text(
+        text, "test-agency", "2026-05-11",
+        bold_headings={"What's Detected", "Glossary"},
+    )
+
+
 def test_overview_marker_accepts_operating_system_phrasing():
     """Flock rephrased the overview boilerplate from
     '<Agency> uses Flock Safety [LPR] technology' to


### PR DESCRIPTION
## Summary

- `archive_agency` no longer writes anything to `assets/transparency.flocksafety.com/<slug>/` until all four artifacts (`.txt`/`.html`/`.json`/`.pdf`) succeed. Staging happens in `tempfile.TemporaryDirectory(prefix=\"flock-<slug>-\")`; `shutil.move` promotes the full set into the slug dir.
- A `parse_portal_text` `ValueError` returns `(\"failed\", \"parse_error\")` with no side effects. `PARSE_ERROR: <slug> <date>` is still logged so the workflows surface it.
- `probe-slugs.yml` mirrors `refresh-flock-data.yml` — adds an \"issues: write\" perm and a \"Surface parser failures as an issue\" step that comments on (or opens) the rolling `parser`-labeled issue.
- Six heading aliases for variants seen in recent runs (`Additional Flock Safety Information`, `LPR and other Cameras`, `<title> - Success Story[ies]`, `Glossary`).

## Why

The earlier design saved `.html` + `.txt` *before* parsing — when the parser tripped on a new heading variant (PR #252, PR #333) it left orphaned files on disk with no matching `.json`. That corrupted `diff_scrapes.py` (compares the latest two JSONs assuming html ↔ json parity) and made the PR body show stale diffs as if they were new.

## Test plan

- [x] `pytest tests/test_flock_transparency_headings.py` — 32 passing, includes 4 new cases for the heading aliases
- [x] `pytest tests/test_archive_agency_staging.py` — 2 new cases (parse failure leaves slug_dir empty; happy path writes full four-tuple)
- [x] `pytest tests/` excluding pre-existing build-required failures — 394 passing
- [ ] Next probe-slugs.yml hourly run captures a clean four-tuple or surfaces a parser issue without leaving partials