### PR TITLE
build(make): chain --auto-login into pra-scrape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ pra-update: pra-scrape pra-ocr pra-init pra-build ## Full local PRA refresh
 	@echo "Done. Review new/modified files with: git status -s assets/san-mateo-public-records/"
 	@echo "Then edit any TODO metadata.json files and commit."
 
-pra-scrape: ## Scrape all SMPD portal PRAs
+pra-scrape: ## Auto-login, then scrape all SMPD portal PRAs
+	uv run python scripts/pra_download.py --auto-login
 	uv run python scripts/pra_download.py --all
 
 pra-scrape-one: ## Scrape one PRA: make pra-scrape-one ID=W012XXX-MMDDYY


### PR DESCRIPTION
## Summary
- `make pra-scrape` now runs `pra_download.py --auto-login` before `--all` so the recurring weekly refresh is a single command.
- Easier to whitelist in tool-permission settings and to run unattended.

## Test plan
- [ ] `make -n pra-scrape` prints both commands in order
- [ ] `make pra-scrape` succeeds end-to-end with a working `~/.config/sm-alpr/pra_credentials.json`