### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -486,6 +486,14 @@
         "spring-valley-il-pd": "http_404"
       }
     },
+    "2c800b21-021b-525a-9c12-09fd22b47cff": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T20:20:11.719465+00:00",
+      "tried": {
+        "streator-il-pd": "http_404"
+      }
+    },
     "2c981ce6-8d54-565f-bb99-ac885eee8769": {
       "exhausted": false,
       "found": null,
@@ -772,6 +780,14 @@
       "last_probed": "2026-05-07T23:38:10.582274+00:00",
       "tried": {
         "grundy-county-il-so": "http_404"
+      }
+    },
+    "440cab4b-0602-53bf-9d8a-6614815ccd23": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T20:20:05.952458+00:00",
+      "tried": {
+        "east-hazel-crest-il-pd": "http_404"
       }
     },
     "447d3fff-1d7e-58ed-8254-2dc784fc0275": {
@@ -1838,7 +1854,7 @@
     "a3181593-1121-5cc0-aae2-beb7d164ed58": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-14T16:01:03.899104+00:00",
+      "last_probed": "2026-05-14T20:20:16.441238+00:00",
       "tried": {
         "-hollister-ca": "http_404",
         "-hollister-ca-pd": "http_404",
@@ -1850,6 +1866,7 @@
         "-hollister-pd-ca": "http_404",
         "-hollister-po": "http_404",
         "-hollister-po-ca": "http_404",
+        "-hollister-police": "http_404",
         "-hollister-police-ca": "http_404",
         "-hollister-police-department": "http_404",
         "-hollister-police-department-ca": "http_404",
@@ -2811,6 +2828,6 @@
       }
     }
   },
-  "updated": "2026-05-14T16:01:03.929549+00:00",
+  "updated": "2026-05-14T20:20:16.476060+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -881,6 +881,14 @@
         "lebanon-tn-pd": "http_404"
       }
     },
+    "4bf989d8-16c1-5eee-bb24-5a6b46749eb3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-14T21:53:53.300296+00:00",
+      "tried": {
+        "rutherford-county-nc-so": "http_404"
+      }
+    },
     "4cc1fd23-7711-52b8-be07-9d6e1ad7b364": {
       "exhausted": false,
       "found": null,
@@ -1170,7 +1178,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-14T11:04:53.860232+00:00",
+      "last_probed": "2026-05-14T21:54:03.444529+00:00",
       "tried": {
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -1197,7 +1205,8 @@
         "beverlyhills-ca-police": "http_404",
         "beverlyhills-ca-police-department": "http_404",
         "beverlyhills-ca-ps": "http_404",
-        "beverlyhills-pd-ca": "http_404"
+        "beverlyhills-pd-ca": "http_404",
+        "beverlyhills-po-ca": "http_404"
       }
     },
     "6b9c1c80-8c06-5e0a-a0c6-30913fad84fd": {
@@ -2706,9 +2715,10 @@
     "f339d07b-886d-57a3-8d4f-e61933754c14": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-06T13:20:56.232187+00:00",
+      "last_probed": "2026-05-14T21:53:59.565254+00:00",
       "tried": {
-        "hoover-al-pd": "http_404"
+        "hoover-al-pd": "http_404",
+        "hoover-al-po": "http_404"
       }
     },
     "f37d0f09-6a70-5017-8b66-0bda25f8c5a4": {
@@ -2828,6 +2838,6 @@
       }
     }
   },
-  "updated": "2026-05-14T20:20:16.476060+00:00",
+  "updated": "2026-05-14T21:54:03.482684+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.