### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/queue/e5f692ac.json
+++ b/assets/articles/queue/e5f692ac.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wired.com/story/security-news-this-week-fbi-license-plate-reader-real-time-access/",
+  "source_domain": "wired.com",
+  "discovered_at": "2026-05-24T08:04:46Z",
+  "discovered_by": "rss:wired.com"
+}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 322
- Curation: enriched: 197 · mechanical: 114 · needs_review: 11
- Scanner: REVIEW REQUIRED: 208 · WARNINGS: 112 · CLEAN: 2
- Wayback: saved: 138 · submit-failed: 91 · poll-failed: 85 · save-failed: 5 · existing: 3
- PDF: rendered: 271 · skipped-curl-fallback: 51
- Top sources: eff.org (25), smdailyjournal.com (14), thenewstribune.com (13), evanstonroundtable.com (12), kqed.org (11), kcrg.com (11), kvue.com (11), denvergazette.com (11)
- Queue remaining: 0 priority + 54 auto = 54

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
