### PR TITLE
chore: refresh flock transparency data

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -272,6 +272,33 @@
     "flags": []
   },
   {
+    "agency_id": "d561e3c0-2216-56aa-8a7a-b2a1ac12d6ad",
+    "slug": "appleton-wi-pd",
+    "flock_active_slug": "appleton-wi-pd",
+    "flock_slugs": [
+      "appleton-wi-pd"
+    ],
+    "flock_names": [
+      "Appleton WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5502375",
+      "name": "Appleton",
+      "state": "WI",
+      "lat": 44.278873,
+      "lng": -88.388284
+    }
+  },
+  {
     "agency_id": "ab8f096c-5091-5b76-b9a0-1c0cd5c9bfe7",
     "slug": "arlington-pd-wa",
     "flock_active_slug": "arlington-pd-wa",
@@ -432,6 +459,56 @@
       "lng": -117.971286
     },
     "flags": []
+  },
+  {
+    "agency_id": "4f3529e4-27d7-5da5-86a9-07a72a3c70e1",
+    "slug": "bannock-county-id-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Bannock County ID SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "16005",
+      "name": "Bannock",
+      "state": "ID",
+      "lat": 42.692921,
+      "lng": -112.228982
+    }
+  },
+  {
+    "agency_id": "8b2b1c99-6737-5511-9d7d-88cfd416ba8f",
+    "slug": "barron-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Barron WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5504875",
+      "name": "Barron",
+      "state": "WI",
+      "lat": 45.402192,
+      "lng": -91.84435
+    }
   },
   {
     "agency_id": "21b39f7d-aa0c-57f4-bc53-5b10e9444ba4",
@@ -596,6 +673,31 @@
     "flags": []
   },
   {
+    "agency_id": "873cdd6b-ec80-5057-a0b9-d308bef129ea",
+    "slug": "ben-hill-county-ga-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Ben Hill County GA SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "13017",
+      "name": "Ben Hill",
+      "state": "GA",
+      "lat": 31.740772,
+      "lng": -83.147197
+    }
+  },
+  {
     "agency_id": "c7aa543c-ebc0-5058-9720-c2dd84914ca6",
     "slug": "benicia-ca-pd",
     "flock_active_slug": "benicia-ca-pd",
@@ -731,6 +833,27 @@
     "flags": []
   },
   {
+    "agency_id": "1bca513d-bb3d-5f66-bbaf-2d8988296f97",
+    "slug": "brookfield-properties-il",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Brookfield Properties (IL)"
+    ],
+    "display_name": null,
+    "agency_role": "other",
+    "agency_type": "other",
+    "website": null,
+    "tags": [
+      "needs-review"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "state-only",
+      "state": "IL"
+    }
+  },
+  {
     "agency_id": "3ca693da-4c88-5e74-b08c-4321f96f3184",
     "slug": "buckeye-az-pd",
     "flock_active_slug": "buckeye-az-pd",
@@ -810,6 +933,31 @@
       "lng": -118.326405
     },
     "flags": []
+  },
+  {
+    "agency_id": "815e6875-ca3d-5b09-951a-fc3f83409e1e",
+    "slug": "burlington-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Burlington WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5511200",
+      "name": "Burlington",
+      "state": "WI",
+      "lat": 42.675249,
+      "lng": -88.271871
+    }
   },
   {
     "agency_id": "3ea9aacc-f194-58bc-a621-9024ea89293a",
@@ -1104,6 +1252,33 @@
     "flags": []
   },
   {
+    "agency_id": "33d6b084-6b5f-518a-ae00-b21ed8d7af93",
+    "slug": "cascade-wi-pd-inactive",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Cascade WI PD [Inactive]"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [
+      "inactive"
+    ],
+    "geo": {
+      "kind": "place",
+      "fips": "5512825",
+      "name": "Cascade",
+      "state": "WI",
+      "lat": 43.661474,
+      "lng": -88.008806
+    }
+  },
+  {
     "agency_id": "433df0bc-bbfd-5183-b5e4-02bf458f85e8",
     "slug": "cathedral-city-ca-pd",
     "flock_active_slug": "cathedral-city-ca-pd",
@@ -1156,6 +1331,56 @@
       "lng": -122.970947
     },
     "flags": []
+  },
+  {
+    "agency_id": "54cc1aa8-af44-5e35-993a-56a8c7d6cf5d",
+    "slug": "chenequa-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Chenequa WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5514225",
+      "name": "Chenequa",
+      "state": "WI",
+      "lat": 43.123134,
+      "lng": -88.381387
+    }
+  },
+  {
+    "agency_id": "417a02cc-82c6-5638-a5c2-088a14d59beb",
+    "slug": "chilton-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Chilton WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5514475",
+      "name": "Chilton",
+      "state": "WI",
+      "lat": 44.030188,
+      "lng": -88.161667
+    }
   },
   {
     "agency_id": "2329d5a6-b311-56d2-bd0b-3d6caa375ab0",
@@ -1267,6 +1492,31 @@
     "flags": []
   },
   {
+    "agency_id": "fd94623a-b937-553c-afb2-3ec98472fe7a",
+    "slug": "clintonville-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Clintonville WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5515725",
+      "name": "Clintonville",
+      "state": "WI",
+      "lat": 44.62212,
+      "lng": -88.751714
+    }
+  },
+  {
     "agency_id": "daeeaa81-10ea-53a3-86e8-684280bd07c8",
     "slug": "colma-ca-pd",
     "flock_active_slug": "colma-ca-pd",
@@ -1292,6 +1542,56 @@
       "lng": -122.452821
     },
     "flags": []
