### PR TITLE
feat(report): flag "wanted criminals" portal-language boilerplate

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -163,6 +163,7 @@
     html += renderStats(report, meta);
     html += renderSB34Checklist(report, meta);
     html += renderTransparencyChecklist(report, meta);
+    html += renderPortalLanguageNotes(report);
     html += renderSharing(report);
     html += renderRegional(report, meta);
     html += renderLegalSummary(report, meta);
@@ -1525,6 +1526,39 @@
       }
     }
     return line;
+  }
+
+  // ── Portal Language Notes ──
+  // Callouts for Flock-supplied template phrasing carried verbatim on the
+  // agency's transparency portal. Tone: "the portal uses this language",
+  // not "the agency claims..." — most agencies adopt Flock's boilerplate
+  // overview text wholesale.
+  function renderPortalLanguageNotes(report) {
+    const notes = report.portal_language_notes || [];
+    if (!notes.length) return "";
+    let html = `<h2>Portal Language</h2>`;
+    notes.forEach(function(n) {
+      html += '<div class="flag-section">';
+      if (n.id === "wanted_criminals") {
+        const peers = n.peer_count;
+        const pool = n.peer_pool_size;
+        html += `<strong>Portal describes targets as &ldquo;wanted criminals&rdquo;</strong>`;
+        html += `<div style="margin-top:6px;font-size:10pt"><em>${escapeHtml(n.matched_text)}</em></div>`;
+        html += '<div style="margin-top:8px;font-size:10pt">';
+        html += `Real-time hotlist alerting fires <strong>before</strong> any judicial determination &mdash; that is the point of the feature. The vehicles it flags are tied to outstanding arrest warrants, BOLOs, or missing-persons reports; the people in them are accused, sought, or wanted for questioning &mdash; not convicted. Describing them as &ldquo;criminals&rdquo; presumes the outcome the legal process is meant to determine.`;
+        html += '</div>';
+        if (pool) {
+          html += `<div class="muted" style="margin-top:6px;font-size:9.5pt">This is Flock&rsquo;s template phrasing &mdash; the same sentence appears on ${peers} of ${pool} scraped CA agency portals. The agency adopts it by leaving the default in place.</div>`;
+        }
+      } else {
+        // Forward-compat: render unknown ids minimally so a new note id
+        // doesn't disappear from the UI before its dedicated copy lands.
+        html += `<strong>Portal language note</strong>`;
+        html += `<div style="margin-top:6px;font-size:10pt"><em>${escapeHtml(n.matched_text || "")}</em></div>`;
+      }
+      html += '</div>';
+    });
+    return html;
   }
 
   // ── Sharing ──

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1545,7 +1545,7 @@
         html += `<strong>Portal describes targets as &ldquo;wanted criminals&rdquo;</strong>`;
         html += `<div style="margin-top:6px;font-size:10pt"><em>${escapeHtml(n.matched_text)}</em></div>`;
         html += '<div style="margin-top:8px;font-size:10pt">';
