### PR TITLE
fix(parser): drop policy-disclaimer sentences from orgs section

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -13,7 +13,7 @@
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
-    "notes": "Sued by the CA Attorney General for illegally sharing ALPR data with out-of-state agencies in violation of SB 34 (CA Civil Code \u00a71798.90.55(b)). <a href=\"https://oag.ca.gov/news/press-releases/attorney-general-bonta-sues-el-cajon-illegally-sharing-license-plate-data-out\" target=\"_blank\">AG press release</a>.",
+    "notes": "Sued by the CA Attorney General for illegally sharing ALPR data with out-of-state agencies in violation of SB 34 (CA Civil Code §1798.90.55(b)). <a href=\"https://oag.ca.gov/news/press-releases/attorney-general-bonta-sues-el-cajon-illegally-sharing-license-plate-data-out\" target=\"_blank\">AG press release</a>.",
     "tags": [
       "ag-lawsuit",
       "public"
@@ -3363,7 +3363,7 @@
     "agency_role": "intelligence",
     "agency_type": "fusion_center",
     "website": null,
-    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>.<br><br><strong>Federal characteristics:</strong> NCRIC may not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f), which limits the term to the state or a city, county, city-and-county, or political subdivision thereof. NCRIC was created by the Northern California HIDTA Executive Board \u2014 a federal drug-enforcement coordinating body \u2014 rather than by a joint powers agreement among California jurisdictions, so it does not fit the statutory definition. Supporting this: it is housed in the Phillip Burton Federal Building (GSA-managed), staffed primarily with federal analysts under DHS/ODNI grants, and governed by an 18-member board where 9 of 18 seats are held by federal agencies (ATF, DEA, FBI, IRS-CI, U.S. Marshals, DHS, Postal Inspection, U.S. Forest Service, U.S. Attorney NDCA). Federal agencies hold half the governance seats of the entity California agencies are feeding data to.",
+    "notes": "NCRIC is a re-sharing hub: agencies that share with NCRIC have their data redistributed to 318 entities, including private universities (Stanford, USF, UOP) that do not qualify as public agencies under SB 34. An agency sharing with NCRIC may not be aware its data reaches non-public entities. NCRIC's <a href=\"https://ncric.ca.gov/wp-content/uploads/2024/05/NCRIC-ALPR-POLICY-2024.pdf\">ALPR Policy</a> authorizes multi-agency sharing, integration, and access of ALPR data among participating agencies. See also: <a href=\"https://ncric.ca.gov/wp-content/uploads/2021/10/NCRIC-Data-Sharing-MOU.pdf\">NCRIC Data Sharing MOU</a>.<br><br><strong>Federal characteristics:</strong> NCRIC may not qualify as a “public agency” under CA Civil Code §1798.90.5(f), which limits the term to the state or a city, county, city-and-county, or political subdivision thereof. NCRIC was created by the Northern California HIDTA Executive Board — a federal drug-enforcement coordinating body — rather than by a joint powers agreement among California jurisdictions, so it does not fit the statutory definition. Supporting this: it is housed in the Phillip Burton Federal Building (GSA-managed), staffed primarily with federal analysts under DHS/ODNI grants, and governed by an 18-member board where 9 of 18 seats are held by federal agencies (ATF, DEA, FBI, IRS-CI, U.S. Marshals, DHS, Postal Inspection, U.S. Forest Service, U.S. Attorney NDCA). Federal agencies hold half the governance seats of the entity California agencies are feeding data to.",
     "tags": [
       "public"
     ],
