### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/queue/ecf79431.json
+++ b/assets/articles/queue/ecf79431.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.govtech.com/em/safety/despite-successes-alpr-tech-still-raises-privacy-concerns",
+  "source_domain": "govtech.com",
+  "discovered_at": "2026-05-15T08:23:22Z",
+  "discovered_by": "bing:alpr"
+}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 314
- Curation: enriched: 195 · mechanical: 109 · needs_review: 10
- Scanner: REVIEW REQUIRED: 201 · WARNINGS: 111 · CLEAN: 2
- Wayback: saved: 134 · submit-failed: 89 · poll-failed: 84 · save-failed: 5 · existing: 2
- PDF: rendered: 263 · skipped-curl-fallback: 51
- Top sources: eff.org (25), thenewstribune.com (13), smdailyjournal.com (12), evanstonroundtable.com (12), kqed.org (11), kcrg.com (11), denvergazette.com (11), cvillerightnow.com (11)
- Queue remaining: 0 priority + 51 auto = 51

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
