### PR TITLE
feat(report): sharing reciprocity visualization

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -165,6 +165,7 @@
     html += renderTransparencyChecklist(report, meta);
     html += renderPortalLanguageNotes(report);
     html += renderSharing(report);
+    html += renderReciprocity(report);
     html += renderRegional(report, meta);
     html += renderArticles(report, articlesData, slug);
     html += renderLegalSummary(report, meta);
@@ -1876,6 +1877,128 @@
       const label = FLAG_LABELS[refined] || refined.toUpperCase();
       html += ` <span class="flag-tag kind-${escapeHtml(refined)}">${escapeHtml(label)}</span>`;
     }
+    return html;
+  }
+
+  // ── Sharing reciprocity ──
+  //
+  // For every agency B with any known sharing edge to/from this agency
+  // (A), classify the relationship as reciprocal, one-way inbound
+  // (B→A only), or one-way outbound (A→B only). The chart pulls two
+  // rhetorical points to the surface:
+  //   1. "Some of these agencies share to us without us sharing back" —
+  //      counters the "we share to receive" argument.
+  //   2. "Some agencies we share to don't share back to us" — undercuts
+  //      the framing that broad outbound sharing is necessary.
+  // Empty-vs-unpublished matters: a recipient with no published outbound
+  // list isn't "confirmed non-reciprocal", just unverifiable. Those are
+  // shown as a hatched segment + separate caption.
+  function renderReciprocity(report) {
+    const r = report.reciprocity;
+    if (!r) return "";
+    const counts = r.counts || {};
+    const examples = r.examples || {};
+    const recip = counts.reciprocal || 0;
+    const inOnly = counts.one_way_in || 0;
+    const outOnly = counts.one_way_out || 0;
+    const unvOut = counts.unverifiable_out || 0;
+    const unvIn = counts.unverifiable_in || 0;
+    const total = recip + inOnly + outOnly + unvOut + unvIn;
+    if (total === 0) return "";
+
+    let html = `<h2>Sharing Reciprocity</h2>`;
+    html += `<p>Across <strong>${total}</strong> ${total === 1 ? "agency" : "agencies"} with a known sharing edge to or from ${escapeHtml(report.name)}:</p>`;
+
+    // If A hasn't published an outbound list, the whole "do we share
+    // back?" question can't be answered — explain the gap and stop.
+    if (!r.subject_outbound_published && unvIn > 0) {
+      html += `<div class="recip-callout">`;
+      html += `<strong>${escapeHtml(report.name)} has not published an outbound sharing list.</strong> `;
+      html += `${unvIn} ${unvIn === 1 ? "agency publishes" : "agencies publish"} an outbound list that names this agency as a recipient — but whether ${escapeHtml(report.name)} shares back can't be confirmed from public data.`;
+      html += `</div>`;
+      // Still list the senders so readers can see who's sending data here.
+      const ex = examples.unverifiable_in || [];
+      if (ex.length) {
+        html += `<div class="recip-details">`;
+        html += `<details open><summary>Agencies that share to ${escapeHtml(report.name)} (from their published outbound lists)</summary>`;
+        html += recipList(ex, unvIn);
+        html += `</details></div>`;
+      }
+      return html;
+    }
+
+    // Build the stacked bar. Outbound bucket combines confirmed +
+    // unverifiable so the total width matches A's actual outbound
+    // count; the unverifiable portion is hatched.
+    const outTotal = outOnly + unvOut;
+    function segPct(n) { return total ? (100.0 * n / total) : 0; }
+    html += `<div class="recip-bar" role="img" aria-label="Reciprocity breakdown">`;
+    if (recip > 0) {
+      html += `<div class="seg recip-recip" style="flex:${recip}" title="${recip} reciprocal">${recip}</div>`;
+    }
+    if (inOnly > 0) {
+      html += `<div class="seg recip-in" style="flex:${inOnly}" title="${inOnly} one-way inbound">${inOnly}</div>`;
+    }
+    if (outOnly > 0) {
+      html += `<div class="seg recip-out" style="flex:${outOnly}" title="${outOnly} one-way outbound (confirmed)">${outOnly}</div>`;
+    }
+    if (unvOut > 0) {
+      html += `<div class="seg recip-unv" style="flex:${unvOut}" title="${unvOut} outbound recipients haven't published a sharing list">${unvOut}</div>`;
+    }
+    html += `</div>`;
+
+    // Legend
+    html += `<div class="recip-legend">`;
+    html += `<div class="item"><span class="swatch recip-recip"></span><div><strong>Reciprocal (${recip}).</strong> Both agencies share to each other.</div></div>`;
+    html += `<div class="item"><span class="swatch recip-in"></span><div><strong>One-way (inbound): ${inOnly}.</strong> They share to ${escapeHtml(report.name)}; ${escapeHtml(report.name)} does not share back.</div></div>`;
+    html += `<div class="item"><span class="swatch recip-out"></span><div><strong>One-way (outbound): ${outOnly}.</strong> ${escapeHtml(report.name)} shares to them; their published outbound list does not include ${escapeHtml(report.name)}.</div></div>`;
+    if (unvOut > 0) {
+      html += `<div class="item"><span class="swatch recip-unv"></span><div><strong>Unverifiable (${unvOut}).</strong> ${escapeHtml(report.name)} shares to them, but they haven't published an outbound list — reciprocity can't be confirmed.</div></div>`;
+    }
+    html += `</div>`;
+
+    // Per-bucket detail lists
+    html += `<div class="recip-details">`;
+    if (inOnly > 0) {
+      html += `<details open><summary>One-way inbound: ${inOnly} ${inOnly === 1 ? "agency shares" : "agencies share"} to ${escapeHtml(report.name)} without ${escapeHtml(report.name)} sharing back</summary>`;
+      html += recipList(examples.one_way_in || [], inOnly);
+      html += `</details>`;
+    }
+    if (outOnly > 0) {
+      html += `<details><summary>One-way outbound: ${outOnly} ${outOnly === 1 ? "agency receives" : "agencies receive"} data from ${escapeHtml(report.name)} without their published outbound list naming ${escapeHtml(report.name)}</summary>`;
+      html += recipList(examples.one_way_out || [], outOnly);
+      html += `</details>`;
+    }
+    if (unvOut > 0) {
+      html += `<details><summary>Unverifiable: ${unvOut} outbound ${unvOut === 1 ? "recipient hasn't" : "recipients haven't"} published a sharing list</summary>`;
+      html += recipList(examples.unverifiable_out || [], unvOut);
+      html += `</details>`;
+    }
+    html += `</div>`;
+    return html;
+  }
+
+  function recipList(items, total) {
+    if (!items.length) return "";
+    let html = "<ul>";
+    items.forEach(function(b) {
+      const linkable = b.crawled && b.slug;
+      const name = linkable
+        ? `<a href="?agency=${escapeHtml(b.slug)}">${escapeHtml(b.name)}</a>`
+        : escapeHtml(b.name);
+      let line = name;
+      if (b.state && b.state !== "CA") line += ` <span class="muted">(${escapeHtml(b.state)})</span>`;
+      if (b.kind) {
+        const refined = refineKind(b.kind, b.name);
+        const label = FLAG_LABELS[refined] || refined.toUpperCase();
+        line += ` <span class="flag-tag kind-${escapeHtml(refined)}">${escapeHtml(label)}</span>`;
+      }
+      html += `<li>${line}</li>`;
+    });
+    if (total > items.length) {
+      html += `<li class="muted">&hellip; and ${total - items.length} more.</li>`;
+    }
+    html += "</ul>";
     return html;
   }
 

