### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -930,6 +930,14 @@
         "spring-arbor-mi-pd": "http_404"
       }
     },
+    "64aa09f6-ae60-5ac3-bd67-4123f65c0837": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-11T23:42:05.876345+00:00",
+      "tried": {
+        "keller-tx-pd": "http_404"
+      }
+    },
     "64da8ade-ab72-5519-8f11-b65be44e0387": {
       "exhausted": false,
       "found": null,
@@ -1009,7 +1017,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-11T21:54:52.919449+00:00",
+      "last_probed": "2026-05-11T23:42:15.429772+00:00",
       "tried": {
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -1021,6 +1029,7 @@
         "beverly-hills-pdca": "http_404",
         "beverly-hills-po": "http_404",
         "beverly-hills-po-ca": "http_404",
+        "beverly-hills-poca": "http_404",
         "beverly-hills-police": "http_404",
         "beverly-hills-police-ca": "http_404",
         "beverly-hills-police-department": "http_404",
@@ -2367,6 +2376,14 @@
         "sonoma-county-ca-sheriffs-office": "http_404"
       }
     },
+    "fe53eae4-f408-5c80-9a44-2605a361f775": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-11T23:42:11.676321+00:00",
+      "tried": {
+        "south-heidelberg-township-pa-pd": "http_404"
+      }
+    },
     "ffd73c10-b1db-5c04-ad0c-44ddf0674e93": {
       "exhausted": false,
       "found": null,
@@ -2376,6 +2393,6 @@
       }
     }
   },
-  "updated": "2026-05-11T21:54:52.957497+00:00",
+  "updated": "2026-05-11T23:42:15.462389+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -9,6 +9,14 @@
         "desert-hot-springs-ca-police-department": "http_404"
       }
     },
+    "00722523-e762-5e6b-b385-126719c10535": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T01:25:35.301246+00:00",
+      "tried": {
+        "henry-county-il-so": "http_404"
+      }
+    },
     "00e249d7-0d9a-5b27-ba9d-64b1a286a081": {
       "exhausted": false,
       "found": null,
@@ -906,6 +914,14 @@
         "overland-park-ks-pd": "http_404"
       }
     },
+    "6184b16e-aefb-5c87-9eac-ff7428124cf2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T01:25:39.741650+00:00",
+      "tried": {
+        "jackson-wi-pd": "http_404"
+      }
+    },
     "62aae0da-4b76-5f88-848b-f5a68768795f": {
       "exhausted": false,
       "found": "palatine-il-pd",
@@ -1572,7 +1588,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-11T20:25:05.484805+00:00",
+      "last_probed": "2026-05-12T01:25:45.747493+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1581,6 +1597,7 @@
         "-hollister-ca-police-department": "http_404",
         "-hollister-ca-ps": "http_404",
         "-hollister-pd-ca": "http_404",
+        "-hollister-po-ca": "http_404",
         "hollister": "http_404",
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
@@ -2393,6 +2410,6 @@
       }
     }
   },
-  "updated": "2026-05-11T23:42:15.462389+00:00",
+  "updated": "2026-05-12T01:25:45.784505+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.