### PR TITLE
fix(geocode): resolve 25 missing-coord recipients (refs #209)

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -6313,8 +6313,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1772000",
+      "name": "Springfield",
+      "state": "IL",
+      "lat": 39.791063,
+      "lng": -89.644572
     }
   },
   {
@@ -11785,8 +11789,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2937000",
+      "name": "Jefferson City",
+      "state": "MO",
+      "lat": 38.567461,
+      "lng": -92.175254
     }
   },
   {
@@ -12618,8 +12626,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
     }
   },
   {
@@ -13406,8 +13418,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "manual",
+      "name": "Cape Girardeau",
+      "state": "MO",
+      "lat": 37.3059,
+      "lng": -89.5181
     }
   },
   {
@@ -14560,8 +14575,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "cousub",
+      "fips": "1324590168",
+      "name": "Augusta",
+      "state": "GA",
+      "lat": 33.444391,
+      "lng": -82.022096
     }
   },
   {
@@ -15994,8 +16013,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3638077",
+      "name": "Ithaca",
+      "state": "NY",
+      "lat": 42.443937,
+      "lng": -76.503055
     }
   },
   {
@@ -17572,8 +17595,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5135000",
+      "name": "Hampton",
+      "state": "VA",
+      "lat": 37.047961,
+      "lng": -76.297293
     }
   },
   {
@@ -21944,8 +21971,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NJ"
+      "kind": "place",
+      "fips": "3426340",
+      "name": "Glassboro",
+      "state": "NJ",
+      "lat": 39.700096,
+      "lng": -75.111423
     }
   },
   {
@@ -22942,8 +22973,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4260000",
+      "name": "Philadelphia",
+      "state": "PA",
+      "lat": 40.009376,
+      "lng": -75.133346
     }
   },
   {
@@ -23331,8 +23366,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3977000",
+      "name": "Toledo",
+      "state": "OH",
+      "lat": 41.664071,
+      "lng": -83.581861
     }
   },
   {
@@ -25055,8 +25094,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1765442",
+      "name": "Romeoville",
+      "state": "IL",
+      "lat": 41.627924,
+      "lng": -88.101182
     }
   },
   {
@@ -27295,8 +27338,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1851876",
+      "name": "Muncie",
+      "state": "IN",
+      "lat": 40.198826,
+      "lng": -85.395059
     }
   },
   {
@@ -28783,8 +28830,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3611000",
+      "name": "Buffalo",
+      "state": "NY",
+      "lat": 42.892492,
+      "lng": -78.859686
     }
   },
   {
@@ -29377,8 +29428,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -29669,8 +29724,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3712000",
+      "name": "Charlotte",
+      "state": "NC",
+      "lat": 35.209045,
+      "lng": -80.83099
     }
   },
   {
@@ -32148,8 +32207,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3721095",
+      "name": "Elon",
+      "state": "NC",
+      "lat": 36.102266,
+      "lng": -79.508787
     }
   },
   {
@@ -32567,8 +32630,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WV"
+      "kind": "place",
+      "fips": "5426452",
+      "name": "Fairmont",
+      "state": "WV",
+      "lat": 39.476877,
+      "lng": -80.149089
     }
   },
   {
@@ -35726,8 +35793,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1805860",
+      "name": "Bloomington",
+      "state": "IN",
+      "lat": 39.1637,
+      "lng": -86.524264
     }
   },
   {
@@ -41786,8 +41857,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1712385",
+      "name": "Champaign",
+      "state": "IL",
+      "lat": 40.114099,
+      "lng": -88.274619
     }
   },
   {
@@ -42781,8 +42856,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1882862",
+      "name": "West Lafayette",
+      "state": "IN",
+      "lat": 40.443707,
+      "lng": -86.923616
     }
   },
   {
@@ -45881,8 +45960,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1836003",
+      "name": "Indianapolis city (balance)",
+      "state": "IN",
+      "lat": 39.776664,
+      "lng": -86.145935
     }
   },
   {
@@ -46216,8 +46299,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1879208",
+      "name": "Vincennes",
+      "state": "IN",
+      "lat": 38.676621,
+      "lng": -87.509956
     }
   },
   {
@@ -46238,8 +46325,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5107784",
+      "name": "Blacksburg",
+      "state": "VA",
+      "lat": 37.231264,
+      "lng": -80.426745
     }
   },
   {
@@ -47159,8 +47250,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "place",
+      "fips": "2642160",
+      "name": "Kalamazoo",
+      "state": "MI",
+      "lat": 42.275163,
+      "lng": -85.588501
     }
   },
   {
@@ -48565,8 +48660,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3707080",
+      "name": "Boone",
+      "state": "NC",
+      "lat": 36.213842,
+      "lng": -81.665197
     }
   },
   {
@@ -57672,8 +57771,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "manual",
+      "name": "Marietta",
+      "state": "GA",
+      "lat": 33.9526,
+      "lng": -84.5499
     }
   },
   {
@@ -73033,8 +73135,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AR"
+      "kind": "manual",
+      "name": "El Dorado",
+      "state": "AR",
+      "lat": 33.2076,
+      "lng": -92.6663
     }
   },
   {

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -220,6 +220,36 @@ STATE_CITY_ALIASES = {
     # UMMC normalize_agency_name strips parens, leaving "UMMC MS PD" — so
     # the candidate after suffix-strip is "UMMC".
     ("UMMC", "MS"): "Jackson",
+    # Other single-campus universities (main campus is in a single named
+    # city). Add here when a university entry shows up missing coordinates
+    # in scripts/check_recipient_coords.py.
+    ("App State University", "NC"): "Boone",
+    ("Augusta University", "GA"): "Augusta",
+    ("Ball State University", "IN"): "Muncie",
+    ("Buffalo State University", "NY"): "Buffalo",
+    ("Case Western Reserve University", "OH"): "Cleveland",
+    ("Cornell University", "NY"): "Ithaca",
+    ("Elon University", "NC"): "Elon",
+    ("Fairmont State University", "WV"): "Fairmont",
+    ("Hampton University", "VA"): "Hampton",
+    ("Indiana University", "IN"): "Bloomington",
+    ("Lewis University", "IL"): "Romeoville",
+    ("Lincoln Land Community College", "IL"): "Springfield",
+    ("Lincoln University", "MO"): "Jefferson City",
+    ("Ohio State University", "OH"): "Columbus",
+    ("Parkland College", "IL"): "Champaign",
+    ("Purdue University", "IN"): "West Lafayette",
+    ("Rowan University", "NJ"): "Glassboro",
+    ("Temple University", "PA"): "Philadelphia",
+    ("Vincennes University", "IN"): "Vincennes",
+    ("Virginia Tech University", "VA"): "Blacksburg",
+    ("Western Michigan University", "MI"): "Kalamazoo",
+    # Indianapolis is a consolidated city-county; the bare "Indianapolis"
+    # lookup doesn't match the Census name. Pre-resolve to the balance entry.
+    ("University of Indianapolis", "IN"): "Indianapolis city (balance)",
+    ("University of Toledo", "OH"): "Toledo",
+    # Consolidated city-county PD names where the bare city is the Census place.
+    ("Charlotte Mecklenburg", "NC"): "Charlotte",
 
     # Multi-city / colloquial city names.
     ("Lakeside Park-Crestview Hills", "KY"): "Lakeside Park",  # adjacent KY cities; pick larger
@@ -417,9 +447,10 @@ def extract_county_candidate(agency_name):
 # CDPs the Census places gazetteer doesn't index, etc.). Keyed by
 # agency_id; the geocoder applies these before falling back to the
 # Census pipeline. Entries whose location can't be confidently pinned
-# down (e.g. "OK - 477", "Elm Ridge TX PD", multi-county precincts
-# without a county hint) are deliberately omitted — they stay flagged
-# in the CI recipient-coords check until someone narrows them down.
+# down (e.g. "OK - 477", "Elm Ridge TX PD", "Alabama Drug Enforcement
+# Task Force Region G", multi-county TX precincts without a county
+# hint) are deliberately omitted — they stay flagged in the CI
+# recipient-coords check until someone narrows them down.
 MANUAL_OVERRIDES = {
     # 18th Judicial District DTF — Sumner County, TN; based in Gallatin.
     "c9811955-3e45-5ff9-bd62-25a4f54afa6a": {
@@ -550,6 +581,26 @@ MANUAL_OVERRIDES = {
     "e0905266-5997-5468-a68a-55abc5e49065": {
         "kind": "manual", "name": "Tupelo", "state": "MS",
         "lat": 34.2581, "lng": -88.7037,
+    },
+    # GA - MCS/OCU/Intelligence — Marietta-Cobb-Smyrna Narcotics Unit;
+    # joint task force led by Marietta PD in Cobb County, GA.
+    "132123cb-eb61-5dc5-be29-ab9fd39fefde": {
+        "kind": "manual", "name": "Marietta", "state": "GA",
+        "lat": 33.9526, "lng": -84.5499,
+    },
+    # UCPAO AR — Union County Prosecuting Attorney's Office (13th
+    # Judicial District), 307 American Road, El Dorado, AR.
+    "de190cd9-abf6-542a-94c1-eea708ddd05e": {
+        "kind": "manual", "name": "El Dorado", "state": "AR",
+        "lat": 33.2076, "lng": -92.6663,
+    },
+    # SE Missouri State University — Cape Girardeau, MO. Manual override
+    # because the geocoder's _STATE_TOKEN strips the "SE" prefix as a
+    # 2-letter state code, collapsing this to "Missouri State University"
+    # (a different school in Springfield, MO).
+    "b29798ee-748e-5b57-9e49-7f87fcc992d8": {
+        "kind": "manual", "name": "Cape Girardeau", "state": "MO",
+        "lat": 37.3059, "lng": -89.5181,
     },
 }
 


### PR DESCRIPTION
## Summary
- Audit of issue #209 found 129 recipients missing coords (not just the 7 in the stale body) — Cabot AR PD's recent scrape brought in 7 newly-flagged opaque agencies plus a long tail across other portals.
- Resolves 25 of them: 22 single-campus universities via new `STATE_CITY_ALIASES`, plus 3 manual overrides for cases the Census pipeline can't handle.
- 104 still flagged for follow-up (most-common patterns: "X Town NY PD" cousubs, more universities/colleges, park-district PDs, regional task forces, and one parser-junk entry from Las Vegas Metro that captured a policy-statement sentence as an agency name).

## Manual overrides added
- **GA - MCS/OCU/Intelligence** → Marietta, GA (Marietta-Cobb-Smyrna Narcotics Unit, joint Cobb-county task force)
- **UCPAO AR** → El Dorado, AR (Union County PA Office, 13th Judicial District)
- **SE Missouri State University** → Cape Girardeau, MO — needs manual handling because the geocoder's state-token regex strips the "SE" prefix, collapsing the name to "Missouri State University" (a different school in Springfield)

## Deliberately left out
- **Alabama Drug Enforcement Task Force Region G** — ADETF has 7 regional control boards, but Region G's coverage area isn't publicly documented. Added to the deliberately-omitted list in the file comment alongside OK-477, Elm Ridge TX PD, and the Texas precincts.

## Test plan
- [x] `python3 scripts/geocode_agencies.py --apply` matches 25 entries on a fresh run
- [x] `python3 -m pytest tests/test_geo_cache.py` passes (9 tests) — confirms cached coords match the gazetteer
- [x] `python3 scripts/check_recipient_coords.py` count drops from 129 → 104