### PR TITLE
Derive 30-day search count from audit CSV when portal omits the stat

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -655,11 +655,23 @@
 
     // ── Metric 1: Searches performed ─────────────────────────────
     {
-      const v = stats.searches_30d;
+      const portalV = stats.searches_30d;
+      const audit30 = stats.searches_30d_audit;  // {count, window_start, window_end} or null
+      // If the portal doesn't surface a top-line searches_30d but it
+      // (or a PRA import) embeds a search-audit CSV, fall back to
+      // counting rows in a trailing 30-day window. The transparency
+      // checklist still flags the not-published gap; this just lets
+      // the activity block carry a real number instead of "not
+      // reported."
+      const usingAudit = portalV == null && audit30 != null;
+      const v = portalV != null ? portalV : (audit30 ? audit30.count : null);
       const notReported = v == null;
       const pctile = percentiles.searches_30d;
       const lpctile = localPct.searches_30d;
-      const pills = rankPillsForMetric({
+      // Skip rank pills when the value came from the audit fallback:
+      // build-side percentiles were computed against the null portal
+      // stat, so they don't reflect this value.
+      const pills = usingAudit ? "" : rankPillsForMetric({
         pctile, med: medians.searches_30d,
         lpctile, lmed: localMed.searches_30d,
         lsamp: localSample.searches_30d,
@@ -669,16 +681,22 @@
       });
       const rawCell = statsCellHtml({
         cellClass: "raw",
-        concernClass: notReported ? "" : (cellClassFor(pctile, "searches_30d")),
-        label: "Agency raw",
+        concernClass: (notReported || usingAudit) ? "" : (cellClassFor(pctile, "searches_30d")),
+        label: usingAudit ? "Agency raw (computed)" : "Agency raw",
         value: v,
         valueIsNotReported: notReported,
         notReportedHint: notReported ? notReportedHintFor(report, "searches_30d") : "",
         rankPillsHtml: pills,
       });
-      // Per-capita cell
-      const per = per1k.searches_30d;
-      const pvPills = rankPillsForMetric({
+      // Per-capita cell. The build-side per-capita value is only
+      // populated when the portal stat is present, so when we're
+      // showing an audit-derived count we compute the rate here from
+      // the same population denominator the build uses.
+      const popDenom = report.population || null;
+      const per = portalV != null
+        ? per1k.searches_30d
+        : (usingAudit && popDenom ? (audit30.count / popDenom * 1000) : null);
+      const pvPills = usingAudit ? "" : rankPillsForMetric({
         pctile: per1kPct.searches_30d, med: per1kMed.searches_30d,
         lpctile: localPerPct.searches_30d, lmed: localPerMed.searches_30d,
         lsamp: localSample.searches_30d,
@@ -691,18 +709,22 @@
         : "";
       const perCell = statsCellHtml({
         cellClass: "per-capita",
-        concernClass: cellClassFor(per1kPct.searches_30d, "searches_30d"),
-        label: "Per 1,000 residents",
+        concernClass: usingAudit ? "" : cellClassFor(per1kPct.searches_30d, "searches_30d"),
+        label: usingAudit ? "Per 1,000 residents (computed)" : "Per 1,000 residents",
         value: per,
         valueIsNotReported: notReported,
         extrasHtml: pvExtras,
         rankPillsHtml: pvPills,
       });
+      const auditCaveat = usingAudit
+        ? `Not surfaced as a top-line stat on ${short}'s transparency portal; count derived from the search-audit CSV ${short} publishes (or that we obtained via PRA). Window: ${audit30.window_start} to ${audit30.window_end}. Peer rank omitted — peers' counts are reported, not computed.`
+        : "";
       html += metricBlockHtml({
         title: `Searches performed by ${short}`,
         subtitle: "last 30 days",
-        concern: !notReported && (pctile >= 60 || lpctile >= 60),
-        concernMild: notReported,
+        concern: !notReported && !usingAudit && (pctile >= 60 || lpctile >= 60),
+        concernMild: notReported || usingAudit,
+        caveatHtml: auditCaveat,
         cellsHtml: rawCell + perCell,
         inlineConcernHtml: concernsForSection(report, "stat:searches_30d"),
       });

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -471,6 +471,43 @@ def _load_audit_json(reg_entry):
     return {}
 
 
+def _audit_searches_30d(audit):
+    """Trailing 30-day search count derived from the union audit log.
+
+    Anchored to the most recent searchDate present, not real-time —
+    Flock's CSV is a rolling 30-day window and our PRA-imported rows
+    extend further back, so the answer to "how many searches did the
+    agency do in a 30-day month" should slide with whatever data we
+    have. Returns {count, window_start, window_end} or None when there
+    are no usable date rows.
+    """
+    from datetime import date as _date, timedelta
+    rows = audit.get("rows") or []
+    dates = []
+    for r in rows:
+        d = r.get("searchDate")
+        if not d:
+            continue
+        d = str(d)[:10]
+        if len(d) == 10:
+            dates.append(d)
+    if not dates:
+        return None
+    try:
+        max_d = _date.fromisoformat(max(dates))
+    except ValueError:
+        return None
+    cutoff = max_d - timedelta(days=29)
+    cutoff_str = cutoff.isoformat()
+    max_str = max_d.isoformat()
+    count = sum(1 for d in dates if d >= cutoff_str)
+    return {
+        "count": count,
+        "window_start": cutoff_str,
+        "window_end": max_str,
+    }
+
+
 def _audit_vs_inbound(audit, direct_inbound):
     """Compare audit-log row networkCounts against the agency's own
     published inbound list size.
@@ -1682,19 +1719,25 @@ def main():
             key=lambda x: x["removed_on"], reverse=True
         )
 
-        # ── Audit-log vs. inbound check ──
-        # If the agency publishes a search audit, compare per-search
-        # networkCount against the effective inbound size. Searches
-        # that touch more networks than the agency receives data from
-        # imply use of Flock's statewide/nationwide lookup features.
-        # Effective inbound = max(direct portal-listed, inferred from
-        # other agencies' outbound) — the bigger of the two is the
-        # most charitable read.
+        # ── Audit-log derived fields ──
+        # If the agency publishes a search audit (or we've imported one
+        # via PRA), surface two derived signals:
+        #   1. audit_vs_inbound: per-search networkCount vs the agency's
+        #      own published inbound list size — searches touching more
+        #      networks than the agency receives from imply use of
+        #      Flock's statewide/nationwide lookup features.
+        #   2. searches_30d_audit: a trailing 30-day count anchored to
+        #      the latest searchDate in the union log. Lets agencies
+        #      that publish the CSV but not a top-line "searches in the
+        #      last 30 days" stat still get a number in the report.
         audit_vs_inbound = None
-        if crawled and inbound_count:
+        searches_30d_audit = None
+        if crawled:
             audit_json = _load_audit_json(reg)
             if audit_json:
-                audit_vs_inbound = _audit_vs_inbound(audit_json, inbound_count)
+                if inbound_count:
+                    audit_vs_inbound = _audit_vs_inbound(audit_json, inbound_count)
+                searches_30d_audit = _audit_searches_30d(audit_json)
 
         # ── Inferred inbound (for uncrawled agencies mostly) ──
         inbound_source_ids = set(inbound_ids) | inbound_inferred_by_id.get(aid, set())
@@ -1831,6 +1874,10 @@ def main():
                 "hotlist_hits_30d": hotlist_hits,
                 "hotlists_alerted_on": hotlists_alerted_on,
                 "searches_30d": searches_30d,
+                # Derived count from the audit-log CSV when the agency
+                # publishes one but doesn't surface a top-line stat.
+                # {count, window_start, window_end} or None.
+                "searches_30d_audit": searches_30d_audit,
                 "outbound_count": outbound_count,
                 "inbound_count": inbound_count,
             },


### PR DESCRIPTION
## Summary
- Some agencies embed a `search_audit_csv` on their transparency portal but don't surface a top-line `searches_30d` number. SMPD is the motivating case (audit went public 5/4–5/11); Benicia is the same pattern.
- When the audit log (portal-published + PRA-imported) is available but the portal stat is null, derive a trailing 30-day count anchored to the latest `searchDate` and show it in the report's activity block with a caveat naming the source and window.
- Rank pills are intentionally omitted in the fallback path — peers' percentile is computed against reported counts, not derived ones, so the comparison would be mixed-methodology.

## What renders

Without the fix, SMPD's "Searches performed" block read **not reported**. With it:

> **Searches performed by San Mateo** — last 30 days
> _Not surfaced as a top-line stat on San Mateo's transparency portal; count derived from the search-audit CSV San Mateo publishes (or that we obtained via PRA). Window: 2026-04-11 to 2026-05-10. Peer rank omitted — peers' counts are reported, not computed._
> Agency raw (computed): **684**
> Per 1,000 residents (computed): **6.61**

The Transparency checklist still flags "Does not report 30-day search counts" independently — this PR doesn't paper over the disclosure gap, it just fills the activity block with a real number.

Sanity-checked against agencies that publish BOTH: derived count matches portal-published count exactly across 10 sampled agencies (same row-count methodology).

## Test plan
- [x] `uv run python scripts/build_audit_log.py && uv run python scripts/build_report_data.py` succeeds
- [x] `report_data.json` has `searches_30d_audit` for SMPD + Benicia
- [x] Headless render of SMPD report shows derived count + caveat
- [x] Headless render of Alameda (control, has portal stat) unchanged
- [x] `node -c docs/js/report.js` clean