### PR TITLE
Backfill: 76 historical ALPR articles from 16 regional outlets

### DIFF
--- a/assets/articles/queue/029f6b39.json
+++ b/assets/articles/queue/029f6b39.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2025/12/04/think-out-loud-washington-immigration-agencies-license-plate/",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/04377ab9.json
+++ b/assets/articles/queue/04377ab9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/stanwood-reactivates-flock-cameras-spokane-county-joins-pierce-county-shutting-them-down/A7O7L5NXUNGYBJILWMIBGXOGSY/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/0477166d.json
+++ b/assets/articles/queue/0477166d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.krem.com/video/news/investigations/federal-immigration-authorities-accessed-washington-state-license-plate-readers-report-finds/293-b1a65dfb-ec86-4c69-9a79-fe451ce1ac4d",
+  "source_domain": "krem.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/0a54dfe6.json
+++ b/assets/articles/queue/0a54dfe6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2023/05/11/dubuque-police-exploring-automated-license-plate-reading-technology/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/0f322bbf.json
+++ b/assets/articles/queue/0f322bbf.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://ithacavoice.org/2024/03/ithaca-inked-a-deal-to-install-traffic-surveillance-system-from-a-company-with-recent-spate-of-permit-violations/",
+  "source_domain": "ithacavoice.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/116bd982.json
+++ b/assets/articles/queue/116bd982.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/09/24/coralville-city-council-approves-policy-flock-cameras/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/160028a4.json
+++ b/assets/articles/queue/160028a4.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/austin/neighbors-concerned-about-new-flock-license-plate-readers-in-north-austin/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/16ced0bf.json
+++ b/assets/articles/queue/16ced0bf.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2026/04/23/new-oregon-law-regulates-use-license-plate-readers/",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/16d2727a.json
+++ b/assets/articles/queue/16d2727a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.krem.com/article/news/investigations/judge-orders-washington-police-release-surveillance-camera-data-privacy-questions/281-c2037d52-6afb-4bf7-95ad-0eceaf477864",
+  "source_domain": "krem.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/1bc1f6bc.json
+++ b/assets/articles/queue/1bc1f6bc.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/hays-county/san-marcos-city-council-license-plate-reader-cameras-vote/269-59391cfe-2a02-4861-ad8d-93c4bdd85810",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/21be01b2.json
+++ b/assets/articles/queue/21be01b2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/renton-police-department-is-using-automatic-license-plate-readers-again/FQMLHYJCKNDQNNMAWG6OD23KSM/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/24cc2701.json
+++ b/assets/articles/queue/24cc2701.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.seattletimes.com/seattle-news/law-justice/wa-could-regulate-flock-safety-and-other-license-plate-readers-in-2026/",
+  "source_domain": "seattletimes.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/27835922.json
+++ b/assets/articles/queue/27835922.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://ithacavoice.org/2023/12/ithaca-police-introducing-20-license-plate-recognition-cameras-around-city-streets/",
+  "source_domain": "ithacavoice.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/28be52b9.json
+++ b/assets/articles/queue/28be52b9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/12/12/cedar-rapids-police-automated-license-plate-reader-use-strictly-regulated-agency/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/29236968.json
+++ b/assets/articles/queue/29236968.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://ithacavoice.org/2024/05/local-law-enforcement-agencies-awarded-over-450k-from-state-for-new-tech/",
+  "source_domain": "ithacavoice.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/2b1896b3.json
+++ b/assets/articles/queue/2b1896b3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/austin/austin-city-council-to-discuss-possible-license-plate-reader-reinstatement-this-spring/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/36d8a59f.json
+++ b/assets/articles/queue/36d8a59f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/redmond-police-temporarily-shut-down-flock-license-plate-reader-program/XH6QOOT7YVGTLIBTEZHTFCQCWA/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/372df06a.json
+++ b/assets/articles/queue/372df06a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.whsv.com/2025/01/27/proposed-legislation-would-help-regulate-use-automated-license-plate-readers/",
+  "source_domain": "whsv.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/39f579e7.json
+++ b/assets/articles/queue/39f579e7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://cvillerightnow.com/news/208802-cville-police-chief-kochis-says-city-technologically-behind-and-not-catching-up-anytime-soon/",
+  "source_domain": "cvillerightnow.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/3d36a485.json
+++ b/assets/articles/queue/3d36a485.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.krem.com/article/news/local/washington-lawmakers-limit-flock-license-plate-reader-cameras-amid-privacy-concerns/281-b9e69275-8f2c-4ad9-b504-91aa23599de2",
+  "source_domain": "krem.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/4ee34f6a.json
+++ b/assets/articles/queue/4ee34f6a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/cameras-with-license-plate-readers-set-for-installation-around-pflugerville/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/50038b3a.json
+++ b/assets/articles/queue/50038b3a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.news10.com/news/national/ap-license-plate-camera-company-halts-cooperation-with-federal-agencies-among-investigation-concerns/",
+  "source_domain": "news10.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/505a8ab6.json
+++ b/assets/articles/queue/505a8ab6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/license-plate-reading-cameras-up-renton/LMJK2L2MA5CZVHJN7KB2EBAKGU/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/5448bcb3.json
+++ b/assets/articles/queue/5448bcb3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/government-politics/article_dec88164-f172-4c75-b195-f19f73a2da4e.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/54e777d6.json
+++ b/assets/articles/queue/54e777d6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.whsv.com/video/2025/12/22/city-staunton-end-relationship-with-flock-safety-remove-license-plate-readers/",
+  "source_domain": "whsv.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/5afaee84.json
+++ b/assets/articles/queue/5afaee84.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://denvergazette.com/news/as-flock-camera-network-grows-so-do-privacy-and-data-concerns/article_87d8cd8e-b2b1-482b-84f7-fd23b461130a.html",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/601bb5d6.json
+++ b/assets/articles/queue/601bb5d6.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/11/26/coralville-council-amends-automated-license-plate-reader-policy/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/63a967bd.json
+++ b/assets/articles/queue/63a967bd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/content/news/After-more-than-a-year-CRPD-calls-plate-readers-pretty-amazing-442529593.html",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/6dc28f34.json
+++ b/assets/articles/queue/6dc28f34.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.whsv.com/2025/02/04/virginia-lawmakers-debate-license-plate-reader-regulations/",
+  "source_domain": "whsv.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/712abbda.json
+++ b/assets/articles/queue/712abbda.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/legal-concerns-raised-wa-license-plate-data-is-shared-with-federal-agencies/FS3TOCDRWFC2FHQSP3D7WE6CQE/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/721e9b94.json
+++ b/assets/articles/queue/721e9b94.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/seattle-city-council-takes-steps-expand-use-automated-license-plate-readers/I4GWNP5BKZG6HKOVEYHUT7CSHY/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/745d8f28.json
+++ b/assets/articles/queue/745d8f28.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/06/13/statewide-audit-ordered-for-license-plate-readers-used-in-evanston/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/7e4eb0b2.json
+++ b/assets/articles/queue/7e4eb0b2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2025/07/16/privacy-advocates-want-denver-mayor-to-turn-off-flock-cameras-3fa8ff75-7db4-4198-ac45-4ecc4064a5cd/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/8b0b5de7.json
+++ b/assets/articles/queue/8b0b5de7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://ithacavoice.org/2025/06/more-ai-powered-license-plate-cameras-coming-to-county-roads/",
+  "source_domain": "ithacavoice.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/90cbb551.json
+++ b/assets/articles/queue/90cbb551.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/07/29/flock-cameras-and-immigrants/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/91231d79.json
+++ b/assets/articles/queue/91231d79.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2026/03/31/denver-council-narrowly-approves-deal-with-axon/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/9d9e8445.json
+++ b/assets/articles/queue/9d9e8445.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/politics/austin-mayor-and-council/austin-city-council-flock-license-plate-readers/269-f2f8b426-4b8b-4f43-97f7-90b6fb4770f2",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/9e1d595b.json
+++ b/assets/articles/queue/9e1d595b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2025/10/22/denver-mayor-extends-flock-contract-despite-privacy-concerns/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/9e895733.json
+++ b/assets/articles/queue/9e895733.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.toledoblade.com/local/police-fire/2022/02/04/toledo-moves-forward-with-automated-license-plate-reader-study/stories/20220204107",
+  "source_domain": "toledoblade.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/a0246df3.json
+++ b/assets/articles/queue/a0246df3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2026/03/23/denver-delays-axon-alpr-camera-contract/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/a7a1bb35.json
+++ b/assets/articles/queue/a7a1bb35.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/08/28/flock-challenges-citys-termination-of-contract-for-license-plate-readers/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ab0fbe8b.json
+++ b/assets/articles/queue/ab0fbe8b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2026/03/27/denver-city-council-to-consider-axon-alpr-camera-contract/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ad9fbdf2.json
+++ b/assets/articles/queue/ad9fbdf2.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2024/05/14/iowa-police-officer-license-place-reader-credited-with-safe-recovery-endangered-person/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ae41031c.json
+++ b/assets/articles/queue/ae41031c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/education/university/article_f8392b1c-e159-43c1-8b47-b60dde49f632.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/af850768.json
+++ b/assets/articles/queue/af850768.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/list-central-texas-cities-counties-with-license-plate-readers/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/afc07853.json
+++ b/assets/articles/queue/afc07853.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/watch-auburn-police-track-down-stolen-car-using-automated-license-plate-reader/GIXJBJU47FGHJI6O6PNLJRYCRY/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/b1ae1e83.json
+++ b/assets/articles/queue/b1ae1e83.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://denvergazette.com/news/public-safety/denver-license-plate-improvements/article_912a9fb4-2372-11ef-8581-5b7a442329ff.html",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/b50a90d5.json
+++ b/assets/articles/queue/b50a90d5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.toledoblade.com/local/police-fire/2025/07/22/county-commissioners-reverse-decision-automated-license-plate-readers/stories/20250722091",
+  "source_domain": "toledoblade.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/b5efb25f.json
+++ b/assets/articles/queue/b5efb25f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/local/austin/license-plate-reader-company-used-by-apd-setting-the-record-straight-amid-privacy-concerns/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/b9a4c29a.json
+++ b/assets/articles/queue/b9a4c29a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/08/07/oak-park-terminates-flock-license-plate-reader-contract/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/bb7c6bed.json
+++ b/assets/articles/queue/bb7c6bed.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kiro7.com/news/local/everett-flips-flock-cameras-back-under-new-state-law/4LFVLWGM4NAZFJAH6A624267WA/",
+  "source_domain": "kiro7.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/c04a2f28.json
+++ b/assets/articles/queue/c04a2f28.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/lockhart-city-council-rejects-license-plate-readers/269-6a0cdb4b-8743-47a2-843a-4c863111302f",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/c1805350.json
+++ b/assets/articles/queue/c1805350.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/hays-county/san-marcos-lpr-police-privacy/269-4888f65f-eabd-4069-b9e8-7d5ee9ff4356",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/c480f042.json
+++ b/assets/articles/queue/c480f042.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.krem.com/article/associatedpress/associatedpress/border-patrol-is-monitoring-us-drivers-and-detaining-those-with-suspicious-travel-patterns/616-b4cd4bcd-8a6a-4e2d-bc3e-222b5ca68e6d",
+  "source_domain": "krem.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/c4a4e0af.json
+++ b/assets/articles/queue/c4a4e0af.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.opb.org/article/2025/11/24/lawmakers-question-legality-of-border-patrol-license-plate-reader-program/",
+  "source_domain": "opb.org",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/c7e23852.json
+++ b/assets/articles/queue/c7e23852.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/crime-and-courts/dane-county-to-pilot-license-plate-reading-surveillance-cameras/article_e9a5e818-9d45-56f5-810d-d10227354526.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/cad62f6d.json
+++ b/assets/articles/queue/cad62f6d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/12/10/aclu-report-automated-license-plate-readers-not-uniformly-regulated/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/cbf3eb84.json
+++ b/assets/articles/queue/cbf3eb84.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2022/03/22/oak-park-board-divided-on-license-plate-reading-tech/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ce60745f.json
+++ b/assets/articles/queue/ce60745f.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/news/local/crime-courts/article_8df7e143-f17b-4c37-91e7-2a903d9f47f2.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/d020ee10.json
+++ b/assets/articles/queue/d020ee10.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2023/08/08/dubuque-city-council-approves-license-plate-reader-policy/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/d9bf3087.json
+++ b/assets/articles/queue/d9bf3087.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/dps-license-plate-reader-cameras-austin/269-372ec82a-ab8f-4f95-aa45-b0157dbf9b5c",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/deab2e10.json
+++ b/assets/articles/queue/deab2e10.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/09/25/city-covers-up-flock-cameras-while-waiting-for-removal/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/e1de31e1.json
+++ b/assets/articles/queue/e1de31e1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/investigations/defenders/austin-automatic-license-plate-readers-return-council-vote/269-3f0d5eb6-63be-45d8-8c52-e4b6b8abac1b",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/e2ed2ee7.json
+++ b/assets/articles/queue/e2ed2ee7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/08/19/dont-throw-flock-out-with-the-bath-water/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/e335049a.json
+++ b/assets/articles/queue/e335049a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/politics/austin-mayor-and-council/automatic-license-plate-reader-program-austin-city-council-vote/269-460c17c1-f9e1-4a4f-bb20-bfda11245a6f",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ed073af3.json
+++ b/assets/articles/queue/ed073af3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2026/03/11/denver-mayors-office-requests-delay-on-axon-alpr-contract-vote/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ed4c6bbe.json
+++ b/assets/articles/queue/ed4c6bbe.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/01/10/cedar-rapids-police-expanding-use-automated-license-plate-readers/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/ee01087d.json
+++ b/assets/articles/queue/ee01087d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kvue.com/article/news/local/sunset-valley-petition-against-license-plate-readers-lprs/269-9ed86ca3-f1c5-435a-adab-5121085c3619",
+  "source_domain": "kvue.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/efa62168.json
+++ b/assets/articles/queue/efa62168.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kxan.com/news/license-plate-reader-cameras-operating-in-austin-under-new-updated-policy/",
+  "source_domain": "kxan.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f2448ee1.json
+++ b/assets/articles/queue/f2448ee1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://denvergazette.com/news/elbert-county-license-plate-reader-cameras-coming-down/article_521d798c-caac-11ee-a37b-7b0672ff5019.html",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f3ea9516.json
+++ b/assets/articles/queue/f3ea9516.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.denvergazette.com/2025/10/29/council-panel-insists-on-more-robust-discussion-on-denvers-flock-dealings/",
+  "source_domain": "denvergazette.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f4f8ef60.json
+++ b/assets/articles/queue/f4f8ef60.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kcrg.com/2025/08/21/aclu-looks-stop-more-cameras-installing-automatic-license-plate-readers/",
+  "source_domain": "kcrg.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f585d7c8.json
+++ b/assets/articles/queue/f585d7c8.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://madison.com/wsj/news/local/govt-and-politics/bipartisan-bill-would-limit-police-use-of-license-plate-scanners/article_40e4757a-1df8-59fd-a9d8-cadb7739a8ae.html",
+  "source_domain": "madison.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f78d1a8d.json
+++ b/assets/articles/queue/f78d1a8d.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.seattletimes.com/seattle-news/law-justice/what-to-know-about-controversial-automated-license-plate-readers-in-wa/",
+  "source_domain": "seattletimes.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/f8ca6ca1.json
+++ b/assets/articles/queue/f8ca6ca1.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.oakpark.com/2025/12/02/new-reports-emerge-on-border-patrol-use-of-flock-cameras/",
+  "source_domain": "oakpark.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}

