### PR TITLE
feat(pras): deep links to files, inline PDF viewer, exact-ID sort boost

### DIFF
--- a/docs/js/pras.js
+++ b/docs/js/pras.js
@@ -26,18 +26,85 @@ const state = {
 
 const PRA_ID_RE = /\bW\d{6}-\d{6}\b/g;
 
-function focusPra(id) {
+function focusPra(id, filename) {
   if (!state.knownIds.has(id)) return;
   state.expanded.add(id);
   render();
   setTimeout(() => {
-    const target = document.querySelector(`.card[data-id="${id}"]`);
+    const target = document.querySelector(`.card[data-id="${CSS.escape(id)}"]`);
     if (target) {
       target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       target.classList.add('flash');
       setTimeout(() => target.classList.remove('flash'), 1200);
     }
+    if (filename) setTimeout(() => focusFile(id, filename, true), 100);
   }, 0);
+}
+
+function blobToRaw(url) {
+  return url
+    .replace('https://github.com/', 'https://raw.githubusercontent.com/')
+    .replace('/blob/', '/');
+}
+
+function focusFile(praId, filename, autoView) {
+  const decoded = decodeURIComponent(filename);
+  const card = document.querySelector(`.card[data-id="${CSS.escape(praId)}"]`);
+  if (!card) return;
+  const li = card.querySelector(`.file-entry[data-filename="${CSS.escape(decoded)}"]`);
+  if (!li) return;
+  li.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  li.classList.add('file-highlighted');
+  setTimeout(() => li.classList.remove('file-highlighted'), 2000);
+  if (autoView) {
+    const viewBtn = li.querySelector('.file-view-btn');
+    if (viewBtn && !viewBtn.classList.contains('active')) viewBtn.click();
+  }
+}
+
+function renderFileItem(a, praId) {
+  const name = typeof a === 'string' ? a : a.name;
+  const url = typeof a === 'object' ? a.url : null;
+  const isPdf = name.toLowerCase().endsWith('.pdf');
+  const li = el('li', { class: 'file-entry', dataset: { filename: name } });
+  if (url) {
+    li.appendChild(el('a', { href: url, target: '_blank', rel: 'noopener' }, name));
+  } else {
+    li.appendChild(el('code', {}, name));
+  }
+  const actions = el('span', { class: 'file-actions' });
+  const linkBtn = el('button', { class: 'file-action-btn', type: 'button', title: 'Copy shareable link' }, 'link');
+  linkBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const frag = '#' + praId + '/' + encodeURIComponent(name);
+    navigator.clipboard.writeText(location.href.split('#')[0] + frag);
+    history.replaceState(null, '', frag);
+    linkBtn.textContent = 'copied!';
+    setTimeout(() => { linkBtn.textContent = 'link'; }, 1200);
+  });
+  actions.appendChild(linkBtn);
+  if (isPdf && url) {
+    const rawUrl = blobToRaw(url);
+    let frame = null;
+    const viewBtn = el('button', { class: 'file-action-btn file-view-btn', type: 'button' }, 'view');
+    viewBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (frame) {
+        frame.remove();
+        frame = null;
+        viewBtn.classList.remove('active');
+        viewBtn.textContent = 'view';
+      } else {
+        frame = el('iframe', { class: 'pdf-viewer-frame', src: rawUrl, title: name });
+        li.appendChild(frame);
+        viewBtn.classList.add('active');
+        viewBtn.textContent = 'close';
+      }
+    });
+    actions.appendChild(viewBtn);
+  }
+  li.appendChild(actions);
+  return li;
 }
 
 function praLink(id) {
@@ -165,6 +232,14 @@ function filterAndSort() {
     },
   };
   items.sort(sortFns[state.sort] || sortFns['filed-desc']);
+
+  // Exact PRA-ID search: pin that card to the top regardless of sort order
+  const exactId = state.search.trim().toUpperCase();
+  if (/^W\d{6}-\d{6}$/.test(exactId)) {
+    const idx = items.findIndex(p => p.id.toUpperCase() === exactId);
+    if (idx > 0) items.unshift(items.splice(idx, 1)[0]);
+  }
+
   return items;
 }
 
