### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1418,6 +1418,14 @@
         "california-highway-patrol-ca-chp": "http_404"
       }
     },
+    "8c6d8756-60ef-55df-b7d0-554f4f577a7f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T21:57:14.950620+00:00",
+      "tried": {
+        "pelham-al-pd": "http_404"
+      }
+    },
     "8d7fd470-fecf-5788-921d-7f82bc634a71": {
       "exhausted": false,
       "found": null,
@@ -1656,7 +1664,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-12T18:29:55.468459+00:00",
+      "last_probed": "2026-05-12T21:57:20.754439+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1664,6 +1672,7 @@
         "-hollister-ca-police": "http_404",
         "-hollister-ca-police-department": "http_404",
         "-hollister-ca-ps": "http_404",
+        "-hollister-pd": "http_404",
         "-hollister-pd-ca": "http_404",
         "-hollister-po-ca": "http_404",
         "-hollister-police-ca": "http_404",
@@ -2045,6 +2054,14 @@
       "last_probed": "2026-04-24T05:58:32.630231+00:00",
       "tried": {
         "alhambra-ca-po": "http_404"
+      }
+    },
+    "cdfd2ca3-f75b-52a9-ba8a-a37162349117": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-12T21:57:09.529138+00:00",
+      "tried": {
+        "lakeland-fl-pd": "http_404"
       }
     },
     "ce179be7-fd78-5fd3-b518-ee3a04645a5d": {
@@ -2529,6 +2546,6 @@
       }
     }
   },
-  "updated": "2026-05-12T20:21:39.473960+00:00",
+  "updated": "2026-05-12T21:57:20.792198+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.