### PR TITLE
fix(parser): three new heading/value variants from 5/28 refresh batch

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -343,6 +343,7 @@ _HEADING_MAP = {
     "Vehicles detected in the last 30 days": "vehicles_detected_30d",
     "Unique vehicles detected in the last 30 days": "vehicles_detected_30d",
     "Unique Vehicles Detected":              "vehicles_detected_30d",
+    "Distinct Vehicles (No Duplicates) detected in the last 30 days": "vehicles_detected_30d",
     "Hotlist hits in the last 30 days":      "hotlist_hits_30d",
     "Number of Hotlist Hits":                "hotlist_hits_30d",
     "Searches in the last 30 days":          "searches_30d",
@@ -373,7 +374,9 @@ _DYNAMIC_HEADINGS = [
     # Department Automated License Plate Recognition and Internet
     # Protocol Camera System Policy" without forcing every variant
     # into _HEADING_MAP one-by-one.
-    (re.compile(r"^.+Automated License Plate (?:Recognition|Readers?).+Policy.*$", re.IGNORECASE), "alpr_policy"),
+    # Trailing word can be "Policy" or "System" — Alameda County SO uses
+    # "ACSO Policy: GO 5.42 - Automated License Plate Recognition (ALPR) System".
+    (re.compile(r"^.+Automated License Plate (?:Recognition|Readers?).+(?:Policy|System).*$", re.IGNORECASE), "alpr_policy"),
     (re.compile(r"^.+Police Department Policy Manual.*$", re.IGNORECASE), "alpr_policy"),
     # Agency-prefixed bare "Policy" headings, e.g.
     # "Marin County Sheriff's Office Policy" — Flock now bolds these
@@ -386,6 +389,9 @@ _DYNAMIC_HEADINGS = [
     # "Credit Card Skimming Ring - Success story").
     (re.compile(r"^.+ - Facebook Post - .+$", re.IGNORECASE), "success_stories"),
     (re.compile(r"^.+ - Success Stor(?:y|ies)$", re.IGNORECASE), "success_stories"),
+    # Alameda County SO posts each case under "Solved Stories with Flock
+    # ALPR Technology - <case description>" as a separate bold heading.
+    (re.compile(r"^Solved Stor(?:y|ies) with Flock", re.IGNORECASE), "success_stories"),
     # Sentence-style link blurbs, e.g. "Auburn PD's Policies and
     # Procedures can be found at the following link:" — same role as
     # the "Policy Documents" / "Policy Link" exact headings. Placed
@@ -602,6 +608,12 @@ def _parse_number(s, *, field=None, slug=None):
     """
     if not s or not s.strip():
         return None
+    # Flock shows "Data Unavailable" in place of a value when the stat
+    # isn't ready yet (seen on kensington-ca-pd hotlist_hits_30d). Return
+    # None rather than tripping the multi-paragraph-no-number error path.
+    for line in s.split("\n"):
+        if re.fullmatch(r"\s*Data Unavailable\s*", line, re.IGNORECASE):
+            return None
     for line in s.split("\n"):
         stripped = line.strip()
         if re.fullmatch(r"[\d,]+", stripped):

--- a/tests/test_flock_transparency_headings.py
+++ b/tests/test_flock_transparency_headings.py
@@ -137,6 +137,31 @@ def test_parse_number_legacy_value_only_body():
     assert _parse_number("30 days") == 30
 
 
+def test_parse_number_data_unavailable_returns_none():
+    """Flock shows 'Data Unavailable' in place of a value when a stat
+    isn't ready (seen on kensington-ca-pd hotlist_hits_30d). Must
+    return None rather than tripping the multi-paragraph error path."""
+    body = "Total hotlist hits over the last 30 days.\n\nData Unavailable"
+    assert _parse_number(body, field="hotlist_hits_30d", slug="kensington-ca-pd") is None
+    # Case variations
+    assert _parse_number("description.\n\ndata unavailable") is None
+    assert _parse_number("description.\n\nDATA UNAVAILABLE") is None
+
+
+def test_match_heading_new_2026_05_variants():
+    """Heading variants observed in the 5/28/2026 rolling refresh batch.
+
+    - oceanside-ca-pd added "Distinct Vehicles (No Duplicates) ..."
+    - alameda-county-ca-so uses "ACSO Policy: GO 5.42 - ... (ALPR) System"
+      (suffix "System" not "Policy") and posts case stories under
+      "Solved Stories with Flock ALPR Technology - <case>".
+    """
+    assert _match_heading("Distinct Vehicles (No Duplicates) detected in the last 30 days") == "vehicles_detected_30d"
+    assert _match_heading("ACSO Policy: GO 5.42 - Automated License Plate Recognition (ALPR) System") == "alpr_policy"
+    assert _match_heading("Solved Stories with Flock ALPR Technology - Armed Robbery") == "success_stories"
+    assert _match_heading("Solved Story with Flock ALPR Technology - X") == "success_stories"
+
+
 def test_parse_org_names_merges_company_suffix():
     """Flock's data has un-escaped commas in company names like
     "CA - Topgolf USA El Segundo, LLC". On the new grid layout the


### PR DESCRIPTION
## Summary
Three different agencies tripped \`PARSE_ERROR\` in today's rolling refresh, each on a different parser gap:

**1. oceanside-ca-pd — new vehicles-detected variant**
Heading \`Distinct Vehicles (No Duplicates) detected in the last 30 days\` is a new wording of the existing \`vehicles_detected_30d\` field. Added as a \`_HEADING_MAP\` alias.

**2. alameda-county-ca-so — ACSO policy "System" suffix + per-case bold headings**
- \`ACSO Policy: GO 5.42 - Automated License Plate Recognition (ALPR) System\` uses suffix \`System\` not \`Policy\`. Generalized the existing spelled-out ALPR dynamic pattern to match either suffix.
- Posts each case under its own bold heading \`Solved Stories with Flock ALPR Technology - <case>\`. Added a new dynamic pattern routing these to \`success_stories\`.

**3. kensington-ca-pd — \"Data Unavailable\" numeric value**
\`hotlist_hits_30d\` body is \`Total hotlist hits over the last 30 days.\\n\\nData Unavailable\` — Flock shows this string in place of a value when the stat isn't ready. \`_parse_number\` now recognizes \`Data Unavailable\` as a missing-value marker and returns \`None\` instead of tripping the multi-paragraph error path.

## Test plan
- [x] 4 new test cases in \`tests/test_flock_transparency_headings.py\` cover all the observed variants + case-insensitive variants
- [x] Existing 33 heading/parser tests still pass (37 total)
- [ ] Next scheduled run captures all three agencies cleanly