+  },
+  {
+    "agency_id": "882cf9c2-d07f-5e7c-8255-3e2fbf522d6a",
+    "slug": "columbus-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Columbus WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5516450",
+      "name": "Columbus",
+      "state": "WI",
+      "lat": 43.336805,
+      "lng": -89.029988
+    }
+  },
+  {
+    "agency_id": "05643b49-1d44-5bae-9635-ba58b8e8550e",
+    "slug": "conneaut-oh-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Conneaut OH PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "3918350",
+      "name": "Conneaut",
+      "state": "OH",
+      "lat": 41.927299,
+      "lng": -80.568382
+    }
   },
   {
     "agency_id": "86e42e3d-4245-5dc8-b64c-89d45592a7bb",
@@ -1375,6 +1675,31 @@
     "flags": []
   },
   {
+    "agency_id": "d589c3b9-b263-5ff1-bff0-a45c9bc06007",
+    "slug": "cudahy-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Cudahy WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5517975",
+      "name": "Cudahy",
+      "state": "WI",
+      "lat": 42.946711,
+      "lng": -87.864016
+    }
+  },
+  {
     "agency_id": "ecbb841f-9df2-5841-9b28-91f1ce5af0fa",
     "slug": "culver-city-ca-pd",
     "flock_active_slug": "culver-city-ca-pd",
@@ -1456,6 +1781,31 @@
     }
   },
   {
+    "agency_id": "97e518bd-7e01-5e9e-8ca0-2974a09a4afe",
+    "slug": "delafield-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Delafield WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5519400",
+      "name": "Delafield",
+      "state": "WI",
+      "lat": 43.067421,
+      "lng": -88.388833
+    }
+  },
+  {
     "agency_id": "5bb589eb-0d1f-50f1-9a05-55e6b12629fa",
     "slug": "delano-ca-pd",
     "flock_active_slug": "delano-ca-pd",
@@ -1481,6 +1831,31 @@
       "lng": -119.264221
     },
     "flags": []
+  },
+  {
+    "agency_id": "98f968a1-9703-5d3d-b519-08bb80ee7e09",
+    "slug": "dickeyville-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Dickeyville WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5520175",
+      "name": "Dickeyville",
+      "state": "WI",
+      "lat": 42.624653,
+      "lng": -90.591336
+    }
   },
   {
     "agency_id": "ae6099b6-dbb6-520f-b490-73add6ae3107",
@@ -1726,6 +2101,31 @@
     "flags": []
   },
   {
+    "agency_id": "29545821-ba90-50b6-93a9-3804382846bb",
+    "slug": "fitchburg-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Fitchburg WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5525950",
+      "name": "Fitchburg",
+      "state": "WI",
+      "lat": 42.985782,
+      "lng": -89.425334
+    }
+  },
+  {
     "agency_id": "66a47e2e-147b-55eb-ba49-6b49239dc935",
     "slug": "folsom-ca-pd",
     "flock_active_slug": "folsom-ca-pd",
@@ -1751,6 +2151,56 @@
       "lng": -121.141635
     },
     "flags": []
+  },
+  {
+    "agency_id": "5ec7a404-e1e0-5bb8-9abf-10a9fc4c1014",
+    "slug": "fond-du-lac-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Fond du Lac County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55039",
+      "name": "Fond du Lac",
+      "state": "WI",
+      "lat": 43.754722,
+      "lng": -88.493284
+    }
+  },
+  {
+    "agency_id": "5074e471-7489-537d-a2f7-e5cde6268565",
+    "slug": "fond-du-lac-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Fond du Lac WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5526275",
+      "name": "Fond du Lac",
+      "state": "WI",
+      "lat": 43.772182,
+      "lng": -88.440264
+    }
   },
   {
     "agency_id": "8d40ae56-8e48-570e-b485-f6c4a4464423",
@@ -1830,6 +2280,31 @@
       "lng": -123.801757
     },
     "flags": []
+  },
+  {
+    "agency_id": "057044d2-b201-53a3-a63d-057f5ca01e53",
+    "slug": "fort-lauderdale-fl-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Fort Lauderdale FL PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "1224000",
+      "name": "Fort Lauderdale",
+      "state": "FL",
+      "lat": 26.141227,
+      "lng": -80.146731
+    }
   },
   {
     "agency_id": "c7534013-784e-5c7b-8acb-b88b2ad8dfbe",
@@ -1940,6 +2415,56 @@
     "flags": []
   },
   {
+    "agency_id": "986e7419-338b-5915-8cd7-ae2752c377eb",
+    "slug": "genoa-city-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Genoa City WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5528675",
+      "name": "Genoa City",
+      "state": "WI",
+      "lat": 42.5065,
+      "lng": -88.319271
+    }
+  },
+  {
+    "agency_id": "2422a06a-aff1-515a-bca3-cb00cb43f6b1",
+    "slug": "germantown-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Germantown WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5528875",
+      "name": "Germantown",
+      "state": "WI",
+      "lat": 43.234527,
+      "lng": -88.124999
+    }
+  },
+  {
     "agency_id": "cf1a9b74-20d6-5ca7-8c97-47db0f62db96",
     "slug": "gilroy-ca-pd",
     "flock_active_slug": "gilroy-ca-pd",
@@ -1994,6 +2519,56 @@
     "flags": []
   },
   {
+    "agency_id": "7afda64b-5950-562f-bf80-66c791a6ed2a",
+    "slug": "glendale-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Glendale WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5529400",
+      "name": "Glendale",
+      "state": "WI",
+      "lat": 43.126142,
+      "lng": -87.927195
+    }
+  },
+  {
+    "agency_id": "aeec6def-4785-5a47-a156-27f2d79f927d",
+    "slug": "glenrock-wy-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Glenrock WY PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5632435",
+      "name": "Glenrock",
+      "state": "WY",
+      "lat": 42.856473,
+      "lng": -105.862355
+    }
+  },
+  {
     "agency_id": "4936c402-8bf3-5c0a-9f55-f85aa0e5df48",
     "slug": "grass-valley-ca-pd",
     "flock_active_slug": "grass-valley-ca-pd",
@@ -2019,6 +2594,107 @@
       "lng": -121.052654
     },
     "flags": []
