### PR TITLE
fix(pii-scan): exclude transparency.flocksafety.com from scanning

### DIFF
--- a/scripts/pii_scan.py
+++ b/scripts/pii_scan.py
@@ -33,6 +33,11 @@ import io
 # intentional, not leaked PII, and would otherwise flood the scanner.
 EXCLUDED_PATH_PREFIXES = (
     "assets/articles/",
+    # Flock transparency portal PDFs are public-by-design agency
+    # transparency pages. Agencies publish their PIO/info/records contact
+    # addresses on them intentionally (e.g. PIO@lvmpd.com on the
+    # las-vegas-metro portal). Not a PII leak surface.
+    "assets/transparency.flocksafety.com/",
     # W012462 is the Flock-to-SMPD email PRA. Produced records are Flock
     # marketing emails and partner-agency sharing notifications — they
     # intentionally contain external agency email addresses from dozens of


### PR DESCRIPTION
## Summary

Flock transparency portal PDFs are public-by-design agency transparency pages. Agencies publish PIO/info/records contact addresses on them intentionally (e.g. `PIO@lvmpd.com` on the las-vegas-metro portal). They shouldn't be in the PII-leak scan surface.

Path-exclude `assets/transparency.flocksafety.com/` the same way `assets/articles/` already is.

The pre-existing `EMAIL_RE` and `ALLOWED_EMAIL_DOMAINS` logic is unchanged.

## Test plan

- [x] Confirm PR #370 (rolling refresh) passes PII scan after merge