### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1443,6 +1443,14 @@
         "los-angeles-port-ca-po": "http_404"
       }
     },
+    "9546a481-6379-5b80-a336-7ea764558313": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T05:26:01.789142+00:00",
+      "tried": {
+        "maryville-mo-pd": "http_404"
+      }
+    },
     "956b5a6d-a9d8-5eed-b61f-516a6ecf291f": {
       "exhausted": false,
       "found": null,
@@ -1588,7 +1596,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-12T01:25:45.747493+00:00",
+      "last_probed": "2026-05-12T05:26:06.014012+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1598,6 +1606,7 @@
         "-hollister-ca-ps": "http_404",
         "-hollister-pd-ca": "http_404",
         "-hollister-po-ca": "http_404",
+        "-hollister-police-department-ca": "http_404",
         "hollister": "http_404",
         "hollister-ca": "http_404",
         "hollister-ca-po": "http_404",
@@ -1868,6 +1877,14 @@
       "last_probed": "2026-05-08T06:23:54.856215+00:00",
       "tried": {
         "taylor-county-ga-so": "http_404"
+      }
+    },
+    "bff0452b-0682-5103-9dec-657f11133177": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T05:25:57.740861+00:00",
+      "tried": {
+        "four-s-ranch-master-association-ivy-gate-ca-pd": "http_404"
       }
     },
     "c04ede0a-7c98-5c16-890a-1a15eb10c545": {
@@ -2410,6 +2427,6 @@
       }
     }
   },
-  "updated": "2026-05-12T01:25:45.784505+00:00",
+  "updated": "2026-05-12T05:26:06.049796+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.