--- a/docs/report.html
+++ b/docs/report.html
@@ -977,6 +977,78 @@
        of floating and squishing adjacent text. */
     .mini-map-wrap { float: none; max-width: 100%; width: 100%; margin: 8px 0; }
   }
+
+  /* ── Sharing reciprocity ── */
+  .recip-bar {
+    display: flex;
+    width: 100%;
+    height: 28px;
+    margin: 8px 0 10px 0;
+    border-radius: 4px;
+    overflow: hidden;
+    background: #e5e7eb;
+  }
+  .recip-bar .seg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: bold;
+    font-size: 10.5pt;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .recip-bar .seg.recip-recip { background: var(--check-yes); }
+  .recip-bar .seg.recip-in    { background: var(--accent); }
+  .recip-bar .seg.recip-out   { background: var(--flag); }
+  .recip-bar .seg.recip-unv   {
+    background: repeating-linear-gradient(
+      45deg,
+      #9ca3af 0,
+      #9ca3af 6px,
+      #6b7280 6px,
+      #6b7280 12px
+    );
+  }
+  .recip-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 18px;
+    margin: 6px 0 10px 0;
+    font-size: 10pt;
+    line-height: 1.35;
+  }
+  .recip-legend .item { display: flex; align-items: flex-start; gap: 6px; }
+  .recip-legend .swatch {
+    flex: 0 0 14px;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    margin-top: 2px;
+  }
+  .recip-legend .swatch.recip-recip { background: var(--check-yes); }
+  .recip-legend .swatch.recip-in    { background: var(--accent); }
+  .recip-legend .swatch.recip-out   { background: var(--flag); }
+  .recip-legend .swatch.recip-unv   {
+    background: repeating-linear-gradient(
+      45deg,
+      #9ca3af 0,
+      #9ca3af 4px,
+      #6b7280 4px,
+      #6b7280 8px
+    );
+  }
+  .recip-details { margin-top: 10px; }
+  .recip-details details { margin: 6px 0; }
+  .recip-details summary { cursor: pointer; font-weight: 600; }
+  .recip-details ul { margin: 4px 0 8px 0; }
+  .recip-callout {
+    background: #fffbeb;
+    border-left: 4px solid var(--warn-border);
+    padding: 10px 14px;
+    margin: 10px 0;
+    font-size: 10.5pt;
+  }
 </style>
 </head>
 <body>

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -1099,6 +1099,15 @@ def main():
 
     # ── Build graph-wide flag classification cache ──
     outbound_by_id = {aid: d.get("sharing_outbound_ids", []) for aid, d in graph_agencies.items()}
