### PR TITLE
fix(parser): re-attach 2-letter state suffixes split by comma in org names

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -253,11 +253,12 @@ _EXPECTS_CONTINUATION = re.compile(
 )
 
 # Pattern for standalone tokens that are clearly a continuation *of* a
-# previous name (e.g. "LLC", "Inc."). Flock's data has split entries
-# like ["CA - Topgolf USA El Segundo", "LLC", ...] from un-escaped
-# commas in their source — re-attach the suffix to the prior entry.
+# previous name (e.g. "LLC", "Inc.", "CA"). Flock's data has split entries
+# from un-escaped commas in their source — e.g. "Brickyard Cove - Richmond, CA"
+# splits into ["Brickyard Cove - Richmond", "CA"]. Re-attach to the prior entry.
+# Two-letter tokens are US state abbreviations (CA, NY, TX, …).
 _IS_CONTINUATION_SUFFIX = re.compile(
-    r"^(LLC|L\.L\.C\.?|Inc\.?|Corp\.?|Ltd\.?|Co\.?)$",
+    r"^(LLC|L\.L\.C\.?|Inc\.?|Corp\.?|Ltd\.?|Co\.?|[A-Z]{2})$",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary

- `"Brickyard Cove - Richmond, CA"` was producing two spurious registry entries (`Brickyard Cove - Richmond` + `CA`) on portals that use the legacy comma-separated sharing layout (seen in PR #407, richmond-ca-pd)
- Root cause: `_parse_org_names` splits on `", "` in the comma-layout path; `CA` was being treated as a standalone org name
- Fix: extend `_IS_CONTINUATION_SUFFIX` to match bare 2-letter tokens (US state abbreviations), re-joining them to the previous name — same mechanism already used for `LLC`/`Inc.` split-offs

## Test plan

- [ ] Verify next richmond-ca-pd scrape produces `"Brickyard Cove - Richmond, CA"` as a single entry and does not create a bare `"CA"` agency
- [ ] The spurious `ca` and `brickyard-cove-richmond` registry entries from PR #407 can be cleaned up after that scrape confirms the fix