+  },
+  {
+    "agency_id": "3157a2bf-3ac9-5534-a6c2-5353df154f45",
+    "slug": "great-parks-of-hamilton-county-oh-pd",
+    "flock_active_slug": "great-parks-of-hamilton-county-oh-pd",
+    "flock_slugs": [
+      "great-parks-of-hamilton-county-oh-pd"
+    ],
+    "flock_names": [
+      "Great Parks of Hamilton County OH PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "39061",
+      "name": "Hamilton",
+      "state": "OH",
+      "lat": 39.196927,
+      "lng": -84.544187
+    }
+  },
+  {
+    "agency_id": "7a0d0f8a-6792-502b-85c4-1c1680e4784c",
+    "slug": "green-bay-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Green Bay WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5531000",
+      "name": "Green Bay",
+      "state": "WI",
+      "lat": 44.521542,
+      "lng": -87.986568
+    }
+  },
+  {
+    "agency_id": "2d2c6129-4d1d-51eb-9ce9-c4e2a48b37ff",
+    "slug": "greendale-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Greendale WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5531125",
+      "name": "Greendale",
+      "state": "WI",
+      "lat": 42.939993,
+      "lng": -88.000857
+    }
+  },
+  {
+    "agency_id": "0b656cf9-d4d2-5c1c-8f08-31c5e3e4623a",
+    "slug": "greenhills-oh-police-department-inactive",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Greenhills OH Police Department [Inactive]"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "federal",
+    "website": null,
+    "tags": [
+      "federal",
+      "public"
+    ],
+    "flags": [
+      "inactive"
+    ],
+    "geo": {
+      "kind": "state-only",
+      "state": "OH"
+    }
   },
   {
     "agency_id": "6e00bdda-c3f3-5c16-81d8-22d6009bfb37",
@@ -2075,6 +2751,56 @@
     "flags": []
   },
   {
+    "agency_id": "b4628e4d-0519-5ea8-95cc-1c7239d5bf2a",
+    "slug": "hartford-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Hartford WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5533000",
+      "name": "Hartford",
+      "state": "WI",
+      "lat": 43.322467,
+      "lng": -88.377737
+    }
+  },
+  {
+    "agency_id": "68a77a5f-6a59-56cc-b699-52df994e6b9d",
+    "slug": "hartland-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Hartland WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5533100",
+      "name": "Hartland",
+      "state": "WI",
+      "lat": 43.102352,
+      "lng": -88.335595
+    }
+  },
+  {
     "agency_id": "831b5ef5-d075-5433-b2d0-60f3a4e95ecd",
     "slug": "hayward-ca-pd",
     "flock_active_slug": "hayward-ca-pd",
@@ -2100,6 +2826,33 @@
       "lng": -122.104015
     },
     "flags": []
+  },
+  {
+    "agency_id": "0686d2fb-93de-55cb-9f16-2408466316aa",
+    "slug": "hayward-wi-pd-inactive",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Hayward WI PD [Inactive]"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [
+      "inactive"
+    ],
+    "geo": {
+      "kind": "place",
+      "fips": "5533450",
+      "name": "Hayward",
+      "state": "WI",
+      "lat": 46.006588,
+      "lng": -91.489684
+    }
   },
   {
     "agency_id": "ad35fbf9-4e02-5b42-b917-16bbe751564d",
@@ -2210,6 +2963,27 @@
     "flags": []
   },
   {
+    "agency_id": "908eb9fc-dbce-5d9f-9056-38667560a8ee",
+    "slug": "hobart-lawrence-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Hobart-Lawrence WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "state-only",
+      "state": "WI"
+    }
+  },
+  {
     "agency_id": "a3181593-1121-5cc0-aae2-beb7d164ed58",
     "slug": "hollister-ca-pd",
     "flock_active_slug": "hollister-ca-pd",
@@ -2235,6 +3009,31 @@
       "lng": -121.398598
     },
     "flags": []