+    # Set-form lookup for fast "is X in Y's outbound?" reciprocity checks.
+    outbound_set_by_id = {aid: set(ids) for aid, ids in outbound_by_id.items()}
+    # True/False/None — None when uncrawled (we have no portal to know
+    # whether the agency published an outbound section at all). Used to
+    # distinguish "B confirmed no sharing back" from "B's portal doesn't
+    # publish a sharing list" in the reciprocity buckets below.
+    outbound_pub_by_id = {
+        aid: d.get("sharing_outbound_published") for aid, d in graph_agencies.items()
+    }
 
     # ── Pass 2: build a report entry for EVERY agency in the registry ──
     #
@@ -1784,6 +1793,79 @@ def main():
         for target_id in sorted(inferred_out_ids):
             outbound_list.append(_outbound_entry(target_id, True))
 
+        # ── Sharing reciprocity buckets ──
+        #
+        # Classify every agency with any known sharing edge to/from A
+        # into mutually-exclusive buckets:
+        #   reciprocal:       A → B  AND  B → A
+        #   one_way_in:       B → A only — they share to us, we don't share back
+        #   one_way_out:      A → B only AND B published an outbound list
+        #                     confirming A is absent
+        #   unverifiable_out: A → B  AND  B has not published outbound — we
+        #                     can't tell whether they reciprocate
+        #   unverifiable_in:  B → A only AND we haven't published outbound —
+        #                     we can't claim "we don't share back"
+        #
+        # The visualization shows three primary buckets (reciprocal /
+        # one-way inbound / one-way outbound) with the unverifiable
+        # tallies surfaced as caveats so empty-vs-unpublished isn't
+        # confused with a confirmed answer.
+        subject_outbound_published = (
+            bool(gdata.get("sharing_outbound_published")) if crawled else False
+        )
+        a_out_set = set(outbound_ids)
+        inferred_in_ids = inbound_inferred_by_id.get(aid, set())
+        recip_partners = (a_out_set | inferred_in_ids) - {aid}
+        recip_buckets = {
+            "reciprocal": [],
+            "one_way_in": [],
+            "one_way_out": [],
+            "unverifiable_out": [],
+            "unverifiable_in": [],
+        }
+        for bid in recip_partners:
+            b_pub = outbound_pub_by_id.get(bid)
+            b_out = outbound_set_by_id.get(bid, set())
+            a_in_b = aid in b_out
+            b_in_a = bid in a_out_set
+            if a_in_b and b_in_a:
+                recip_buckets["reciprocal"].append(bid)
+            elif a_in_b and not b_in_a:
+                if subject_outbound_published:
+                    recip_buckets["one_way_in"].append(bid)
+                else:
+                    recip_buckets["unverifiable_in"].append(bid)
+            elif b_in_a and not a_in_b:
+                if b_pub:
+                    recip_buckets["one_way_out"].append(bid)
+                else:
+                    recip_buckets["unverifiable_out"].append(bid)
+
+        def _recip_example(bid):
+            br = reg_by_id.get(bid, {})
+            bslug = id_to_slug.get(bid, bid)
+            return {
+                "agency_id": bid,
+                "slug": bslug,
+                "name": agency_display_name(br, bslug),
+                "kind": is_flagged_entity(bid, reg_by_id),
+                "state": agency_state(br),
+                "crawled": bool(graph_agencies.get(bid, {}).get("crawled")),
+            }
+
+        # Sort each bucket's example list alphabetically by name so the
+        # rendered output is stable across runs.
+        RECIP_EXAMPLE_LIMIT = 25
+        reciprocity = {
+            "subject_outbound_published": subject_outbound_published,
+            "counts": {k: len(v) for k, v in recip_buckets.items()},
+            "examples": {},
+        }
+        for k, bids in recip_buckets.items():
+            entries = [_recip_example(b) for b in bids]
+            entries.sort(key=lambda e: (e["name"] or "").lower())
+            reciprocity["examples"][k] = entries[:RECIP_EXAMPLE_LIMIT]
+
         # ── Regional context: crawled CA agencies within REGIONAL_RADIUS_KM ──
         regional = []
         if lat is not None and lng is not None:
