### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -479,6 +479,14 @@
         "orange-county-ca-so": "http_404"
       }
     },
+    "2cc10417-2158-56c5-861c-3f58a91fcc06": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T05:35:36.326948+00:00",
+      "tried": {
+        "new-madrid-county-mo-so": "http_404"
+      }
+    },
     "2e1e1b36-7a6b-5c97-8143-65347503186c": {
       "exhausted": false,
       "found": null,
@@ -1469,6 +1477,14 @@
         "hamilton-township-oh-pd": "http_200"
       }
     },
+    "87ced6b8-24d2-5127-8bdb-2333a325cbfd": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T05:35:42.165860+00:00",
+      "tried": {
+        "washington-il-pd": "http_404"
+      }
+    },
     "8850cc76-6d6f-5a25-8e97-8af1c309e550": {
       "exhausted": false,
       "found": null,
@@ -1787,7 +1803,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-12T21:57:20.754439+00:00",
+      "last_probed": "2026-05-14T05:35:46.989039+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1797,6 +1813,7 @@
         "-hollister-ca-ps": "http_404",
         "-hollister-pd": "http_404",
         "-hollister-pd-ca": "http_404",
+        "-hollister-po": "http_404",
         "-hollister-po-ca": "http_404",
         "-hollister-police-ca": "http_404",
         "-hollister-police-department-ca": "http_404",
@@ -2726,6 +2743,6 @@
       }
     }
   },
-  "updated": "2026-05-14T01:34:54.191902+00:00",
+  "updated": "2026-05-14T05:35:47.025898+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -251,6 +251,14 @@
         "sidney-oh-pd": "http_200"
       }
     },
+    "1575e160-5ccc-5940-817e-14a0cc4ea440": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T13:20:45.474135+00:00",
+      "tried": {
+        "kansas-city-mo-pd": "http_404"
+      }
+    },
     "15a953dc-dc7b-53c0-80c5-0ee5eba74221": {
       "exhausted": false,
       "found": null,
@@ -364,7 +372,7 @@
     "23febb79-0d19-5c75-b964-46a43c1cd423": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-14T01:34:54.151931+00:00",
+      "last_probed": "2026-05-14T13:20:51.998542+00:00",
       "tried": {
         "national-city": "http_404",
         "national-city-ca": "http_404",
@@ -395,6 +403,7 @@
         "nationalcity-pd-ca": "http_404",
         "nationalcity-po": "http_404",
         "nationalcity-po-ca": "http_404",
+        "nationalcity-police": "http_404",
         "nationalcity-police-ca": "http_404",
         "nationalcity-police-department": "http_404",
         "nationalcity-police-department-ca": "http_404",
@@ -2181,6 +2190,14 @@
         "jeffersontown-ky-pd": "http_404"
       }
     },
+    "c214c5b9-8c55-5112-9921-fcd18d33382c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T13:20:40.969849+00:00",
+      "tried": {
+        "middle-tennessee-state-tn-pd": "http_404"
+      }
+    },
     "c246371a-5810-5428-b861-52b526e54678": {
       "exhausted": false,
       "found": null,
@@ -2777,6 +2794,6 @@
       }
     }
   },
-  "updated": "2026-05-14T11:04:53.897708+00:00",
+  "updated": "2026-05-14T13:20:52.030278+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1137,7 +1137,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-13T21:12:21.213743+00:00",
+      "last_probed": "2026-05-14T08:19:28.475012+00:00",
       "tried": {
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -1158,6 +1158,7 @@
         "beverly-hills-ps": "http_404",
         "beverly-hills-ps-ca": "http_404",
         "beverly-hills-psca": "http_404",
+        "beverlyhills-ca": "http_404",
         "beverlyhills-ca-pd": "http_404",
         "beverlyhills-ca-po": "http_404",
         "beverlyhills-ca-police": "http_404",
@@ -1897,6 +1898,14 @@
         "livingston-county-il-so": "http_404"
       }
     },
+    "ad1f8353-ce87-54b6-bbcc-30d60098a809": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T08:19:18.375796+00:00",
+      "tried": {
+        "burton-mi-pd": "http_404"
+      }
+    },
     "ae8c6210-8473-5a62-96af-7ea959cb19ff": {
       "exhausted": false,
       "found": "riverside-county-ca-sd",
@@ -2567,6 +2576,14 @@
         "bishop-ca-po": "http_404"
       }
     },
+    "ef8ce1d9-daaa-5651-844c-6d677d938479": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T08:19:23.545208+00:00",
+      "tried": {
+        "kenosha-county-wi-so": "http_404"
+      }
+    },
     "ef91b9f5-4ab8-5c30-b42f-3ef0a4e88ec4": {
       "exhausted": false,
       "found": null,
@@ -2743,6 +2760,6 @@
       }
     }
   },
-  "updated": "2026-05-14T05:35:47.025898+00:00",
+  "updated": "2026-05-14T08:19:28.513846+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -267,6 +267,14 @@
         "elk-grove-ca-po": "http_404"
       }
     },
+    "17453cbc-25c2-54d6-a06b-edbebd3c64b2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T11:04:44.666112+00:00",
+      "tried": {
+        "bristol-in-pd": "http_404"
+      }
+    },
     "191e3ac2-94b7-542a-b2bc-f51adf6a8303": {
       "exhausted": false,
       "found": null,
@@ -1137,7 +1145,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-14T08:19:28.475012+00:00",
+      "last_probed": "2026-05-14T11:04:53.860232+00:00",
       "tried": {
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -1163,7 +1171,8 @@
         "beverlyhills-ca-po": "http_404",
         "beverlyhills-ca-police": "http_404",
         "beverlyhills-ca-police-department": "http_404",
-        "beverlyhills-ca-ps": "http_404"
+        "beverlyhills-ca-ps": "http_404",
+        "beverlyhills-pd-ca": "http_404"
       }
     },
     "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd": {
@@ -1251,6 +1260,14 @@
       "last_probed": "2026-04-25T23:23:49.936037+00:00",
       "tried": {
         "trinity-county-ca-so": "http_404"
+      }
+    },
+    "74177e29-6bac-5f35-8a72-d1fa6e6c4357": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T11:04:48.808393+00:00",
+      "tried": {
+        "newells-mobile-city-ca-pd": "http_404"
       }
     },
     "74719b7b-43cb-57ec-a0bc-26515454b5dc": {
@@ -2760,6 +2777,6 @@
       }
     }
   },
-  "updated": "2026-05-14T08:19:28.513846+00:00",
+  "updated": "2026-05-14T11:04:53.897708+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.