--- a/assets/articles/queue/faaa80fd.json
+++ b/assets/articles/queue/faaa80fd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://evanstonroundtable.com/2025/08/26/evanston-shuts-down-license-plate-cameras-terminates-contract-with-flock-safety/",
+  "source_domain": "evanstonroundtable.com",
+  "discovered_at": "2026-05-12T02:30:46Z",
+  "discovered_by": "backfill:google-search-2026-05-11"
+}


### PR DESCRIPTION
## Summary
Backfills past ALPR/Flock coverage from the 16 regional outlets (out of 18) wired up in #349. Queues 76 URLs for the standard crawl → curate pipeline.

Forward-only RSS polling on those new feeds was hitting ≈0 new URLs/day — most regional papers don't publish ALPR stories often enough to validate the wiring on a per-day basis. This commit gets the existing archive of coverage in immediately so the geographic-coverage thesis can actually be tested.

## Methodology
For each of the 18 newly-wired domains:
```
site:DOMAIN (alpr OR flock OR "license plate reader")
```
Filtered noise (license-plate fees, fake plates, peeling plates, etc.) by URL-slug inspection, then pushed through `article_queue_add.py --discovered-by 'backfill:google-search-2026-05-11'`.

## Yield by region
- **WA (kiro7, krem, opb, seattletimes)**: 17
- **TX (kvue, kxan)**: 14
- **CO (denvergazette)**: 10
- **IA (kcrg)**: 10
- **IL suburbs (oakpark, evanstonroundtable)**: 9
- **WI (madison)**: 5
- **NY (ithacavoice, news10)**: 5
- **VA (whsv, cvillerightnow)**: 4
- **OH (toledoblade)**: 2

Total: 98 candidates → 76 newly queued + 22 duplicates against existing queue/registry.

## Notes
- `mlive.com` yielded zero — Michigan papers don't appear to cover the ALPR beat. Worth flagging if expanding coverage there.
- 22 dupes are a useful signal: the termination-ledger import + earlier RSS polls had already caught some of this corpus.

## Test plan
- [x] All 76 queue files created with valid JSON shape
- [x] `discovered_by` set to `backfill:google-search-2026-05-11` for traceability
- [ ] Next `Crawl & Curate Articles` run picks them up — confirm via the `article-registry-bot` PR