@@ -1918,6 +2000,7 @@ def main():
             "removed_flagged_recipients": removed_flagged_recipients,
             "outbound": outbound_list,
             "inbound": inbound_list,
+            "reciprocity": reciprocity,
             "regional": regional,
             "audit_vs_inbound": audit_vs_inbound,
             "recent_outbound_additions": recent_outbound_additions,

--- a/scripts/build_sharing_graph.py
+++ b/scripts/build_sharing_graph.py
@@ -94,6 +94,15 @@ def main():
         raw_text = txts[-1].read_text(encoding="utf-8")
         portal_data = json.loads(jsons[-1].read_text()) if jsons else {}
 
+        # Whether the portal published the outbound/inbound sections at
+        # all. The parser collapses "section absent" and "section present
+        # but empty" to `[]`, so we re-derive published-ness from the raw
+        # text label presence. Used downstream to distinguish
+        # "they confirmed 0 sharing" (rare) from "they didn't publish a
+        # sharing list" (common — e.g. Foster City).
+        outbound_published = "Organizations granted access" in raw_text
+        inbound_published = "Organizations sharing their data with" in raw_text
+
         # Support both old and new field names during transition
         outbound_names = portal_data.get("sharing_outbound") or portal_data.get("shared_org_names", [])
         outbound_ids = _resolve_names_to_ids(outbound_names)
@@ -111,8 +120,10 @@ def main():
             "data_retention_days": portal_data.get("data_retention_days"),
             "sharing_outbound_count": len(outbound_names),
             "sharing_outbound_ids": outbound_ids,
+            "sharing_outbound_published": outbound_published,
             "sharing_inbound_count": len(inbound_names),
             "sharing_inbound_ids": inbound_ids,
+            "sharing_inbound_published": inbound_published,
         }
 
     # ── Build bidirectional graph ──
@@ -190,7 +201,9 @@ def main():
             "sharing_outbound_count": len(sends_to),
             "sharing_inbound_count": inbound_counts.get(entity_id, 0),
             "sharing_outbound_ids": sends_to,
+            "sharing_outbound_published": None,
             "sharing_inbound_ids": received_from,
+            "sharing_inbound_published": None,
         }
 
     # Merge crawled + uncrawled
@@ -204,7 +217,9 @@ def main():
             "sharing_outbound_count": d["sharing_outbound_count"],
             "sharing_inbound_count": d["sharing_inbound_count"],
             "sharing_outbound_ids": d["sharing_outbound_ids"],
+            "sharing_outbound_published": d["sharing_outbound_published"],
             "sharing_inbound_ids": d["sharing_inbound_ids"],
+            "sharing_inbound_published": d["sharing_inbound_published"],
         }
     all_agencies.update(uncrawled)
 


### PR DESCRIPTION
## Summary

- Adds a **Sharing Reciprocity** section to every agency report page, between Data Sharing and Regional Context
- Stacked bar with four buckets: reciprocal / one-way inbound / one-way outbound / unverifiable (recipient hasn't published a list)
- Named example agencies under each bucket (up to 25, linked to their reports)
- Agencies that haven't published their own outbound list (e.g. Foster City) get an explanation callout instead of the bar, plus a list of agencies whose outbound lists name them as a recipient

## Rhetorical use case

Two points surfaced for advocacy:
1. **"They share to us without us sharing back"** (one-way inbound) — counters the "we have to share to receive" argument
2. **"We share to them but they don't share back"** (one-way outbound, confirmed) — undercuts the framing that broad outbound sharing is necessary

For SMPD: 122 reciprocal, 7 one-way inbound, 10 one-way outbound, 146 unverifiable.

## Pipeline changes

`build_sharing_graph.py` now detects whether the "Organizations granted access" heading appears in the raw portal text, adding `sharing_outbound_published`/`sharing_inbound_published` booleans. This distinguishes "confirmed zero sharing" from "section not published at all" — previously both collapsed to an empty list.

`build_report_data.py` computes reciprocity buckets per agency using the full sharing graph and attaches them to each report entry.

## Test plan

- [x] Playwright smoke test verified SMPD and Foster City render correctly
- [x] `test_map_smoke.py` and `test_scoreboard.py` pass
- [ ] Visually review SMPD report reciprocity section on staging
- [ ] Spot-check a high-outbound agency (e.g. El Cajon)