+  },
+  {
+    "agency_id": "6b534ee1-c5d3-5fc8-96f4-49087214665b",
+    "slug": "horicon-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Horicon WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5535750",
+      "name": "Horicon",
+      "state": "WI",
+      "lat": 43.445001,
+      "lng": -88.640328
+    }
   },
   {
     "agency_id": "e881b333-fb53-5bec-9510-9d3c68095e89",
@@ -2264,6 +3063,31 @@
     "flags": []
   },
   {
+    "agency_id": "6683c1c6-b8b6-5628-83e2-3574bd6417b3",
+    "slug": "hurley-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Hurley WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5536525",
+      "name": "Hurley",
+      "state": "WI",
+      "lat": 46.444285,
+      "lng": -90.211266
+    }
+  },
+  {
     "agency_id": "f0611d4b-4911-5e4c-ae43-e30fd897e328",
     "slug": "huron-oh-pd",
     "flock_active_slug": "huron-oh-pd",
@@ -2288,6 +3112,81 @@
       "state": "OH",
       "lat": 41.397631,
       "lng": -82.562569
+    }
+  },
+  {
+    "agency_id": "531db486-3572-57ef-8871-8a70d17afcbc",
+    "slug": "jackson-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Jackson County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55053",
+      "name": "Jackson",
+      "state": "WI",
+      "lat": 44.32459,
+      "lng": -90.79951
+    }
+  },
+  {
+    "agency_id": "eb16d89c-c5c8-5ff2-b844-335ce50db3e7",
+    "slug": "jefferson-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Jefferson County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55055",
+      "name": "Jefferson",
+      "state": "WI",
+      "lat": 43.013804,
+      "lng": -88.773985
+    }
+  },
+  {
+    "agency_id": "6e7fd746-e913-5c11-95fe-d0526915d764",
+    "slug": "jefferson-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Jefferson WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5537900",
+      "name": "Jefferson",
+      "state": "WI",
+      "lat": 43.003955,
+      "lng": -88.808473
     }
   },
   {
@@ -2343,6 +3242,31 @@
     "flags": []
   },
   {
+    "agency_id": "5d2f0875-291d-5645-b93e-19da7e21217f",
+    "slug": "kohler-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Kohler WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5540275",
+      "name": "Kohler",
+      "state": "WI",
+      "lat": 43.739983,
+      "lng": -87.776838
+    }
+  },
+  {
     "agency_id": "af9ca9ad-22f2-5472-bbdd-f195383212bf",
     "slug": "lafayette-in-pd",
     "flock_active_slug": "lafayette-pd-in",
@@ -2395,6 +3319,31 @@
       "lng": -122.745217
     },
     "flags": []
+  },
+  {
+    "agency_id": "658ed32a-7282-53f6-bdca-7314f265df64",
+    "slug": "lake-mills-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Lake Mills WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5541675",
+      "name": "Lake Mills",
+      "state": "WI",
+      "lat": 43.077639,
+      "lng": -88.906411
+    }
   },
   {
     "agency_id": "ad5d1953-7d8a-5cf5-b0c7-c7c12bd430d3",
@@ -2641,6 +3590,31 @@
     "flags": []
   },
   {
+    "agency_id": "fbf25caa-b669-544c-96e2-effdcaec6937",
+    "slug": "madison-sd-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Madison SD PD"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4640220",
+      "name": "Madison",
+      "state": "SD",
+      "lat": 44.006223,
+      "lng": -97.108481
+    }
+  },
+  {
     "agency_id": "32431759-b238-510c-928f-5328978003dd",
     "slug": "mammoth-lakes-ca-pd",
     "flock_active_slug": "mammoth-lakes-ca-pd",
@@ -2666,6 +3640,31 @@
       "lng": -118.988432
     },
     "flags": []
+  },
+  {
+    "agency_id": "8dacfabc-13d4-5cec-9939-3f72ed53441d",
+    "slug": "manitowoc-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Manitowoc WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5548500",
+      "name": "Manitowoc",
+      "state": "WI",
+      "lat": 44.097981,
+      "lng": -87.678945
+    }
   },
   {
     "agency_id": "731b41be-02b5-52e5-a7f7-3d00b5d034e9",
@@ -2747,6 +3746,31 @@
       "lng": -121.789368
     },
     "flags": []
+  },
+  {
+    "agency_id": "ed166e16-86e5-5557-8466-67e57182c825",
+    "slug": "marion-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Marion WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5549400",
+      "name": "Marion",
+      "state": "WI",
+      "lat": 44.677313,
+      "lng": -88.902362
+    }
   },
   {
     "agency_id": "e940061b-0f3b-53ba-a1cb-a2e12672a989",
@@ -2831,6 +3855,31 @@
     "flags": []
   },
   {
+    "agency_id": "699b8967-4a13-51b7-b92f-af2aa9410aed",
+    "slug": "menominee-co-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Menominee Co. WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55078",
+      "name": "Menominee",
+      "state": "WI",
+      "lat": 44.991304,
+      "lng": -88.669251
+    }
+  },
+  {
     "agency_id": "fdbb9d9e-7030-50bf-b82f-e393edc99f86",
     "slug": "merced-county-ca-so",
     "flock_active_slug": "merced-county-ca-so",
@@ -2856,6 +3905,56 @@
       "lng": -120.722802
     },
     "flags": []
+  },
+  {
+    "agency_id": "07b084ce-7dd3-5a7c-81aa-12612a4fb028",
+    "slug": "meriwether-county-ga-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Meriwether County GA SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "13199",
+      "name": "Meriwether",
+      "state": "GA",
+      "lat": 33.029267,
+      "lng": -84.667058
+    }
+  },
+  {
+    "agency_id": "c1c9169c-41ee-5ec2-8484-96ebe8fa270b",
+    "slug": "merrill-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Merrill WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5551250",
+      "name": "Merrill",
+      "state": "WI",
+      "lat": 45.180635,
+      "lng": -89.700339
+    }
   },
   {
     "agency_id": "0046d4c9-07ce-5064-aa1c-0a02d26d0360",
@@ -2910,6 +4009,31 @@
       "lng": -120.71837
     },
     "flags": []