-        html += `Real-time hotlist alerting fires <strong>before</strong> any judicial determination &mdash; that is the point of the feature. The vehicles it flags are tied to outstanding arrest warrants, BOLOs, or missing-persons reports; the people in them are accused, sought, or wanted for questioning &mdash; not convicted. Describing them as &ldquo;criminals&rdquo; presumes the outcome the legal process is meant to determine.`;
+        html += `Real-time hotlist alerting fires <strong>before</strong> any judicial determination &mdash; that is the point of the feature. The vehicles it flags are tied to outstanding arrest warrants, BOLOs, Amber Alerts, Silver Alerts, and missing-persons reports. The subjects include people accused or sought for questioning, but also <strong>missing children, kidnap victims, and adults who have wandered off</strong> &mdash; none of whom are &ldquo;criminals&rdquo; by any reading. Describing the targets as &ldquo;wanted criminals&rdquo; both presumes the legal outcome the process is meant to determine and mischaracterizes the substantial share of searches aimed at victims or other non-criminal subjects.`;
         html += '</div>';
         if (pool) {
           html += `<div class="muted" style="margin-top:6px;font-size:9.5pt">This is Flock&rsquo;s template phrasing &mdash; the same sentence appears on ${peers} of ${pool} scraped CA agency portals. The agency adopts it by leaving the default in place.</div>`;

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -136,6 +136,37 @@ _AUDIT_TERMS_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Flock-supplied template phrase in many portal `overview` fields:
+# "real-time alerting of hotlist vehicles to capture wanted criminals."
+# Hotlist hits are typically warrants/BOLOs/missing-persons — pre-conviction
+# by design. We surface the phrase as a portal-language note (not a
+# recipient-flag) and contextualize it as boilerplate.
+_WANTED_CRIMINALS_RE = re.compile(r"\bwanted\s+criminals?\b", re.IGNORECASE)
+
+
+def _portal_language_notes(portal, wanted_criminals_peer_count, wanted_criminals_peer_pool):
+    """Detect Flock-template portal language worth surfacing as a callout.
+
+    Returns a list of note objects keyed by `id`; the JS renderer hardcodes
+    copy per id. Empty list when nothing matches.
+    """
+    notes = []
+    overview = portal.get("overview")
+    if isinstance(overview, str):
+        m = _WANTED_CRIMINALS_RE.search(overview)
+        if m:
+            start = overview.rfind('.', 0, m.start())
+            start = 0 if start == -1 else start + 1
+            end = overview.find('.', m.end())
+            end = len(overview) if end == -1 else end + 1
+            notes.append({
+                "id": "wanted_criminals",
+                "matched_text": overview[start:end].strip(),
+                "peer_count": wanted_criminals_peer_count,
+                "peer_pool_size": wanted_criminals_peer_pool,
+            })
+    return notes
+
 
 def _has_value(portal, key):
     """True if the portal field is a non-empty string."""
@@ -676,6 +707,18 @@ def main():
 
     print(f"CA crawled agencies: {len(ca_crawled)}")
 
+    # ── Portal-language peer counts ──
+    # Count crawled CA agencies whose latest portal "overview" carries the
+    # Flock template phrase "wanted criminals". Surfaced in per-agency
+    # reports so readers can see it's boilerplate, not agency-specific
+    # framing.
+    wanted_criminals_peers = 0
+    for a in ca_crawled:
+        ov = a["portal"].get("overview")
+        if isinstance(ov, str) and _WANTED_CRIMINALS_RE.search(ov):
+            wanted_criminals_peers += 1
+    wanted_criminals_peer_pool = len(ca_crawled)
+
     # ── Checklist completion counts (by agency_type and overall) ──
     #
     # We compute peer totals against ALL CA agencies with Flock cameras,
@@ -1059,6 +1102,13 @@ def main():
         crawled = bool(gdata.get("crawled"))
         portal = _load_portal_json(reg) if crawled else {}
         atype = reg.get("agency_type") or "other"
+
+        # Flock-template language flags (e.g., "wanted criminals" in the
+        # overview blurb). Only crawled agencies have an overview to scan.
+        portal_language_notes = (
+            _portal_language_notes(portal, wanted_criminals_peers, wanted_criminals_peer_pool)
+            if crawled else []
+        )
 
         lat, lng = agency_coords(reg)
         state = agency_state(reg)
@@ -1825,6 +1875,7 @@ def main():
             "audit_vs_inbound": audit_vs_inbound,
             "recent_outbound_additions": recent_outbound_additions,
             "recent_outbound_removals": recent_outbound_removals,
+            "portal_language_notes": portal_language_notes,
         }
 
     # ── Metadata ──


### PR DESCRIPTION
## Summary
- New **Portal Language** section on per-agency reports that flags Flock's template phrase *"real-time alerting of hotlist vehicles to capture wanted criminals."* Renders the matched sentence verbatim, then a note that real-time hotlist alerting fires before any judicial determination — the people the system flags are accused/sought/wanted, not convicted.
- Tone is *"the portal uses this language"*, not *"the agency claims..."*: 155 of 163 scraped CA crawled portals carry the same sentence, so the note explicitly calls out the boilerplate and frames the agency's responsibility as adopting it by leaving the default in place.
- Data side: `scripts/build_report_data.py` adds `_WANTED_CRIMINALS_RE`, a portal-language-notes helper, a peer-count precompute, and a new `portal_language_notes` list on each report record. UI side: `docs/js/report.js` adds `renderPortalLanguageNotes()` between the Transparency and Sharing sections, reusing the existing `.flag-section` style.

## Test plan
- [x] Builder runs: 155 of 163 CA crawled agencies tagged
- [x] Headless-browser check on `report.html?agency=san-mateo-ca-pd` — section renders with full copy, no JS errors
- [x] Headless-browser check on `report.html?agency=palo-alto-ca-pd` (one of 8 portals without the phrase) — section correctly absent
- [ ] Eyeball the rendered section in the live preview