@@ -4589,13 +4589,13 @@
       },
       {
         "title": "Policy posted, but not in full",
-        "description": "The transparency page links to the department's <strong>internal Policy Manual</strong>, which delegates several ALPR-specific items (audit criteria, committee structure, end-user procedures, annual review) to <strong>SOP 205</strong>. SOP 205 itself is <strong>not publicly posted</strong>, despite being required to be conspicuously posted by its own text and CA Civil Code \u00a71798.90.51(a). The city acknowledged this gap on March 3, 2026 and stated it was \u201cactively working\u201d to publish SOP 205. As of the findings doc revision, it remains unavailable.",
+        "description": "The transparency page links to the department's <strong>internal Policy Manual</strong>, which delegates several ALPR-specific items (audit criteria, committee structure, end-user procedures, annual review) to <strong>SOP 205</strong>. SOP 205 itself is <strong>not publicly posted</strong>, despite being required to be conspicuously posted by its own text and CA Civil Code §1798.90.51(a). The city acknowledged this gap on March 3, 2026 and stated it was “actively working” to publish SOP 205. As of the findings doc revision, it remains unavailable.",
         "source_url": "SMPD_ALPR_Findings.pdf",
         "section": "check:published_policy"
       },
       {
         "title": "Policy documents audits the department did not perform",
-        "description": "Policy 462/463 and SOP 205 have required quarterly operator audits (and NCRIC end-user audits) since at least October 2019. A PRA for audit records returned \u201cno records responsive\u201d for any period before December 2025. Kelly O\u2019Keefe confirmed in February 2026: \u201cWe do not have any records of audits prior to December [2025].\u201d A September 1, 2020 staff report to Council (File ID 20-3547) presented that \u201cSMPD conducts regular audits to ensure access to the ALPR Databases are within policy\u201d \u2014 a representation not supported by any records the department was able to produce.",
+        "description": "Policy 462/463 and SOP 205 have required quarterly operator audits (and NCRIC end-user audits) since at least October 2019. A PRA for audit records returned “no records responsive” for any period before December 2025. Kelly O’Keefe confirmed in February 2026: “We do not have any records of audits prior to December [2025].” A September 1, 2020 staff report to Council (File ID 20-3547) presented that “SMPD conducts regular audits to ensure access to the ALPR Databases are within policy” — a representation not supported by any records the department was able to produce.",
         "source_url": "SMPD_ALPR_Findings.pdf",
         "section": "check:documented_audit"
       }
@@ -5166,7 +5166,7 @@
     "agency_role": "campus_safety",
     "agency_type": "private",
     "website": null,
-    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Stanford is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>.",
+    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Stanford is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>.",
     "tags": [
       "private"
     ],
@@ -6710,24 +6710,6 @@
       "lat": 42.480614,
       "lng": -87.829557
     }
