### PR TITLE
fix(article-curate): fold LLM-chosen PSAs back into agencies[]

### DIFF
--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -681,6 +681,16 @@ def run_phase2(registry: list[dict], *, tags_data: dict,
         existing_tags.add(f"genre:{data['genre']}")
         entry["tags"] = sorted(existing_tags)
         entry["primary_subject_agency_ids"] = data["primary_subject_agency_ids"]
+        # LLM judgment on PSA trumps the Phase-1 fuzzy-score cutoff: if the
+        # model identifies a candidate as the article's subject, fold it into
+        # agencies[] so downstream lookups (and lint_articles.py's subset
+        # check) see it.
+        if data["primary_subject_agency_ids"]:
+            merged = list(entry.get("agencies") or [])
+            for psa in data["primary_subject_agency_ids"]:
+                if psa not in merged:
+                    merged.append(psa)
+            entry["agencies"] = merged
         entry["curation_status"] = "enriched"
         entry["curated_at"] = now_iso()
         entry.pop("curation_error", None)


### PR DESCRIPTION
## Summary

The article-registry-bot has been failing every run since 5/24 22:05, leaving PR #439 stuck at "0 new articles" while the queue grew to 56+. Root cause:

- Phase-2 enricher lets the LLM pick `primary_subject_agency_ids` from `agency_candidates[]` (full proposal set).
- `agencies[]` only retains candidates scoring ≥ 2.0 from the fuzzy matcher.
- `lint_articles.py` requires `primary_subject_agency_ids ⊆ agencies[]` — a sensible invariant.
- For [art_325 (Oaklandside)](https://oaklandside.org/2023/08/17/oaklands-license-plate-readers-have-been-off-for-months-so-why-does-the-city-want-more/), the Oakland PD candidate scored below 2.0 (so wasn't in `agencies[]`) but was correctly identified by the LLM as the article's subject. Lint rejected → bot crashed before commit, every single run.

Fix: after Phase-2 succeeds, union the LLM's `primary_subject_agency_ids` into `agencies[]`. The model's read of "this article is about agency X" is a stronger signal than a fuzzy-match score, and downstream lookups should see it.

## Test plan

- [x] `lint_articles.py` still passes on the current 322-entry registry (no error change; same 20 known outcome:* warnings)
- [x] Syntax check of the modified file
- [ ] First crawl run after merge: art_325 enriches cleanly and commits, queue starts draining