+  },
+  {
+    "agency_id": "7a688598-e699-5e87-a05e-5c50ab975c4e",
+    "slug": "mondovi-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Mondovi WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5553600",
+      "name": "Mondovi",
+      "state": "WI",
+      "lat": 44.570255,
+      "lng": -91.666851
+    }
   },
   {
     "agency_id": "7c43fa8b-01d2-5d3a-9e7b-92bd1bf6435f",
@@ -3209,6 +4333,31 @@
     "flags": []
   },
   {
+    "agency_id": "29ca7032-8c4f-5e51-bb48-e6992795e20b",
+    "slug": "neenah-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Neenah WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5555750",
+      "name": "Neenah",
+      "state": "WI",
+      "lat": 44.164925,
+      "lng": -88.479628
+    }
+  },
+  {
     "agency_id": "8b59e382-0153-52e4-b127-fdfadbe7a54c",
     "slug": "nevada-county-ca-so",
     "flock_active_slug": "nevada-county-ca-so",
@@ -3236,6 +4385,31 @@
     "flags": []
   },
   {
+    "agency_id": "bf114946-58fe-564c-99bb-145427ee04a8",
+    "slug": "new-lisbon-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "New Lisbon WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5556900",
+      "name": "New Lisbon",
+      "state": "WI",
+      "lat": 43.875292,
+      "lng": -90.162379
+    }
+  },
+  {
     "agency_id": "684c2432-b5ab-5c9e-9bc7-6dd9df1e3b2f",
     "slug": "newport-beach-pd-ca",
     "flock_active_slug": "newport-beach-pd-ca",
@@ -3261,6 +4435,81 @@
       "lng": -117.890352
     },
     "flags": []
+  },
+  {
+    "agency_id": "8d34f1ad-c556-5d96-907d-d78cc9abdc39",
+    "slug": "norfolk-ne-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Norfolk NE PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "3134615",
+      "name": "Norfolk",
+      "state": "NE",
+      "lat": 42.028216,
+      "lng": -97.427807
+    }
+  },
+  {
+    "agency_id": "9352ca43-949b-5624-b6a6-14d49f2af5ab",
+    "slug": "north-fond-du-lac-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "North Fond Du Lac WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5558000",
+      "name": "North Fond du Lac",
+      "state": "WI",
+      "lat": 43.811004,
+      "lng": -88.48549
+    }
+  },
+  {
+    "agency_id": "5bbd30aa-80aa-5085-ba0c-8963ec096b5e",
+    "slug": "north-hudson-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "North Hudson WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5558050",
+      "name": "North Hudson",
+      "state": "WI",
+      "lat": 44.995765,
+      "lng": -92.754998
+    }
   },
   {
     "agency_id": "c375bce6-848b-5729-aa4c-28a6a21b685f",
@@ -3371,6 +4620,81 @@
     "flags": []
   },
   {
+    "agency_id": "e438af3a-ea48-5498-b897-fb73d5d7af9f",
+    "slug": "oconto-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Oconto WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5559350",
+      "name": "Oconto",
+      "state": "WI",
+      "lat": 44.892663,
+      "lng": -87.868509
+    }
+  },
+  {
+    "agency_id": "9c5b75a1-31cc-5ea4-a559-b69b6014121a",
+    "slug": "ogden-city-ut-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Ogden City UT PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4955980",
+      "name": "Ogden",
+      "state": "UT",
+      "lat": 41.228391,
+      "lng": -111.968147
+    }
+  },
+  {
+    "agency_id": "5b4d9a5a-d842-5b83-b340-859cfce154cc",
+    "slug": "oneida-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Oneida County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55085",
+      "name": "Oneida",
+      "state": "WI",
+      "lat": 45.716176,
+      "lng": -89.534533
+    }
+  },
+  {
     "agency_id": "10d8673e-60c9-5345-a1e1-eb25f18d157b",
     "slug": "ontario-ca-pd",
     "flock_active_slug": "ontario-ca-pd",
@@ -3450,6 +4774,53 @@
       "lng": -121.560069
     },
     "flags": []
+  },
+  {
+    "agency_id": "d495778e-ff26-53df-be67-4f65a5577d88",
+    "slug": "outagamie-county-das-office-wi",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Outagamie County DA's Office WI"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "federal",
+    "website": null,
+    "tags": [
+      "federal",
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "state-only",
+      "state": "WI"
+    }
+  },
+  {
+    "agency_id": "5b87d585-d4d6-5550-90e7-126d1ae7fdfc",
+    "slug": "outagamie-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Outagamie County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55087",
+      "name": "Outagamie",
+      "state": "WI",
+      "lat": 44.418226,
+      "lng": -88.464988
+    }
   },
   {
     "agency_id": "42811e97-66b2-569c-9eb5-71791f5549f6",
@@ -3695,6 +5066,31 @@
     "flags": []
   },
   {
+    "agency_id": "0970e5a4-2c42-5cc2-b497-b131b1ee67fd",
+    "slug": "phillips-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Phillips WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5562450",
+      "name": "Phillips",
+      "state": "WI",
+      "lat": 45.694035,
+      "lng": -90.40142
+    }
+  },
+  {
     "agency_id": "b43d910e-99ca-56e2-8f1f-8f715885c247",
     "slug": "piedmont-ca-pd",
     "flock_active_slug": "piedmont-ca-pd",
@@ -3720,6 +5116,31 @@
       "lng": -122.230024
     },
     "flags": []
