### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1736,6 +1736,14 @@
         "santa-rosa-band-of-cahuilla-indians-ca-po": "http_404"
       }
     },
+    "9a80fff3-3332-5596-b292-768893dd3391": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T16:00:53.485733+00:00",
+      "tried": {
+        "warren-mi-pd": "http_404"
+      }
+    },
     "9ac8088b-6a6c-550e-92ef-6b9e90470c4c": {
       "exhausted": false,
       "found": null,
@@ -1830,7 +1838,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-14T05:35:46.989039+00:00",
+      "last_probed": "2026-05-14T16:01:03.899104+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1843,6 +1851,7 @@
         "-hollister-po": "http_404",
         "-hollister-po-ca": "http_404",
         "-hollister-police-ca": "http_404",
+        "-hollister-police-department": "http_404",
         "-hollister-police-department-ca": "http_404",
         "-hollister-ps-ca": "http_404",
         "hollister": "http_404",
@@ -2236,6 +2245,14 @@
       "last_probed": "2026-05-10T17:38:12.485785+00:00",
       "tried": {
         "prescott-valley-az-pd": "http_200"
+      }
+    },
+    "c9dacd3f-79dc-593d-8c1e-11c91d429a2b": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T16:00:59.202676+00:00",
+      "tried": {
+        "erwin-nc-pd": "http_404"
       }
     },
     "ca169c85-b556-58a0-a0bc-988c09bc6d01": {
@@ -2794,6 +2811,6 @@
       }
     }
   },
-  "updated": "2026-05-14T13:20:52.030278+00:00",
+  "updated": "2026-05-14T16:01:03.929549+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.