### PR TITLE
fix(crawl): include on-disk slugs in --all-agencies refresh candidates

### DIFF
--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -155,6 +155,23 @@ def content_hash(text):
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+def crawled_slugs_on_disk(data_dir):
+    """Slugs that have at least one date-named portal JSON capture on disk.
+
+    Used by the refresh path (--all-agencies) to ensure every previously
+    crawled agency stays a candidate regardless of whether the seed's
+    current outbound graph still points at it. Without this, an agency
+    the seed drops from sharing (e.g. SMPD removed NCRIC on 2026-05-11)
+    silently falls off the rotation despite having years of history.
+    """
+    if not data_dir.is_dir():
+        return []
+    return [
+        d.name for d in data_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and portal_jsons(d)
+    ]
+
+
 def is_stale(slug, data_dir, max_age_days=STALE_DAYS):
     """Check if a slug's latest capture is older than max_age_days."""
     slug_dir = data_dir / slug
@@ -1250,6 +1267,14 @@ def cmd_crawl(args):
                 # appears in some peer's outbound list) get picked up on the same
                 # level it's discovered, instead of waiting for a deeper run.
                 candidates = dedupe(list(slugs) + discovered_from_existing)
+                # Refresh path: include every on-disk crawled slug as a
+                # candidate at level 0, not just those still reachable
+                # via the seed's outbound graph. Otherwise a slug the
+                # seed drops from sharing falls off the rotation despite
+                # being stale and locally captured. Level 0 only — deeper
+                # levels do BFS discovery for genuinely new slugs.
+                if args.all_agencies and level == 0:
+                    candidates = dedupe(candidates + crawled_slugs_on_disk(data_dir))
                 new_slugs = [s for s in candidates if s not in visited]
                 # Crawl order by tier:
                 #   0 never attempted — fills gaps like newly-seeded registry

--- a/tests/test_crawled_slugs_on_disk.py
+++ b/tests/test_crawled_slugs_on_disk.py
@@ -1,0 +1,64 @@
+"""Tests for crawled_slugs_on_disk — the refresh path's candidate set.
+
+The refresh rotation must include every previously crawled agency, not
+just those still reachable via the seed's outbound graph. Otherwise a
+slug the seed drops from sharing (e.g. SMPD removed NCRIC on 2026-05-11)
+falls off the rotation despite years of history on disk.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from flock_transparency import crawled_slugs_on_disk
+
+
+def _touch_capture(slug_dir, datestamp):
+    """Create a minimal date-named JSON capture so the slug counts as crawled."""
+    slug_dir.mkdir(parents=True, exist_ok=True)
+    (slug_dir / f"{datestamp}.json").write_text("{}")
+
+
+def test_returns_empty_for_missing_dir(tmp_path):
+    assert crawled_slugs_on_disk(tmp_path / "does-not-exist") == []
+
+
+def test_returns_slug_dirs_with_portal_json(tmp_path):
+    _touch_capture(tmp_path / "san-mateo-ca-pd", "2026-05-27")
+    _touch_capture(tmp_path / "ncric", "2026-05-12")
+    _touch_capture(tmp_path / "alameda-county-ca-so", "2026-05-22")
+    result = set(crawled_slugs_on_disk(tmp_path))
+    assert result == {"san-mateo-ca-pd", "ncric", "alameda-county-ca-so"}
+
+
+def test_excludes_dot_dirs(tmp_path):
+    """Meta files like .failed_slugs.json sit beside slug dirs; the loop
+    must not treat hidden entries as slugs even if they contain JSON."""
+    (tmp_path / ".meta").mkdir()
+    (tmp_path / ".meta" / "2026-05-27.json").write_text("{}")
+    _touch_capture(tmp_path / "real-slug", "2026-05-27")
+    assert crawled_slugs_on_disk(tmp_path) == ["real-slug"]
+
+
+def test_excludes_dirs_without_portal_json(tmp_path):
+    """A slug dir with only sidecar artifacts (no date-named .json) hasn't
+    been successfully captured and shouldn't enter the refresh rotation."""
+    pra_only = tmp_path / "smpd-pra-only"
+    pra_only.mkdir()
+    (pra_only / "pra-W012541-041426.json").write_text("{}")
+    _touch_capture(tmp_path / "real-slug", "2026-05-27")
+    result = crawled_slugs_on_disk(tmp_path)
+    assert result == ["real-slug"]
+
+
+def test_excludes_dirs_with_only_html_or_txt(tmp_path):
+    """An interrupted capture might leave .html/.txt without a .json
+    (the artifact-set integrity rule prevents this on the happy path,
+    but legacy data exists). Without a date-named .json, the slug is
+    not 'successfully crawled' and shouldn't be a refresh candidate."""
+    stub = tmp_path / "stub-slug"
+    stub.mkdir()
+    (stub / "2026-05-27.html").write_text("<html></html>")
+    (stub / "2026-05-27.txt").write_text("text")
+    _touch_capture(tmp_path / "real-slug", "2026-05-27")
+    assert crawled_slugs_on_disk(tmp_path) == ["real-slug"]


### PR DESCRIPTION
## Summary
\`DEFAULT_SLUGS\` is just \`["san-mateo-ca-pd"]\`, so the \`--all-agencies\` BFS crawl only sees agencies SMPD currently shares with. When SMPD removes an agency from its outbound list, that agency silently falls off the refresh rotation regardless of how long it's been since the last capture or how much history exists on disk.

**Concrete case:** SMPD stopped sharing to NCRIC between 2026-05-04 and 2026-05-11. NCRIC has 600+ snapshots on disk and was last captured 2026-05-12. With \`--max-age 7\` it should've been queued for ~10 days. Every scheduled run since ~5/19 ignored it because NCRIC no longer appears in SMPD's outbound graph.

## Fix
At level 0 of the \`--all-agencies\` crawl, union the candidate set with every slug that has at least one date-named portal JSON on disk. The existing \`visited\` filter still excludes anything captured within \`--max-age\`, so we don't over-crawl. Level 0 only — deeper BFS levels keep doing graph discovery for genuinely new slugs.

New helper [\`crawled_slugs_on_disk\`](scripts/flock_transparency.py) returns the 237 currently-known agencies (anything with date-named portal JSONs), excluding hidden \`.\`-dirs and dirs with only sidecar artifacts (PRA JSONs, partial captures).

## Test plan
- [x] New \`tests/test_crawled_slugs_on_disk.py\` covers helper edge cases (empty dirs, dot-dirs, sidecar-only dirs, partial-capture dirs)
- [x] 5 new tests + 37 existing parser/heading tests all pass
- [ ] After merge, confirm next scheduled run queues NCRIC (and any other dropped-from-SMPD-outbound agencies that are stale)