### PR TITLE
feat(articles): per-agency search, deep links, and report integration

### DIFF
--- a/docs/articles.html
+++ b/docs/articles.html
@@ -47,6 +47,112 @@
     padding: 0 20px 60px;
   }
 
+  .agency-search-row {
+    position: relative;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 12px;
+  }
+  .agency-search-row h2 {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #94a3b8;
+    margin-bottom: 8px;
+  }
+  .agency-search-row input {
+    width: 100%;
+    padding: 8px 12px;
+    background: #0f172a;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    color: #e2e8f0;
+    font-size: 14px;
+    font-family: inherit;
+  }
+  .agency-search-row input:focus {
+    outline: none;
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 2px rgba(96,165,250,0.18);
+  }
+  .agency-search-results {
+    position: absolute;
+    top: 100%;
+    left: 18px;
+    right: 18px;
+    background: #1e293b;
+    border: 1px solid #475569;
+    border-radius: 6px;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+    max-height: 320px;
+    overflow-y: auto;
+    z-index: 1000;
+    display: none;
+    margin-top: 2px;
+  }
+  .agency-search-results.open { display: block; }
+  .agency-search-results a {
+    display: block;
+    padding: 7px 12px;
+    color: #e2e8f0;
+    text-decoration: none;
+    font-size: 13px;
+    border-bottom: 1px solid #334155;
+  }
+  .agency-search-results a:last-child { border-bottom: none; }
+  .agency-search-results a:hover,
+  .agency-search-results a.hl { background: #334155; }
+  .agency-search-results .sr-state {
+    color: #94a3b8;
+    font-size: 11px;
+    margin-left: 6px;
+  }
+  .agency-search-results .sr-count {
+    color: #94a3b8;
+    font-size: 11px;
+    float: right;
+  }
+  .agency-search-results .sr-empty {
+    padding: 8px 12px;
+    color: #94a3b8;
+    font-size: 13px;
+  }
+  .agency-pin-inline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    background: #1e3a8a;
+    color: #dbeafe;
+    border: 1px solid #3b82f6;
+    border-radius: 6px;
+    padding: 9px 12px;
+    font-size: 14px;
+  }
+  .agency-pin-inline .pin-label {
+    font-weight: 600;
+  }
+  .agency-pin-inline .pin-meta {
+    color: #93c5fd;
+    font-size: 12px;
+    margin-left: 6px;
+    font-weight: normal;
+  }
+  .agency-pin-inline button {
+    background: rgba(15, 23, 42, 0.4);
+    border: 1px solid #3b82f6;
+    color: white;
+    font-size: 12px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px 10px;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
+  .agency-pin-inline button:hover { background: rgba(15, 23, 42, 0.7); }
+
   .filter-panel {
     background: #1e293b;
     border: 1px solid #334155;
@@ -225,6 +331,14 @@
 
 <main>
   <div id="map"></div>
+
+  <div class="agency-search-row" id="agency-search">
+    <h2>Filter by city or agency</h2>
+    <div class="agency-search-input-wrap" id="agency-search-input-wrap">
+      <input type="text" id="agency-search-input" placeholder="Type a city or agency name&hellip;" autocomplete="off" spellcheck="false">
+    </div>
+    <div class="agency-search-results" id="agency-search-results" role="listbox"></div>
+  </div>
 
   <div class="filter-panel" id="filter-panel">
     <h2>Filter by tag</h2>

--- a/docs/js/articles.js
+++ b/docs/js/articles.js
@@ -2,7 +2,9 @@
 
 var STATE = {
   data: null,
-  filters: {},   // tag -> 'include' | 'exclude'
+  filters: {},          // tag -> 'include' | 'exclude'
+  agencyFilter: null,   // agency_id when narrowed by city/agency
+  agencyIndex: [],      // [{ agency_id, slug, name, state, count, _lower }]
   map: null,
   markerLayer: null
 };
@@ -35,7 +37,69 @@ function cycleFilter(tag) {
 
 function clearFilters() {
   STATE.filters = {};
+  STATE.agencyFilter = null;
+  syncUrl();
   render();
+}
+
+function setAgencyFilter(agencyId) {
+  STATE.agencyFilter = agencyId || null;
+  syncUrl();
+  render();
+}
+
+// Reflect the active agency filter in the URL so the page is shareable
+// and the sharing_map / report pages can deep-link in. Use replaceState
+// (not pushState) so the browser back button doesn't trap users in a
+// chain of intermediate filter states.
+function syncUrl() {
+  var url = new URL(window.location.href);
+  if (STATE.agencyFilter) {
+    var entry = (STATE.data && STATE.data.articles_by_agency || {})[STATE.agencyFilter];
+    var key = (entry && entry.slug) || STATE.agencyFilter;
+    url.searchParams.set('agency', key);
+  } else {
+    url.searchParams.delete('agency');
+  }
+  history.replaceState(null, '', url.toString());
+}
+
+function resolveAgencyParam(data, param) {
+  if (!param) return null;
+  var byAgency = data.articles_by_agency || {};
+  if (byAgency[param]) return param;
+  for (var id in byAgency) {
+    if (byAgency[id].slug === param) return id;
+  }
+  return null;
+}
+
+function buildAgencyIndex(data) {
+  var byAgency = data.articles_by_agency || {};
+  var out = [];
+  for (var id in byAgency) {
+    var e = byAgency[id];
+    // primary_count matches what articles.html actually shows after
+    // a filter is applied — mention-only matches are excluded so they
+    // don't pad the suggestion's "N articles" badge with stories the
+    // filter won't surface.
+    var count = e.primary_count || 0;
+    if (!count) continue;
+    var label = e.name || id;
+    out.push({
+      agency_id: id,
+      slug: e.slug || '',
+      name: label,
+      state: e.state || '',
+      count: count,
+      _lower: label.toLowerCase()
+    });
+  }
+  out.sort(function (a, b) {
+    if (b.count !== a.count) return b.count - a.count;
+    return a._lower < b._lower ? -1 : 1;
+  });
+  return out;
 }
 
 function tagNamespace(tag) {
@@ -47,6 +111,25 @@ function tagNamespace(tag) {
 // outcome:rejected widens the result), AND across namespaces. Excludes always
 // drop matching articles regardless of grouping.
 function articleMatches(article) {
+  // Match the agency filter against primary_subject_agencies only,
+  // not the broader agencies[] mentions list. The mentions list is
+  // noisy — name-checks, list asides, and curator slip-ups (e.g. an
+  // article about Bloomington IN tagged with Bloomington IL PD) leak
+  // into the filter result and make it feel like the filter is broken.
+  // Primary subjects are the curator's judgment of what the piece is
+  // substantively about, which is what users expect when they pick a
+  // city.
+  if (STATE.agencyFilter) {
+    var primaries = article.primary_subject_agencies || [];
+    var hit = false;
+    for (var pi = 0; pi < primaries.length; pi++) {
+      if (primaries[pi] && primaries[pi].agency_id === STATE.agencyFilter) {
+        hit = true;
+        break;
+      }
+    }
+    if (!hit) return false;
+  }
   var tags = article.tags || [];
   var tagSet = {};
   for (var i = 0; i < tags.length; i++) tagSet[tags[i]] = true;
@@ -141,9 +224,38 @@ function renderTagGroups() {
   }
 }
 
+function renderAgencyPin() {
+  var wrap = document.getElementById('agency-search-input-wrap');
+  if (!wrap) return;
+  if (!STATE.agencyFilter) {
+    // Restore the search input if it was replaced by the pin earlier.
+    if (!document.getElementById('agency-search-input')) {
+      wrap.innerHTML = '<input type="text" id="agency-search-input" '
+        + 'placeholder="Type a city or agency name…" '
+        + 'autocomplete="off" spellcheck="false">';
+      wireAgencySearchInput();
+    }
+    return;
+  }
+  var byAgency = (STATE.data && STATE.data.articles_by_agency) || {};
+  var ag = byAgency[STATE.agencyFilter];
+  var label = ag ? ag.name : STATE.agencyFilter;
+  var state = ag && ag.state ? ag.state : '';
+  var count = ag ? (ag.primary_count || 0) : 0;
+  wrap.innerHTML = '<div class="agency-pin-inline">'
+    + '<div><span class="pin-label">' + escapeHtml(label) + '</span>'
+    + (state ? '<span class="pin-meta">' + escapeHtml(state) + '</span>' : '')
+    + '<span class="pin-meta">· ' + count + ' article' + (count !== 1 ? 's' : '') + '</span>'
+    + '</div>'
+    + '<button type="button" id="clear-agency-btn" aria-label="Clear city filter">'
+    + '× Remove filter</button>'
+    + '</div>';
+  var btn = document.getElementById('clear-agency-btn');
+  if (btn) btn.addEventListener('click', function () { setAgencyFilter(null); });
+}
+
 function renderActiveBar(matchedCount, totalCount) {
   var bar = document.getElementById('active-bar');
-  var parts = [];
   var includes = [], excludes = [];
   for (var t in STATE.filters) {
     if (STATE.filters[t] === 'include') includes.push(t);
@@ -245,14 +357,45 @@ function renderArticleList(matched) {
   renderActiveBar(matched.length, articles.length);
 }
 
+// Cluster icon that totals articles across all clustered agencies.
+// The plain agency count was misleading — a cluster of 3 cities with
+// 2/4/1 articles read as "3" but the bubble actually carries 7 pieces
+// of coverage. Format: "ARTICLES / CITIES" when the cluster spans more
+// than one city, just "ARTICLES" otherwise.
+function articleClusterIcon(cluster) {
+  var children = cluster.getAllChildMarkers();
+  var totalArticles = 0;
+  for (var i = 0; i < children.length; i++) {
+    totalArticles += (children[i].options.articleCount || 0);
+  }
+  var label = children.length > 1
+    ? (totalArticles + ' / ' + children.length)
+    : String(totalArticles);
+  // Scale with article count so heavier clusters read as bigger pins.
+  var size = Math.min(54, 22 + Math.sqrt(totalArticles) * 6);
+  var r = size / 2;
+  var fontSize = label.length > 4 ? 10 : 12;
+  var svg = '<svg width="' + size + '" height="' + size
+    + '" xmlns="http://www.w3.org/2000/svg">'
+    + '<circle cx="' + r + '" cy="' + r + '" r="' + (r - 1)
+      + '" fill="#60a5fa" fill-opacity="0.85" stroke="#1e3a8a" stroke-width="1"/>'
+    + '<text x="' + r + '" y="' + (r + fontSize / 3)
+      + '" text-anchor="middle" font-size="' + fontSize
+      + '" font-weight="bold" fill="#0f172a">'
+      + label + '</text>'
+    + '</svg>';
+  return L.divIcon({ html: svg, className: '', iconSize: [size, size] });
+}
+
 function initMap() {
   if (STATE.map) return;
   var map = MapCommon.createCartoMap('map', { theme: 'dark' });
   var markerLayer = L.markerClusterGroup(MapCommon.clusterOptions({
-    iconCreateFunction: MapCommon.countClusterIcon()
+    iconCreateFunction: articleClusterIcon
   }));
   MapCommon.attachClusterTooltips(markerLayer, function (cm) {
-    return cm.options.agencyName;
+    var n = cm.options.articleCount || 0;
+    return cm.options.agencyName + ' — ' + n + ' article' + (n !== 1 ? 's' : '');
   });
   markerLayer.addTo(map);
   // Vendor-bucket pip lives outside the cluster group so it never
@@ -283,8 +426,12 @@ function renderMap(matched) {
   // three pins; an article that merely name-checks them gets zero
   // (the curator filters those out). Vendor-primary entries (no real
   // subject city) get bucketed into a single off-coast pip.
-  // Dedupe per agency so a single article never adds two pins at the
-  // same agency, even if the curator returned a duplicate.
+  //
+  // When an agency filter is active, suppress sibling-subject pins:
+  // a multi-city article only contributes a pin at the *filtered*
+  // agency. Otherwise an article tagged [San Mateo, Foster City] would
+  // still drop a Foster City pin even though the user narrowed to
+  // San Mateo, which reads as "the filter leaked."
   var byAgency = {};
   var vendorBucket = { articles: [], names: {} };
   for (var i = 0; i < matched.length; i++) {
@@ -295,6 +442,7 @@ function renderMap(matched) {
     for (var s = 0; s < subjects.length; s++) {
       var ag = subjects[s];
       if (!ag) continue;
+      if (STATE.agencyFilter && ag.agency_id !== STATE.agencyFilter) continue;
       if (ag.is_vendor) {
         if (vendorAddedForArticle) continue;
         vendorBucket.articles.push(a);
@@ -345,6 +493,10 @@ function renderMap(matched) {
     }
     popup += '</ul>';
     marker.bindPopup(popup);
+    marker.bindTooltip(
+      ag.name + ' — ' + arts.length + ' article' + (arts.length !== 1 ? 's' : ''),
+      { direction: 'top', offset: [0, -4] }
+    );
     STATE.markerLayer.addLayer(marker);
     bounds.push([ag.lat, ag.lng]);
   }
@@ -379,6 +531,10 @@ function renderMap(matched) {
     }
     popup += '</ul>';
     marker.bindPopup(popup);
+    marker.bindTooltip(
+      label + ' — ' + arts.length + ' article' + (arts.length !== 1 ? 's' : ''),
+      { direction: 'top', offset: [0, -4] }
+    );
     STATE.vendorLayer.addLayer(marker);
     bounds.push(VENDOR_BUCKET_LATLNG);
   }
@@ -399,9 +555,126 @@ function getMatched() {
 
 function render() {
   var matched = getMatched();
+  renderAgencyPin();
   renderTagGroups();
   renderMap(matched);
   renderArticleList(matched);
+}
+
+// Toolbar-style "Jump to city" search modeled on report.js#wireAgencySearch.
+// Selecting a suggestion sets STATE.agencyFilter (rather than navigating)
+// so the result feels like another filter in the chip system. ↓/↑ moves
+// highlight, Enter accepts, Esc closes. Exposed via wireAgencySearchInput
+// because renderAgencyPin() removes and rebuilds the <input> element
+// when the user clears the pin, and the new input needs handlers wired.
+function wireAgencySearchInput() {
+  var input = document.getElementById('agency-search-input');
+  var results = document.getElementById('agency-search-results');
+  if (!input || !results) return;
+  var highlightIdx = -1;
+
+  function close() {
+    results.classList.remove('open');
+    results.innerHTML = '';
+    highlightIdx = -1;
+  }
+
+  function pick(agencyId) {
+    input.value = '';
+    close();
+    setAgencyFilter(agencyId);
+  }
+
+  function doSearch(q) {
+    q = (q || '').trim().toLowerCase();
+    if (!q) { close(); return; }
+    var matches = [];
+    for (var i = 0; i < STATE.agencyIndex.length; i++) {
+      var e = STATE.agencyIndex[i];
+      var n = e._lower;
+      var score = 0;
+      if (n === q) score = 100;
+      else if (n.indexOf(q) === 0) score = 50;
+      else if (n.indexOf(q) >= 0) score = 10;
+      if (score > 0) matches.push({ e: e, score: score });
+    }
+    matches.sort(function (a, b) {
+      if (b.score !== a.score) return b.score - a.score;
+      if (b.e.count !== a.e.count) return b.e.count - a.e.count;
+      return a.e._lower < b.e._lower ? -1 : 1;
+    });
+    var shown = matches.slice(0, 15);
+    if (!shown.length) {
+      results.innerHTML = '<div class="sr-empty">No matching agency in the article library</div>';
+    } else {
+      var html = '';
+      for (var k = 0; k < shown.length; k++) {
+        var ent = shown[k].e;
+        var state = ent.state ? '<span class="sr-state">' + escapeHtml(ent.state) + '</span>' : '';
+        var count = '<span class="sr-count">' + ent.count + ' article' + (ent.count !== 1 ? 's' : '') + '</span>';
+        html += '<a href="#" data-id="' + escapeHtml(ent.agency_id) + '">'
+          + count
+          + escapeHtml(ent.name) + state
+          + '</a>';
+      }
+      results.innerHTML = html;
+    }
+    results.classList.add('open');
+    highlightIdx = -1;
+    var links = results.querySelectorAll('a');
+    for (var li = 0; li < links.length; li++) {
+      links[li].addEventListener('click', function (ev) {
+        ev.preventDefault();
+        pick(ev.currentTarget.getAttribute('data-id'));
+      });
+    }
+  }
+
+  function updateHighlight() {
+    var links = results.querySelectorAll('a');
+    for (var i = 0; i < links.length; i++) {
+      links[i].classList.toggle('hl', i === highlightIdx);
+    }
+    if (highlightIdx >= 0 && links[highlightIdx]) {
+      links[highlightIdx].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  input.addEventListener('input', function () { doSearch(input.value); });
+  input.addEventListener('keydown', function (e) {
+    var links = results.querySelectorAll('a');
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!results.classList.contains('open')) doSearch(input.value);
+      if (links.length) {
+        highlightIdx = Math.min(highlightIdx + 1, links.length - 1);
+        updateHighlight();
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (links.length) {
+        highlightIdx = Math.max(highlightIdx - 1, 0);
+        updateHighlight();
+      }
+    } else if (e.key === 'Enter') {
+      if (highlightIdx >= 0 && links[highlightIdx]) {
+        e.preventDefault();
+        pick(links[highlightIdx].getAttribute('data-id'));
+      } else if (links.length === 1) {
+        e.preventDefault();
+        pick(links[0].getAttribute('data-id'));
+      }
+    } else if (e.key === 'Escape') {
+      close();
+      input.blur();
+    }
+  });
+  input.addEventListener('focus', function () {
+    if (input.value.trim()) doSearch(input.value);
+  });
+  document.addEventListener('click', function (e) {
+    if (!e.target.closest('#agency-search')) close();
+  });
 }
 
 fetch('data/articles_data.json')
@@ -411,7 +684,14 @@ fetch('data/articles_data.json')
   })
   .then(function (data) {
     STATE.data = data;
+    STATE.agencyIndex = buildAgencyIndex(data);
+    var param = new URL(window.location.href).searchParams.get('agency');
+    STATE.agencyFilter = resolveAgencyParam(data, param);
+    // If a URL param pointed at an unknown agency, drop it from the URL
+    // rather than leaving a dead query string sitting on the address bar.
+    if (param && !STATE.agencyFilter) syncUrl();
     initMap();
+    wireAgencySearchInput();
     render();
   })
   .catch(function (err) {

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -145,7 +145,7 @@
   }
 
   // ── Main render ──
-  function render(data, slug) {
+  function render(data, slug, articlesData) {
     const report = (data.reports || {})[slug];
     const meta = data.metadata || {};
     const container = document.getElementById("report");
@@ -166,10 +166,65 @@
     html += renderPortalLanguageNotes(report);
     html += renderSharing(report);
     html += renderRegional(report, meta);
+    html += renderArticles(report, articlesData, slug);
     html += renderLegalSummary(report, meta);
     html += renderQuestions(report, meta);
     html += renderFooter(report, meta);
     container.innerHTML = html;
+  }
+
+  // ── Press coverage ── articles that cite this agency, from
+  // assets/article_registry.json via build_articles_data.py. Hidden when
+  // no articles match (an empty table is just visual noise on the long
+  // tail of agencies). "Primary subject" badge distinguishes pieces
+  // substantively *about* this agency from pieces that merely cite it
+  // in a regional roundup.
+  function renderArticles(report, articlesData, slug) {
+    if (!articlesData || !articlesData.articles_by_agency) return "";
+    const byAgency = articlesData.articles_by_agency;
+    let entry = report.agency_id ? byAgency[report.agency_id] : null;
+    if (!entry) {
+      for (const aid in byAgency) {
+        if (byAgency[aid].slug === slug) { entry = byAgency[aid]; break; }
+      }
+    }
+    if (!entry || !entry.articles || !entry.articles.length) return "";
+
+    const articles = entry.articles;
+    const agencyKey = entry.slug || entry.agency_id;
+    const rows = articles.map(function(a) {
+      const date = a.published_at ? formatArticleDate(a.published_at) : "<span class=\"muted\">—</span>";
+      const titleCell = a.url
+        ? `<a href="${escapeHtml(a.url)}" target="_blank" rel="noopener">${escapeHtml(a.title || a.url)}</a>`
+        : escapeHtml(a.title || "");
+      const primaryBadge = a.is_primary
+        ? `<span class="article-primary-badge" title="This piece is substantively about ${escapeHtml(report.name)}">primary subject</span>`
+        : "";
+      const source = a.source_domain ? escapeHtml(a.source_domain) : "<span class=\"muted\">—</span>";
+      return `<tr>
+        <td class="article-date">${date}</td>
+        <td>${titleCell} ${primaryBadge}</td>
+        <td class="article-source">${source}</td>
+      </tr>`;
+    }).join("");
+
+    return `
+      <h2>Press Coverage</h2>
+      <p class="muted">News and analysis citing ${escapeHtml(report.name)}.
+        See the full <a href="articles.html?agency=${encodeURIComponent(agencyKey)}">article library filtered to this agency</a>
+        for tags, summaries, and source filters.</p>
+      <table class="article-table">
+        <thead><tr><th>Date</th><th>Article</th><th>Source</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  }
+
+  function formatArticleDate(iso) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return escapeHtml(iso);
+    return d.toLocaleDateString(undefined,
+      { year: "numeric", month: "short", day: "numeric" });
   }
 
   function renderNotFound(slug, data) {
@@ -2634,10 +2689,16 @@
       return;
     }
 
-    fetch("data/report_data.json?v=" + Date.now())
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        render(data, slug);
+    Promise.all([
+      fetch("data/report_data.json?v=" + Date.now()).then(function(r) { return r.json(); }),
+      fetch("data/articles_data.json?v=" + Date.now())
+        .then(function(r) { return r.ok ? r.json() : null; })
+        .catch(function() { return null; }),
+    ])
+      .then(function(results) {
+        const data = results[0];
+        const articlesData = results[1];
+        render(data, slug, articlesData);
         wireAgencySearch(data, slug);
       })
       .catch(function(err) {

--- a/docs/report.html
+++ b/docs/report.html
@@ -807,6 +807,38 @@
   }
   .footer a { color: var(--muted); }
 
+  .article-table {
+    font-size: 10pt;
+    table-layout: fixed;
+  }
+  .article-table th:first-child,
+  .article-table td.article-date {
+    width: 90px;
+    white-space: nowrap;
+    color: var(--muted);
+  }
+  .article-table th:last-child,
+  .article-table td.article-source {
+    width: 150px;
+    color: var(--muted);
+    font-size: 9.5pt;
+    word-break: break-word;
+  }
+  .article-table td a { color: var(--accent); text-decoration: none; }
+  .article-table td a:hover { text-decoration: underline; }
+  .article-primary-badge {
+    display: inline-block;
+    background: #e0f2fe;
+    color: #075985;
+    font-size: 8pt;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 3px;
+    margin-left: 4px;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
   .legal-note {
     font-size: 10pt;
     background: #f3f4f6;

--- a/scripts/build_articles_data.py
+++ b/scripts/build_articles_data.py
@@ -132,14 +132,88 @@ def main() -> int:
                            key=lambda kv: (-kv[1], kv[0]))
     ]
 
+    # Per-agency index. Lets the sharing_map page show an "Articles (N)"
+    # link and the report page render a press-coverage list without
+    # having to load and traverse the full articles array. Includes the
+    # registry slug so callers using ?agency=<slug> URL params (report,
+    # justifications) can resolve the lookup without an extra fetch.
+    articles_by_agency: dict[str, dict] = {}
+    for a in articles:
+        primary_ids = set()
+        for p in (a.get("primary_subject_agencies") or []):
+            pid = p.get("agency_id")
+            if pid:
+                primary_ids.add(pid)
+        seen_ids: set[str] = set()
+        for ag in (a.get("agencies") or []):
+            aid = ag.get("agency_id")
+            if not aid or aid in seen_ids:
+                continue
+            seen_ids.add(aid)
+            entry = articles_by_agency.setdefault(aid, {
+                "agency_id": aid,
+                "name": ag.get("name"),
+                "state": ag.get("state"),
+                "articles": [],
+            })
+            entry["articles"].append({
+                "article_id": a["article_id"],
+                "title": a["title"],
+                "url": a["url"],
+                "source_domain": a.get("source_domain"),
+                "published_at": a.get("published_at"),
+                "is_primary": aid in primary_ids,
+            })
+        # Primary subjects are usually in the agencies list, but defend
+        # against the case where they're not — we still want them
+        # indexed so the report page can find their press coverage.
+        for pid in primary_ids - seen_ids:
+            ag_entry = reg_by_id.get(pid)
+            if not ag_entry:
+                continue
+            entry = articles_by_agency.setdefault(pid, {
+                "agency_id": pid,
+                "name": agency_display_name(ag_entry, fallback=pid),
+                "state": agency_state(ag_entry),
+                "articles": [],
+            })
+            entry["articles"].append({
+                "article_id": a["article_id"],
+                "title": a["title"],
+                "url": a["url"],
+                "source_domain": a.get("source_domain"),
+                "published_at": a.get("published_at"),
+                "is_primary": True,
+            })
+
+    for aid, entry in articles_by_agency.items():
+        reg_entry = reg_by_id.get(aid) or {}
+        slug = reg_entry.get("active_slug") or reg_entry.get("slug")
+        if slug:
+            entry["slug"] = slug
+        entry["articles"].sort(
+            key=lambda x: (x["published_at"] or "", x["article_id"]),
+            reverse=True,
+        )
+        # primary_count is "articles this piece is substantively *about*"
+        # — used by sharing_map's "Articles (N)" link so the badge
+        # matches what articles.html actually filters to. The wider
+        # entry["articles"] list (primary + mentions) stays available
+        # for the report page, which surfaces peripheral coverage too.
+        entry["primary_count"] = sum(
+            1 for a in entry["articles"] if a.get("is_primary")
+        )
+
     out = {
         "articles": articles,
         "tags": tags_out,
         "sources": sources_out,
         "namespace_order": namespace_order,
+        "articles_by_agency": articles_by_agency,
         "counts": {
             "total_articles": len(articles),
             "total_tags": len(tags_out),
+            "agencies_with_articles": len(articles_by_agency),
         },
     }
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -15,7 +15,8 @@ function safeSlug(s) { return SLUG_RE.test(s) ? s : ''; }
 Promise.all([
   fetch('data/map_data.json?v=CACHE_BUST').then(r => r.json()),
   fetch('data/agency_changelog.json?v=CACHE_BUST').then(r => r.ok ? r.json() : null).catch(() => null),
-]).then(([data, changelog]) => {
+  fetch('data/articles_data.json?v=CACHE_BUST').then(r => r.ok ? r.json() : null).catch(() => null),
+]).then(([data, changelog, articlesData]) => {
   const markers = data.markers;
   const coords = data.coords;
   const agencyInfo = data.agencyInfo;
@@ -49,6 +50,30 @@ Promise.all([
     });
     return result;
   }
+  // Article counts keyed by both slug and agency_id so the info panel
+  // can show "Articles (N) →" for the selected agency regardless of how
+  // it's identified. Uses primary_count (articles substantively about
+  // this agency) rather than the full count — articles.html filters on
+  // primary subjects too, so the badge here matches what the user sees
+  // after clicking through. Falls back to empty map when articles_data
+  // failed to load (offline build, fetch error) — links just don't show.
+  const articleCountBySlug = Object.create(null);
+  const articleCountByAgencyId = Object.create(null);
+  if (articlesData && articlesData.articles_by_agency) {
+    for (const aid in articlesData.articles_by_agency) {
+      const entry = articlesData.articles_by_agency[aid];
+      const n = entry.primary_count || 0;
+      if (!n) continue;
+      articleCountByAgencyId[aid] = n;
+      if (entry.slug) articleCountBySlug[entry.slug] = n;
+    }
+  }
+  function articleCountFor(slug, agencyId) {
+    if (slug && articleCountBySlug[slug]) return articleCountBySlug[slug];
+    if (agencyId && articleCountByAgencyId[agencyId]) return articleCountByAgencyId[agencyId];
+    return 0;
+  }
+
   const changelogBySlug = (changelog && changelog.by_slug) || {};
   const changelogMeta = changelog || { window_days: 90, tracking_days: null, window_complete: false };
   let showChanges = localStorage.getItem('smalpr-show-changes') !== 'false';
@@ -480,6 +505,10 @@ Promise.all([
     html += '<h3>' + escapeHtml(agencyInfo[m.slug]?.name || m.slug) + ' <a href="' + escapeHtml(shareUrl) + '" data-share-url="' + escapeHtml(shareUrl) + '" style="font-size:14px;text-decoration:none" title="Copy link">\ud83d\udd17</a></h3>';
     html += '<p class="stat"><a href="report.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb;font-weight:600">View full report \u2192</a>';
     html += ' &middot; <a href="justifications.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb">Justifications \u2192</a>';
+    const artCount = articleCountFor(m.slug, m.agency_id);
+    if (artCount > 0) {
+      html += ' &middot; <a href="articles.html?agency=' + encodeURIComponent(m.slug) + '" style="color:#2563eb">Articles (' + artCount + ') \u2192</a>';
+    }
     if (m.crawled) {
       html += ' &middot; <a href="https://transparency.flocksafety.com/' + safeSlug(m.slug) + '" target="_blank" style="color:#2563eb">Transparency portal \u2197</a>';
     }
@@ -743,6 +772,10 @@ Promise.all([
       let html = '<h3>' + escapeHtml(info.name || slug) + '</h3>';
       html += '<p class="stat" style="color:#f97316">No map location</p>';
       html += '<p class="stat"><a href="report.html?agency=' + encodeURIComponent(slug) + '" style="color:#2563eb;font-weight:600">View full report \u2192</a>';
+      const offMapArtCount = articleCountFor(slug, info.agency_id);
+      if (offMapArtCount > 0) {
+        html += ' &middot; <a href="articles.html?agency=' + encodeURIComponent(slug) + '" style="color:#2563eb">Articles (' + offMapArtCount + ') \u2192</a>';
+      }
       if (info.crawled) {
         html += ' &middot; <a href="https://transparency.flocksafety.com/' + safeSlug(slug) + '" target="_blank" style="color:#2563eb">Transparency portal \u2197</a>';
       }


### PR DESCRIPTION
## Summary

- **articles.html**: new "Filter by city or agency" search box (modeled on report.html's toolbar search). Selecting a city narrows the article list, map, and tag filters to articles substantively about that city. Selected agency appears as a prominent in-place pin with a "× Remove filter" button.
- **Deep links**: `articles.html?agency=<slug-or-agency-id>` carries users straight to the filtered view. Sharing map info panels grow an "Articles (N) →" link to that URL when there's primary coverage for the agency.
- **report.html**: new "Press Coverage" table per agency, with a "primary subject" badge to distinguish substantive coverage from peripheral citations.
- **Map polish**: cluster bubbles now show "ARTICLES / CITIES" instead of just an agency count; individual bubbles get hover tooltips ("Berkeley CA PD — 1 article") to fix the prior gap where un-clustered markers had no on-hover label.

## Filter semantics

Filter matches on `primary_subject_agencies` only, not the broader `agencies[]` mentions list. Mentions are noisy — e.g. a piece about Bloomington IN can be tagged with Bloomington IL PD as a disambiguation safety net, and matching on that would leak the article into the wrong city's filter result. `articles_by_agency` carries both, with a `primary_count` summary field used by sharing_map's count badge so the link's "(N)" matches what the filter actually surfaces.

## Test plan

- [ ] `articles.html` — type "san mateo", "berkeley", "san francisco" and confirm the search dropdown / filter narrowing
- [ ] `articles.html?agency=san-mateo-ca-pd` — pin renders, list and map are filtered, "× Remove filter" clears
- [ ] Multi-subject articles (e.g. SM+Foster City) — filtering by SM doesn't drop an orphan Foster City pin
- [ ] `sharing_map.html` — pick any agency with coverage (SF, Berkeley, SMPD) and confirm "Articles (N) →" links through correctly
- [ ] `report.html?agency=san-mateo-ca-pd` — scroll past Regional Context for the "Press Coverage" section
- [ ] Map cluster bubbles show "N / M" format; un-clustered bubbles have hover tooltips
- [ ] `pytest tests/test_map_smoke.py tests/test_lint_articles.py tests/test_article_pr_body.py tests/test_discover_articles.py` (63 passing locally after rebase)