### PR TITLE
fix(registry): detect_state prefers explicit 2-letter code over place-name words

### DIFF
--- a/scripts/build_agency_registry.py
+++ b/scripts/build_agency_registry.py
@@ -56,16 +56,22 @@ ALL_STATES = {
     "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "DC",
 }
 
-CA_RE = re.compile(r"\bCA\b|California|Cal Fire|Cal State|NCRIC|Cal Poly", re.IGNORECASE)
+CA_RE = re.compile(r"California|Cal Fire|Cal State|NCRIC|Cal Poly", re.IGNORECASE)
 
 
 def detect_state(name):
+    # Prefer an explicit 2-letter state code at a word boundary. In Flock's
+    # canonical "<place> <state> <type>" naming, the 2-letter code is the
+    # authoritative state — even when the place name itself contains a
+    # state-name word (e.g. "City of California MO PD" is Missouri, not CA).
+    for code in sorted(ALL_STATES):
+        if re.search(r"(?<![A-Za-z])" + code + r"(?![A-Za-z])", name):
+            return code
+    # Fallback for CA-only word forms ("California", "Cal Fire", "NCRIC",
+    # "Cal Poly", "Cal State") — no 2-letter code present, but the name
+    # implies California.
     if CA_RE.search(name):
         return "CA"
-    for code in ALL_STATES - {"CA"}:
-        if re.search(r"(?<![A-Za-z])" + code + r"(?![A-Za-z])", name):
-            if not CA_RE.search(name):
-                return code
     return None
 
 

--- a/tests/test_detect_state.py
+++ b/tests/test_detect_state.py
@@ -1,0 +1,44 @@
+"""Tests for detect_state in build_agency_registry.
+
+The function must extract the correct US state code from a Flock-style
+agency display name. The hard case is when the place name itself
+contains a state-name word (e.g. "City of California, Missouri" where
+the explicit 2-letter code "MO" must beat the substring "California").
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from build_agency_registry import detect_state
+
+
+@pytest.mark.parametrize("name,expected", [
+    # The bug: a Missouri agency whose place name is "California" must
+    # resolve to MO, not CA.
+    ("City of California MO PD", "MO"),
+    # Other place names that collide with state-name words.
+    ("California MD PD", "MD"),
+    ("Indiana PA PD", "PA"),
+    ("Nevada IA PD", "IA"),
+    ("Mississippi MI PD", "MI"),
+    # Canonical California cases must keep working.
+    ("Pacifica CA PD", "CA"),
+    ("Los Angeles CA PD", "CA"),
+    # Word-form California identifiers fall back to CA when no explicit
+    # 2-letter code is present.
+    ("Cal Fire", "CA"),
+    ("Cal Poly Pomona", "CA"),
+    ("Cal State Fullerton", "CA"),
+    ("NCRIC", "CA"),
+    # DC and edge cases.
+    ("Washington DC MPD", "DC"),
+])
+def test_detect_state(name, expected):
+    assert detect_state(name) == expected
+
+
+def test_detect_state_no_match():
+    assert detect_state("Some Agency With No State Hint") is None


### PR DESCRIPTION
## Summary
\`detect_state("City of California MO PD")\` was returning \`"CA"\` because the function tested a broad regex first (\`\bCA\b|California|Cal Fire|Cal State|NCRIC|Cal Poly\`) and returned on any hit. \"California\" matches as a substring of the place name even though the actual state is Missouri — noticed when \`city-of-california-mo-pd\` (City of California, MO PD) was discovered through Flock's sharing graph.

The fix flips the order: look for an explicit 2-letter state code at a word boundary *first* (the authoritative signal in Flock's \`<place> <state> <type>\` naming), and only fall back to the CA-word-form regex when no 2-letter code is present.

## Why this works for all existing cases
- \`"Pacifica CA PD"\` → CA: step 1 matches \`CA\` at word boundary
- \`"City of California MO PD"\` → MO: step 1 matches \`MO\`; \`California\` doesn't match \`(?<![A-Za-z])CA(?![A-Za-z])\` because the following \`l\` is a letter
- \`"Cal Fire"\` / \`"NCRIC"\` / \`"Cal Poly Pomona"\` → CA: step 1 finds no 2-letter code; step 2 fallback fires
- \`"Indiana PA PD"\` / \`"Nevada IA PD"\` / \`"Mississippi MI PD"\` → all correct (each name contains a state-name word that isn't the actual state)

No existing registry entry has \"California\" in its display name (verified by jq scan), so no backfill needed — this fix only affects future entries.

## Test plan
- [x] New tests in \`tests/test_detect_state.py\` (13 cases) all pass
- [x] Existing registry tests (\`test_registry_prune.py\`, \`test_registry_html_safety.py\`, \`test_agency_lookup.py\`) still pass — 31 tests