### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -100304,8 +100304,10 @@
   {
     "agency_id": "2511076a-5a0c-5581-8e67-bcea492b116b",
     "slug": "muskegon-mi-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
+    "flock_active_slug": "muskegon-mi-pd",
+    "flock_slugs": [
+      "muskegon-mi-pd"
+    ],
     "flock_names": [
       "Muskegon MI PD"
     ],

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1455,9 +1455,10 @@
     "59b1f730-2412-5790-92fd-a707e3ac23cd": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-28T07:56:45.495922+00:00",
+      "last_probed": "2026-05-25T16:53:58.982446+00:00",
       "tried": {
         "pleasant-hill-ca-po": "http_404",
+        "pleasant-hill-ca-police": "http_404",
         "pleasant-hill-ca-police-department": "http_404"
       }
     },
@@ -1516,6 +1517,14 @@
       "last_probed": "2026-05-12T13:27:24.223060+00:00",
       "tried": {
         "lodi-wi-pd": "http_404"
+      }
+    },
+    "5d07ba57-485b-59c0-ac64-1d8d4634c23a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T16:54:02.562026+00:00",
+      "tried": {
+        "msd-wayne-township-in-pd": "http_404"
       }
     },
     "5d327e7e-cc00-5be7-abc0-982c6e7ca247": {
@@ -2284,6 +2293,14 @@
       "last_probed": "2026-05-12T21:57:14.950620+00:00",
       "tried": {
         "pelham-al-pd": "http_404"
+      }
+    },
+    "8d40ae56-8e48-570e-b485-f6c4a4464423": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T16:54:08.900321+00:00",
+      "tried": {
+        "fontana-ca-po": "http_404"
       }
     },
     "8d7fd470-fecf-5788-921d-7f82bc634a71": {
@@ -3992,6 +4009,6 @@
       }
     }
   },
-  "updated": "2026-05-25T14:23:56.860386+00:00",
+  "updated": "2026-05-25T16:54:08.940329+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -587,6 +587,14 @@
         "nationalcity-psca": "http_404"
       }
     },
+    "2511076a-5a0c-5581-8e67-bcea492b116b": {
+      "exhausted": false,
+      "found": "muskegon-mi-pd",
+      "last_probed": "2026-05-25T06:57:51.263761+00:00",
+      "tried": {
+        "muskegon-mi-pd": "http_200"
+      }
+    },
     "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
       "exhausted": false,
       "found": null,
@@ -1239,6 +1247,14 @@
         "indio-ca-po": "http_404",
         "indio-ca-police": "http_404",
         "indio-ca-police-department": "http_404"
+      }
+    },
+    "4e689ee7-da7f-5530-bef1-c987d872e792": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T06:58:04.401882+00:00",
+      "tried": {
+        "oceanside-ca-po": "http_404"
       }
     },
     "4e876f28-fcca-5c87-9e65-f0730980ea1d": {
@@ -2730,6 +2746,14 @@
         "mount-morris-township-mi-pd": "http_404"
       }
     },
+    "ab72c709-a28e-5f83-b6ab-8dfe17c4cd40": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T06:58:00.007127+00:00",
+      "tried": {
+        "hendry-county-fl-so": "http_404"
+      }
+    },
     "abd9ac18-4eff-57ec-9008-7c62a27c374c": {
       "exhausted": false,
       "found": null,
@@ -3920,6 +3944,6 @@
       }
     }
   },
-  "updated": "2026-05-21T22:53:36.715588+00:00",
+  "updated": "2026-05-25T06:58:04.453655+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1105,6 +1105,14 @@
         "grundy-county-il-so": "http_404"
       }
     },
+    "43c1eb5e-475c-5627-a594-25e50c5383d5": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T14:23:45.911770+00:00",
+      "tried": {
+        "portage-in-pd": "http_404"
+      }
+    },
     "440cab4b-0602-53bf-9d8a-6614815ccd23": {
       "exhausted": false,
       "found": null,
@@ -1279,6 +1287,14 @@
       "last_probed": "2026-05-19T04:48:04.327935+00:00",
       "tried": {
         "saline-county-ks-so": "http_404"
+      }
+    },
+    "4f241c0e-e0e9-56fe-acb8-531d82bc7f0c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T14:23:50.448883+00:00",
+      "tried": {
+        "las-vegas-nm-pd": "http_404"
       }
     },
     "506efefe-608f-5fbb-896c-c7747df5287f": {
@@ -1823,6 +1839,14 @@
       "last_probed": "2026-04-28T22:41:32.304622+00:00",
       "tried": {
         "santa-maria-ca-po": "http_404"
+      }
+    },
+    "6d11ec03-586d-570a-b110-56f9e37261ff": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T14:23:56.828034+00:00",
+      "tried": {
+        "san-mateo-county-ca-sd": "http_404"
       }
     },
     "6d2789e3-41cc-5154-8588-01370a616fcf": {
@@ -3968,6 +3992,6 @@
       }
     }
   },
-  "updated": "2026-05-25T11:39:52.656058+00:00",
+  "updated": "2026-05-25T14:23:56.860386+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -827,6 +827,14 @@
         "peru-in-pd": "http_404"
       }
     },
+    "34274c0f-3463-563f-82e5-b56843cd8dc3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T11:39:48.151299+00:00",
+      "tried": {
+        "newton-nc-pd": "http_404"
+      }
+    },
     "347b387e-6d62-5b46-8c1a-3dd5400f7a9d": {
       "exhausted": false,
       "found": null,
@@ -2502,6 +2510,14 @@
         "monterey-county-ca-sd": "http_404"
       }
     },
+    "9c1c5b61-7dec-5fce-a5ec-a3be9ed47c86": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T11:39:52.618750+00:00",
+      "tried": {
+        "alameda-county-ca-sd": "http_404"
+      }
+    },
     "9ca34cca-3e9a-5277-b490-6d06516ccbee": {
       "exhausted": false,
       "found": null,
@@ -3351,6 +3367,14 @@
         "herrin-il-pd": "http_200"
       }
     },
+    "d89a7347-b229-5e28-8897-0d12974e6970": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-25T11:39:43.364227+00:00",
+      "tried": {
+        "avoca-pa-po": "http_404"
+      }
+    },
     "d8a94e88-50c9-5801-aa66-3716e0f4b648": {
       "exhausted": false,
       "found": null,
@@ -3944,6 +3968,6 @@
       }
     }
   },
-  "updated": "2026-05-25T06:58:04.453655+00:00",
+  "updated": "2026-05-25T11:39:52.656058+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.