### PR TITLE
queue: LAist articles on Inglewood PD ALPR/ICE context

### DIFF
--- a/assets/articles/queue/538c65ac.json
+++ b/assets/articles/queue/538c65ac.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://laist.com/news/politics/inglewood-city-council-police-body-cams-automated-license-plate-readers",
+  "source_domain": "laist.com",
+  "discovered_at": "2026-05-13T20:51:58Z",
+  "discovered_by": "inglewood-outbound-drop research"
+}

--- a/assets/articles/queue/8b169b1e.json
+++ b/assets/articles/queue/8b169b1e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://laist.com/brief/news/activists-want-inglewood-to-take-a-stand-against-ice-ahead-of-the-world-cup",
+  "source_domain": "laist.com",
+  "discovered_at": "2026-05-13T20:51:58Z",
+  "discovered_by": "inglewood-outbound-drop research"
+}


### PR DESCRIPTION
## Summary
- Queues two LAist articles for the curator pipeline:
  - [Inglewood City Council greenlights police body cams + ALPR (April 2026 Axon contract)](https://laist.com/news/politics/inglewood-city-council-police-body-cams-automated-license-plate-readers)
  - [Activists want Inglewood to take a stand against ICE ahead of the World Cup](https://laist.com/brief/news/activists-want-inglewood-to-take-a-stand-against-ice-ahead-of-the-world-cup)
- Context: investigating why Delano, SMCO SO, Stockton, and Yolo SO each individually dropped Inglewood CA PD from outbound sharing between 5/6 and 5/13 (see PR #380's diff). Inglewood has no Flock portal of its own and just approved a \$6.3M Axon ALPR contract — these articles cover that backdrop.
- NPR's "Why some cities are canceling Flock" was also surfaced but is already in the registry.
- `thelalocal.org` was rejected by the allowlist; held off on registering a new publisher.

## Test plan
- [ ] Crawler picks up both queue entries on next run
- [ ] Curator output lands in `assets/article_registry.json` with reasonable tags