### PR TITLE
fix(flock): don't permanently quarantine 403s or explicit-slug retries

### DIFF
--- a/assets/transparency.flocksafety.com/.failed_slugs.json
+++ b/assets/transparency.flocksafety.com/.failed_slugs.json
@@ -27,10 +27,6 @@
     "date": "2026-04-26",
     "reason": "http_404"
   },
-  "alameda-county-ca-so": {
-    "date": "2026-05-22",
-    "reason": "http_403"
-  },
   "albion-mi-dps": {
     "date": "2026-04-26",
     "reason": "http_404"
@@ -126,10 +122,6 @@
   "benton-county-wa-so": {
     "date": "2026-04-29",
     "reason": "http_404"
-  },
-  "beverly-hills-ca-pd": {
-    "date": "2026-05-05",
-    "reason": "not_a_portal"
   },
   "bienville-parish-la-so": {
     "date": "2026-04-29",
@@ -243,10 +235,6 @@
     "date": "2026-04-25",
     "reason": "http_404"
   },
-  "california-highway-patrol": {
-    "date": "2026-04-01",
-    "reason": "navigation_error"
-  },
   "california-state-parks": {
     "date": "2026-04-01",
     "reason": "http_404"
@@ -274,10 +262,6 @@
   "cartersville-ga-pd": {
     "date": "2026-04-30",
     "reason": "http_404"
-  },
-  "cathedral-city-ca-pd": {
-    "date": "2026-05-23",
-    "reason": "http_403"
   },
   "central-marin-ca-pd": {
     "date": "2026-04-02",
@@ -310,10 +294,6 @@
   "chino-ca-pd": {
     "date": "2026-04-19",
     "reason": "http_404"
-  },
-  "chula-vista-ca-pd": {
-    "date": "2026-05-23",
-    "reason": "http_403"
   },
   "city-of-half-moon-bay": {
     "date": "2026-04-25",
@@ -379,10 +359,6 @@
     "date": "2026-04-02",
     "reason": "http_404"
   },
-  "danville-ca-pd": {
-    "date": "2026-05-23",
-    "reason": "http_403"
-  },
   "decommissioned-org": {
     "date": "2026-04-24",
     "reason": "http_404"
@@ -391,17 +367,9 @@
     "date": "2026-04-19",
     "reason": "http_404"
   },
-  "delano-ca-pd": {
-    "date": "2026-05-23",
-    "reason": "http_403"
-  },
   "desert-hot-springs-ca-pd": {
     "date": "2026-04-02",
     "reason": "http_404"
-  },
-  "dixon-ca-pd": {
-    "date": "2026-05-23",
-    "reason": "http_403"
   },
   "dnu": {
     "date": "2026-04-25",
@@ -455,10 +423,6 @@
     "date": "2026-04-24",
     "reason": "http_404"
   },
-  "fontana-ca-pd": {
-    "date": "2026-05-24",
-    "reason": "http_403"
-  },
   "foothill-deanza-ca-pd": {
     "date": "2026-04-03",
     "reason": "http_404"
@@ -503,10 +467,6 @@
     "date": "2026-04-19",
     "reason": "http_404"
   },
-  "hollister-ca-pd": {
-    "date": "2026-04-19",
-    "reason": "http_403"
-  },
   "huntington-beach-ca-pd": {
     "date": "2026-04-03",
     "reason": "http_404"
@@ -534,10 +494,6 @@
   "irwindale-ca-pd": {
     "date": "2026-04-03",
     "reason": "http_404"
-  },
-  "kensington-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
   },
   "kerman-ca-pd": {
     "date": "2026-04-03",
@@ -595,14 +551,6 @@
     "date": "2026-04-24",
     "reason": "http_404"
   },
-  "livingston-ca-pd": {
-    "date": "2026-05-25",
-    "reason": "http_403"
-  },
-  "logan-county-ne-so": {
-    "date": "2026-05-10",
-    "reason": "not_a_portal"
-  },
   "los-alamitos-pd-ca": {
     "date": "2026-04-03",
     "reason": "http_404"
@@ -643,10 +591,6 @@
     "date": "2026-04-03",
     "reason": "http_404"
   },
-  "mendocino-county-soca": {
-    "date": "2026-05-22",
-    "reason": "http_403"
-  },
   "mendota-ca-pd": {
     "date": "2026-04-03",
     "reason": "http_404"
@@ -675,29 +619,13 @@
     "date": "2026-04-24",
     "reason": "http_404"
   },
-  "national-city-ca-pd": {
-    "date": "2026-04-14",
-    "reason": "http_403"
-  },
   "nevada-city-ca-pd": {
     "date": "2026-04-20",
     "reason": "http_404"
   },
-  "nevada-county-ca-so": {
-    "date": "2026-05-26",
-    "reason": "http_403"
-  },
   "newark-ca-pd": {
     "date": "2026-04-08",
     "reason": "http_404"
-  },
-  "oakley-ca-pd": {
-    "date": "2026-05-26",
-    "reason": "http_403"
-  },
-  "oceanside-ca-pd": {
-    "date": "2026-05-22",
-    "reason": "http_403"
   },
   "orange-coast-college-campus-ca-pd": {
     "date": "2026-04-25",
@@ -723,14 +651,6 @@
     "date": "2026-04-08",
     "reason": "http_404"
   },
-  "palo-alto-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
-  },
-  "piedmont-ca-pd": {
-    "date": "2026-05-26",
-    "reason": "http_403"
-  },
   "placentia-ca-pd": {
     "date": "2026-04-09",
     "reason": "http_404"
@@ -739,10 +659,6 @@
     "date": "2026-04-09",
     "reason": "http_404"
   },
-  "placer-county-ca-so": {
-    "date": "2026-05-27",
-    "reason": "http_403"
-  },
   "pleasant-hill-ca-pd": {
     "date": "2026-04-09",
     "reason": "http_404"
@@ -750,18 +666,6 @@
   "pomona-ca-pd": {
     "date": "2026-04-09",
     "reason": "http_404"
-  },
-  "port-hueneme-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
-  },
-  "port-of-stockton-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
-  },
-  "porterville-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
   },
   "redding-pd-ca": {
     "date": "2026-04-20",
@@ -774,10 +678,6 @@
   "rialto-pd-ca": {
     "date": "2026-04-20",
     "reason": "http_404"
-  },
-  "ridgecrest-ca-pd": {
-    "date": "2026-05-27",
-    "reason": "http_403"
   },
   "rio-hondo-college-pd-ca": {
     "date": "2026-04-09",
@@ -798,10 +698,6 @@
   "rocklin-ca-pd": {
     "date": "2026-04-09",
     "reason": "http_404"
-  },
-  "rohnert-park-department-of-public-safety-ca": {
-    "date": "2026-05-19",
-    "reason": "http_403"
   },
   "roseville-ca-pd": {
     "date": "2026-04-09",
@@ -886,14 +782,6 @@
   "san-luis-obispo-county-ca-sheriff": {
     "date": "2026-04-09",
     "reason": "http_404"
-  },
-  "san-mateo-ca-pd": {
-    "date": "2026-05-25",
-    "reason": "http_403"
-  },
-  "san-mateo-county-ca-so": {
-    "date": "2026-05-23",
-    "reason": "http_403"
   },
   "san-pablo-ca-pd": {
     "date": "2026-04-09",

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -1052,15 +1052,20 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
 
 
 def run_crawl_batch(page, slugs, data_dir, force, delay, hashes, failed_slugs,
-                    try_variations=False):
-    """Crawl a list of slugs. Returns (results, discovered_slugs)."""
+                    try_variations=False, explicit=False):
+    """Crawl a list of slugs. Returns (results, discovered_slugs).
+
+    explicit=True means the caller named these slugs directly (vs auto-picked
+    from the oldest-agencies rotation) — in that case, don't skip on prior
+    failure. The human knows the slug; they want a fresh attempt.
+    """
     results = []
     discovered = []
 
     total = len(slugs)
     for i, slug in enumerate(slugs):
         progress = f"({i + 1}/{total})"
-        if slug in failed_slugs:
+        if slug in failed_slugs and not explicit:
             reason = failed_slugs[slug].get("reason", "unknown") if isinstance(failed_slugs[slug], dict) else "unknown"
             print(f"  {progress} {slug} -> previously failed ({reason}), skipping")
             results.append((slug, None))
@@ -1098,14 +1103,13 @@ def run_crawl_batch(page, slugs, data_dir, force, delay, hashes, failed_slugs,
         if discovered_slugs:
             discovered.extend(discovered_slugs)
         if isinstance(status, tuple) and status[0] == "failed":
-            # parse_error means we got the page but the parser tripped on
-            # a new format variant — nothing was written to the asset tree
-            # (archive_agency stages and only commits on full success).
-            # Don't permanently quarantine these: leave them out of
-            # failed_slugs so the next crawl re-fetches and re-parses
-            # against an updated parser. The PARSE_ERROR log line is
-            # surfaced as a tracking issue by the workflow.
-            if status[1] != "parse_error":
+            # Don't permanently quarantine transient failures:
+            #   parse_error: parser tripped on a new format variant; archive_agency
+            #     stages and only commits on full success so no artifacts written.
+            #     Surfaced as a tracking issue by the workflow.
+            #   http_403: Flock's Cloudflare uses 403 (not 429) for rate limiting.
+            #     A 403 here doesn't mean blocked — it means try again next run.
+            if status[1] not in ("parse_error", "http_403"):
                 failed_slugs[slug] = {"reason": status[1], "date": date.today().isoformat()}
 
         save_json(data_dir / HASH_FILE, hashes)
@@ -1295,6 +1299,7 @@ def cmd_crawl(args):
                 page, slugs, data_dir, args.force,
                 args.delay, hashes, failed_slugs,
                 try_variations=args.try_variations,
+                explicit=True,
             )
             all_results.extend(results)
 


### PR DESCRIPTION
## Summary
- Flock's Cloudflare appears to use HTTP 403 (not 429) as its rate-limit response. A transient 403 during one crawl was silently quarantining agencies indefinitely. SMPD hit this on 5/25 and went 9 days without a refresh; 15 agencies total were affected (SMC SO, Alameda County SO, Chula Vista, Fontana, Oceanside, etc.).
- 403 now follows the same path as `parse_error` — reports failed for the run but stays in rotation for the next scheduled crawl. Not promoted to in-run 429-style backoff retry because that costs ~15min/slug and the next run does it for free.
- Explicit-slug crawls (`workflow_dispatch` slugs input, or CLI positional args) now bypass the previously-failed skip-check. A human naming a slug means "give it a fresh attempt."
- Strips the 18 existing transient quarantines (15 `http_403`, 2 `not_a_portal`, 1 `navigation_error`) from `.failed_slugs.json`. The 251 `http_404` entries are kept — those are Flock-confirmed nonexistent portals.

## Test plan
- [ ] After merge, watch the next scheduled `refresh-flock-data` run pick up SMPD (or one of the other cleared slugs) in the oldest-agencies rotation
- [ ] Workflow_dispatch with `slugs: san-mateo-ca-pd` succeeds (previously skipped with `previously failed (http_403)`)
- [ ] If a slug 403s in a future run, confirm via log that it appears as "1 failed" but is **not** added to `.failed_slugs.json`