+  },
+  {
+    "agency_id": "2779f753-7245-5b78-a720-dcfdc716a90f",
+    "slug": "pittsville-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Pittsville WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5563100",
+      "name": "Pittsville",
+      "state": "WI",
+      "lat": 44.441673,
+      "lng": -90.136571
+    }
   },
   {
     "agency_id": "d5302daa-76cc-5e29-b769-f9723a093309",
@@ -3828,6 +5249,31 @@
     "flags": []
   },
   {
+    "agency_id": "8a283e42-6453-54c7-b511-693956692bff",
+    "slug": "port-washington-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Port Washington WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5564450",
+      "name": "Port Washington",
+      "state": "WI",
+      "lat": 43.384921,
+      "lng": -87.884134
+    }
+  },
+  {
     "agency_id": "f57a9f4b-3015-5edd-93ed-7716591b86f8",
     "slug": "porterville-ca-pd",
     "flock_active_slug": "porterville-ca-pd",
@@ -3853,6 +5299,78 @@
       "lng": -119.0336
     },
     "flags": []
+  },
+  {
+    "agency_id": "daa4c38c-bab7-5c17-9b36-890b77ac6b31",
+    "slug": "poynette-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Poynette WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5564900",
+      "name": "Poynette",
+      "state": "WI",
+      "lat": 43.392165,
+      "lng": -89.404787
+    }
+  },
+  {
+    "agency_id": "dc0ef002-5559-57c7-9094-ab9c354b6c0f",
+    "slug": "price-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Price County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "federal",
+    "website": null,
+    "tags": [
+      "federal",
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "state-only",
+      "state": "WI"
+    }
+  },
+  {
+    "agency_id": "8885957d-08c0-5d61-bf55-a8b24784894f",
+    "slug": "redgranite-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Redgranite WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5566625",
+      "name": "Redgranite",
+      "state": "WI",
+      "lat": 44.053283,
+      "lng": -89.115869
+    }
   },
   {
     "agency_id": "dbb41fa5-9662-50ba-ae51-7061815de463",
@@ -4015,6 +5533,56 @@
       "lng": -121.703406
     },
     "flags": []
+  },
+  {
+    "agency_id": "afa5df93-ed8e-5837-b664-25ef1ef57a5d",
+    "slug": "ripon-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Ripon WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5568175",
+      "name": "Ripon",
+      "state": "WI",
+      "lat": 43.84356,
+      "lng": -88.837936
+    }
+  },
+  {
+    "agency_id": "df065d17-c1cc-52a7-9210-00368db0fa6e",
+    "slug": "riverdale-ut-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Riverdale UT PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4964010",
+      "name": "Riverdale",
+      "state": "UT",
+      "lat": 41.173136,
+      "lng": -112.002256
+    }
   },
   {
     "agency_id": "ae8c6210-8473-5a62-96af-7ea959cb19ff",
@@ -4636,6 +6204,27 @@
     "flags": []
   },
   {
+    "agency_id": "ea85dbdd-5957-5508-9a72-bf380ecd103d",
+    "slug": "sd-lake-traverse-reservation",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "SD - Lake Traverse Reservation"
+    ],
+    "display_name": null,
+    "agency_role": "tribal",
+    "agency_type": "tribal",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "state-only",
+      "state": "SD"
+    }
+  },
+  {
     "agency_id": "e1fd4de4-56ea-5947-91a1-6d8c59bd1974",
     "slug": "seaside-ca-pd",
     "flock_active_slug": "seaside-ca-pd",
@@ -4714,6 +6303,31 @@
       "lng": -122.043556
     },
     "flags": []
+  },
+  {
+    "agency_id": "bb182559-4cad-5dd8-9a82-d9934b26bd60",
+    "slug": "shawano-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Shawano WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5572925",
+      "name": "Shawano",
+      "state": "WI",
+      "lat": 44.777894,
+      "lng": -88.586019
+    }
   },
   {
     "agency_id": "150d904a-950c-59e0-adbe-5885edf71ffd",
@@ -4822,6 +6436,31 @@
       "lng": -118.192761
     },
     "flags": []
+  },
+  {
+    "agency_id": "62a31ee3-bc72-52c7-80fe-cbcef3f142da",
+    "slug": "south-milwaukee-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "South Milwaukee WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5575125",
+      "name": "South Milwaukee",
+      "state": "WI",
+      "lat": 42.912643,
+      "lng": -87.862312
+    }
   },
   {
     "agency_id": "5448e966-a286-5dac-a301-1ed74914217e",
@@ -4958,6 +6597,85 @@
     "flags": []
   },
   {
+    "agency_id": "b741b214-a6eb-5809-9b66-03a12d5bec29",
+    "slug": "sturtevant-wi-pd-inactive",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Sturtevant WI PD [Inactive]"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [
+      "inactive"
+    ],
+    "geo": {
+      "kind": "place",
+      "fips": "5577925",
+      "name": "Sturtevant",
+      "state": "WI",
+      "lat": 42.6989,
+      "lng": -87.901553
+    }
+  },
+  {
+    "agency_id": "8a9af692-fc85-5272-bd09-59d28e1dbc6f",
+    "slug": "summerset-sd-pd",
+    "flock_active_slug": "summerset-sd-pd",
+    "flock_slugs": [
+      "summerset-sd-pd"
+    ],
+    "flock_names": [
+      "Summerset SD PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "geo": {
+      "kind": "place",
+      "fips": "4662155",
+      "name": "Summerset",
+      "state": "SD",
+      "lat": 44.193309,
+      "lng": -103.342237
+    },
+    "flags": []
+  },
+  {
+    "agency_id": "f1350cb6-499b-5ed1-af52-202d5bf21001",
+    "slug": "sun-prairie-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Sun Prairie WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5578600",
+      "name": "Sun Prairie",
+      "state": "WI",
+      "lat": 43.182622,
+      "lng": -89.237824
+    }
+  },
+  {
     "agency_id": "7ef62d29-d50a-5f12-85fe-6061de259c8d",
     "slug": "sunnyvale-ca-pd",
     "flock_active_slug": "sunnyvale-ca-pd",
@@ -5010,6 +6728,32 @@
       "lng": -122.462619
     },
     "flags": []
