### PR TITLE
Article curation: backlog triage tooling + drain 79 entries

### DIFF
--- a/assets/article_registry.json
+++ b/assets/article_registry.json
@@ -8897,6 +8897,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -8925,12 +8930,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-08T20:22:17Z",
+    "summary": "Hays County, Texas commissioners voted to end all contracts with Flock Safety, removing its six ALPR cameras and canceling a planned purchase of four more, citing privacy concerns and worries about data sharing with ICE and out-of-state agencies. The sheriff opposed the decision, citing investigative benefits.",
+    "key_quotes": [
+      {
+        "quote": "Hays County will no longer use Flock Safety automatic license plate reader cameras (APLRs). On Tuesday, county commissioners voted to end all contracts with the security company, after facing pushback over privacy concerns.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "It's not so much what our agency might do; it's what other agencies can do that we have no control over ... We know that it has been used by ICE to target immigrants.",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "Hays County is the first county in the state to end its contract with Flock",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:12:41Z",
     "article_id": "art_074",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "5beab980-d0ca-5fcd-9465-126e42183cb9"
+    ]
   },
   {
     "url": "https://www.opb.org/article/2026/01/08/bend-flock-cameras-ai-license-plate-camera-law-enforcement/",
@@ -9031,6 +9051,10 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:terminated",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -9117,10 +9141,19 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T00:15:03Z",
+    "summary": "Lake County, FL commissioners ordered the removal of about 100 Flock Safety ALPR cameras installed by the Lake County Sheriff's Office under a pilot program, citing lack of approval and permitting violations. The sheriff's office terminated the pilot with Flock Safety following the board's vote.",
+    "key_quotes": [
+      {
+        "quote": "Lake County commissioners said they are sending a cease-and-desist letter to Flock Safety after the company installed surveillance cameras that monitor license plates and vehicle details.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "The Lake County Sheriff's Office has since terminated the pilot program with Flock Safety",
+        "paragraph_idx": 19
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:12:46Z",
     "article_id": "art_076",
     "primary_subject_agency_ids": []
   },
@@ -9148,6 +9181,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "legal:court-ruling",
+      "legal:pra",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -9262,12 +9300,28 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:22:43Z",
+    "summary": "Sedro-Woolley disabled its seven Flock Safety ALPR cameras in June while it and the city of Stanwood seek a Skagit County Superior Court declaratory judgment on whether Flock-stored data and images are subject to Washington's Public Records Act. Mount Vernon continues to operate its six Flock cameras; police chiefs in both cities defend the technology's crime-solving value and say data is not shared with federal immigration enforcement.",
+    "key_quotes": [
+      {
+        "quote": "The system is currently disabled and not collecting any data. They are still out there, but they are not on.",
+        "paragraph_idx": 36
+      },
+      {
+        "quote": "The Cities respectfully request the Court issue a Declaratory Judgment that the data and images stored in the Flock AWS Cloud system are not public records unless and until a public agency accesses the particular data.",
+        "paragraph_idx": 39
+      },
+      {
+        "quote": "And Flock data is not shared with federal agencies for immigration enforcement.",
+        "paragraph_idx": 51
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:12:56Z",
     "article_id": "art_077",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "f9528ae9-97e1-555d-8dd3-f842543cb473",
+      "d791f0a4-e22d-5acd-972a-08ab21020e2e"
+    ]
   },
   {
     "url": "https://shorewoodmn.gov/Blog.aspx?IID=21",
@@ -9571,6 +9625,13 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "incident:wrongful-stop",
+      "legal:legislation",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -9678,12 +9739,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:45:08Z",
+    "summary": "Colorado state Sen. Judy Amabile is considering legislation to regulate ALPR use and data sharing after Louisville deactivated its Flock cameras when a resident discovered out-of-state and federal immigration access. Aurora's police chief defends the technology while acknowledging past misuses including a wrongful stop of an innocent family.",
+    "key_quotes": [
+      {
+        "quote": "police should only be allowed to share camera data if another agency has a warrant based on probable cause",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "I've terminated people very recently based upon them getting into information and data they should not have gotten into.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "Aurora police held an innocent family at gunpoint after a camera wrongly flagged their SUV as a stolen motorcycle from out-of-state",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:04Z",
     "article_id": "art_081",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "3f90431b-2cb9-5b7e-84aa-7fb9a03c955b"
+    ]
   },
   {
     "url": "https://www.denvergazette.com/2024/02/17/big-brother-or-crime-fighter-elbert-county-says-no-to-license-plate-readers-521d798c-caac-11ee-a37b-7b0672ff5019/",
@@ -9709,6 +9785,10 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "legal:legislation",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -9811,10 +9891,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:45:11Z",
+    "summary": "Elbert County, Colorado commissioners voted 3-0 in December 2023 not to renew the contract for nine Flock Safety license plate readers, citing privacy and 'Big Brother' concerns, over the objections of the county sheriff. The article contrasts Elbert's decision with Denver's plan to install 109 Flock cameras and Castle Rock/Douglas County's expanded use.",
+    "key_quotes": [
+      {
+        "quote": "the Elbert County Commissioners voted, 3-0, against renewing the contract for the region's nine Flock Safety brand license plate readers because constant surveillance of passing vehicles is too much \"Big Brother\" for their comfort.",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "Fisher advised Flock Safety that its contract is not being renewed. All nine of Elbert County's cameras will be removed this May.",
+        "paragraph_idx": 27
+      },
+      {
+        "quote": "This Spring, Denver will give a substantial nod to Flock technology by installing 109 of the license plate readers in high-crime areas",
+        "paragraph_idx": 38
+      },
+      {
+        "quote": "In 2022, the Colorado lawmakers passed a statute that requires all \"passive surveillance\" to be destroyed after three years",
+        "paragraph_idx": 42
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:12Z",
     "article_id": "art_082",
     "primary_subject_agency_ids": []
   },
@@ -9842,6 +9939,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:pra",
+      "outcome:terminated",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -9938,12 +10041,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:45:13Z",
+    "summary": "The Mountlake Terrace City Council unanimously voted on Dec. 4, 2025 to cancel its $54,000 two-year Flock Safety ALPR contract, citing community division and public records concerns following revelations that federal agencies accessed Flock networks in Snohomish County. The city had not yet installed cameras and appears to be the first in Washington to fully cancel, while other cities like Lynnwood, Stanwood, Redmond, and Olympia have paused their networks.",
+    "key_quotes": [
+      {
+        "quote": "We adopted it with the intent of improving public safety, but since then we have seen that it has been weaponized against cities and their residents and brought great division to our community,",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "Mountlake Terrace appears to be the first city in the state to cancel its contract completely.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "federal agencies \u2014 including U.S. Border Patrol and Homeland Security Investigations \u2014 gained access to multiple Flock networks in Snohomish County, often without police departments knowing.",
+        "paragraph_idx": 5
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:19Z",
     "article_id": "art_083",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "161ac51a-c857-5ec9-9567-addd22bb89b8"
+    ]
   },
   {
     "url": "https://www.koamnewsnow.com/news/top-stories/seneca-police-end-flock-camera-contract-after-less-than-90-days/article_d493c47c-a4ab-4270-83c9-f52e784b24ea.html",
@@ -9969,6 +10087,10 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:misuse",
+      "outcome:terminated",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -10037,12 +10159,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:45:14Z",
+    "summary": "The Seneca, Missouri Police Department ended its Flock license plate reader contract less than 90 days after installation, citing poor customer service, a malfunctioning camera, and concerns about reports of misuse and security vulnerabilities nationwide. Chief James Altic said he won't pursue similar technology unless vendors address these concerns.",
+    "key_quotes": [
+      {
+        "quote": "These cameras cannot be compromised. And until we are 100% sure they can't be compromised, we're not going to be a part of the system.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "We couldn't get calls back. We couldn't get any feedback. It just wasn't working out real well.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "There will have to be some legislation passed. There should have to be some better guidelines down the road.",
+        "paragraph_idx": 12
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:25Z",
     "article_id": "art_084",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "bb7482a8-7d18-5d5d-887f-fe49c63a5b60"
+    ]
   },
   {
     "url": "https://kstp.com/kstp-news/top-news/roadside-cameras-going-dark-another-department-makes-changes-to-program-over-accountability-concerns/",
@@ -10068,6 +10205,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -10095,12 +10237,28 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T02:45:15Z",
+    "summary": "Brooklyn Park, MN police canceled its Flock Safety contract at the end of December, citing concerns over customer support and data-sharing protocols. The article also notes that Anoka County Sheriff's Office added new restrictions\u2014removing two federal agencies from data access and filtering out immigration-related nationwide searches\u2014amid concerns about federal immigration access to ALPR data.",
+    "key_quotes": [
+      {
+        "quote": "The city of Brooklyn Park canceled its contract with the company Flock Safety at the end of December.",
+        "paragraph_idx": 2
+      },
+      {
+        "quote": "due to concerns over customer support and poor data sharing protocols.",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "The county has since removed two federal agencies from its long list of agencies granted access to the data, and they also added a filter to be excluded from any nationwide searches involving immigration.",
+        "paragraph_idx": 7
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:33Z",
     "article_id": "art_085",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "1320544c-4c09-5a08-9264-52d844f58fd1",
+      "deb5d422-b112-5049-95c2-dd46d38d13d1"
+    ]
   },
   {
     "url": "https://laist.com/news/south-pasadena-cancels-flock-safety-contract-privacy-concerns",
@@ -12274,10 +12432,12 @@
     "agency_candidates": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-09T16:06:22Z",
     "article_id": "art_111",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [],
+    "curation_error": "validation: primary_subject_agency_ids not in candidate set: ['warrenton-pd-va']",
+    "curation_raw": "{\"refusal\":false,\"refusal_reason\":null,\"summary\":\"The Warrenton (VA) Town Council voted 5-1 on Oct. 14, 2025 to permanently suspend all consideration of a Warrenton Police Department proposal to install Flock Safety Falcon ALPR cameras at the town's main entrances, and to reallocate the funds. Two planned public input meetings were canceled.\",\"key_quotes\":[{\"quote\":\"The Warrenton Town Council voted 5-1 Tuesday afternoon to permanently suspend all future discussion and consideration of the Warrenton Police Department's proposal to install automated license plate reader cameras at the town's main entrances.\",\"paragraph_idx\":6},{\"quote\":\"At some point we've got to exercise some oversight on mass surveillance technologies like this, and say, 'Not on our watch.'\",\"paragraph_idx\":13}],\"topic_tags\":[\"outcome:rejected\",\"scope:local\"],\"genre\":\"investigative\",\"primary_subject_agency_ids\":[\"warrenton-pd-va\"]}"
   },
   {
     "url": "https://www.heraldnet.com/2025/09/10/stanwood-pauses-flock-cameras-amid-public-records-lawsuits/",
@@ -12303,14 +12463,32 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:court-ruling",
+      "legal:pra",
+      "outcome:terminated",
       "vendor:flock"
     ],
     "agencies": [],
     "agency_candidates": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T16:06:24Z",
+    "summary": "Stanwood, WA paused its Flock ALPR program in May amid litigation over whether Flock footage is subject to the state Public Records Act. Stanwood and Sedro-Woolley are seeking a court judgment that the footage is not a public record or is exempt, while a requester has sued Stanwood for non-disclosure. The article also notes Mountlake Terrace council pushback after revelations about Flock's federal pilot with CBP/HSI.",
+    "key_quotes": [
+      {
+        "quote": "The city of Stanwood has paused use of its Flock cameras in light of questions over whether footage is subject to public records requests under state law.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "Stanwood and Sedro-Woolley argue that Flock footage is only public record once a public agency extracts and downloads the data.",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "In July, Stanwood City Attorney wrote a letter to State Sen. Ron Muzzall, R-Oak Harbor, asking him to sponsor or support legislation to create a specific exemption for automated license plate reader data in the Public Records Act.",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:48Z",
     "article_id": "art_112",
     "primary_subject_agency_ids": []
   },
@@ -12338,6 +12516,10 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -12385,12 +12567,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T16:06:25Z",
+    "summary": "The South Tucson mayor and council voted to end the city's contract with Flock Safety, deactivating five sets of ALPR cameras that police credit with 14 arrests and other case clearances over six months. The mayor cited community concerns, particularly fears about immigration enforcement use of the data, while the police chief said data was not shared with ICE.",
+    "key_quotes": [
+      {
+        "quote": "South Tucson is the third city in Arizona to end contracts with its respective Flock camera providers, Sedona and Flagstaff being the other two.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "It was clear that people felt having the presence of these cameras could lead to further scrutiny in our community, a community that's made of mostly people of color",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "I can tell you that like any information that we had from five cameras belonged to the city of South Tucson and we did not share that information with ICE or the federal government",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:13:56Z",
     "article_id": "art_113",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "cb01b81f-bb94-5ffe-b3cc-21df118f78d4"
+    ]
   },
   {
     "url": "https://www.kiro7.com/news/local/renton-police-shut-down-license-plate-cameras-comply-with-new-privacy-law/JHCHPR4FQBGKNJOOWZ7LM3J6W4/",
@@ -12781,6 +12978,11 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:pra",
+      "outcome:terminated",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -12891,12 +13093,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T16:48:28Z",
+    "summary": "Monona (WI) Police Chief Brian Chaney told the City Council on May 4 that he opted not to renew the department's two-year Flock Safety ALPR contract, suspending use of its cameras. Chaney cited the Dane County Board's recent vote to defund its own Flock subscription, the burden of fulfilling numerous open records requests, and national concerns about ICE access to Flock data.",
+    "key_quotes": [
+      {
+        "quote": "I have opted to suspend our use of Flock",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "his department has also been receiving numerous open records requests regarding the Flock system \u2013 with the majority not being Monona from residents \u2013 and staff was spending an exorbitant amount of time fulfilling those requests",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "Besides Dane County and now Monona, the Oshkosh Police Department has also ended its contract with Flock.",
+        "paragraph_idx": 15
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:05Z",
     "article_id": "art_119",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "ee951b26-f4f7-5998-9926-07dad383c19c"
+    ]
   },
   {
     "url": "https://ww2.kqed.org/news/2026/05/08/berkeley-extends-surveillance-contract-with-flock-safety-but-rejects-major-expansion/",
@@ -12922,6 +13139,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:ag-lawsuit",
+      "outcome:restricted",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -13009,12 +13232,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T16:48:31Z",
+    "summary": "Berkeley City Council voted 5-4 to extend its existing Flock Safety ALPR contract for up to 12 months but rejected an 8-1 proposed $1.4M expansion that would have added drones, more cameras, and investigative software. The decision followed a leaked city attorney memo warning about Flock data being shared with federal immigration agencies and out-of-state agencies in violation of California law.",
+    "key_quotes": [
+      {
+        "quote": "Flock's track record raises serious concerns about data sharing, accountability and oversight",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "In 2025, Flock began a pilot program with the U.S. Border Patrol that allowed the agency to search its \"National Lookup\" database without alerting affected jurisdictions",
+        "paragraph_idx": 16
+      },
+      {
+        "quote": "Federal agencies have accessed data from Flock cameras in Oakland, and the city of Richmond earlier this year deactivated its own camera network after discovering that federal officials could search its database.",
+        "paragraph_idx": 20
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:13Z",
     "article_id": "art_120",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "eca5a0e5-4ab4-5868-a688-c03da1dff9b1"
+    ]
   },
   {
     "url": "https://www.nbc26.com/oshkosh/oshkosh-ends-flock-safety-contract-but-will-keep-license-plate-readers",
@@ -13243,6 +13481,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "policy:audit",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -13349,12 +13593,31 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T17:05:09Z",
+    "summary": "Activists protested outside Flock Safety's Atlanta headquarters, citing concerns about mass surveillance, data sharing, and potential ICE access to ALPR data. Flock disputed the ICE claims and pointed to retention limits and audit logs, while organizers framed Atlanta as a flashpoint in a national debate.",
+    "key_quotes": [
+      {
+        "quote": "This is about rejecting surveillance as a model for public safety",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "There is misinformation out there that Flock works with ICE\u2026 and it's simply not true",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "There are ways this data can be accessed\u2026 sometimes off the books",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "more than 30 cities across the country have recently reconsidered or canceled contracts tied to similar technology",
+        "paragraph_idx": 6
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:21Z",
     "article_id": "art_123",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "978d5b81-63f1-5f5d-bf83-4f108c15abcb"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/podcasts/city-flock-camera-program-discussion/",
@@ -13585,6 +13848,9 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:press-release",
+      "policy:audit",
+      "policy:sharing",
       "vendor:flock"
     ],
     "agencies": [
@@ -13601,10 +13867,23 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T17:05:16Z",
+    "summary": "Flock Safety launched Audit Assistance, an automated tool within its Trust and Compliance suite that monitors ALPR search activity and flags anomalous queries. The release comes amid scrutiny over privacy, immigration data sharing, and accuracy concerns, including Illinois's accusation that Flock illegally shared data.",
+    "key_quotes": [
+      {
+        "quote": "Audit Assistance \"continuously monitors system activity and surfaces search patterns that fall outside an agency's typical usage.\"",
+        "paragraph_idx": 5
+      },
+      {
+        "quote": "Illinois has accused Flock of illegally sharing data gathered by its products, though Flock has said it works hard to make sure its tech remains in compliance with relevant laws, and that the company's job is not to \"police the police.\"",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "This audit tool ensures every LPR search is accountable, transparent and aligned with our department policies",
+        "paragraph_idx": 9
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:26Z",
     "article_id": "art_126",
     "primary_subject_agency_ids": []
   },
@@ -13632,6 +13911,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:misuse",
+      "outcome:reconsidering",
+      "policy:audit",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -13740,12 +14024,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-09T17:05:18Z",
+    "summary": "The Costa Mesa City Council ordered an audit of the police department's Flock ALPR program and a study of alternative vendors after former officer Robert Jay Josett was fired and pleaded guilty to misusing the system to track his wife, ex-girlfriend and her partner. Residents urged the city to amend or terminate its Flock contract, while councilmembers expressed concern but also defended the technology's crime-fighting value.",
+    "key_quotes": [
+      {
+        "quote": "Former Costa Mesa Police Officer Robert Jay Josett, 35, was fired from the department after investigators learned he had accessed the Flock system 13 times to find and track the whereabouts of his wife, his ex-girlfriend and a person the latter woman was dating.",
+        "paragraph_idx": 5
+      },
+      {
+        "quote": "She was one of three members of the public who called on the city to conduct a more in-depth audit and consider either substantially amending its data-sharing agreement with Flock or terminate their contract entirely.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "I don't want to have a knee-jerk reaction and roll back something that had done a lot of good in solving crimes",
+        "paragraph_idx": 12
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:34Z",
     "article_id": "art_127",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "1808b50d-b58e-5245-b233-3b7b31dd5c29"
+    ]
   },
   {
     "url": "https://www.nbc26.com/oshkosh/appleton-mayor-calls-to-remove-flock-cameras",
@@ -15749,6 +16048,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:axon",
       "vendor:flock",
       "vendor:motorola"
@@ -15767,12 +16072,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T07:40:22Z",
+    "summary": "Denver is ending its ALPR contract with Flock Safety and awarding a new contract to Axon, pending council approval. The decision follows 9NEWS investigations revealing Flock shared Denver data with federal immigration enforcement and a city auditor's refusal to countersign the Flock contract.",
+    "key_quotes": [
+      {
+        "quote": "Denver is getting rid of its controversial automated license plate reading (ALPR) camera vendor Flock Safety, choosing to award its new ALPR contract to Axon",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "the company placed Denver's tracking data on a national network accessible to law enforcement agencies that assisted immigration enforcement, and after 9NEWS uncovered the company had a secret partnership with the U.S. Border Patrol",
+        "paragraph_idx": 16
+      },
+      {
+        "quote": "Denver City Auditor Tim O'Brien announced last Friday that he could not, in good conscience, countersign the city's contract with Flock",
+        "paragraph_idx": 20
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:41Z",
     "article_id": "art_146",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2026/02/24/denver-flock-license-plate-cameras-contract-axon/",
@@ -15969,6 +16289,12 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:press-release",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -15997,12 +16323,23 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T09:54:32Z",
+    "summary": "The City of Evanston and Evanston Police Department deactivated all 19 Flock Safety ALPR cameras on August 26, 2025, and issued a termination notice effective September 26, 2025. The decision followed findings from an Illinois Secretary of State audit and Flock's admission it failed to establish distinct permissions for a federal pilot program.",
+    "key_quotes": [
+      {
+        "quote": "On August 26, the City of Evanston and the Evanston Police Department deactivated all 19 Flock Safety ALPR cameras.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "The findings of the Illinois Secretary of State's audit, combined with Flock's admission that it failed to establish distinct permissions and protocols to ensure local compliance while running a pilot program with federal users, are deeply troubling.",
+        "paragraph_idx": 5
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:47Z",
     "article_id": "art_149",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "a597ac19-0e62-585c-82a0-f9c7b87c55e8"
+    ]
   },
   {
     "url": "https://www.santacruzsentinel.com/2026/01/13/santa-cruz-votes-to-terminate-its-contract-with-flock-safety/",
@@ -16792,6 +17129,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "incident:ice-cooperation",
+      "incident:wrongful-stop",
+      "legal:court-ruling",
+      "legal:pra",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -16897,10 +17240,23 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T13:58:39Z",
+    "summary": "Multiple Washington state police agencies \u2014 including Stanwood, Sedro-Woolley, Redmond, Lynnwood, and Skamania County \u2014 have turned off their Flock Safety ALPR cameras around the time of a Skagit County Superior Court ruling that ALPR images and data are public records subject to disclosure under Washington's Public Records Act. The article also notes Border Patrol searches of Flock data at 18 WA agencies and an ICE-related incident in Redmond.",
+    "key_quotes": [
+      {
+        "quote": "The Flock images generated by the Flock cameras \u2026 are public records",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "Researchers at the University of Washington Center for Human Rights reported last month that 18 Washington police agencies had their Flock Safety databases searched this year by the U.S. Border Patrol.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "The Redmond Police Dept. started deploying ALPR cameras this summer but turned them off earlier this month after U.S. Immigration and Customs Enforcement agents arrested seven people",
+        "paragraph_idx": 12
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:14:54Z",
     "article_id": "art_157",
     "primary_subject_agency_ids": []
   },
@@ -17003,6 +17359,12 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "legal:court-ruling",
+      "legal:pra",
+      "outcome:terminated",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -17111,12 +17473,23 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T15:14:35Z",
+    "summary": "The Walla Walla Police Department shut down its Flock Safety ALPR program after a Washington court ruling made the camera images subject to public records disclosure. Officials cited an overwhelming volume of disclosure requests, legal liability from the 30-day auto-deletion, and safety concerns that stalkers or PIs could obtain victims' location data.",
+    "key_quotes": [
+      {
+        "quote": "So our cameras are not active \u2014 they are not taking pictures \u2014 and at some point Flock is going to show up and take their cameras back",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "The Walla Walla Police Department shut down the Flock Safety camera program this month after a court ruling made all images public record",
+        "paragraph_idx": 9
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T05:15:05Z",
     "article_id": "art_159",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "b24c55d3-3dd6-55d6-a443-d361be29e6aa"
+    ]
   },
   {
     "url": "https://www.denverpost.com/2026/03/11/denver-axon-contract-flock-cameras/",
@@ -17226,6 +17599,15 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -17254,12 +17636,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T15:14:40Z",
+    "summary": "Spokane County Sheriff's Office announced it is deactivating its ALPR (Flock) cameras in response to Washington's new Senate Bill 6002, signed by Governor Ferguson on March 30, which imposes privacy restrictions including a 21-day retention limit, prohibitions on immigration enforcement use, and annual reporting requirements. Sheriff John Nowels criticized the law as 'ill-considered' and said it exposes deputies to gross misdemeanor charges.",
+    "key_quotes": [
+      {
+        "quote": "Spokane County Sheriff's Office (SCSO) announced Wednesday that it is being forced to deactivate automated license plate reader (ALPR) technology and associated systems due to a new state law that introduces privacy protections and regulations in how ALPR data is accessed, stored and monitored.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "The bill was introduced in January after an October 2025 report by the University of Washington Center for Human Rights that showed federal agents were accessing ALPR, also known as Flock camera, data to pull over immigrants.",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "These imposed restrictions have made it nearly impossible for law enforcement agencies across the State of Washington to continue using ALPR systems as currently designed and implemented, and that is unacceptable.",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T16:24:11Z",
     "article_id": "art_161",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "ae292ffc-510d-5af1-b78d-7c026bfe1754"
+    ]
   },
   {
     "url": "https://cvillerightnow.com/podcasts/michael-payne-on-flock-budgets-and-audits/",
@@ -18007,6 +18404,13 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "outcome:rejected",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -18064,10 +18468,19 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T17:19:42Z",
+    "summary": "The Eureka, California City Council unanimously voted to reject a proposed two-year contract with Flock Safety for 21 automated license plate reader cameras after two hours of public comment opposing the cameras. Council members and commenters cited privacy concerns, potential data sharing with federal immigration or out-of-state agencies, and risks of misuse, despite policy safeguards added by the police chief.",
+    "key_quotes": [
+      {
+        "quote": "After two hours of public comment opposing the cameras, they unanimously voted to deny a request for Eureka Police Department to enter into a two-year contract with Flock Safety for the cameras",
+        "paragraph_idx": 2
+      },
+      {
+        "quote": "council members were concerned that a federal court could subpoena the data, which Flock said is owned by EPD and automatically deleted after 30 days",
+        "paragraph_idx": 9
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:48:21Z",
     "article_id": "art_169",
     "primary_subject_agency_ids": []
   },
@@ -18200,6 +18613,14 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:court-ruling",
+      "legal:legislation",
+      "legal:pra",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -18276,10 +18697,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T19:27:15Z",
+    "summary": "Washington's SB 6002, the state's first ALPR regulation, passed both chambers and heads to the governor, addressing public records exemptions, permitted uses, and shortening retention to 21 days. The article also surveys Snohomish County cities' varied responses to Flock cameras, including Everett's pause, Lynnwood's contract termination, Mountlake Terrace's cancellation, and Stanwood's continued pause.",
+    "key_quotes": [
+      {
+        "quote": "Last month, the Lynnwood City Council unanimously voted to terminate its contract with Flock.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "In December, Mountlake Terrace canceled its contract with Flock before its cameras were installed, citing community division and public records concerns.",
+        "paragraph_idx": 15
+      },
+      {
+        "quote": "SB 6002 also shortens the amount of time police departments can retain ALPR data. Most departments have been retaining Flock data for 30 days... lawmakers amended it to 21 days.",
+        "paragraph_idx": 18
+      },
+      {
+        "quote": "federal agencies \u2014 including U.S. Customs and Border Protection \u2014 accessed several Flock networks in the county without police departments' knowledge",
+        "paragraph_idx": 7
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:48:29Z",
     "article_id": "art_172",
     "primary_subject_agency_ids": []
   },
@@ -18307,6 +18745,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:restricted",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -18394,12 +18837,27 @@
         ]
       }
     ],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-10T19:27:18Z",
+    "summary": "Berkeley City Council voted 5-4 to extend its existing Flock Safety ALPR contract for up to 12 months but rejected (8-1) a proposed $1.4M expansion that would have added drones, more cameras, and investigative software. The decision followed a leaked city attorney memo raising concerns about Flock data being shared with federal immigration agencies and out-of-state agencies in violation of California law.",
+    "key_quotes": [
+      {
+        "quote": "Flock's track record raises serious concerns about data sharing, accountability and oversight",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "The council voted 5 to 4 to approve an extension of up to 12 months of its existing contract with Flock",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "In 2025, Flock began a pilot program with the U.S. Border Patrol that allowed the agency to search its 'National Lookup' database without alerting affected jurisdictions",
+        "paragraph_idx": 15
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:48:38Z",
     "article_id": "art_173",
-    "primary_subject_agency_ids": []
+    "primary_subject_agency_ids": [
+      "eca5a0e5-4ab4-5868-a688-c03da1dff9b1"
+    ]
   },
   {
     "url": "https://www.thenewstribune.com/news/local/article315353591.html",
@@ -20264,7 +20722,10 @@
     "wayback_timestamp": "20260511222243",
     "wayback_source": "saved",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:press-release",
+      "scope:local"
+    ],
     "agencies": [
       "926a7e76-714b-50a2-977e-522e4ec651ec",
       "847ce8af-3e88-59ca-90f3-d621db6f31f6",
@@ -20372,11 +20833,18 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-11T22:26:35Z",
+    "primary_subject_agency_ids": [
+      "f94b9663-269f-51eb-b204-b6d4c8cee4de"
+    ],
+    "summary": "Redwood City police arrested two San Jose men suspected of a January theft from a Cycle Gear store after an ALPR alert detected their vehicle. Officers conducted a traffic stop and booked the suspects on grand theft charges.",
+    "key_quotes": [
+      {
+        "quote": "Two San Jose men were arrested Tuesday after Redwood City officers used automated license plate reader technology to track a vehicle linked to a January theft of more than $4,000 in merchandise from a motorcycle store, police said.",
+        "paragraph_idx": 0
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:48:50Z",
     "article_id": "art_191"
   },
   {
@@ -21612,6 +22080,10 @@
     "wayback_source": "saved",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "policy:audit",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -21660,11 +22132,30 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T04:55:18Z",
+    "primary_subject_agency_ids": [
+      "d22f3264-52b5-5139-ad7c-849564e02eb1"
+    ],
+    "summary": "Ithaca, NY signed a $69,300 one-year contract with Flock Safety to install 22 license-plate-recognition cameras, even as Flock faces scrutiny for permitting violations in at least five states. Police Chief Thomas Kelly and Mayor Robert Cantelmo defended the deal, citing audits, 30-day retention, and crime-fighting utility.",
+    "key_quotes": [
+      {
+        "quote": "In December, the City of Ithaca inked a $69,300 one-year contract with Flock to install 22 cameras on city streets, with annual recurring payments of $66,000 upon renewal.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "South Carolina and North Carolina have banned Flock employees from installing the camera system, citing the company's permitting transgressions.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "IPD will ensure there are regular audits to guarantee compliance with policy.",
+        "paragraph_idx": 19
+      },
+      {
+        "quote": "state, county, and city jurisdictional lines are not always as clear as we would like, and with the scale at which Flock operates we are going to make mistakes",
+        "paragraph_idx": 20
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:48:59Z",
     "article_id": "art_203"
   },
   {
@@ -21690,7 +22181,10 @@
     "wayback_timestamp": "20260512045155",
     "wayback_source": "saved",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:explainer",
+      "scope:local"
+    ],
     "agencies": [
       "7f866083-eff9-59e4-92b4-d90a091d147f",
       "308e7ece-43c7-53c1-90a6-82f1e7a26d68",
@@ -21726,11 +22220,18 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T04:55:20Z",
+    "primary_subject_agency_ids": [
+      "7f866083-eff9-59e4-92b4-d90a091d147f"
+    ],
+    "summary": "The Dubuque City Council will hold a work session on May 15, 2023 to consider Dubuque Police Chief Jeremy Jensen's request to purchase automated license plate-reading (ALPR) technology. Funding was approved in the FY2024 budget but requires council approval before implementation.",
+    "key_quotes": [
+      {
+        "quote": "Dubuque Police Chief Jeremy Jensen requested funding to purchase ALPR technology in the City's 2024 fiscal year budget. The funding was approved, but the City Council must first grant approval before police purchase or implement the technology.",
+        "paragraph_idx": 7
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:03Z",
     "article_id": "art_204"
   },
   {
@@ -21848,7 +22349,12 @@
     "wayback_timestamp": null,
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "policy:sharing",
+      "scope:state"
+    ],
     "agencies": [
       "8171a2b1-544d-544d-8a90-31029959bd72"
     ],
@@ -21864,10 +22370,15 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T04:55:23Z",
+    "summary": "A KREM news brief reports that federal immigration authorities accessed Washington state license plate reader data, prompting several police departments to restrict access and investigate how federal agents gained entry.",
+    "key_quotes": [
+      {
+        "quote": "The findings have prompted several police departments to restrict access to their surveillance systems and investigate how federal agents gained entry.",
+        "paragraph_idx": 0
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:06Z",
     "article_id": "art_206"
   },
   {
@@ -21967,6 +22478,9 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "policy:purpose-limitation",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -22013,11 +22527,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T08:00:53Z",
+    "primary_subject_agency_ids": [
+      "40521632-8a29-5e5d-a064-1b57410743b5"
+    ],
+    "summary": "After more than two hours of discussion and public input on privacy and camera locations, the Coralville City Council voted to approve a policy governing the use of Flock automated license plate readers. The mayor cited a recent Marshalltown shooting arrest aided by the cameras, and a Flock representative answered council and community questions.",
+    "key_quotes": [
+      {
+        "quote": "the council voted and approved the resolution approving a policy for the license plate reader technology.",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "Mayor Meghann Foster mentioned her concerns, as well as how authorities in Marshalltown were able to make an arrest in a shooting recently with the use of these kinds of cameras.",
+        "paragraph_idx": 4
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:12Z",
     "article_id": "art_208"
   },
   {
@@ -22124,6 +22649,10 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:court-ruling",
+      "legal:pra",
       "vendor:flock"
     ],
     "agencies": [
@@ -22230,11 +22759,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T08:00:57Z",
+    "primary_subject_agency_ids": [
+      "37330114-0b02-5b61-a889-2fc214849095"
+    ],
+    "summary": "A Skagit County judge ruled that images captured by Flock ALPR cameras are public records subject to Washington's Public Records Act, siding with a citizen who filed records requests against dozens of Washington agencies. The ruling came after Sedro Woolley and Stanwood sued to block the requests; both cities have since deactivated their Flock cameras.",
+    "key_quotes": [
+      {
+        "quote": "The Flock data do qualify as public records subject to the Public Records Act",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "so broad and indiscriminate",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "I think a lot of cities are discovering right now that we don't know who all has access to this.",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:18Z",
     "article_id": "art_210"
   },
   {
@@ -22261,6 +22805,12 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:rejected",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -22288,10 +22838,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T08:00:58Z",
+    "summary": "The San Marcos City Council voted against expanding its license plate reader program from 14 to 33 cameras after public comment raised concerns about ICE access, mass surveillance, and lack of audits. The proposal would have cost $124,000 in year one (grant-funded) plus $102,000 annually thereafter.",
+    "key_quotes": [
+      {
+        "quote": "It's just a gross overreach of police power. It creates a mass surveillance network.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "Our own policy, that the department created themselves, requires annual audits. I have yet to see an audit",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "I do not know if we did a carte blanche share within the state, within 50 miles or nationwide.",
+        "paragraph_idx": 8
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:23Z",
     "article_id": "art_211"
   },
   {
@@ -22318,6 +22881,14 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -22391,10 +22962,31 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T08:01:02Z",
+    "summary": "Oregon's new SB 1516 regulates police use of automated license plate readers, limiting data retention to 30 days, requiring search logging and public audits, barring use that violates sanctuary laws, and allowing Oregonians to sue vendors who improperly share data. Advocates note enforcement relies heavily on private lawsuits and that the law requires but doesn't define end-to-end encryption.",
+    "key_quotes": [
+      {
+        "quote": "Senate Bill 1516, signed into law by Gov. Tina Kotek on March 31, went into effect immediately due to an emergency clause lawmakers tucked into the legislation.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "the law limits the retention of such data to 30 days unless it is linked to a criminal inquiry or court proceedings",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "Any member of the public could sue for damages caused by vendors who act \"intentionally or with gross negligence\" by selling, disclosing or sharing the data.",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "Every misuse of the system that we found was because of the public auditing these companies",
+        "paragraph_idx": 21
+      },
+      {
+        "quote": "The bill requires it, but doesn't define it. My biggest concern is that these vendors are going to try and skirt that aspect of the bill",
+        "paragraph_idx": 23
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:31Z",
     "article_id": "art_212"
   },
   {
@@ -22455,6 +23047,9 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:analysis",
+      "outcome:restricted",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -22502,11 +23097,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T10:48:33Z",
+    "primary_subject_agency_ids": [
+      "f5f58d7a-0f1e-5f15-ba9f-1d4ce0da5ab3"
+    ],
+    "summary": "Charlottesville Police Chief Michael Kochis told WINA that the city lags behind peer Virginia localities in police data technology, noting that Charlottesville has suspended Peregrine and limited its Flock ALPR program while cities like Fairfax, Richmond, Norfolk, Portsmouth, and Alexandria continue to expand such systems. Kochis said he respects council policy choices but is frustrated and doesn't see the city catching up soon.",
+    "key_quotes": [
+      {
+        "quote": "we are so far behind in this city when it comes to technology and the way we aggregate and bring together data",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "some City Councilors at that conference expressed surprise that Charlottesville has suspended Peregrine for now and limited its Flock program",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "spending one day with Fairfax County's police chief and getting a look at their real-time crime center with hundreds of Flock cameras",
+        "paragraph_idx": 10
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:39Z",
     "article_id": "art_214"
   },
   {
@@ -22532,6 +23142,10 @@
     "wayback_source": "saved",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:explainer",
+      "policy:audit",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -22621,11 +23235,27 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T10:48:37Z",
+    "primary_subject_agency_ids": [
+      "d22f3264-52b5-5139-ad7c-849564e02eb1",
+      "2cc3a31d-7f98-5714-bc85-927815444575"
+    ],
+    "summary": "Ithaca's acting police chief introduced plans to install 20 Flock Safety ALPR cameras around the city, jointly used with the Tompkins County Sheriff's Office, funded by a GIVE grant. The presentation covered 30-day retention, privacy safeguards, and intended investigative uses, while one alderperson raised mass-surveillance concerns.",
+    "key_quotes": [
+      {
+        "quote": "Flock keeps the data for 30 days, after which it is automatically deleted.",
+        "paragraph_idx": 14
+      },
+      {
+        "quote": "Schwartz said the data will not be used for immigration enforcement and that the cameras are not designed to be used as speed traps.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "every new customer that buys and installs the company's cameras extends Flock's network, contributing to the creation of a centralized mass surveillance system of Orwellian scope.",
+        "paragraph_idx": 20
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:47Z",
     "article_id": "art_215"
   },
   {
@@ -22652,6 +23282,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock",
       "vendor:vigilant"
     ],
@@ -22680,11 +23316,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T10:48:39Z",
+    "primary_subject_agency_ids": [
+      "308e7ece-43c7-53c1-90a6-82f1e7a26d68"
+    ],
+    "summary": "Cedar Rapids Police Department defended its ALPR program after an ACLU/University of Iowa report raised concerns, saying its 76 Flock and Vigilant readers have strict policies: 30-day retention, public location disclosure, quarterly transparency reports, approval requirements for outside agency access, and no use for immigration enforcement. The department cited recent cases including an attempted-murder arrest and locating a missing man with dementia.",
+    "key_quotes": [
+      {
+        "quote": "The data is only available for 30 days, and a transparency portal keeps track of how many license plate images are captured, plates associated with persons of interest and how many searches are made.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "The data is also not used for immigration enforcement, according to the department's policies.",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "CRPD's policy states misuse or abuse of ALPR data will result in disciplinary action and may lead to termination.",
+        "paragraph_idx": 9
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:53Z",
     "article_id": "art_216"
   },
   {
@@ -22877,7 +23528,10 @@
     "wayback_timestamp": "20260512131111",
     "wayback_source": "saved",
     "pdf_status": "skipped-curl-fallback",
-    "tags": [],
+    "tags": [
+      "genre:explainer",
+      "scope:state"
+    ],
     "agencies": [
       "d22f3264-52b5-5139-ad7c-849564e02eb1",
       "2cc3a31d-7f98-5714-bc85-927815444575",
@@ -22917,10 +23571,19 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T13:19:15Z",
+    "summary": "New York State's Division of Criminal Justice Services awarded roughly $450,000 to several Tompkins County\u2013area law enforcement agencies for technology upgrades, part of a $127 million statewide grant program. Over half of statewide funding will go toward license plate readers, body/vehicle cameras, and public safety camera systems; local recipients plan to spend funds on 3D crime scanners, radios, in-car systems, and (for Trumansburg) a license plate reader.",
+    "key_quotes": [
+      {
+        "quote": "The department has been without technologies most departments would consider essential since Nelson became chief about five years ago, such as a license plate reader and functioning portable radios.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "Departments around the state will use over half of the total funding to fund the aforementioned license plate readers, body-worn and patrol vehicle equipment and public safety camera systems.",
+        "paragraph_idx": 12
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:49:59Z",
     "article_id": "art_219"
   },
   {
@@ -23020,6 +23683,12 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -23111,10 +23780,27 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T13:19:18Z",
+    "summary": "Washington lawmakers held hearings on two bills to regulate Flock ALPR cameras, which would limit federal access to data and require deletion of raw data within 72 hours. The push follows a UW Center for Human Rights report that federal agents used Flock data to target immigrants; police chiefs argue the 72-hour retention is too short.",
+    "key_quotes": [
+      {
+        "quote": "last October, the University of Washington Center for Human Rights reported federal agents accessed Flock data to pull over immigrants",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "The proposed bills would limit federal agencies from accessing Flock data and require agencies to delete raw data, including pictures of vehicles and their license plates, within 72 hours of collection.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "The 72-hour retention limit is too short for real-world investigations",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "It struck me these cameras vacuum up all data regardless of if there is criminal wrongdoing.",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:50:07Z",
     "article_id": "art_221"
   },
   {
@@ -23251,9 +23937,11 @@
     "primary_subject_agency_ids": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-12T13:19:28Z",
-    "article_id": "art_222"
+    "article_id": "art_222",
+    "curation_error": "schema parse failed or refusal",
+    "curation_raw": "[model refusal]"
   },
   {
     "url": "https://denvergazette.com/news/as-flock-camera-network-grows-so-do-privacy-and-data-concerns/article_87d8cd8e-b2b1-482b-84f7-fd23b461130a.html",
@@ -23279,6 +23967,15 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "incident:wrongful-stop",
+      "policy:audit",
+      "policy:hotlist",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -23392,11 +24089,35 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T16:39:37Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458",
+      "e6d03602-bbe7-50c4-8f03-6b4c8c87e13c",
+      "b33d2cc2-8380-57b3-b6bf-bb7664b94f90",
+      "3f90431b-2cb9-5b7e-84aa-7fb9a03c955b",
+      "b50c68c1-cb1a-5994-9830-ff47fdf1ba1d",
+      "cf1e330c-8a42-5cd9-813d-cfe383b83802"
+    ],
+    "summary": "The Denver Gazette surveys growing privacy and data-sharing concerns about Flock ALPR cameras across Colorado, reporting that Denver disabled national lookup and saw its council reject a contract extension, Jefferson County opted out of national lookup, and Arapahoe County approved expansion. The piece also recounts misuse incidents (Aurora wrongful detention, Kechi/Wichita stalking) and contrasting views from law enforcement, Flock, and privacy advocates.",
+    "key_quotes": [
+      {
+        "quote": "Shortly before the Denver City Council rejected a two-year contract extension with Flock, the DPD quietly opted out of the national lookup feature tied to more than 100 solar-powered license plate-reading cameras across the city.",
+        "paragraph_idx": 24
+      },
+      {
+        "quote": "As of June 3, 2025, Jefferson County also opted out of Flock's national look-up tool.",
+        "paragraph_idx": 33
+      },
+      {
+        "quote": "In Arapahoe County, commissioners recently approved a $127,000 contract extension with Flock, adding 17 new cameras starting next year.",
+        "paragraph_idx": 36
+      },
+      {
+        "quote": "Three years ago, a lieutenant with the Kechi Police Department in Kansas was arrested for using the Wichita Police Department's Flock camera system to stalk his former wife.",
+        "paragraph_idx": 48
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:50:26Z",
     "article_id": "art_223"
   },
   {
@@ -23422,6 +24143,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:audit",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -23534,11 +24261,33 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T16:39:43Z",
+    "primary_subject_agency_ids": [
+      "a597ac19-0e62-585c-82a0-f9c7b87c55e8",
+      "f9d0e316-2a82-5430-83ac-b575bbbd3b30",
+      "4a1c911b-5e90-53fd-805e-3b55f344434d",
+      "ba107933-2f9d-5af5-836f-72a35dd288ba"
+    ],
+    "summary": "Illinois Secretary of State Alexi Giannoulias ordered a statewide audit of Flock Safety license plate readers after 404 Media reported that out-of-state police used the network to search Illinois data\u2014including Mount Prospect and Danville\u2014for abortion and immigration-related investigations, in possible violation of a 2023 state law. Flock revoked access for 46 out-of-state agencies. The article details Evanston's 18 Flock cameras, its $242,500 five-year renewal, and EPD's stated policies barring immigration and reproductive-health uses.",
+    "key_quotes": [
+      {
+        "quote": "the Mount Prospect Police Department was included in a May 9 search by the Johnson County (Texas) Sheriff's Office looking for a woman who it said had a self-administered abortion",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "Giannoulias has ordered Flock to \"immediately shut off access for the out-of-state authorities illegally using the system\"",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "Flock stated it removed access to Illinois data for 17 agencies found to have \"conducted multiple searches using reasons impermissible under Illinois law,\" and later revoked access for another 29",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "The city denied these records June 4, citing \"ongoing investigations.\"",
+        "paragraph_idx": 22
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:50:40Z",
     "article_id": "art_224"
   },
   {
@@ -23564,6 +24313,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:explainer",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -23603,11 +24357,27 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T16:39:47Z",
+    "primary_subject_agency_ids": [
+      "d22f3264-52b5-5139-ad7c-849564e02eb1",
+      "2cc3a31d-7f98-5714-bc85-927815444575"
+    ],
+    "summary": "Tompkins County has activated about 20 of 50 contracted Flock ALPR cameras, adding to 21 cameras run by Ithaca Police and others in Trumansburg and Cayuga Heights. The article details data retention (30 days), sharing with 106+ agencies including the US Postal Inspection Service, policies against aiding federal immigration enforcement, and ACLU concerns about surveillance expansion.",
+    "key_quotes": [
+      {
+        "quote": "So far, the county has activated about 20 of the 50 total devices under its contract.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "Ithaca officials have approved data access rights for some 106 other law enforcement agencies, including the Tompkins County Sheriff's Office",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "Both Tompkins County and the City of Ithaca have policies forbidding local law enforcement from aiding federal immigration enforcement efforts.",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:52:44Z",
     "article_id": "art_225"
   },
   {
@@ -23634,6 +24404,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -23670,11 +24445,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T16:39:48Z",
+    "primary_subject_agency_ids": [
+      "40521632-8a29-5e5d-a064-1b57410743b5"
+    ],
+    "summary": "The Coralville city council voted to amend its ALPR policy, clarifying when officers can act on Flock camera alerts and expanding data sharing with North Liberty PD and University of Iowa PD. Council members remain divided over the 30-day data retention window, with some worried about potential ICE access.",
+    "key_quotes": [
+      {
+        "quote": "the council clarified when officers can take action based on alerts from the Flock cameras and expanded data sharing with other agencies that already use the technology in Johnson County \u2014 North Liberty and the University of Iowa Police Department.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "I think it has the potential to be abused by ICE and other agencies",
+        "paragraph_idx": 7
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:52:49Z",
     "article_id": "art_226"
   },
   {
@@ -23930,6 +24716,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -23990,11 +24781,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T19:14:54Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Privacy advocates with the Denver Task Force to Reimagine Policing and Public Safety plan to deliver a petition to Mayor Mike Johnston asking him to turn off Denver's 111 Flock ALPR cameras until stronger policy guardrails are in place. The Denver City Council unanimously rejected a $666,000 two-year contract extension in May, but Johnston has kept the cameras running, citing public safety.",
+    "key_quotes": [
+      {
+        "quote": "the Denver City Council rejected a resolution that would have added two years and $666,000 to an existing contract between the Denver Police Department and Flock Group, Inc. for cameras that read license plates.",
+        "paragraph_idx": 15
+      },
+      {
+        "quote": "the city has \"every intention of making sure these cameras stay up, the public safety is in place, and we can track down violent criminals.\"",
+        "paragraph_idx": 24
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:52:57Z",
     "article_id": "art_229"
   },
   {
@@ -24020,7 +24822,10 @@
     "wayback_timestamp": "20260512190612",
     "wayback_source": "saved",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:explainer",
+      "scope:local"
+    ],
     "agencies": [
       "308e7ece-43c7-53c1-90a6-82f1e7a26d68"
     ],
@@ -24036,11 +24841,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T19:14:56Z",
+    "primary_subject_agency_ids": [
+      "308e7ece-43c7-53c1-90a6-82f1e7a26d68"
+    ],
+    "summary": "Cedar Rapids Police Department reports positive results after 18 months using ALPRs on two SUVs, having scanned over a million plates and recovered stolen vehicles, plates, and located wanted/missing persons. CRPD is considering expanding the program, while the ACLU of Iowa urges careful regulation and Iowa City notes a local ordinance prohibits ALPR use.",
+    "key_quotes": [
+      {
+        "quote": "Since February 2016, the two sets of readers have scanned more than one million vehicles, they've helped find, 24 stolen vehicles, seven stolen plates, 48 wanted persons, two missing people.",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "When used in a narrow and carefully regulated way, ALPRs can help police recover stolen cars and arrest people with outstanding warrants",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "Iowa City police told TV9 in 2015 they had no interest in asking for license plate readers since a council ordinance specifically prohibits it.",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:53:04Z",
     "article_id": "art_230"
   },
   {
@@ -24143,6 +24963,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:reconsidering",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -24230,11 +25056,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T19:15:00Z",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ],
+    "summary": "The Austin City Council is set to vote on the future of APD's license plate reader pilot program after an audit raised privacy concerns, including contract language allowing Flock to share data with outside agencies and undisclosed prior data requests. Councilmember Mike Siegel is calling to end the program, citing risks around immigration and reproductive-care surveillance, while the police association defends it as an effective tool.",
+    "key_quotes": [
+      {
+        "quote": "I think the privacy trade-offs are too severe",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "Flock, this business that is doing business with Austin, also does business with ICE, you know, the Immigration and Customs Enforcement agency, and allows ICE access to basically [use] all of the data in the program.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "out of roughly 75 million license plates scanned during a nine-month period, the devices aided in 165 arrests and possibly 134 prosecutions",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:53:11Z",
     "article_id": "art_232"
   },
   {
@@ -24454,6 +25295,10 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "policy:purpose-limitation",
+      "policy:sharing",
+      "scope:local",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -24491,11 +25336,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T20:58:13Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "The Denver City Council voted 7-6 to approve a one-year, $150,000 contract with Axon for 50 ALPR cameras, replacing Flock, whose cameras were removed the same day. Dissenting members objected that the contract was approved before the surveillance task force could craft guardrails and an ordinance, and raised concerns about Axon's federal ties and potential use of data for immigration or abortion enforcement.",
+    "key_quotes": [
+      {
+        "quote": "After weeks of delay, the Denver City Council narrowly approved a one-year $150,000 contract with Axon for 50 automated license plate-reading cameras and the necessary system hardware, replacing the city's former vendor, Flock.",
+        "paragraph_idx": 2
+      },
+      {
+        "quote": "with these strengthened privacy and data protections, we are ensuring that no federal agency or federal agent can access this data\u2014now or ever.",
+        "paragraph_idx": 5
+      },
+      {
+        "quote": "Axon has open ties to the Department of Homeland Security and other federal agencies.",
+        "paragraph_idx": 11
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:53:18Z",
     "article_id": "art_235"
   },
   {
@@ -24521,6 +25381,13 @@
     "wayback_source": "submit-failed",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -24549,11 +25416,30 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T20:58:18Z",
+    "primary_subject_agency_ids": [
+      "a597ac19-0e62-585c-82a0-f9c7b87c55e8"
+    ],
+    "summary": "Flock Safety is contesting Evanston's termination of its ALPR contract after the city ordered all 19 cameras deactivated, citing an Illinois Secretary of State audit finding that Flock shared data with U.S. Customs and Border Protection in violation of state law and Evanston's Welcoming City Ordinance. Flock denies wrongdoing, claims the city failed to provide a cure period, and may seek to enforce the contract, potentially leaving Evanston liable for $145,500 over the remaining three years.",
+    "key_quotes": [
+      {
+        "quote": "Flock unlawfully made data collected within Evanston and the State of Illinois available to federal agencies",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "this breach is material, intentional, and cannot be cured. The City will not entertain remediation efforts or renegotiation.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "We are aware of no legal basis for your apparent belief that the City may relieve itself of clear and unambiguous contractual obligations",
+        "paragraph_idx": 15
+      },
+      {
+        "quote": "his office's audit of Flock networks across the state revealed that Illinois data had been shared with U.S. Customs and Border Protection through a \"pilot program\"",
+        "paragraph_idx": 7
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:53:29Z",
     "article_id": "art_236"
   },
   {
@@ -24580,6 +25466,9 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:press-release",
+      "policy:hotlist",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -24617,10 +25506,15 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T20:58:20Z",
+    "summary": "Indianola, Iowa police credited a newly installed Flock license plate reader and Officer Drew Stever with recovering a missing person with dementia from Missouri after the LPR alerted the officer to the vehicle. The driver was safely reunited with family.",
+    "key_quotes": [
+      {
+        "quote": "The Flock cameras were just installed within the last two weeks to scan license plates and send alerts to officers if a plate matches one on a national criminal database.",
+        "paragraph_idx": 8
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T06:53:35Z",
     "article_id": "art_237"
   },
   {
@@ -24762,9 +25656,11 @@
     "primary_subject_agency_ids": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-12T20:58:33Z",
-    "article_id": "art_238"
+    "article_id": "art_238",
+    "curation_error": "schema parse failed or refusal",
+    "curation_raw": "[model refusal]"
   },
   {
     "url": "https://www.toledoblade.com/local/police-fire/2022/02/04/toledo-moves-forward-with-automated-license-plate-reader-study/stories/20220204107",
@@ -24919,6 +25815,12 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:restricted",
+      "policy:purpose-limitation",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -25010,11 +25912,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T22:29:18Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Denver Mayor Mike Johnston announced a no-cost five-month extension of the city's Flock Safety ALPR contract, despite the City Council having rejected a two-year extension. The new terms cut off data access to other agencies absent an MOU, bar federal access including for task force officers, limit search terms, and impose $100,000 penalties for breaches. Councilmembers criticized the move as bypassing democratic oversight.",
+    "key_quotes": [
+      {
+        "quote": "Effective Oct. 22, access to Denver's Flock LPR data has been shut off to all other agencies and, going forward, it will only be available to law enforcement agencies that sign a memorandum of understanding with Denver",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "Extending Flock again without a vote undermines democratic oversight and public trust.",
+        "paragraph_idx": 16
+      },
+      {
+        "quote": "any data sharing with the federal government regarding civil immigration enforcement will result in an immediate loss of access and referral to the Colorado Attorney General's Office for prosecution",
+        "paragraph_idx": 19
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T16:24:20Z",
     "article_id": "art_240"
   },
   {
@@ -25193,6 +26110,9 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:rejected",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -25240,10 +26160,19 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-12T22:29:21Z",
+    "summary": "The Lockhart, Texas City Council voted 6-1 against a proposal to contract with Flock Safety for seven ALPR cameras within city limits. Opposition was organized by local activist groups citing mass surveillance and ICE-cooperation concerns.",
+    "key_quotes": [
+      {
+        "quote": "the Lockhart City Council voted 6-1 against a proposal to enter a contract with Flock Safety to install seven license-plate-reading cameras in the city limits",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "some concerned that the cameras could be used for mass surveillance and by federal agencies like Immigration and Customs Enforcement (ICE)",
+        "paragraph_idx": 9
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:08:18Z",
     "article_id": "art_242"
   },
   {
@@ -25514,6 +26443,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:reconsidering",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -25562,11 +26496,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T00:20:45Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Denver City Council postponed by one week a vote on a proposed $150,000 contract with Axon for 50 ALPR cameras to replace the city's expiring Flock Safety contract. Council members and advocates raised concerns about rushing the deal without a surveillance ordinance in place, while the mayor and police support the technology.",
+    "key_quotes": [
+      {
+        "quote": "The City and County of Denver still hasn't officially broken up with automated license plate reading camera vendor Flock Group, as members of the City Council agreed Monday to delay approving a new contract with Arizona-based ALPR maker Axon.",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "The city cannot simply move from one dragnet surveillance company to another and trust that these for-profit companies will put people's civil liberties first",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "Take a breath, turn off the Flock cameras on March 31, put a hood on them until they are removed",
+        "paragraph_idx": 8
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:08:27Z",
     "article_id": "art_245"
   },
   {
@@ -25700,6 +26649,13 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:court-ruling",
+      "policy:hotlist",
+      "policy:purpose-limitation",
+      "policy:sharing",
+      "scope:national",
       "vendor:flock",
       "vendor:vigilant"
     ],
@@ -25808,10 +26764,27 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T00:20:56Z",
+    "summary": "An AP investigation reveals that U.S. Border Patrol operates a secretive nationwide license plate reader program that flags drivers with 'suspicious' travel patterns, leading to pretextual 'whisper stops' by local law enforcement. The program draws on DEA, private vendor (including Flock), and locally-owned ALPR networks funded by federal Stonegarden grants, and has expanded far into the U.S. interior.",
+    "key_quotes": [
+      {
+        "quote": "A network of cameras scans and records vehicle license plate information, and an algorithm flags vehicles deemed suspicious based on where they came from, where they were going and which route they took.",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "Through Flock alone, Border Patrol for a time had access to at least 1,600 license plate readers across 22 states, and some counties have reported looking up license plates on behalf of CBP even in states like California and Illinois that ban sharing data with federal immigration authorities",
+        "paragraph_idx": 41
+      },
+      {
+        "quote": "Border Patrol agents and local police have many names for these kinds of stops: \"whisper,\" \"intel\" or \"wall\" stops.",
+        "paragraph_idx": 24
+      },
+      {
+        "quote": "A federal grant program called Operation Stonegarden, which has existed in some form for nearly two decades, has handed out hundreds of millions of dollars to buy automated license plate readers",
+        "paragraph_idx": 48
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:08:39Z",
     "article_id": "art_247"
   },
   {
@@ -25838,6 +26811,12 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:restricted",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -25865,10 +26844,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T00:20:57Z",
+    "summary": "San Marcos Police Department announced new privacy safeguards for its Flock ALPR program, including ending automatic data sharing with outside agencies, deactivating five cameras (leaving 14), formalizing annual audits, and amending its Flock contract to limit aggregated data collection. The announcement followed a city council decision a week earlier to decline adding more ALPRs; a local advocacy group expressed skepticism.",
+    "key_quotes": [
+      {
+        "quote": "The city said the SMPD stopped automatically sharing ALPR data with outside agencies on June 9. Instead, that data will now only be shared upon request and with confirmation of a criminal investigation or prosecution.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "The police department has also deactivated five ALPR cameras, leaving only the original 14 that were installed in 2022.",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "All inquiries into the ALPR system must now be tied to an active investigation and users will be required to enter both a reason for the inquiry and an associated case number.",
+        "paragraph_idx": 10
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:08:46Z",
     "article_id": "art_248"
   },
   {
@@ -26012,9 +27004,11 @@
     "primary_subject_agency_ids": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-13T00:21:09Z",
-    "article_id": "art_249"
+    "article_id": "art_249",
+    "curation_error": "schema parse failed or refusal",
+    "curation_raw": "[model refusal]"
   },
   {
     "url": "https://www.denvergazette.com/2026/03/27/denver-city-council-to-consider-axon-alpr-camera-contract/",
@@ -26040,6 +27034,8 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "scope:local",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -26077,11 +27073,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T05:07:16Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Denver City Council is set to consider a delayed 12-month, $150,000 contract with Axon for approximately 50 ALPR cameras to replace the 111 Flock cameras currently in use, whose contract expires March 31. The article is a council agenda preview that also covers unrelated housing and financing items.",
+    "key_quotes": [
+      {
+        "quote": "The 12-month, $150,000 agreement with Axon would deliver approximately 50 new cameras, replacing the 111 Flock cameras currently operating throughout the city.",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "The city\u2019s agreement with Flock ends March 31.",
+        "paragraph_idx": 3
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:08:56Z",
     "article_id": "art_250"
   },
   {
@@ -26107,6 +27114,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -26134,11 +27146,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T05:07:20Z",
+    "primary_subject_agency_ids": [
+      "a597ac19-0e62-585c-82a0-f9c7b87c55e8"
+    ],
+    "summary": "Evanston covered its Flock ALPR cameras with black plastic while awaiting their removal, after Flock reinstalled cameras the city had ordered shut down. The city had terminated its contract following revelations that Flock allowed CBP access to Illinois cameras in violation of state law.",
+    "key_quotes": [
+      {
+        "quote": "Flock has committed to removing the cameras promptly, but in the meantime, City staff have placed covers over them.",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "The city previously ordered Flock to shut down 19 cameras (18 stationary and one flex camera that can be attached to a squad car) provided by the company and put its contract with Flock on a 30-day termination notice on Aug. 26.",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "The city's shutdown decision came after Illinois Secretary of State Alexi Giannoulias announced his office discovered Flock had allowed U.S. Customs and Border Protection to access Illinois cameras in a 'pilot program' against state law",
+        "paragraph_idx": 12
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:09:06Z",
     "article_id": "art_251"
   },
   {
@@ -26165,6 +27192,15 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "incident:wrongful-stop",
+      "legal:legislation",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -26253,10 +27289,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T05:07:22Z",
+    "summary": "KCRG reports on an ACLU/University of Iowa Technology Law Clinic report reviewing ALPR deployment across 43 Iowa agencies, finding rapid expansion, inconsistent data retention, broad data sharing including with ICE, and instances of misuse. The report recommends state legislation establishing uniform minimum policies, a one-week retention limit, in-state-only sharing, and access restrictions.",
+    "key_quotes": [
+      {
+        "quote": "Of the agencies that provided information, Cedar Rapids has the most cameras at 76, followed by West Des Moines with 64.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "some Flock contracts allow data sharing internationally",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "the ACLU recommends state legislation that makes uniform, minimum policies for agencies",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:09:12Z",
     "article_id": "art_252"
   },
   {
@@ -26283,6 +27332,12 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -26320,11 +27375,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T05:07:24Z",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ],
+    "summary": "Texas DPS installed Flock ALPR cameras along state rights-of-way in Austin on Feb. 2, months after Austin City Council ended its own Flock contract over privacy concerns. DPS confirmed a $24 million Flock contract with 30-day image retention and one-year metadata retention, drawing criticism from EFF-Austin and support from the Austin Police Association.",
+    "key_quotes": [
+      {
+        "quote": "The move comes months after Austin City Council voted to end the city's contract with Flock Safety following community pushback over privacy concerns.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "There's no oversight for this massive amount of data being shared across the country",
+        "paragraph_idx": 20
+      },
+      {
+        "quote": "DPS said images and data collected by the cameras will remain in Flock Safety's database for 30 days. Limited metadata will also be stored in a DPS database for up to one year.",
+        "paragraph_idx": 18
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:09:19Z",
     "article_id": "art_253"
   },
   {
@@ -26467,9 +27537,11 @@
     "primary_subject_agency_ids": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-13T05:07:35Z",
-    "article_id": "art_254"
+    "article_id": "art_254",
+    "curation_error": "schema parse failed or refusal",
+    "curation_raw": "[model refusal]"
   },
   {
     "url": "https://www.oakpark.com/2022/03/22/oak-park-board-divided-on-license-plate-reading-tech/",
@@ -26614,6 +27686,8 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:press-release",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -26652,11 +27726,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T08:15:29Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Denver Police report early public safety improvements from its Automated License Plate Reader pilot, with 55 of 111 planned cameras installed and more than 15 felony arrests or investigative assists in May. The article notes Elbert County previously rejected renewing its Flock ALPR contract.",
+    "key_quotes": [
+      {
+        "quote": "there have been more than 15 cases where the system resulted in felony arrests or assisted officers and investigators in May",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "Earlier this year, the Elbert County Commissioners voted , 3-0, against renewing the contract for the region's nine Flock Safety brand license plate readers, calling the constant surveillance of passing vehicles \"Big Brother.\"",
+        "paragraph_idx": 10
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:09:31Z",
     "article_id": "art_256"
   },
   {
@@ -26682,7 +27767,12 @@
     "wayback_timestamp": "20260513081026",
     "wayback_source": "saved",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:explainer",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "scope:local"
+    ],
     "agencies": [
       "308e7ece-43c7-53c1-90a6-82f1e7a26d68",
       "7f866083-eff9-59e4-92b4-d90a091d147f"
@@ -26708,11 +27798,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T08:15:31Z",
+    "primary_subject_agency_ids": [
+      "7f866083-eff9-59e4-92b4-d90a091d147f"
+    ],
+    "summary": "The Dubuque city council voted 6-1 to approve a policy for installing automated license plate readers. The policy includes a 30-day data retention period and internal access restrictions, with Police Chief Jeremy Jensen saying misuse will be punished.",
+    "key_quotes": [
+      {
+        "quote": "The council voted 6-to-1 Monday night to approve the new policy.",
+        "paragraph_idx": 2
+      },
+      {
+        "quote": "Data from someone's license plate will be stored for a 30 day period.",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "Chief Jensen says any officer misusing the cameras will be punished.",
+        "paragraph_idx": 8
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:09:38Z",
     "article_id": "art_257"
   },
   {
@@ -26739,6 +27844,13 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:reconsidering",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -26756,11 +27868,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T08:15:33Z",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ],
+    "summary": "Austin City Council postponed to June 1 a vote on a pilot program letting APD use Flock Safety ALPRs, which were removed in 2020. Police argue the 40-camera system would help solve crimes amid staffing shortages, while EFF Austin and some council members raised concerns about data sharing and retention policy language.",
+    "key_quotes": [
+      {
+        "quote": "If ICE asked us to use the LPR system to help enforce immigration laws, we're just simply not going to assist unless they have some sort of a serious ongoing criminal investigation.",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "It also does not clarify that, per Resolution 56, data sharing means that no other law enforcement agency, even for a valid investigation, will be given direct access to the ALPR database",
+        "paragraph_idx": 14
+      },
+      {
+        "quote": "A quarterly audit will ensure it isn't being abused per policy.",
+        "paragraph_idx": 15
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:15:48Z",
     "article_id": "art_258"
   },
   {
@@ -26903,6 +28030,13 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -26952,11 +28086,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T11:44:53Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "Denver Mayor Mike Johnston's office asked the City Council's Health and Safety Committee to delay by one week its vote on a proposed 12-month, $150,000 contract with Axon for 50 ALPR cameras to replace the city's expiring Flock Safety contract. The new contract would include protections such as 21-day retention, no federal access, no AI training use, and opt-out of data sharing. Flock cameras will enter 'decommission mode' when the contract ends March 31.",
+    "key_quotes": [
+      {
+        "quote": "Any new contract must include rigorous guardrails around data retention, information sharing, and access limitations.",
+        "paragraph_idx": 14
+      },
+      {
+        "quote": "Axon would agree to abide by Colorado law, including restricting access to the city's data for civil immigration enforcement, abortion-related investigations, or any purpose not explicitly agreed to.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "In February, Denver City Auditor Tim O'Brien refused to countersign a new contract with Flock, citing concerns of 'a risk of liability for the city.'",
+        "paragraph_idx": 11
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:15:58Z",
     "article_id": "art_260"
   },
   {
@@ -26982,6 +28131,13 @@
     "wayback_source": "saved",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27040,11 +28196,30 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T11:44:57Z",
+    "primary_subject_agency_ids": [
+      "a597ac19-0e62-585c-82a0-f9c7b87c55e8"
+    ],
+    "summary": "Evanston deactivated all 19 of its Flock Safety license plate cameras and issued notice to terminate its contract effective Sept. 26, following an Illinois Secretary of State audit that found Flock had allowed federal agencies including CBP to access Illinois ALPR data in violation of a 2024 state law barring sharing for immigration enforcement. City officials cited Flock's admission that it failed to establish proper permissions for federal users during a pilot program.",
+    "key_quotes": [
+      {
+        "quote": "The City of Evanston has shut down its network of automated license plate readers and will end its contract with vendor Flock Safety early after a state audit found the company was illegally sharing Illinois data with federal agencies.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "allowed U.S. Customs and Border Protection to access Illinois license plate cameras on Illinois roads and surveil drivers",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "We also didn't create distinct permissions and protocols in the Flock system to ensure local compliance for federal agency users",
+        "paragraph_idx": 20
+      },
+      {
+        "quote": "This vendor has failed to follow state and local data protection laws.",
+        "paragraph_idx": 22
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T08:16:09Z",
     "article_id": "art_261"
   },
   {
@@ -27071,6 +28246,9 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27109,11 +28287,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T11:44:58Z",
+    "primary_subject_agency_ids": [
+      "308e7ece-43c7-53c1-90a6-82f1e7a26d68"
+    ],
+    "summary": "Cedar Rapids Police Department signed a two-year, nearly half-million-dollar contract with Flock Group to install 75 ALPR cameras across the city, expanding from two patrol-car-mounted readers. Chief David Dostal says the cameras have contributed to more than 30 arrests since October; ACLU of Iowa has raised privacy concerns, and data is deleted after 30 days.",
+    "key_quotes": [
+      {
+        "quote": "the city of Cedar Rapids signed a two-year contract this summer with Flock Group for nearly half a million dollars to add 75 cameras",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "the new cameras have played a part in more than 30 arrests since going up in October",
+        "paragraph_idx": 6
+      },
+      {
+        "quote": "the data is automatically deleted after 30 days",
+        "paragraph_idx": 8
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T16:24:26Z",
     "article_id": "art_262"
   },
   {
@@ -27140,6 +28333,13 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:audit",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27176,11 +28376,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T11:45:00Z",
+    "primary_subject_agency_ids": [
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ],
+    "summary": "Austin's city manager pulled an item to extend the city's ALPR pilot program from the June council agenda after a work session where residents raised privacy concerns, especially about ICE access to data. The withdrawal effectively ends the pilot on June 30, despite Police Chief Lisa Davis and Assistant Chief Sheldon Askew defending the program's role in solving violent crimes.",
+    "key_quotes": [
+      {
+        "quote": "Given concerns expressed today, I have decided to withdraw this item from the agenda at this time to provide more opportunities to address council members' questions and do our due diligence to alleviate concerns prior to bringing this item back to City Council for consideration.",
+        "paragraph_idx": 8
+      },
+      {
+        "quote": "Siegel said a flaw in the city's contract lets Flock, the ALPR company, access the data and the city has no say about what Flock does with it.",
+        "paragraph_idx": 18
+      },
+      {
+        "quote": "Has APD shared any data with ICE or any immigration related entity that's seeking that data?",
+        "paragraph_idx": 15
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:08:50Z",
     "article_id": "art_263"
   },
   {
@@ -27347,6 +28562,17 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:explainer",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "incident:wrongful-stop",
+      "legal:court-ruling",
+      "legal:legislation",
+      "policy:hotlist",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:axon",
       "vendor:flock"
     ],
@@ -27457,10 +28683,27 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T11:45:07Z",
+    "summary": "A Seattle Times explainer on automated license plate readers in Washington state, describing how ALPRs work, their proliferation via state grants, controversies including federal access to data, a Skagit County ruling making footage public, and pending state legislation that would set the first WA-wide ALPR regulations. The piece notes multiple WA cities have turned off cameras and mentions Lynnwood's upcoming vote on terminating its Flock contract.",
+    "key_quotes": [
+      {
+        "quote": "University of Washington researchers published a report showing U.S. Border Patrol had searched the Flock Safety databases of at least 18 police departments in the state \u2014 often without their knowledge.",
+        "paragraph_idx": 26
+      },
+      {
+        "quote": "Washington state lawmakers are considering a bill that could result in the state's first ALPR regulations.",
+        "paragraph_idx": 33
+      },
+      {
+        "quote": "In Kansas, a police chief had his police certification revoked in 2024 after state investigators learned he used his city's Flock Safety system to search for his ex-girlfriend's car",
+        "paragraph_idx": 32
+      },
+      {
+        "quote": "a Skagit County judge ruled that footage captured by two cities' Flock Safety cameras are public records",
+        "paragraph_idx": 28
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:08:59Z",
     "article_id": "art_265"
   },
   {
@@ -27487,6 +28730,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "legal:legislation",
+      "outcome:terminated",
+      "policy:retention",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27591,11 +28839,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T15:05:03Z",
+    "primary_subject_agency_ids": [
+      "59970831-4f53-57f5-876c-78db7e83bfac"
+    ],
+    "summary": "Elbert County, Colorado commissioners voted 3-0 in December 2023 not to renew the contract for nine Flock Safety license plate readers, citing 'Big Brother' surveillance concerns; the cameras will be removed in May. The article contrasts Elbert's decision with Denver's plan to install 109 Flock cameras and Douglas County/Castle Rock's embrace of the technology.",
+    "key_quotes": [
+      {
+        "quote": "the Elbert County Commissioners voted, 3-0, against renewing the contract for the region's nine Flock Safety brand license plate readers because constant surveillance of passing vehicles is too much \"Big Brother\" for their comfort.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "Fisher advised Flock Safety that its contract is not being renewed. All nine of Elbert County's cameras will be removed this May.",
+        "paragraph_idx": 22
+      },
+      {
+        "quote": "This Spring, Denver will give a substantial nod to Flock technology by installing 109 of the license plate readers in high-crime areas",
+        "paragraph_idx": 33
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:09:08Z",
     "article_id": "art_266"
   },
   {
@@ -27622,6 +28885,10 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27702,11 +28969,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T15:05:06Z",
+    "primary_subject_agency_ids": [
+      "a0d35e50-b919-5848-88fb-505b2bef93c9"
+    ],
+    "summary": "Baraboo, Wisconsin's Common Council voted 8-1 to approve a one-year pilot of six Flock Safety license plate reader cameras, funded by approximately $20,000 in donations rather than tax dollars. The lone dissenter raised concerns about privacy and potential ICE access to camera data, particularly given Sauk County Sheriff's existing ICE housing agreement, while the police chief said Baraboo would not share data with ICE but could not control other municipalities' sharing.",
+    "key_quotes": [
+      {
+        "quote": "If you scratch the surface on these Flock cameras just a little bit, it's being widely reported that they are being used, for example, by ICE to support their operations",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "Baraboo Police would not be required to provide network information to ICE or any other agency if they chose not to, Carloni said, but Baraboo Police could not dictate whether data from other municipalities could be shared with ICE.",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:09:19Z",
     "article_id": "art_267"
   },
   {
@@ -27733,6 +29011,10 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -27789,11 +29071,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T15:05:09Z",
+    "primary_subject_agency_ids": [
+      "40521632-8a29-5e5d-a064-1b57410743b5"
+    ],
+    "summary": "The ACLU of Iowa held a community meeting in Coralville to raise Fourth Amendment concerns as the city considers installing Flock ALPR cameras, joining Cedar Rapids, North Liberty, and Dubuque. Flock responded with a statement defending its safeguards and noting local agencies control their data.",
+    "key_quotes": [
+      {
+        "quote": "The new increase in the number of cameras, but how they are being used, that has us really concerned",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "The functionality of them allows for misuse",
+        "paragraph_idx": 15
+      },
+      {
+        "quote": "In Cedar Rapids, the footage is stored for 30 days after that, Flock said the video is deleted and unrecoverable.",
+        "paragraph_idx": 17
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:09:27Z",
     "article_id": "art_268"
   },
   {
@@ -27996,6 +29293,12 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:restricted",
+      "policy:audit",
+      "policy:retention",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -28088,11 +29391,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T17:31:45Z",
+    "primary_subject_agency_ids": [
+      "8ba7c038-a01d-5359-9eeb-5c3a6faa8458"
+    ],
+    "summary": "A Denver City Council committee is demanding more input from the city's Surveillance Technology Task Force on Mayor Mike Johnston's dealings with Flock Safety, after Johnston entered a no-cost five-month trial contract with the vendor despite council opposition. The new contract restricts data sharing to agencies signing an MOU with Denver and imposes $100,000 per-incident fines for leaks, but councilmembers expressed frustration over the lack of transparency and collaboration.",
+    "key_quotes": [
+      {
+        "quote": "Effective Oct. 22, 2026 access to Denver's Flock LPR data has been shut off to all other agencies and, going forward, will only be accessible to law enforcement agencies that sign a memorandum of understanding (MOU) with the City and County of Denver.",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "the city had entered into a \"no-cost five-month\" trial contract with Flock Safety under several stipulations, notably locking down access to data gathered by the city's 111 ALPR cameras and imposing a $100,000 per incident fine to the vendor for any data leaks",
+        "paragraph_idx": 5
+      },
+      {
+        "quote": "There was absolutely no mention of a national network of any sort, and that lack of transparency continues through today",
+        "paragraph_idx": 11
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T16:24:35Z",
     "article_id": "art_271"
   },
   {
@@ -28119,6 +29437,13 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:audit",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -28232,11 +29557,34 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-13T17:31:50Z",
+    "primary_subject_agency_ids": [
+      "61928d8f-f9a4-569c-8f7e-72f2223862a1",
+      "3f3ff099-4cf8-54c9-94c2-48633a083e10",
+      "9a80fff3-3332-5596-b292-768893dd3391",
+      "22e90ef0-84b4-5f14-b976-c00dc15a7e0c",
+      "25b04479-d425-52a6-a197-c941bcd88952"
+    ],
+    "summary": "More than 180 Michigan law enforcement agencies now use Flock Safety ALPR technology, up from about 60 in 2022, prompting privacy concerns and a bipartisan state bill (HB 5492/5493) that would require data deletion after 14 days (likely amended to 30) and quarterly transparency reports. The article surveys deployments in Waterford Township, Detroit, Grand Rapids, Warren, and Oakland County, and examines concerns about ICE access to LPR data.",
+    "key_quotes": [
+      {
+        "quote": "Statewide, more than 180 law enforcement agencies \u2015 nearly a third of all agencies in Michigan \u2015 now use Flock Safety technology",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "They'll say, 'Hey, we've got this person who we think is under ICE's purview' or whatever, and then the officer will search for the license plate associated with that person for an immigration search",
+        "paragraph_idx": 29
+      },
+      {
+        "quote": "House Bill 5493 would require LPR data to disappear after 14 days unless it's used in a criminal investigation.",
+        "paragraph_idx": 38
+      },
+      {
+        "quote": "Currently, it's a bit of the Wild West since we don't have these regulations.",
+        "paragraph_idx": 40
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:51:22Z",
     "article_id": "art_272"
   },
   {
@@ -29934,9 +31282,10 @@
     "primary_subject_agency_ids": [],
     "summary": null,
     "key_quotes": [],
-    "curation_status": "mechanical",
+    "curation_status": "needs_review",
     "curated_at": "2026-05-14T10:38:01Z",
-    "article_id": "art_286"
+    "article_id": "art_286",
+    "curation_error": "refusal: Article is about data broker audit requirements under California Delete Act, not ALPR or police surveillance."
   },
   {
     "url": "https://oaklandside.org/2026/02/11/flock-contract-alameda-county-ice-federal/",
@@ -32337,6 +33686,11 @@
     "wayback_source": "submit-failed",
     "pdf_status": "skipped-curl-fallback",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:terminated",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -32384,11 +33738,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-14T23:17:09Z",
+    "primary_subject_agency_ids": [
+      "2cc3a31d-7f98-5714-bc85-927815444575"
+    ],
+    "summary": "The Tompkins County Legislature voted 12-1 to end its contract with Flock Safety after months of activist pressure over concerns that ALPR data could be accessed by federal immigration enforcement, undermining the county's sanctuary status. The sheriff's office plans to continue its GIVE grant participation by exploring alternative tools such as mobile surveillance trailers.",
+    "key_quotes": [
+      {
+        "quote": "Legislators voted 12-1 to end the county's contract with Flock Safety, an Atlanta-based tech company.",
+        "paragraph_idx": 12
+      },
+      {
+        "quote": "It's clear to me that Flock is not the contractor that we want to move forward with in any event, largely because it is a company that has allowed itself to be co-opted by a federal administration that consistently subverts our justice system",
+        "paragraph_idx": 20
+      },
+      {
+        "quote": "activists have argued those safeguards aren't airtight, and that Flock's presence threatens the effectiveness of the county's sanctuary status.",
+        "paragraph_idx": 17
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:51:34Z",
     "article_id": "art_307"
   },
   {
@@ -33494,16 +34863,28 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "policy:sharing",
+      "scope:national",
       "vendor:flock",
       "vendor:motorola"
     ],
     "agencies": [],
     "agency_candidates": [],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-19T10:12:30Z",
+    "summary": "FBI procurement records reviewed by 404 Media show the bureau is seeking to purchase nationwide access to automated license plate reader data, which would enable warrantless tracking of vehicle movements across the country. The article notes only a few vendors, likely Flock and Motorola, could fulfill the request.",
+    "key_quotes": [
+      {
+        "quote": "The FBI wants to buy access to automated license plate readers (ALPRs) nationwide, which would likely allow the agency to track the movements of vehicles\u2014and by extension people\u2014across the country without a warrant, according to FBI procurement records reviewed by 404 Media.",
+        "paragraph_idx": 3
+      },
+      {
+        "quote": "Only a couple vendors could likely fulfill what the FBI is after, namely Flock and Motorola.",
+        "paragraph_idx": 2
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:51:39Z",
     "article_id": "art_315"
   },
   {
@@ -33529,12 +34910,20 @@
     "wayback_timestamp": "20260519100531",
     "wayback_source": "saved",
     "pdf_status": "rendered",
-    "tags": [],
+    "tags": [
+      "genre:analysis",
+      "incident:ice-cooperation",
+      "incident:misuse",
+      "legal:court-ruling",
+      "policy:sharing",
+      "scope:national"
+    ],
     "agencies": [
       "14b510e3-7bde-5474-8249-6ef49a16cfc5",
       "09d70d09-1c2d-59cc-a227-a21fe402ac91",
       "7cabcca1-9a07-54d1-9983-fb34e7384b0e",
-      "0e8fdf8c-1752-5528-9a84-b98041c02002"
+      "0e8fdf8c-1752-5528-9a84-b98041c02002",
+      "030b796b-eb59-5d03-8f7f-b1d5ce1a005c"
     ],
     "agency_candidates": [
       {
@@ -33592,11 +34981,32 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-19T10:12:33Z",
+    "primary_subject_agency_ids": [
+      "030b796b-eb59-5d03-8f7f-b1d5ce1a005c",
+      "14b510e3-7bde-5474-8249-6ef49a16cfc5",
+      "09d70d09-1c2d-59cc-a227-a21fe402ac91"
+    ],
+    "summary": "Government Technology surveys ALPR deployments in Houston, San Francisco, and Chicago, where police cite crime-solving successes, alongside privacy critiques from EFF and the Independent Institute concerning travel-pattern tracking, data sharing across states, and immigration enforcement.",
+    "key_quotes": [
+      {
+        "quote": "Houston has 3,800 ALPR cameras strategically located throughout the city and isn't apologetic about it.",
+        "paragraph_idx": 5
+      },
+      {
+        "quote": "studies have shown that the license plate readers do not have a discernable effect on solving crime",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "Unlike consumer cameras, ALPRs log and retain other information, such as time and place",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "California has sanctuary laws, but sometimes the ALPR data can make its way to immigration authorities.",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:51:49Z",
     "article_id": "art_316"
   },
   {
@@ -33623,6 +35033,10 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:rejected",
+      "policy:sharing",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -33733,11 +35147,22 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-19T10:12:41Z",
+    "primary_subject_agency_ids": [
+      "1dcdab89-7f4f-5f52-9b08-1c81d79875da"
+    ],
+    "summary": "The McFarland (WI) Police Department announced it will not proceed with a planned purchase of Flock Safety ALPR cameras, citing the shrinking Dane County camera network after Dane County and Monona ended their Flock contracts, plus resident concerns about privacy and data sharing. The village board had approved the $18,000/year, six-camera plan in December, but Chief Brian Redman said the reduced network undermined the return on investment.",
+    "key_quotes": [
+      {
+        "quote": "Once Dane County lost their funding for Flock, we lost about half of the potential camera network within Dane County",
+        "paragraph_idx": 15
+      },
+      {
+        "quote": "The police department has not made a purchase from Flock Safety and has notified the company of its intention not to pursue a contract",
+        "paragraph_idx": 25
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:00Z",
     "article_id": "art_317"
   },
   {
@@ -33923,6 +35348,11 @@
     "wayback_source": "existing",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:sharing",
+      "scope:national",
       "vendor:flock",
       "vendor:motorola"
     ],
@@ -33961,10 +35391,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-20T12:04:19Z",
+    "summary": "The FBI issued an RFP seeking one or more vendors to provide nationwide, near-real-time access to license plate reader data covering 75% of US locations, with contracts worth up to $36 million over five years. Flock and Motorola Solutions are seen as likely bidders, though state laws and Flock's opt-in sharing policies may limit federal access.",
+    "key_quotes": [
+      {
+        "quote": "the FBI requires professional service firms that can provide License Plate Readers (LPRs) for tracking subjects on roads and highways over the US and its territories",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "Flock data belongs to the agency that owns the cameras. There is no backdoor into Flock. Any access is explicitly permission-based and opt-in by the local agency",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "California prohibits state and local agencies from sharing ALPR camera data with out-of-state or federal law enforcement agencies.",
+        "paragraph_idx": 19
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:09Z",
     "article_id": "art_319"
   },
   {
@@ -34037,6 +35480,8 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -34084,11 +35529,18 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-20T12:04:22Z",
+    "primary_subject_agency_ids": [
+      "95b86430-f962-57dc-978f-349b3b91f5b3"
+    ],
+    "summary": "Luling police arrested a man who allegedly threatened a mass shooting at a local business after a multi-agency pursuit. Officers used Flock Safety ALPR cameras to track the suspect's vehicle south on US 183, where Gonzales County deputies took him into custody.",
+    "key_quotes": [
+      {
+        "quote": "Police used the Flock Safety camera system to track the suspect, who had left the city and was traveling south on U.S. Highway 183.",
+        "paragraph_idx": 4
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:13Z",
     "article_id": "art_321"
   },
   {
@@ -34269,6 +35721,9 @@
     "wayback_source": "submit-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "outcome:terminated",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -34376,11 +35831,26 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-26T04:30:39Z",
+    "primary_subject_agency_ids": [
+      "02c1a2cc-6f98-50e0-b4d3-7923d539cc36"
+    ],
+    "summary": "The Clawson, Michigan City Council deadlocked 3-3 on renewing the city's Flock Safety license plate reader contract, causing the motion to fail and ending the program. Two officers threatened to quit at the meeting; residents had raised privacy and data-control concerns.",
+    "key_quotes": [
+      {
+        "quote": "Two Clawson police officers threatened to quit their jobs at a City Council meeting last week after the board voted not to renew the city's contract for license plate readers.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "The motion to renew the city's contract with Flock was tied 3-3, resulting in its failure and the nonrenewal of the contract.",
+        "paragraph_idx": 17
+      },
+      {
+        "quote": "It's tough because of this not being able to control the data.",
+        "paragraph_idx": 19
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:20Z",
     "article_id": "art_323"
   },
   {
@@ -34407,6 +35877,8 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -34457,11 +35929,23 @@
         ]
       }
     ],
-    "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-26T04:30:41Z",
+    "primary_subject_agency_ids": [
+      "62ce4269-bebc-5d09-88f0-e69799aeb94a",
+      "d4637ecc-7773-5a1c-b251-5d4e3dc2ff58"
+    ],
+    "summary": "Buda police said Flock Safety camera data and physical evidence linked a May 17 shooting at a Main Street business in Buda to a series of 12 shootings in South Austin the same weekend, for which three teenagers have been arrested.",
+    "key_quotes": [
+      {
+        "quote": "Detectives used evidence from the scene and Flock Safety camera data that tied the two shooting incidents together.",
+        "paragraph_idx": 13
+      },
+      {
+        "quote": "We know the vehicle, and so that's a contributing factor to what ties to the Austin shootings",
+        "paragraph_idx": 14
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:26Z",
     "article_id": "art_324"
   },
   {
@@ -34697,6 +36181,13 @@
     "wayback_source": "poll-failed",
     "pdf_status": "rendered",
     "tags": [
+      "genre:analysis",
+      "incident:ice-cooperation",
+      "legal:legislation",
+      "policy:purpose-limitation",
+      "policy:retention",
+      "policy:sharing",
+      "scope:state",
       "vendor:flock"
     ],
     "agencies": [
@@ -34773,10 +36264,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-26T08:48:39Z",
+    "summary": "The Washington state Senate passed SB 6002 on a 40-9 vote, which would regulate ALPR use by limiting data retention to 21 days, barring immigration enforcement access, and prohibiting use to track protests or near sensitive locations. The bill now heads to the state House; multiple Washington cities including Olympia and Redmond have already rolled back Flock camera use.",
+    "key_quotes": [
+      {
+        "quote": "It is literally the wild, wild west when it comes to data protection.",
+        "paragraph_idx": 7
+      },
+      {
+        "quote": "Multiple Washington cities have rolled back the use of Flock cameras in recent months, including Olympia and Redmond.",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "Eight or more Washington law enforcement agencies seem to have allowed their reader networks to be shared with U.S. Border Patrol in 2025",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:32Z",
     "article_id": "art_327"
   },
   {
@@ -35702,6 +37206,12 @@
     "wayback_source": "existing",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:misuse",
+      "policy:audit",
+      "policy:purpose-limitation",
+      "policy:sharing",
+      "scope:national",
       "vendor:flock"
     ],
     "agencies": [
@@ -35827,10 +37337,23 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-27T12:38:08Z",
+    "summary": "EFF analyzed Flock Safety ALPR network audit logs and found law enforcement agencies using the system for low-level, non-criminal purposes including school residency verification, employment background checks, and noise complaints. The report names dozens of agencies engaging in this mission creep and argues the absence of a warrant requirement enables such misuse.",
+    "key_quotes": [
+      {
+        "quote": "in the absence of a warrant requirement to search ALPR databases, law enforcement agencies have moved beyond specific investigations to use these surveillance networks for virtually any whim.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "Between January 2025 and March 2026, school police ran more than 375 searches where officers listed school residency verification, or simply \"RV,\" as the reason for the search.",
+        "paragraph_idx": 11
+      },
+      {
+        "quote": "EFF identified 26 agencies where officers felt it was appropriate to pry into a driver's life because of a noise complaint",
+        "paragraph_idx": 18
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:40Z",
     "article_id": "art_334"
   },
   {
@@ -35857,6 +37380,11 @@
     "wayback_source": "saved",
     "pdf_status": "rendered",
     "tags": [
+      "genre:investigative",
+      "incident:ice-cooperation",
+      "outcome:reconsidering",
+      "policy:audit",
+      "scope:local",
       "vendor:flock"
     ],
     "agencies": [
@@ -35921,10 +37449,27 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": null,
-    "key_quotes": [],
-    "curation_status": "mechanical",
-    "curated_at": "2026-05-27T12:38:10Z",
+    "summary": "The Albany, Oregon City Council is set to vote on whether to reactivate the city's Flock ALPR camera, which was turned off in February and then stolen. The Public Safety Commission recommended resuming use despite community concerns about privacy, misuse, and ICE access, noting other Oregon cities like Eugene and Springfield have permanently disabled their Flock cameras.",
+    "key_quotes": [
+      {
+        "quote": "Only one of the four contracted Flock cameras has been installed in Albany, and was turned off after a City Council vote in February. The camera was then stolen.",
+        "paragraph_idx": 4
+      },
+      {
+        "quote": "Other cities in Oregon, including Eugene and Springfield, had implemented these cameras, but have permanently disabled them due to similar concerns.",
+        "paragraph_idx": 9
+      },
+      {
+        "quote": "We dropped the ball way earlier. We should have been in the conversation, putting up guardrails immediately",
+        "paragraph_idx": 10
+      },
+      {
+        "quote": "the commission voted to recommend resuming camera use to the city council",
+        "paragraph_idx": 13
+      }
+    ],
+    "curation_status": "enriched",
+    "curated_at": "2026-05-28T09:52:46Z",
     "article_id": "art_335"
   },
   {

--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -585,7 +585,8 @@ def call_claude_for_curation(entry: dict, text: str, *,
 def run_phase2(registry: list[dict], *, tags_data: dict,
                limit: int, model: str, dry_run: bool,
                reenrich: bool = False,
-               include_flagged: bool = False) -> int:
+               include_flagged: bool = False,
+               ids: set[str] | None = None) -> int:
     if not dry_run and not os.environ.get("ANTHROPIC_API_KEY"):
         print("phase2: ANTHROPIC_API_KEY not set; skipping (Phase 1 still ran)")
         return 0
@@ -608,6 +609,15 @@ def run_phase2(registry: list[dict], *, tags_data: dict,
 
     eligible = []
     for e in registry:
+        # --ids targets a specific approved set (e.g. from the review UI);
+        # those bypass the scanner gate AND the status/tier filters, since
+        # the user vouched for each id. Lets you retry timed-out
+        # needs_review entries by id without flipping them back manually.
+        if ids is not None:
+            if e.get("article_id") not in ids:
+                continue
+            eligible.append(e)
+            continue
         if e.get("curation_status") not in accepted_statuses:
             continue
         if e.get("tier") not in PHASE2_ELIGIBLE_TIERS:
@@ -725,6 +735,10 @@ def main() -> int:
                         "scanner verdict REVIEW REQUIRED. Use on known-source "
                         "batches; Phase 2 has no tools so the scanner is "
                         "defense-in-depth rather than a hard wall.")
+    p.add_argument("--ids", default=None,
+                   help="Phase 2 only: comma- or space-separated article_ids "
+                        "to enrich. Bypasses the scanner gate for those ids "
+                        "(use after human review, e.g. review_mechanical.py).")
     args = p.parse_args()
 
     registry = read_json(REGISTRY_PATH, [])
@@ -737,10 +751,17 @@ def main() -> int:
 
     if args.phase in ("2", "both"):
         limit = args.limit if args.limit is not None else DEFAULT_PHASE2_LIMIT
+        ids = None
+        if args.ids:
+            ids = {t for t in re.split(r"[,\s]+", args.ids) if t}
+            # --ids implies "I picked these deliberately, run them all"
+            if args.limit is None:
+                limit = len(ids)
         run_phase2(registry, tags_data=tags_data, limit=limit,
                    model=args.model, dry_run=args.dry_run,
                    reenrich=args.reenrich,
-                   include_flagged=args.include_flagged)
+                   include_flagged=args.include_flagged,
+                   ids=ids)
 
     if not args.dry_run:
         write_json(REGISTRY_PATH, registry)

--- a/scripts/article_reject.py
+++ b/scripts/article_reject.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Flip article registry entries to `needs_review` after human rejection.
+
+Companion to scripts/review_mechanical.py: when the review UI emits a
+`reject: art_X art_Y …` line, this script marks those entries so they
+stop showing up in future reviews. Existing consumers already skip
+`needs_review`, so no other code needs to change.
+
+Usage:
+  scripts/article_reject.py --ids "art_111 art_222"
+  scripts/article_reject.py --ids art_111,art_222 --reason "off-topic"
+  scripts/article_reject.py --ids art_111 --dry-run
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "assets" / "article_registry.json"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ids", required=True,
+                    help="comma- or space-separated article_ids to reject")
+    ap.add_argument("--reason", default="rejected in review",
+                    help="reason recorded in curation_error (default: %(default)r)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    ids = {t for t in re.split(r"[,\s]+", args.ids) if t}
+    if not ids:
+        print("no ids given", file=sys.stderr)
+        return 1
+
+    registry = json.loads(REGISTRY.read_text())
+    found, flipped, skipped = 0, 0, 0
+    for e in registry:
+        if e.get("article_id") not in ids:
+            continue
+        found += 1
+        status = e.get("curation_status")
+        if status == "enriched":
+            print(f"skip {e['article_id']}: already enriched (use a different "
+                  f"flow to demote enriched entries)", file=sys.stderr)
+            skipped += 1
+            continue
+        e["curation_status"] = "needs_review"
+        e["curation_error"] = f"rejected: {args.reason}"
+        e["curated_at"] = now_iso()
+        flipped += 1
+        print(f"{'would flip' if args.dry_run else 'flipped'} {e['article_id']} "
+              f"({status} → needs_review)")
+
+    missing = ids - {e["article_id"] for e in registry if e.get("article_id") in ids}
+    for m in sorted(missing):
+        print(f"NOT FOUND: {m}", file=sys.stderr)
+
+    if not args.dry_run and flipped:
+        REGISTRY.write_text(json.dumps(registry, indent=2, sort_keys=False) + "\n")
+    print(f"summary: found={found} flipped={flipped} skipped={skipped} "
+          f"not_found={len(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review_mechanical.py
+++ b/scripts/review_mechanical.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Generate a local HTML review UI for `mechanical`-status articles.
+
+Reads assets/article_registry.json, pulls the first ~500 chars of each
+entry's extracted .txt for inline preview, and writes a single static
+HTML file with one row per article. Radios per row (approve/reject/skip),
+localStorage persistence, and a "Copy decisions" button at the bottom.
+
+Usage:
+  scripts/review_mechanical.py                 # writes /tmp/review_mechanical.html
+  scripts/review_mechanical.py --open          # also `open` it
+  scripts/review_mechanical.py --out path.html
+
+Output format the button copies — paste back into chat:
+  approve: art_001 art_002 ...
+  reject:  art_003 art_004 ...
+"""
+
+import argparse
+import html
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "assets" / "article_registry.json"
+DEFAULT_OUT = Path("/tmp/review_mechanical.html")
+EXCERPT_CHARS = 600
+
+
+def excerpt_for(entry: dict) -> str:
+    txt_rel = (entry.get("paths") or {}).get("txt")
+    if not txt_rel:
+        return ""
+    path = ROOT / txt_rel
+    if not path.exists():
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > EXCERPT_CHARS:
+        text = text[:EXCERPT_CHARS].rsplit(" ", 1)[0] + "…"
+    return text
+
+
+def score_of(entry: dict) -> int:
+    m = re.search(r"(\d+) pts", entry.get("scanner_verdict") or "")
+    return int(m.group(1)) if m else 9999
+
+
+def build_rows(registry: list[dict]) -> list[dict]:
+    rows = []
+    for e in registry:
+        if e.get("curation_status") != "mechanical":
+            continue
+        rows.append({
+            "id": e.get("article_id"),
+            "domain": e.get("source_domain") or "",
+            "tier": e.get("tier"),
+            "score": score_of(e),
+            "title": e.get("title") or "(no title)",
+            "url": e.get("url") or "",
+            "excerpt": excerpt_for(e),
+        })
+    rows.sort(key=lambda r: (r["tier"] or 99, r["domain"], r["score"]))
+    return rows
+
+
+HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Article review — mechanical backlog</title>
+<style>
+  :root {
+    --bg: #fafaf7; --fg: #1a1a1a; --muted: #666;
+    --card: #fff; --border: #e0ddd5;
+    --approve: #2d7a2d; --reject: #a33; --skip: #888;
+    --tier1: #1a4480; --tier2: #555;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #999;
+            --card: #242424; --border: #333; }
+  }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI",
+         sans-serif; background: var(--bg); color: var(--fg);
+         margin: 0; padding: 0 0 96px 0; }
+  header { position: sticky; top: 0; background: var(--bg);
+           border-bottom: 1px solid var(--border); padding: 12px 20px;
+           z-index: 10; display: flex; gap: 24px; align-items: baseline; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .counts { font-variant-numeric: tabular-nums; color: var(--muted); }
+  header .counts b { color: var(--fg); }
+  header .filter { margin-left: auto; }
+  header input[type=search] { padding: 4px 8px; font: inherit;
+    background: var(--card); border: 1px solid var(--border);
+    color: var(--fg); border-radius: 4px; width: 200px; }
+  main { padding: 16px 20px; }
+  .row { background: var(--card); border: 1px solid var(--border);
+         border-radius: 6px; padding: 10px 12px; margin: 0 0 8px;
+         display: grid; grid-template-columns: auto 1fr auto;
+         gap: 10px 14px; align-items: start; }
+  .row[data-state=approve] { border-left: 3px solid var(--approve); }
+  .row[data-state=reject]  { border-left: 3px solid var(--reject); }
+  .meta { font-size: 12px; color: var(--muted); white-space: nowrap;
+          font-variant-numeric: tabular-nums; }
+  .meta .id { font-family: ui-monospace, SFMono-Regular, monospace;
+              color: var(--fg); }
+  .meta .tier1 { color: var(--tier1); font-weight: 600; }
+  .meta .tier2 { color: var(--tier2); }
+  .meta .score-low  { color: var(--approve); }
+  .meta .score-mid  { color: #b87a00; }
+  .meta .score-high { color: var(--reject); }
+  .title a { color: var(--fg); text-decoration: none;
+             font-weight: 500; }
+  .title a:hover { text-decoration: underline; }
+  .excerpt { font-size: 13px; color: var(--muted);
+             margin-top: 4px; max-width: 75ch; }
+  .controls { display: flex; gap: 6px; align-items: center; }
+  .controls label { padding: 4px 10px; border: 1px solid var(--border);
+                    border-radius: 4px; cursor: pointer; font-size: 12px;
+                    user-select: none; }
+  .controls input { display: none; }
+  .controls input:checked + span.lbl-approve { background: var(--approve);
+    color: #fff; border-radius: 4px; padding: 4px 10px; margin: -4px -10px; }
+  .controls input:checked + span.lbl-reject  { background: var(--reject);
+    color: #fff; border-radius: 4px; padding: 4px 10px; margin: -4px -10px; }
+  .controls input:checked + span.lbl-skip    { background: var(--skip);
+    color: #fff; border-radius: 4px; padding: 4px 10px; margin: -4px -10px; }
+  .row.hidden { display: none; }
+  footer { position: fixed; bottom: 0; left: 0; right: 0;
+           background: var(--bg); border-top: 1px solid var(--border);
+           padding: 12px 20px; display: flex; gap: 14px;
+           align-items: center; z-index: 10; }
+  footer button { font: inherit; padding: 8px 14px;
+    background: var(--fg); color: var(--bg); border: 0;
+    border-radius: 4px; cursor: pointer; font-weight: 500; }
+  footer button.secondary { background: transparent; color: var(--fg);
+    border: 1px solid var(--border); font-weight: 400; }
+  footer .preview { color: var(--muted); font-size: 12px;
+    font-family: ui-monospace, monospace; flex: 1;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .toast { position: fixed; bottom: 70px; left: 50%;
+           transform: translateX(-50%); background: var(--fg);
+           color: var(--bg); padding: 8px 16px; border-radius: 4px;
+           opacity: 0; transition: opacity .2s; pointer-events: none; }
+  .toast.show { opacity: 1; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Article review — mechanical backlog</h1>
+  <span class="counts">
+    <b id="c-total">0</b> total ·
+    <b id="c-approve">0</b> approve ·
+    <b id="c-reject">0</b> reject ·
+    <b id="c-skip">0</b> skip
+  </span>
+  <span class="filter">
+    <input type="search" id="filter" placeholder="filter by domain/title…">
+  </span>
+</header>
+<main id="rows"></main>
+<footer>
+  <button id="copy">Copy decisions</button>
+  <button id="reset" class="secondary">Reset all</button>
+  <span class="preview" id="preview"></span>
+</footer>
+<div class="toast" id="toast">copied</div>
+<script>
+const ROWS = __ROWS_JSON__;
+const STORAGE_KEY = 'sm-alpr-review-mechanical-v1';
+const state = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+
+function scoreClass(s) {
+  if (s < 50) return 'score-low';
+  if (s < 130) return 'score-mid';
+  return 'score-high';
+}
+
+function render() {
+  const main = document.getElementById('rows');
+  main.innerHTML = ROWS.map(r => {
+    const st = state[r.id] || 'skip';
+    const esc = s => s.replace(/[&<>"']/g, c => ({
+      '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    return `<div class="row" data-state="${st}" data-id="${r.id}"
+      data-search="${esc((r.domain + ' ' + r.title).toLowerCase())}">
+      <div class="meta">
+        <div class="id">${esc(r.id)}</div>
+        <div class="tier${r.tier}">tier ${r.tier}</div>
+        <div class="${scoreClass(r.score)}">${r.score} pts</div>
+      </div>
+      <div>
+        <div class="title">
+          <a href="${esc(r.url)}" target="_blank" rel="noopener noreferrer">${esc(r.title)}</a>
+          <span style="color:var(--muted);font-size:12px"> · ${esc(r.domain)}</span>
+        </div>
+        ${r.excerpt ? `<div class="excerpt">${esc(r.excerpt)}</div>` : ''}
+      </div>
+      <div class="controls">
+        <label><input type="radio" name="s-${r.id}" value="approve"
+          ${st==='approve'?'checked':''}><span class="lbl-approve">✓</span></label>
+        <label><input type="radio" name="s-${r.id}" value="reject"
+          ${st==='reject'?'checked':''}><span class="lbl-reject">✗</span></label>
+        <label><input type="radio" name="s-${r.id}" value="skip"
+          ${st==='skip'?'checked':''}><span class="lbl-skip">–</span></label>
+      </div>
+    </div>`;
+  }).join('');
+  updateCounts();
+  updatePreview();
+}
+
+function updateCounts() {
+  let a=0, r=0, s=0;
+  ROWS.forEach(row => {
+    const v = state[row.id] || 'skip';
+    if (v === 'approve') a++;
+    else if (v === 'reject') r++;
+    else s++;
+  });
+  document.getElementById('c-total').textContent = ROWS.length;
+  document.getElementById('c-approve').textContent = a;
+  document.getElementById('c-reject').textContent = r;
+  document.getElementById('c-skip').textContent = s;
+}
+
+function decisionsText() {
+  const approve = ROWS.filter(r => state[r.id] === 'approve').map(r => r.id);
+  const reject  = ROWS.filter(r => state[r.id] === 'reject').map(r => r.id);
+  const lines = [];
+  if (approve.length) lines.push('approve: ' + approve.join(' '));
+  if (reject.length)  lines.push('reject: '  + reject.join(' '));
+  return lines.join('\\n') || '(no decisions)';
+}
+
+function updatePreview() {
+  document.getElementById('preview').textContent =
+    decisionsText().replace(/\\n/g, ' · ');
+}
+
+document.addEventListener('change', e => {
+  if (e.target.type !== 'radio') return;
+  const row = e.target.closest('.row');
+  const id = row.dataset.id;
+  state[id] = e.target.value;
+  row.dataset.state = e.target.value;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  updateCounts();
+  updatePreview();
+});
+
+document.getElementById('copy').addEventListener('click', async () => {
+  const txt = decisionsText();
+  await navigator.clipboard.writeText(txt);
+  const toast = document.getElementById('toast');
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 1200);
+});
+
+document.getElementById('reset').addEventListener('click', () => {
+  if (!confirm('Clear all decisions?')) return;
+  Object.keys(state).forEach(k => delete state[k]);
+  localStorage.removeItem(STORAGE_KEY);
+  render();
+});
+
+document.getElementById('filter').addEventListener('input', e => {
+  const q = e.target.value.toLowerCase().trim();
+  document.querySelectorAll('.row').forEach(row => {
+    row.classList.toggle('hidden', q && !row.dataset.search.includes(q));
+  });
+});
+
+render();
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--open", action="store_true",
+                    help="open the generated HTML after writing")
+    args = ap.parse_args()
+
+    registry = json.loads(REGISTRY.read_text())
+    rows = build_rows(registry)
+    if not rows:
+        print("no mechanical entries pending")
+        return 0
+
+    page = HTML_TEMPLATE.replace("__ROWS_JSON__",
+                                 json.dumps(rows, ensure_ascii=False))
+    args.out.write_text(page, encoding="utf-8")
+    print(f"wrote {args.out}  ({len(rows)} rows)")
+    if args.open:
+        subprocess.run(["open", str(args.out)], check=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Triage tooling**: `scripts/review_mechanical.py` generates a local HTML reviewer for backlog entries (radios + copy-decisions clipboard); `article_curate.py --ids` enriches a specific approved set bypassing scanner/status filters; `scripts/article_reject.py` flips rejected entries to `needs_review`.
- **Data**: 79 of 121 mechanical entries enriched after human approval. All 121 were tier 1/2 but blocked by `scanner_verdict = REVIEW REQUIRED` — the scanner trips on common news-template elements (script tags, analytics) more than true-positive injection.
- 6 unprocessed: 1 hallucinated agency_id caught by validator (`art_111`), 4 malformed-JSON parse failures (`art_222/238/249/254`), 1 correct off-topic refusal (`art_286`).

## Test plan

- [x] Dry-run `article_curate.py --phase 2 --dry-run --ids "..."` reports correct selection
- [x] Real run: 75/85 succeeded; 4 timeouts retried successfully on second pass
- [x] `article_reject.py --dry-run --ids art_doesnotexist` reports NOT FOUND cleanly
- [x] `review_mechanical.py` opens, sorts by tier→domain→score, persists toggles, copies expected format
- [ ] Spot-check a few enriched entries in the registry for plausible `summary` / `key_quotes` / `topic_tags`