-  },
-  {
-    "agency_id": "809c2380-80b3-5988-b6fa-cf94ca8f7fb9",
-    "slug": "access-to-or-disclosure-of-alpr-data-will-only-be-provided-to-individuals-within-the-department-or-other-authorized-governmental-agencies",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Access to or disclosure of ALPR data will only be provided to individuals within the department or other authorized governmental agencies."
-    ],
-    "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "tags": [
-      "needs-review"
-    ],
-    "flags": [],
-    "geo": null
   },
   {
     "agency_id": "8c265ca8-0310-5903-98cb-4234650996db",
@@ -16758,7 +16740,7 @@
     "geo": {
       "kind": "place",
       "fips": "3525170",
-      "name": "Espa\u00f1ola",
+      "name": "Española",
       "state": "NM",
       "lat": 36.003959,
       "lng": -106.070131
@@ -95549,7 +95531,7 @@
     "geo": {
       "kind": "place",
       "fips": "0811810",
-      "name": "Ca\u00f1on City",
+      "name": "Cañon City",
       "state": "CO",
       "lat": 38.441886,
       "lng": -105.220899
@@ -107430,7 +107412,7 @@
     "agency_role": "school",
     "agency_type": "private",
     "website": "https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770",
-    "notes": "Private school receiving ALPR data from law enforcement agencies. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>. <a href=\"https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770\" target=\"_blank\">CDE listing</a>.",
+    "notes": "Private school receiving ALPR data from law enforcement agencies. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>. <a href=\"https://www.cde.ca.gov/schooldirectory/details?cdscode=30736357091770\" target=\"_blank\">CDE listing</a>.",
     "tags": [
       "private"
     ],
@@ -107880,7 +107862,7 @@
     "agency_role": "decommissioned",
     "agency_type": "decommissioned",
     "website": null,
-    "notes": "Santa Clara University is a private institution. Entry marked \"Do Not Use\" by Flock but still appears in sharing lists. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only.",
+    "notes": "Santa Clara University is a private institution. Entry marked \"Do Not Use\" by Flock but still appears in sharing lists. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only.",
     "tags": [
       "private"
     ],
@@ -114126,7 +114108,7 @@
     "agency_role": "campus_safety",
     "agency_type": "private",
     "website": null,
-    "notes": "Private Jesuit university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. USF is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">\u00a71798.90.5(f)</a>.",
+    "notes": "Private Jesuit university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. USF is not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">§1798.90.5(f)</a>.",
     "tags": [
       "private"
     ],
@@ -114150,7 +114132,7 @@
     "agency_role": "other",
     "agency_type": "private",
     "website": null,
-    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. UOP Chief of Police confirmed in writing that University of the Pacific is \"a private institution and therefore not subject to the CPRA.\" UOP was removed from SMPD\u2019s portal after a resident raised the issue; it remains on Stockton PD\u2019s portal. (<a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings, Source 29</a>)",
+    "notes": "Private university. Sharing ALPR data with this entity likely violates <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.55.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.55(b)</a>, which restricts ALPR data sharing to public agencies only. UOP Chief of Police confirmed in writing that University of the Pacific is \"a private institution and therefore not subject to the CPRA.\" UOP was removed from SMPD’s portal after a resident raised the issue; it remains on Stockton PD’s portal. (<a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings, Source 29</a>)",
     "tags": [
       "private"
     ],
@@ -114536,7 +114518,7 @@
     "agency_role": "intelligence",
     "agency_type": "fusion_center",
     "website": "https://oag.ca.gov/bi/wsin",
-    "notes": "WSIN is a <strong>501(c)(3) nonprofit corporation</strong> (EIN 27-1453421), not a government agency. It is one of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers, 100% funded by BJA (DOJ) grants. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub \u2014 data shared with WSIN may be redistributed across five states and international partners.<br><br><strong>Not a public agency:</strong> WSIN incorporated as a California nonprofit in 2009 after separating from CA DOJ, which previously served as its fiscal agent. It employs 47 nonprofit employees (explicitly \u201cnot state positions\u201d). Its policy board is composed entirely of state/local officials from five states (no federal seats), but it operates under 28 CFR Part 23 (federal regulation) and is 100% federally funded (~$7.5M/yr from BJA). As a 501(c)(3) nonprofit, WSIN likely does not qualify as a \u201cpublic agency\u201d under CA Civil Code \u00a71798.90.5(f), which defines public agency as \u201cthe state, any city, county, or city and county, or any agency or political subdivision\u201d thereof.",
+    "notes": "WSIN is a <strong>501(c)(3) nonprofit corporation</strong> (EIN 27-1453421), not a government agency. It is one of six <a href=\"https://www.riss.net/\" target=\"_blank\">RISS</a> centers, 100% funded by BJA (DOJ) grants. Serves Alaska, California, Hawaii, Oregon, and Washington. <a href=\"https://oag.ca.gov/bi/wsin\" target=\"_blank\">CA DOJ page</a>. Multi-state sharing hub — data shared with WSIN may be redistributed across five states and international partners.<br><br><strong>Not a public agency:</strong> WSIN incorporated as a California nonprofit in 2009 after separating from CA DOJ, which previously served as its fiscal agent. It employs 47 nonprofit employees (explicitly “not state positions”). Its policy board is composed entirely of state/local officials from five states (no federal seats), but it operates under 28 CFR Part 23 (federal regulation) and is 100% federally funded (~$7.5M/yr from BJA). As a 501(c)(3) nonprofit, WSIN likely does not qualify as a “public agency” under CA Civil Code §1798.90.5(f), which defines public agency as “the state, any city, county, or city and county, or any agency or political subdivision” thereof.",
     "tags": [
       "private"
     ],
@@ -114858,7 +114840,7 @@
     "agency_role": "police",
     "agency_type": "private",
     "website": null,
-    "notes": "Union Pacific Railroad Police is a <a href=\"https://en.wikipedia.org/wiki/Union_Pacific_Police_Department\" target=\"_blank\">private railroad police</a> force. While railroad police have some law enforcement authority under federal law (49 USC \u00a728101), Union Pacific is a private corporation. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">CA Civil Code \u00a71798.90.5(f)</a>.",
+    "notes": "Union Pacific Railroad Police is a <a href=\"https://en.wikipedia.org/wiki/Union_Pacific_Police_Department\" target=\"_blank\">private railroad police</a> force. While railroad police have some law enforcement authority under federal law (49 USC §28101), Union Pacific is a private corporation. Not a public agency under <a href=\"https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1798.90.5.&lawCode=CIV\" target=\"_blank\">CA Civil Code §1798.90.5(f)</a>.",
     "tags": [
       "private"
     ],
@@ -114882,7 +114864,7 @@
     "agency_role": "vendor",
     "agency_type": "private",
     "website": "https://www.flocksafety.com",
-    "notes": "Private surveillance vendor headquartered in Atlanta, GA. Flock MSA \u00a75.3 grants Flock independent authority to \"access, use, preserve and/or disclose\" agency footage to law enforcement, government officials, and third parties based on Flock's own \"good faith belief\" \u2014 including for Flock's own technical purposes. No agency approval or notification required. This provision survives contract termination (\u00a77.3). The <a href=\"https://information.auditor.ca.gov/reports/2019-118/summary.html\" target=\"_blank\">CA State Auditor (Report 2019-118)</a> found that agencies' vendor contracts lacked necessary data security safeguards and recommended agencies update vendor contracts. The subsequent <a href=\"https://oag.ca.gov/system/files/media/2023-dle-06.pdf\" target=\"_blank\">AG Bulletin 2023-DLE-06</a> directed agencies to review vendor contracts for provisions allowing non-public access to ALPR data \u2014 \u00a75.3 is exactly the type of provision both warned about. See <a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings \u00a75</a>.",
+    "notes": "Private surveillance vendor headquartered in Atlanta, GA. Flock MSA §5.3 grants Flock independent authority to \"access, use, preserve and/or disclose\" agency footage to law enforcement, government officials, and third parties based on Flock's own \"good faith belief\" — including for Flock's own technical purposes. No agency approval or notification required. This provision survives contract termination (§7.3). The <a href=\"https://information.auditor.ca.gov/reports/2019-118/summary.html\" target=\"_blank\">CA State Auditor (Report 2019-118)</a> found that agencies' vendor contracts lacked necessary data security safeguards and recommended agencies update vendor contracts. The subsequent <a href=\"https://oag.ca.gov/system/files/media/2023-dle-06.pdf\" target=\"_blank\">AG Bulletin 2023-DLE-06</a> directed agencies to review vendor contracts for provisions allowing non-public access to ALPR data — §5.3 is exactly the type of provision both warned about. See <a href=\"SMPD_ALPR_Findings.pdf\" target=\"_blank\">Findings §5</a>.",
     "tags": [
       "private"
     ],

--- a/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-07.json
+++ b/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-07.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 2133824,
   "hotlist_hits_30d": 29143,
   "searches_30d": 3992,
-  "sharing_outbound": [
-    "Access to or disclosure of ALPR data will only be provided to individuals within the department or other authorized governmental agencies."
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Las Vegas Metro Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Las Vegas Metro Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Las Vegas Metro Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-11.json
+++ b/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-11.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 2149272,
   "hotlist_hits_30d": 22552,
   "searches_30d": 3888,
-  "sharing_outbound": [
-    "Access to or disclosure of ALPR data will only be provided to individuals within the department or other authorized governmental agencies."
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Las Vegas Metro Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Las Vegas Metro Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Las Vegas Metro Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-12.json
+++ b/assets/transparency.flocksafety.com/las-vegas-metro-nv-pd/2026-05-12.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 2144037,
   "hotlist_hits_30d": 22248,
   "searches_30d": 3847,
-  "sharing_outbound": [
-    "Access to or disclosure of ALPR data will only be provided to individuals within the department or other authorized governmental agencies."
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Las Vegas Metro Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Las Vegas Metro Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Las Vegas Metro Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -638,6 +638,20 @@ _ORG_DESCRIPTION_RE = re.compile(
 )
 
 
+def _looks_like_disclaimer(line):
+    """True if a line in the orgs section is a policy sentence, not an
+    agency name. Real agency names are short (<80 chars) and don't end
+    with a period; e.g. LVMPD's portal puts "Access to or disclosure of
+    ALPR data will only be provided to individuals within the department
+    or other authorized governmental agencies." where the agency list
+    should be, and we don't want a 137-character disclaimer ingested as
+    a recipient agency.
+    """
+    if not line.endswith("."):
+        return False
+    return len(line) > 100 or len(line.split()) > 12
+
+
 def _parse_org_names(body):
     """Extract org names from a shared-orgs section body.
 
@@ -651,11 +665,14 @@ def _parse_org_names(body):
         return []
     body = _strip_leading_description(body)
     lines = [L.strip() for L in body.split("\n") if L.strip()]
-    # Drop the description sentence — _strip_leading_description only
-    # fires when ≥2 paragraphs are present, so when the table is empty
+    # Drop description / disclaimer sentences — _strip_leading_description
+    # only fires when ≥2 paragraphs are present, so when the table is empty
     # the lone description line survives and would be parsed as a fake
-    # org name (PR #240).
-    lines = [L for L in lines if not _ORG_DESCRIPTION_RE.match(L)]
+    # org name (PR #240; LVMPD disclaimer case for #209).
+    lines = [
+        L for L in lines
+        if not _ORG_DESCRIPTION_RE.match(L) and not _looks_like_disclaimer(L)
+    ]
     if not lines:
         return []
     if len(lines) >= 3 and sum(1 for L in lines if "," not in L) >= len(lines) * 0.8:

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -213,6 +213,29 @@ def test_parse_org_names_description_only_empty_table():
     ) == []
 
 
+def test_parse_org_names_drops_policy_disclaimer():
+    """Some portals (LVMPD 2026-05) render a policy disclaimer in the
+    orgs section instead of an agency list. The disclaimer doesn't
+    match the "Organizations granted access" boilerplate, but it is
+    obviously a sentence (long, ends with a period) rather than an
+    agency name. Drop it so we don't ingest 137-char prose as a
+    recipient agency (issue #209)."""
+    assert _parse_org_names(
+        "Access to or disclosure of ALPR data will only be provided "
+        "to individuals within the department or other authorized "
+        "governmental agencies."
+    ) == []
+    # Real agency names — even unusually long ones — survive: they
+    # don't end with a period, so the heuristic doesn't touch them.
+    assert _parse_org_names(
+        "Ohio Department of Rehabilitation and Correction - Office of "
+        "the Chief Inspector"
+    ) == [
+        "Ohio Department of Rehabilitation and Correction - Office of "
+        "the Chief Inspector"
+    ]
+
+
 def test_extract_bold_headings_matches_2026_layout():
     """The 2026 layout uses font-weight:600 for field headings (was
     700) and h3 + text-transform:uppercase for section dividers."""


### PR DESCRIPTION
## Summary
- LVMPD's Flock portal renders a policy disclaimer where the outbound-sharing agency list should be, and the parser ingested the 137-character sentence as a fake agency. Result: a junk recipient on the sharing map called "Access to or disclosure of ALPR data will only be provided to individuals within the department or other authorized governmental agencies."
- Existing description-stripping logic only catches the "Organizations granted access to … data." boilerplate (PR #240); it doesn't generalize to other disclaimer phrasings.
- Add a length+period heuristic: a line in the orgs section that ends with a period and is either >100 chars or >12 words is treated as a policy sentence, not an agency name.

## Why the threshold is safe
- Longest real agency name in the registry is 80 chars ("Ohio Department of Rehabilitation and Correction - Office of the Chief Inspector").
- None of the top-10 longest agency names end with a period.

## Also in this PR
- Re-parsed LVMPD's three stored scrapes (`2026-05-07`, `2026-05-11`, `2026-05-12`); `sharing_outbound` is now `[]`.
- Removed the orphaned junk entry (`agency_id: 809c2380-…`) from `assets/agency_registry.json`.
- New test in `tests/test_flock_transparency_headings.py` covers the LVMPD disclaimer and asserts that the longest real agency name still survives.

## Test plan
- [x] `python3 -m pytest tests/test_flock_transparency_headings.py tests/test_flock_transparency_name_extraction.py tests/test_geo_cache.py` — 56 passed
- [x] `python3 scripts/flock_transparency.py parse --slug las-vegas-metro-nv-pd --force` — 3 files, 0 orgs each
- [x] `grep -r 809c2380-80b3-5988-b6fa-cf94ca8f7fb9 assets/ docs/ scripts/` — no stray references