+  },
+  {
+    "agency_id": "935d12a2-0236-5c39-a334-aa597c2dbeef",
+    "slug": "town-of-milton-wi",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Town of Milton WI"
+    ],
+    "display_name": null,
+    "agency_role": "other",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5552200",
+      "name": "Milton",
+      "state": "WI",
+      "lat": 42.774675,
+      "lng": -88.939991
+    }
   },
   {
     "agency_id": "e29c469f-b2b6-515e-8d3c-93b3075ad896",
@@ -5067,6 +6811,31 @@
     "flags": []
   },
   {
+    "agency_id": "9aaa7c29-aa45-57fb-b159-db6d0e0c597f",
+    "slug": "trempealeau-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Trempealeau County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55121",
+      "name": "Trempealeau",
+      "state": "WI",
+      "lat": 44.30305,
+      "lng": -91.358867
+    }
+  },
+  {
     "agency_id": "babe8d1b-3500-5f2b-a064-c54430c60e74",
     "slug": "truckee-ca-pd",
     "flock_active_slug": "truckee-ca-pd",
@@ -5119,6 +6888,58 @@
       "lng": -122.01884
     },
     "flags": []
+  },
+  {
+    "agency_id": "3ce8db75-5280-5b6f-b105-23acb4c676ec",
+    "slug": "university-of-wisconsin-milwaukee-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "University of Wisconsin - Milwaukee WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5553000",
+      "name": "Milwaukee",
+      "state": "WI",
+      "lat": 43.063348,
+      "lng": -87.966695
+    }
+  },
+  {
+    "agency_id": "bce0b06b-6c84-50f5-be02-ffff11b48463",
+    "slug": "university-of-wisconsin-oshkosh-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "University of Wisconsin - Oshkosh PD"
+    ],
+    "display_name": null,
+    "agency_role": "campus_safety",
+    "agency_type": "university",
+    "website": null,
+    "tags": [
+      "needs-review",
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5560500",
+      "name": "Oshkosh",
+      "state": "WI",
+      "lat": 44.023168,
+      "lng": -88.56226
+    }
   },
   {
     "agency_id": "b8c857d4-5045-5088-a4bc-67a87461caff",
@@ -5202,6 +7023,133 @@
     "flags": []
   },
   {
+    "agency_id": "6fd32ad4-f84d-5d12-a177-b710f044da14",
+    "slug": "verona-wi-pd-inactive",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Verona WI PD [Inactive]"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [
+      "inactive"
+    ],
+    "geo": {
+      "kind": "place",
+      "fips": "5582600",
+      "name": "Verona",
+      "state": "WI",
+      "lat": 42.990061,
+      "lng": -89.538868
+    }
+  },
+  {
+    "agency_id": "45869f43-6b8a-5c48-ab1d-1909eee09c9a",
+    "slug": "vilas-county-wi-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Vilas County WI SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "55125",
+      "name": "Vilas",
+      "state": "WI",
+      "lat": 46.049848,
+      "lng": -89.501254
+    }
+  },
+  {
+    "agency_id": "64336728-25e8-58b6-a97d-8c0cdc8bb9ff",
+    "slug": "village-of-fox-crossing-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Village of Fox Crossing WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5526982",
+      "name": "Fox Crossing",
+      "state": "WI",
+      "lat": 44.223603,
+      "lng": -88.479075
+    }
+  },
+  {
+    "agency_id": "97b4da7d-f1b2-520c-b0b0-d2b1c546090d",
+    "slug": "village-of-fox-point-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Village of Fox Point WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5527075",
+      "name": "Fox Point",
+      "state": "WI",
+      "lat": 43.158126,
+      "lng": -87.901392
+    }
+  },
+  {
+    "agency_id": "851aa019-d0fa-5277-8c10-4ed1b62baf8f",
+    "slug": "village-of-pewaukee-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Village of Pewaukee WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5562240",
+      "name": "Pewaukee",
+      "state": "WI",
+      "lat": 43.066141,
+      "lng": -88.244465
+    }
+  },
+  {
     "agency_id": "e6d3f4c0-575b-5bc5-86d4-939b2cd50a3f",
     "slug": "visalia-ca-pd",
     "flock_active_slug": "visalia-ca-pd",
@@ -5256,6 +7204,106 @@
     "flags": []
   },
   {
+    "agency_id": "9fbac126-8acc-574e-b3ae-2cc806f4442c",
+    "slug": "waupaca-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Waupaca WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5584375",
+      "name": "Waupaca",
+      "state": "WI",
+      "lat": 44.350048,
+      "lng": -89.070003
+    }
+  },
+  {
+    "agency_id": "4e105696-93e0-52ec-a40c-8475bcde9334",
+    "slug": "waupun-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Waupun WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5584425",
+      "name": "Waupun",
+      "state": "WI",
+      "lat": 43.631547,
+      "lng": -88.737534
+    }
+  },
+  {
+    "agency_id": "dda6dc07-0b23-50c7-9be6-39ab939e891f",
+    "slug": "wausau-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Wausau WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5584475",
+      "name": "Wausau",
+      "state": "WI",
+      "lat": 44.961766,
+      "lng": -89.646538
+    }
+  },
+  {
+    "agency_id": "fd054441-0759-544a-8df6-b6d5b73e3224",
+    "slug": "wautoma-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Wautoma WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5584625",
+      "name": "Wautoma",
+      "state": "WI",
+      "lat": 44.067377,
+      "lng": -89.291119
+    }
+  },
+  {
     "agency_id": "79304dc7-17d0-5c18-8ea3-c1bebd5be181",
     "slug": "webster-groves-mo-pd",
     "flock_active_slug": "webster-groves-mo-pd",
@@ -5283,6 +7331,31 @@
     }
   },
   {
+    "agency_id": "3610c9a5-d716-5a0a-b278-b810903318cc",
+    "slug": "webster-parish-la-so",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Webster Parish LA SO"
+    ],
+    "display_name": null,
+    "agency_role": "sheriff",
+    "agency_type": "county",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "county",
+      "fips": "22119",
+      "name": "Webster",
+      "state": "LA",
+      "lat": 32.732152,
+      "lng": -93.339825
+    }
+  },
+  {
     "agency_id": "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd",
     "slug": "wellington-ks-pd",
     "flock_active_slug": "wellington-ks-pd",
@@ -5307,6 +7380,31 @@
       "state": "KS",
       "lat": 37.278109,
       "lng": -97.406672
+    }
+  },
+  {
+    "agency_id": "c17f02d7-a4af-5368-8348-2bb0c4e62c63",
+    "slug": "west-allis-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "West Allis WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5585300",
+      "name": "West Allis",
+      "state": "WI",
+      "lat": 43.007186,
+      "lng": -88.028986
     }
   },
   {
@@ -5418,6 +7516,56 @@
     "flags": []
   },
   {
+    "agency_id": "e690ea7b-4f03-543b-9a78-e442a512cfb4",
+    "slug": "weyauwega-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Weyauwega WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5586400",
+      "name": "Weyauwega",
+      "state": "WI",
+      "lat": 44.323593,
+      "lng": -88.933131
+    }
+  },
+  {
+    "agency_id": "46a87886-3fc8-51a3-88c4-4910ecd39287",
+    "slug": "whitefish-bay-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Whitefish Bay WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5586700",
+      "name": "Whitefish Bay",
+      "state": "WI",
+      "lat": 43.113137,
+      "lng": -87.900475
+    }
+  },
+  {
     "agency_id": "43d4e7c3-70a0-55fb-b84c-45c1c8bf7156",
     "slug": "williams-ca-pd",
     "flock_active_slug": "williams-ca-pd",
@@ -5443,6 +7591,31 @@
       "lng": -122.138968
     },
     "flags": []
