### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -340,5 +340,5 @@
     "https://epic.org/epic-encourages-calprivacy-to-prohibit-dark-patterns-in-privacy-policies/",
     "https://epic.org/epic-coalition-urge-congress-to-ban-flock-automatic-license-plate-readers/"
   ],
-  "last_run": "2026-05-28T17:01:23Z"
+  "last_run": "2026-05-28T19:43:13Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -340,5 +340,5 @@
     "https://epic.org/epic-encourages-calprivacy-to-prohibit-dark-patterns-in-privacy-policies/",
     "https://epic.org/epic-coalition-urge-congress-to-ban-flock-automatic-license-plate-readers/"
   ],
-  "last_run": "2026-05-28T12:45:56Z"
+  "last_run": "2026-05-28T17:01:23Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 339
- Curation: enriched: 282 · mechanical: 39 · needs_review: 18
- Scanner: REVIEW REQUIRED: 225 · WARNINGS: 112 · CLEAN: 2
- Wayback: saved: 145 · submit-failed: 94 · poll-failed: 89 · save-failed: 6 · existing: 5
- PDF: rendered: 284 · skipped-curl-fallback: 55
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), kvue.com (12), oaklandside.org (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