@@ -517,14 +592,7 @@ function renderCard(pra) {
     const scroller = el('div', { class: 'files-scroll' });
     const ul = el('ul', { class: 'files-list' });
     for (const a of pra.derived.attachments) {
-      const name = typeof a === 'string' ? a : a.name;
-      const url = typeof a === 'object' ? a.url : null;
-      if (url) {
-        ul.appendChild(el('li', {},
-          el('a', { href: url, target: '_blank', rel: 'noopener' }, name)));
-      } else {
-        ul.appendChild(el('li', {}, el('code', {}, name)));
-      }
+      ul.appendChild(renderFileItem(a, pra.id));
     }
     scroller.appendChild(ul);
     details.appendChild(scroller);
@@ -622,13 +690,20 @@ async function init() {
   wireControls();
   render();
 
+  function parseHash() {
+    const raw = window.location.hash.slice(1);
+    const slash = raw.indexOf('/');
+    return slash >= 0
+      ? { id: raw.slice(0, slash), filename: raw.slice(slash + 1) }
+      : { id: raw, filename: null };
+  }
   if (window.location.hash) {
-    const id = window.location.hash.slice(1);
-    if (state.knownIds.has(id)) focusPra(id);
+    const { id, filename } = parseHash();
+    if (state.knownIds.has(id)) focusPra(id, filename);
   }
   window.addEventListener('hashchange', () => {
-    const id = window.location.hash.slice(1);
-    if (state.knownIds.has(id)) focusPra(id);
+    const { id, filename } = parseHash();
+    if (state.knownIds.has(id)) focusPra(id, filename);
   });
 }
 

--- a/docs/pras.html
+++ b/docs/pras.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com; frame-src https://raw.githubusercontent.com;">
 <title>PRA Tracker — SMPD ALPR Investigation</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -622,6 +622,37 @@
   }
   .requester-msg.open .requester-msg-body { display: block; }
   .requester-msg.open .requester-msg-preview { display: none; }
+
+  .file-entry { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+  .file-entry.file-highlighted {
+    background: rgba(96, 165, 250, 0.1);
+    border-radius: 4px;
+    padding: 3px 6px;
+    margin: 0 -6px;
+  }
+  .file-actions { display: inline-flex; gap: 3px; flex-shrink: 0; }
+  .file-action-btn {
+    background: none;
+    border: 1px solid #334155;
+    color: #64748b;
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-family: inherit;
+    line-height: 1.5;
+  }
+  .file-action-btn:hover { border-color: #60a5fa; color: #dbeafe; }
+  .file-action-btn.active { border-color: #60a5fa; color: #93c5fd; background: rgba(96,165,250,0.08); }
+  .pdf-viewer-frame {
+    width: 100%;
+    height: 640px;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    margin-top: 6px;
+    display: block;
+    flex-basis: 100%;
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- `#PRAID/filename` hash format expands the card, highlights the file row, and auto-opens the inline PDF viewer
- Per-file **link** button copies the shareable URL; **view/close** toggle embeds PDFs inline via `raw.githubusercontent.com` (no GitHub blob viewer redirect)
- Searching an exact PRA ID pins that card to the top regardless of sort order
- CSP updated: `frame-src https://raw.githubusercontent.com`

## Test plan

- [ ] Navigate to `pras.html#W012129-020926` — card expands and scrolls into view
- [ ] Navigate to `pras.html#W012129-020926/Flock%20Questions-Response.pdf` — card expands, file row highlights, inline viewer opens
- [ ] Click **link** on any file — address bar updates, clipboard contains the `#PRAID/filename` URL
- [ ] Click **view** on a PDF — 640px iframe loads; click **close** — iframe collapses
- [ ] Type a full PRA ID (e.g. `W012129-020926`) in search — that card appears first even if other cards reference it in notes