+  },
+  {
+    "agency_id": "4a899df7-49f2-51be-b19c-8dc99efd323f",
+    "slug": "wisconsin-rapids-wi-pd",
+    "flock_active_slug": null,
+    "flock_slugs": [],
+    "flock_names": [
+      "Wisconsin Rapids WI PD"
+    ],
+    "display_name": null,
+    "agency_role": "police",
+    "agency_type": "city",
+    "website": null,
+    "tags": [
+      "public"
+    ],
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "5588200",
+      "name": "Wisconsin Rapids",
+      "state": "WI",
+      "lat": 44.392923,
+      "lng": -89.826749
+    }
   },
   {
     "agency_id": "950988b0-50de-5366-8f7d-46b0add309de",
@@ -13735,33 +15908,6 @@
       "state": "OH",
       "lat": 40.0568,
       "lng": -82.50414
-    }
-  },
-  {
-    "agency_id": "3157a2bf-3ac9-5534-a6c2-5353df154f45",
-    "slug": "great-parks-of-hamilton-county-oh-pd",
-    "flock_active_slug": "great-parks-of-hamilton-county-oh-pd",
-    "flock_slugs": [
-      "great-parks-of-hamilton-county-oh-pd"
-    ],
-    "flock_names": [
-      "Great Parks of Hamilton County OH PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "county",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "county",
-      "fips": "39061",
-      "name": "Hamilton",
-      "state": "OH",
-      "lat": 39.196927,
-      "lng": -84.544187
     }
   },
   {
@@ -73905,33 +76051,6 @@
     }
   },
   {
-    "agency_id": "d561e3c0-2216-56aa-8a7a-b2a1ac12d6ad",
-    "slug": "appleton-wi-pd",
-    "flock_active_slug": "appleton-wi-pd",
-    "flock_slugs": [
-      "appleton-wi-pd"
-    ],
-    "flock_names": [
-      "Appleton WI PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "5502375",
-      "name": "Appleton",
-      "state": "WI",
-      "lat": 44.278873,
-      "lng": -88.388284
-    }
-  },
-  {
     "agency_id": "5d2a3059-5d50-5f67-85a4-6131c307cf45",
     "slug": "ar-alma-pd",
     "flock_active_slug": null,
@@ -100696,33 +102815,6 @@
       "state": "MO",
       "lat": 36.745822,
       "lng": -93.457842
-    },
-    "flags": []
-  },
-  {
-    "agency_id": "8a9af692-fc85-5272-bd09-59d28e1dbc6f",
-    "slug": "summerset-sd-pd",
-    "flock_active_slug": "summerset-sd-pd",
-    "flock_slugs": [
-      "summerset-sd-pd"
-    ],
-    "flock_names": [
-      "Summerset SD PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "geo": {
-      "kind": "place",
-      "fips": "4662155",
-      "name": "Summerset",
-      "state": "SD",
-      "lat": 44.193309,
-      "lng": -103.342237
     },
     "flags": []
   },


### PR DESCRIPTION
Automated rolling refresh of Flock Safety transparency portal data.

This PR accumulates hourly batches. Merge when ready — the next run will create a fresh branch from main.

### Cumulative diff vs main

```
No agency scrape files changed since main.
```
