### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/article_registry.json
+++ b/assets/article_registry.json
@@ -4,12 +4,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock Safety’s Feature Updates Cannot Make Automated License Plate Readers Safe",
+    "title": "Flock Safety\u2019s Feature Updates Cannot Make Automated License Plate Readers Safe",
     "byline": "Sarah Hamid and Rindala Alajaji",
     "published_at": "2025-06-27T17:36:58-07:00",
     "fetched_at": "2026-05-04T21:19:38Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8d3e3bed2e66f066465931d75a59ad6eedc01e06827d442adb9559e4e4f66252",
     "paths": {
@@ -157,7 +157,7 @@
     "published_at": "2025-11-12T15:00:00-08:00",
     "fetched_at": "2026-05-04T21:17:24Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "3a31d41980b484b54c531d8e6fd5e32e115d80a0a14be9255eda5225e031ecbd",
     "paths": {
@@ -312,7 +312,7 @@
     "published_at": "2025-12-30T11:03:19-08:00",
     "fetched_at": "2026-05-04T21:21:16Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "be180c1f687d6f36f117956cb5bb77cbf831e3bb77364f2f1b74a5e5fbc37db6",
     "paths": {
@@ -462,12 +462,12 @@
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "Oakland’s License Plate Camera Contract Is Back Up for a Vote. Critics Are Crying Foul | KQED",
+    "title": "Oakland\u2019s License Plate Camera Contract Is Back Up for a Vote. Critics Are Crying Foul | KQED",
     "byline": "Katie DeBenedetti",
     "published_at": "2025-12-13T08:00:41-08:00",
     "fetched_at": "2026-05-04T23:08:16Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "6574373b7ee6709731eba54cc5afc63dd196654305ca284acb8769e981719170",
     "paths": {
@@ -625,7 +625,7 @@
     "published_at": "2026-01-14T16:48:54-08:00",
     "fetched_at": "2026-05-04T23:06:29Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "00b8d1303383a6f722d78658d5ae11704fbfb532895b4ca2598000d89a03b16b",
     "paths": {
@@ -776,12 +776,12 @@
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "San José Is the Latest Bay Area City to Restrict Flock License Plate Cameras | KQED",
+    "title": "San Jos\u00e9 Is the Latest Bay Area City to Restrict Flock License Plate Cameras | KQED",
     "byline": "Ayah Ali-Ahmad",
     "published_at": "2026-03-11T11:41:49-07:00",
     "fetched_at": "2026-05-04T23:09:34Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "3839d423ff9d03f5bcab1f7e15c867b0c83ec0b982f136e561dc877bb8ddb411",
     "paths": {
@@ -902,7 +902,7 @@
         ]
       }
     ],
-    "summary": "The San José City Council unanimously voted to tighten restrictions on its 474-camera Flock Safety ALPR network, reducing data retention from one year to 30 days, prohibiting cameras near reproductive health facilities and places of worship, and adding access documentation requirements. Two additional memos direct exploration of alternative vendors, ban facial recognition integration, and add consulates and gender-affirming care facilities to sensitive-location restrictions. Advocates and Councilmember Peter Ortiz called for ending the Flock contract entirely; the contract is up for renewal in June.",
+    "summary": "The San Jos\u00e9 City Council unanimously voted to tighten restrictions on its 474-camera Flock Safety ALPR network, reducing data retention from one year to 30 days, prohibiting cameras near reproductive health facilities and places of worship, and adding access documentation requirements. Two additional memos direct exploration of alternative vendors, ban facial recognition integration, and add consulates and gender-affirming care facilities to sensitive-location restrictions. Advocates and Councilmember Peter Ortiz called for ending the Flock contract entirely; the contract is up for renewal in June.",
     "key_quotes": [
       {
         "quote": "The city's changes reduce the default data retention period from one year to 30 days, prohibit placing cameras near reproductive health care facilities and places of worship, and add new documentation and authentication requirements for agencies requesting access to the data.",
@@ -934,7 +934,7 @@
     "published_at": "2026-04-30T13:25:36.000Z",
     "fetched_at": "2026-05-05T08:29:47Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 30 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 30 pts, low/medium only",
     "scanner_score": 30,
     "content_hash": "bb1af747e113c28486c33be1c77caa94061b553a500b1d219d51df6f6258fc97",
     "paths": {
@@ -1036,7 +1036,7 @@
         ]
       }
     ],
-    "summary": "Dunwoody, Georgia residents discovered via public records requests that Flock sales employees accessed local cameras—including at a Jewish Community Center pool, children's gymnastics room, and other sensitive locations—as part of sales demonstrations to other police departments. After public outcry, Flock agreed to stop using Dunwoody's cameras for demos and said employees would be trained to only demo in public locations like retail parking lots, but the city renewed its contract anyway.",
+    "summary": "Dunwoody, Georgia residents discovered via public records requests that Flock sales employees accessed local cameras\u2014including at a Jewish Community Center pool, children's gymnastics room, and other sensitive locations\u2014as part of sales demonstrations to other police departments. After public outcry, Flock agreed to stop using Dunwoody's cameras for demos and said employees would be trained to only demo in public locations like retail parking lots, but the city renewed its contract anyway.",
     "key_quotes": [
       {
         "quote": "The cities involved in this program have authorized select Flock employees to demonstrate new products and features as we develop them in partnership with the city.",
@@ -1066,7 +1066,7 @@
     "published_at": "2025-06-25T15:08:13.000Z",
     "fetched_at": "2026-05-05T08:29:38Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 30 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 30 pts, low/medium only",
     "scanner_score": 30,
     "content_hash": "9ea04f46b04da6bef3c45897b18a30b85c75c08aae08e34f77b8f56f486e36c6",
     "paths": {
@@ -1142,7 +1142,7 @@
     "published_at": "2025-06-03T13:13:25-07:00",
     "fetched_at": "2026-05-05T08:29:43Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "97e2a928c31e58617c0b6ac38cae48988fc0dbc57f9812c19ea05d423f5910f0",
     "paths": {
@@ -1259,7 +1259,7 @@
     "summary": "EFF reports on the TRUST Coalition's campaign urging the San Diego City Council to end its Flock Safety ALPR contract ahead of the program's first annual review. The article cites concerns about data sharing with federal agencies, unauthorized deployments at events, and a Privacy Board recommendation to reject the Surveillance Use Policy.",
     "key_quotes": [
       {
-        "quote": "San Diego Police have reportedly disclosed license plate data to federal agencies— including Homeland Security Investigations and Customs and Border Patrol.",
+        "quote": "San Diego Police have reportedly disclosed license plate data to federal agencies\u2014 including Homeland Security Investigations and Customs and Border Patrol.",
         "paragraph_idx": 6
       },
       {
@@ -1288,7 +1288,7 @@
     "published_at": "2025-06-06T15:38:32-07:00",
     "fetched_at": "2026-05-05T08:29:35Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "fe2c8e128d23190b3d007112c52b1bc5503b04bbc3c8470c76136c62785a7065",
     "paths": {
@@ -1416,7 +1416,7 @@
     "published_at": "2026-02-09T14:31:43-08:00",
     "fetched_at": "2026-05-05T08:29:51Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "1293a51918013062322d5325408baa2344063ffd33b4d2c5fb0d6d0548d05575",
     "paths": {
@@ -1525,7 +1525,7 @@
     "summary": "EFF promotes an upcoming livestream event discussing growing resistance to Flock Safety ALPR contracts across U.S. cities, featuring speakers from EFF, Fight for the Future, and Rural Privacy Coalition. The post argues Flock cameras enable surveillance of abortion-seekers, protesters, and over-policed communities, and highlights that cities from Austin to Cambridge have rejected Flock.",
     "key_quotes": [
       {
-        "quote": "From Austin to Cambridge to small towns across Texas, jurisdictions are rejecting Flock contracts altogether, proving that surveillance isn't inevitable—it's a choice.",
+        "quote": "From Austin to Cambridge to small towns across Texas, jurisdictions are rejecting Flock contracts altogether, proving that surveillance isn't inevitable\u2014it's a choice.",
         "paragraph_idx": 4
       },
       {
@@ -1548,7 +1548,7 @@
     "published_at": "2026-02-03T16:31:59-08:00",
     "fetched_at": "2026-05-05T08:29:29Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "728bfa59d43fd53e7004dfae1725038cf2d085f5df9cb7a0d2a877d64773fc74",
     "paths": {
@@ -1708,7 +1708,7 @@
     "published_at": "2025-10-16T13:00:05.000Z",
     "fetched_at": "2026-05-05T08:35:24Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 33 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 33 pts, low/medium only",
     "scanner_score": 33,
     "content_hash": "7a6f12f14c3dc21d792178b80b943235fad9355179aac92679bf44e450bdc7f1",
     "paths": {
@@ -1769,12 +1769,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "“Free” Surveillance Tech Still Comes at a High and Dangerous Cost",
+    "title": "\u201cFree\u201d Surveillance Tech Still Comes at a High and Dangerous Cost",
     "byline": "Beryl Lipton and Sarah Hamid",
     "published_at": "2026-02-11T10:00:12-08:00",
     "fetched_at": "2026-05-05T08:35:13Z",
     "discovered_by": "claude-search:contracts-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "73a85a61809f7bf940bf14b6442d6f6791eadf2b52a63aebdcaffa2a0c5d8d89",
     "paths": {
@@ -1903,7 +1903,7 @@
         ]
       }
     ],
-    "summary": "EFF argues that 'free' surveillance technology—via vendor trials, police foundation gifts, wealthy donors, and federal grants—bypasses local oversight and locks municipalities into long-term costs and federal data-sharing pipelines including with ICE. The piece surveys examples in Denver, Atlanta, San Francisco, Santa Cruz, Sumner WA, and Fall River MA, and urges cities to reject such offers or shut down existing systems.",
+    "summary": "EFF argues that 'free' surveillance technology\u2014via vendor trials, police foundation gifts, wealthy donors, and federal grants\u2014bypasses local oversight and locks municipalities into long-term costs and federal data-sharing pipelines including with ICE. The piece surveys examples in Denver, Atlanta, San Francisco, Santa Cruz, Sumner WA, and Fall River MA, and urges cities to reject such offers or shut down existing systems.",
     "key_quotes": [
       {
         "quote": "In May 2025, Denver's city council unanimously rejected a $666,000 contract extension for Flock Safety ALPR cameras after weeks of public outcry over mass surveillance data sharing with federal immigration enforcement.",
@@ -1914,7 +1914,7 @@
         "paragraph_idx": 22
       },
       {
-        "quote": "ICE agents using a Philadelphia‑area fusion center to query the city's ALPR network to track undocumented drivers in a self‑described sanctuary city.",
+        "quote": "ICE agents using a Philadelphia\u2011area fusion center to query the city's ALPR network to track undocumented drivers in a self\u2011described sanctuary city.",
         "paragraph_idx": 24
       }
     ],
@@ -1933,7 +1933,7 @@
     "published_at": "2026-04-02T10:57:16-07:00",
     "fetched_at": "2026-05-05T08:35:19Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "0209abec89b3d186ab2ea850b9bffb6170fd61f6821867c5d06b31e31e711bb4",
     "paths": {
@@ -1999,12 +1999,12 @@
     "source_domain": "kqed.org",
     "tier": 1,
     "stance": "neutral",
-    "title": "Civil Liberties Groups Sue San José Over License Plate Reader Use | KQED",
+    "title": "Civil Liberties Groups Sue San Jos\u00e9 Over License Plate Reader Use | KQED",
     "byline": "Joseph Geha",
     "published_at": "2025-11-18T16:16:38-08:00",
     "fetched_at": "2026-05-05T08:35:32Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "2b77def78e152046599817f53497d4ddebf1baf917ba262fa3414c913c2dc1c6",
     "paths": {
@@ -2127,7 +2127,7 @@
         ]
       }
     ],
-    "summary": "The ACLU of Northern California and EFF, on behalf of CAIR-CA and SIREN, sued San José over its nearly 500 Flock ALPR cameras, alleging the one-year data retention and retrospective searches constitute mass surveillance violating California privacy rights. The suit seeks to require warrants for searching stored ALPR data. Oakland was sued the same day in a separate case.",
+    "summary": "The ACLU of Northern California and EFF, on behalf of CAIR-CA and SIREN, sued San Jos\u00e9 over its nearly 500 Flock ALPR cameras, alleging the one-year data retention and retrospective searches constitute mass surveillance violating California privacy rights. The suit seeks to require warrants for searching stored ALPR data. Oakland was sued the same day in a separate case.",
     "key_quotes": [
       {
         "quote": "its surveillance of residents \"is especially pervasive in both time and space.\"",
@@ -2138,7 +2138,7 @@
         "paragraph_idx": 12
       },
       {
-        "quote": "nearly everyone whose ALPR information is stored by San José were under no suspicion whatsoever at the time the ALPR system captured that information",
+        "quote": "nearly everyone whose ALPR information is stored by San Jos\u00e9 were under no suspicion whatsoever at the time the ALPR system captured that information",
         "paragraph_idx": 18
       },
       {
@@ -2167,7 +2167,7 @@
     "published_at": "2025-12-22T16:05:19.000Z",
     "fetched_at": "2026-05-05T16:49:59Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "9ee8add536a274a36117bbc08f5f2354a400c823c4d055bc544307f92bd56922",
     "paths": {
@@ -2286,7 +2286,7 @@
     "published_at": "2026-02-03T17:08:29+00:00",
     "fetched_at": "2026-05-05T16:54:39Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "e7d64ae9313aecde43441856924422a270bea0c68ec1cbe2bc332a25c81c9d3e",
     "paths": {
@@ -2381,7 +2381,7 @@
     "published_at": "2019-06-26T15:59:24-07:00",
     "fetched_at": "2026-05-05T16:51:33Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8f0a4d5232c571bb50531fd3347c34d7859b26127b9207b0bf210158511a9f10",
     "paths": {
@@ -2546,7 +2546,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T16:52:43Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "d04d6588d42d46a28dcdbed29b1ea9653e5ce67efa2115e8f06113eb48be350b",
     "paths": {
@@ -2642,7 +2642,7 @@
     "published_at": "2025-12-17T12:59:42-08:00",
     "fetched_at": "2026-05-05T16:57:23Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "192e03fbb1e01be0397fb2291f4c8ad3fd168766697cc8744e00f4f0dc1dbf66",
     "paths": {
@@ -2815,7 +2815,7 @@
     "published_at": "2025-10-24T18:28:33+00:00",
     "fetched_at": "2026-05-05T18:24:30Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "a545fafd38e45088daf00d1deadce30d85984b6364a0231ec0a946100a3b0cce",
     "paths": {
@@ -2909,7 +2909,7 @@
         "paragraph_idx": 3
       },
       {
-        "quote": "one Virginia agency, the Warren County Sheriff's Office, performed more immigration searches than any other in the state — and confirmed that it did so because federal immigration agents asked them to.",
+        "quote": "one Virginia agency, the Warren County Sheriff's Office, performed more immigration searches than any other in the state \u2014 and confirmed that it did so because federal immigration agents asked them to.",
         "paragraph_idx": 9
       },
       {
@@ -2932,7 +2932,7 @@
     "published_at": "2026-02-17T10:55:34-08:00",
     "fetched_at": "2026-05-05T18:21:26Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "372f7744aa98f199764f2890a4a3adcc9b1aa1a5a0b9d956d94d81f21b5a84d0",
     "paths": {
@@ -3095,7 +3095,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T18:29:55Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "8ea7a6aac7a1b58bd3931125f2d4bbef1deec71a5c7707355b050193fa511b07",
     "paths": {
@@ -3190,7 +3190,7 @@
     "published_at": "2026-02-25T10:57:27-08:00",
     "fetched_at": "2026-05-05T18:26:06Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "9e9ce162da1cf6db70baa427b16f8fee127873df1062f2849da322dc75a228da",
     "paths": {
@@ -3331,7 +3331,7 @@
         "paragraph_idx": 13
       },
       {
-        "quote": "There is no guarantee that rival ALPR vendors will do better. These companies market their systems as easy to share with other law enforcement agencies — sharing is by design, and vendors are incentivized to facilitate it.",
+        "quote": "There is no guarantee that rival ALPR vendors will do better. These companies market their systems as easy to share with other law enforcement agencies \u2014 sharing is by design, and vendors are incentivized to facilitate it.",
         "paragraph_idx": 21
       },
       {
@@ -3355,12 +3355,12 @@
     "source_domain": "themarkup.org",
     "tier": 2,
     "stance": "critical",
-    "title": "He saw an abandoned trailer. Then, he uncovered a surveillance network on California's border – The Markup",
+    "title": "He saw an abandoned trailer. Then, he uncovered a surveillance network on California's border \u2013 The Markup",
     "byline": null,
     "published_at": "2026-03-06T08:00:00+00:00",
     "fetched_at": "2026-05-05T18:28:00Z",
     "discovered_by": "rss:themarkup.org",
-    "scanner_verdict": "CLEAN — no findings",
+    "scanner_verdict": "CLEAN \u2014 no findings",
     "scanner_score": 0,
     "content_hash": "d48b2dde44b79eb2f5cb471e6926388510a11d85b25148db3e44a78d0e18b5b5",
     "paths": {
@@ -3524,7 +3524,7 @@
     "published_at": "2026-04-06T13:53:56.000Z",
     "fetched_at": "2026-05-05T20:23:46Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "f6a1cead9da96b46c528e54df9c567e53fdb47c52ff78f14fac9aab06fd9c7df",
     "paths": {
@@ -3688,12 +3688,12 @@
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "License Plate Readings Shouldn’t Be Public Data | ACLU",
+    "title": "License Plate Readings Shouldn\u2019t Be Public Data | ACLU",
     "byline": "Jay Stanley, Chad Marlow",
     "published_at": "2026-02-25T14:52:09+00:00",
     "fetched_at": "2026-05-05T20:18:08Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "59dc1abf8d110303877c7f202d31ad6f384b576f63fc6c23ca41199bd480ed48",
     "paths": {
@@ -3786,7 +3786,7 @@
     "published_at": "2020-09-14T12:38:12-07:00",
     "fetched_at": "2026-05-05T20:16:50Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "d541f69af823e73340def8970bc8d81b158202bc4de7237d00b325734711d4e1",
     "paths": {
@@ -3946,7 +3946,7 @@
     "published_at": null,
     "fetched_at": "2026-05-05T20:19:56Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "5b0b71f3e5e6aa6c870b349eba4aafb0a201daa0308f05d0ea705fa6c0d7d4e1",
     "paths": {
@@ -4025,7 +4025,7 @@
         ]
       }
     ],
-    "summary": "EPIC reports on a federal court ruling in the Eastern District of Virginia denying Norfolk's motion to dismiss a §1983 suit challenging the city's use of Flock ALPR cameras under the Fourth Amendment. The court found plaintiffs plausibly alleged a reasonable expectation of privacy in their long-term movements under Carpenter v. United States and that warrantless querying of Flock's database likely constitutes an unconstitutional search.",
+    "summary": "EPIC reports on a federal court ruling in the Eastern District of Virginia denying Norfolk's motion to dismiss a \u00a71983 suit challenging the city's use of Flock ALPR cameras under the Fourth Amendment. The court found plaintiffs plausibly alleged a reasonable expectation of privacy in their long-term movements under Carpenter v. United States and that warrantless querying of Flock's database likely constitutes an unconstitutional search.",
     "key_quotes": [
       {
         "quote": "the city's tracking of individuals through the use of Flock was \"notably similar to [the facts] in Carpenter.\"",
@@ -4055,7 +4055,7 @@
     "published_at": "2025-12-18T09:00:09-08:00",
     "fetched_at": "2026-05-05T20:21:57Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "dd48c36986d52ec0883f30238fbe47b4eacced27d91207184597b90edc9e4a4a",
     "paths": {
@@ -4189,7 +4189,7 @@
         ]
       }
     ],
-    "summary": "KQED reports that despite federal surveillance concerns, most California cities are continuing or expanding their Flock ALPR contracts — Oakland's City Council voted 7-1 to renew and expand OPD's contract with added privacy amendments. The article contrasts Oakland's decision with Richmond's recent shutdown after a Flock configuration error and Santa Cruz's November move to temporarily limit outside-agency access, while civil-liberties advocates warn the data feeds federal immigration enforcement.",
+    "summary": "KQED reports that despite federal surveillance concerns, most California cities are continuing or expanding their Flock ALPR contracts \u2014 Oakland's City Council voted 7-1 to renew and expand OPD's contract with added privacy amendments. The article contrasts Oakland's decision with Richmond's recent shutdown after a Flock configuration error and Santa Cruz's November move to temporarily limit outside-agency access, while civil-liberties advocates warn the data feeds federal immigration enforcement.",
     "key_quotes": [
       {
         "quote": "More than three hours of public comment preceded the City Council's 7-1 vote to renew and expand the Oakland Police Department's contract with Flock Safety",
@@ -4227,7 +4227,7 @@
     "published_at": "2025-05-27T13:36:43.000Z",
     "fetched_at": "2026-05-06T00:03:36Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "7dfaeb1fab6b09b6dfaf47d33a57108834b3cac28b17ea44c2598867411dfdd6",
     "paths": {
@@ -4290,12 +4290,12 @@
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "How to Pump the Brakes on Your Police Department’s Use of Flock’s Mass Surveillance License Plate Readers | ACLU",
+    "title": "How to Pump the Brakes on Your Police Department\u2019s Use of Flock\u2019s Mass Surveillance License Plate Readers | ACLU",
     "byline": "Chad Marlow, Jay Stanley",
     "published_at": "2023-02-13T21:30:27+00:00",
     "fetched_at": "2026-05-06T00:00:20Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 12 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 12 pts, low/medium only",
     "scanner_score": 12,
     "content_hash": "426c659b5c145150e29ef44e3508b94d3724a9cb4f04014c17aecd6deac391c1",
     "paths": {
@@ -4406,12 +4406,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock’s Gunshot Detection Microphones Will Start Listening for Human Voices",
+    "title": "Flock\u2019s Gunshot Detection Microphones Will Start Listening for Human Voices",
     "byline": "Matthew Guariglia",
     "published_at": "2025-10-02T08:45:18-07:00",
     "fetched_at": "2026-05-05T23:58:57Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "8265d3690aa93919405fb9e4c8821c829f8a735408d8840edb1d7146644dbebd",
     "paths": {
@@ -4498,7 +4498,7 @@
     "summary": "EFF warns that Flock Safety is adding a 'human distress' audio-detection feature to its Raven gunshot-detection microphones, raising civil liberties and eavesdropping-law concerns. The post urges cities to cancel Flock contracts, citing prior controversies including ICE data access in Illinois, a North Carolina licensing halt, and Evanston's contract cancellation dispute.",
     "key_quotes": [
       {
-        "quote": "Flock has been touting new features to their Raven product—including the ability of the device to alert police based on sounds, including \"distress.\"",
+        "quote": "Flock has been touting new features to their Raven product\u2014including the ability of the device to alert police based on sounds, including \"distress.\"",
         "paragraph_idx": 6
       },
       {
@@ -4506,7 +4506,7 @@
         "paragraph_idx": 8
       },
       {
-        "quote": "When the city of Evanston, Illinois recently canceled its contract with Flock, it ordered the company to take down their license plate readers–only for Flock to mysteriously reinstall them a few days later.",
+        "quote": "When the city of Evanston, Illinois recently canceled its contract with Flock, it ordered the company to take down their license plate readers\u2013only for Flock to mysteriously reinstall them a few days later.",
         "paragraph_idx": 8
       },
       {
@@ -4524,12 +4524,12 @@
     "source_domain": "epic.org",
     "tier": 2,
     "stance": "critical",
-    "title": "EPIC Files Amicus Brief Arguing City’s Use of Flock ALPRs Violated Fourth Amendment",
+    "title": "EPIC Files Amicus Brief Arguing City\u2019s Use of Flock ALPRs Violated Fourth Amendment",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-06T00:05:01Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "740227f44ae12a76bc974bff9e6f43fcd7e5d0ea218b92ea3e793e9ef87734fe",
     "paths": {
@@ -4588,7 +4588,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T00:02:05Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "32144f2716c5407777cada012e0d62e116401214de3cc2e15cc3ea2e1c2a0886",
     "paths": {
@@ -4736,7 +4736,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T00:06:43Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 233 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 233 pts, HIGH/CRITICAL findings",
     "scanner_score": 233,
     "content_hash": "da8579564d6fed6d8fa049736ef84c9a38f33edbb8217550853257cad7e05f38",
     "paths": {
@@ -4876,7 +4876,7 @@
         "paragraph_idx": 10
       },
       {
-        "quote": "data would be stored only for 30 days — unless particular license plates are part of ongoing investigations",
+        "quote": "data would be stored only for 30 days \u2014 unless particular license plates are part of ongoing investigations",
         "paragraph_idx": 8
       }
     ],
@@ -4892,12 +4892,12 @@
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Municipalities: Beware of Changes in Flock’s Legal Terms if You’re Using or Considering License Plate Readers | ACLU",
+    "title": "Municipalities: Beware of Changes in Flock\u2019s Legal Terms if You\u2019re Using or Considering License Plate Readers | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2026-04-16T18:48:54+00:00",
     "fetched_at": "2026-05-06T06:42:17Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "377998b9f05c5762eddee6c34a73920fd6bb078e9582d793d904e20d9cb0c6ea",
     "paths": {
@@ -4969,7 +4969,7 @@
         "paragraph_idx": 5
       },
       {
-        "quote": "The T&C now add a \"perpetual\" right for Flock to use customer data to \"support and improve\" its services — allowing the company to keep using driver surveillance data even after a town, city, or other customer has terminated its relationship with Flock",
+        "quote": "The T&C now add a \"perpetual\" right for Flock to use customer data to \"support and improve\" its services \u2014 allowing the company to keep using driver surveillance data even after a town, city, or other customer has terminated its relationship with Flock",
         "paragraph_idx": 7
       },
       {
@@ -4992,7 +4992,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T06:46:33Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "962f31949b926e068611e62833634559ee1a445e3cea19538942108fb4b71ee9",
     "paths": {
@@ -5168,12 +5168,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "California Auditor Releases Damning Report About Law Enforcement’s Use of Automated License Plate Readers",
+    "title": "California Auditor Releases Damning Report About Law Enforcement\u2019s Use of Automated License Plate Readers",
     "byline": "Dave Maass and Hayley Tsukayama",
     "published_at": "2020-02-13T12:58:11-08:00",
     "fetched_at": "2026-05-06T06:40:57Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "cbd3b075eb3561209d91ea420ba2069e2f220086a8676eefa1f90b76f61a47ef",
     "paths": {
@@ -5321,7 +5321,7 @@
         "paragraph_idx": 8
       },
       {
-        "quote": "the three agencies storing ALPR data in Vigilant's cloud—Fresno, Marin, and Sacramento—do not have sufficient data security safeguards in their contracts",
+        "quote": "the three agencies storing ALPR data in Vigilant's cloud\u2014Fresno, Marin, and Sacramento\u2014do not have sufficient data security safeguards in their contracts",
         "paragraph_idx": 10
       },
       {
@@ -5353,7 +5353,7 @@
     "published_at": null,
     "fetched_at": "2026-05-06T06:47:45Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "REVIEW REQUIRED — 23 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 23 pts, HIGH/CRITICAL findings",
     "scanner_score": 23,
     "content_hash": "c1fcafcc90d59aedbbdcba9005a595471573b49f1e9adf0408aa5643277cb258",
     "paths": {
@@ -5501,7 +5501,7 @@
     "published_at": "2025-11-07",
     "fetched_at": "2026-05-06T06:43:32Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 20 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 20 pts, low/medium only",
     "scanner_score": 20,
     "content_hash": "0d43e1b88566bb20dcda69fffd9d15170c3537ba15ce0e5bd98bff2bbc2f8a42",
     "paths": {
@@ -5595,7 +5595,7 @@
     "published_at": "2024-02-13T20:37:08+00:00",
     "fetched_at": "2026-05-06T09:41:54Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "a8b7185512a5de6c756208f9f8e5f06d818991c7171deb2a39bbd320742f9101",
     "paths": {
@@ -5664,7 +5664,7 @@
     "summary": "The ACLU of Northern California describes its ongoing campaign to enforce SB 34, which bars California police from sharing ALPR data with out-of-state and federal agencies. It recounts sending AG Bonta a letter identifying 35 noncompliant agencies and references its earlier 2021 suit against Marin County, which settled with the sheriff agreeing to comply.",
     "key_quotes": [
       {
-        "quote": "In 2021 we sued Marin County, California for illegally sharing millions of local drivers’ license plates and locations with federal and out-of-state agencies, including ICE.",
+        "quote": "In 2021 we sued Marin County, California for illegally sharing millions of local drivers\u2019 license plates and locations with federal and out-of-state agencies, including ICE.",
         "paragraph_idx": 11
       },
       {
@@ -5687,7 +5687,7 @@
     "published_at": "2022-03-01T18:37:50+00:00",
     "fetched_at": "2026-05-06T09:35:45Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "f3105ca3ba673458ce12f0907fcaa060e4bcd7a9160a9fcbc126f3ebe931d87d",
     "paths": {
@@ -5735,7 +5735,7 @@
     "published_at": "2025-09-18T12:44:15-07:00",
     "fetched_at": "2026-05-06T09:40:34Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "df347ae05725680b474cf5caf7f5314b9a36a751ec6a550d810a2752d02bf677",
     "paths": {
@@ -5817,11 +5817,11 @@
     "summary": "EFF and ACLU of Northern California sent SFPD a demand letter and Sunshine Ordinance records request after SF Standard reporting revealed SFPD gave out-of-state and federal agencies direct access to its Flock ALPR database, including at least 19 ICE-related searches and queries from Georgia and Texas. The groups argue this violates California SB 34 and SB 54 and demand an audit, new compliance protocols, and sanctions.",
     "key_quotes": [
       {
-        "quote": "Reporters uncovered that at least 19 searches run by these agencies were marked as related to U.S. Immigration and Customs Enforcement (“ICE”).",
+        "quote": "Reporters uncovered that at least 19 searches run by these agencies were marked as related to U.S. Immigration and Customs Enforcement (\u201cICE\u201d).",
         "paragraph_idx": 6
       },
       {
-        "quote": "Since 2016, sharing ALPR data with out-of-state or federal agencies—for any reason—violates California law ( SB 34 ). If this data is shared for the purpose of assisting with immigration enforcement, agencies violate an additional California law ( SB 54 ).",
+        "quote": "Since 2016, sharing ALPR data with out-of-state or federal agencies\u2014for any reason\u2014violates California law ( SB 34 ). If this data is shared for the purpose of assisting with immigration enforcement, agencies violate an additional California law ( SB 54 ).",
         "paragraph_idx": 8
       },
       {
@@ -5846,7 +5846,7 @@
     "published_at": "2026-04-13T10:35:21-07:00",
     "fetched_at": "2026-05-06T09:34:05Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "4ebe1cb6077afdb72fb0b0e7ed23f5e7a3c6f1bc9ef3b9ecaf16136e85976fa2",
     "paths": {
@@ -5942,7 +5942,7 @@
     "published_at": "2026-02-17",
     "fetched_at": "2026-05-06T09:38:54Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 20 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 20 pts, low/medium only",
     "scanner_score": 20,
     "content_hash": "e4cdb80fba67d6909cb7db3903c2ab9f29c28b8b96d573d8d25cb74e1bb107fc",
     "paths": {
@@ -6095,12 +6095,12 @@
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "I’m Hearing About More Pushback Against Flock, Fueled by Concern Over Anti-Immigrant Uses | ACLU",
+    "title": "I\u2019m Hearing About More Pushback Against Flock, Fueled by Concern Over Anti-Immigrant Uses | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2025-08-21T15:03:29+00:00",
     "fetched_at": "2026-05-06T12:03:00Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "278782b4ebd7eb85c2928a39b5fdbca2be12aaae2328384f06424557e2bc82da",
     "paths": {
@@ -6232,12 +6232,12 @@
     "source_domain": "aclu.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Flock’s Aggressive Expansions Go Far Beyond Simple Driver Surveillance | ACLU",
+    "title": "Flock\u2019s Aggressive Expansions Go Far Beyond Simple Driver Surveillance | ACLU",
     "byline": "Jay Stanley",
     "published_at": "2025-08-18T16:48:27+00:00",
     "fetched_at": "2026-05-06T12:07:26Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "c9200fd77433de7bd46dec41054735e75fa49694c73e8522040ffd5d295dab2d",
     "paths": {
@@ -6323,7 +6323,7 @@
     "published_at": "2023-10-31T13:53:13-07:00",
     "fetched_at": "2026-05-06T12:09:09Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "dfb93f83ad9203cce900c12056fcfca47029f7805d4603b66f53bba40ec11585",
     "paths": {
@@ -6421,7 +6421,7 @@
     "published_at": "2024-11-01T20:17:28-07:00",
     "fetched_at": "2026-05-06T12:01:04Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "69b07e348f4e5bd8dd3f84eaf7cdb121f4be9101a06583f3e7b56a716a844ecd",
     "paths": {
@@ -6507,7 +6507,7 @@
     "published_at": "2025-02-26T10:08:13-08:00",
     "fetched_at": "2026-05-06T12:05:50Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "486051ed042acfaa530ed1ea709a3aeef89c0511472dd01d3d41d2ac053a5386",
     "paths": {
@@ -6589,7 +6589,7 @@
     "published_at": "2021-03-19T15:59:53-07:00",
     "fetched_at": "2026-05-06T14:43:44Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "3a0bbf39d8d92e8e7fd759fd14272afe4f5a35c43810b12132445eacd7a80381",
     "paths": {
@@ -6723,7 +6723,7 @@
     "summary": "EFF announces it is co-sponsoring SB 210 (Sen. Scott Wiener), the License Plate Privacy Act, which would tighten California's 2015 ALPR law (SB 34) by mandating 24-hour data deletion for non-hotlist plates, annual audits, an AG model policy, and restrictions on accessing old ALPR data. The post cites the 2020 State Auditor report finding LAPD, Fresno, Sacramento County, and Marin County noncompliant with SB 34.",
     "key_quotes": [
       {
-        "quote": "While the auditor only conducted a deep-dive into four jurisdictions—Los Angeles, Fresno, Sacramento County and Marin County—all were found to be noncompliant.",
+        "quote": "While the auditor only conducted a deep-dive into four jurisdictions\u2014Los Angeles, Fresno, Sacramento County and Marin County\u2014all were found to be noncompliant.",
         "paragraph_idx": 4
       },
       {
@@ -6750,7 +6750,7 @@
     "published_at": "2025-10-07T06:00:08-07:00",
     "fetched_at": "2026-05-06T14:40:53Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "576e3ba7cdd925e8447a1bf08320ed819a70d05f70b426c63106ce1047df816d",
     "paths": {
@@ -6918,7 +6918,7 @@
     "published_at": "2025-10-14T10:44:24-07:00",
     "fetched_at": "2026-05-06T14:42:18Z",
     "discovered_by": "claude-search:broader-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "a3414944ddb32661da48021e9ca35454c22f11600436e197328b572468d225b4",
     "paths": {
@@ -7000,7 +7000,7 @@
     "published_at": "2026-05-05T00:11:54-07:00",
     "fetched_at": "2026-05-06T14:49:15Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "13dc83fee51aa1ad2af039f5fb1b92a6e3fe584d3e7108e9065554a6c66d3b3f",
     "paths": {
@@ -7037,12 +7037,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Open Records Laws Reveal ALPRs’ Sprawling Surveillance. Now States Want to Block What the Public Sees.",
+    "title": "Open Records Laws Reveal ALPRs\u2019 Sprawling Surveillance. Now States Want to Block What the Public Sees.",
     "byline": "Beryl Lipton, Aaron Mackey, and Adam Schwartz",
     "published_at": "2026-04-30T09:54:10-07:00",
     "fetched_at": "2026-05-06T14:45:50Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "050a92619fa848c915f7522d3118b381a58782d1387c022fd61354bdf156efc9",
     "paths": {
@@ -7077,7 +7077,7 @@
         "paragraph_idx": 17
       },
       {
-        "quote": "These records are not just informational—they are leverage. Communities, journalists, and local officials have used ALPR disclosures to block new deployments, refuse contract renewals, and terminate existing agreements",
+        "quote": "These records are not just informational\u2014they are leverage. Communities, journalists, and local officials have used ALPR disclosures to block new deployments, refuse contract renewals, and terminate existing agreements",
         "paragraph_idx": 11
       },
       {
@@ -7095,12 +7095,12 @@
     "source_domain": "eff.org",
     "tier": 2,
     "stance": "critical",
-    "title": "👁 Selling Mass Surveillance | EFFector 38.7",
+    "title": "\ud83d\udc41 Selling Mass Surveillance | EFFector 38.7",
     "byline": "Christian Romero",
     "published_at": "2026-04-08T09:24:35-07:00",
     "fetched_at": "2026-05-06T14:47:38Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "e144bbf0f2b6f1c9ae804547b7738be56208d2e3419eb17a31251b8b258704e0",
     "paths": {
@@ -7143,7 +7143,7 @@
     "published_at": "2025-11-20T15:58:40-08:00",
     "fetched_at": "2026-05-06T16:51:31Z",
     "discovered_by": "claude-search:initial-seed-2026-05",
-    "scanner_verdict": "WARNINGS — 1 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 1 pts, low/medium only",
     "scanner_score": 1,
     "content_hash": "9d51ae3af133787f82c4fc0cbf6d44b87bb3be7bd0060b031752bd7420582615",
     "paths": {
@@ -7296,7 +7296,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "police are simply prompted to enter text into a \"reason\" field in the Flock Safety system. Usually this is only a few words–or even just one. In these cases, that word was often just \"protest.\"",
+        "quote": "police are simply prompted to enter text into a \"reason\" field in the Flock Safety system. Usually this is only a few words\u2013or even just one. In these cases, that word was often just \"protest.\"",
         "paragraph_idx": 10
       },
       {
@@ -7334,7 +7334,7 @@
     "published_at": "2026-05-07T00:12:30+00:00",
     "fetched_at": "2026-05-07T17:59:25Z",
     "discovered_by": "rss:berkeleyside.org",
-    "scanner_verdict": "REVIEW REQUIRED — 173 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 173 pts, HIGH/CRITICAL findings",
     "scanner_score": 173,
     "content_hash": "f083884c4c81487083e3c0e3f73a0a31334531b04f18d03cbfb1c81272a2ee3d",
     "paths": {
@@ -7461,7 +7461,7 @@
     "published_at": "2026-05-06T22:25:27+00:00",
     "fetched_at": "2026-05-07T17:59:42Z",
     "discovered_by": "rss:berkeleyside.org",
-    "scanner_verdict": "REVIEW REQUIRED — 169 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 169 pts, HIGH/CRITICAL findings",
     "scanner_score": 169,
     "content_hash": "21fab13a2506c1f1a6931062d7ab3deb1f2ed743545844c95a14d219e6e404c0",
     "paths": {
@@ -7543,7 +7543,7 @@
     "summary": "The chair and vice chair of Berkeley's Police Accountability Board argue against the City Council's proposed expansion of its Flock Safety surveillance contract, citing data-sharing with federal immigration authorities, lack of competitive procurement, and BPD's failure to consider alternatives. They urge the council to reject the expansion ahead of a May 7 vote.",
     "key_quotes": [
       {
-        "quote": "Flock Safety — a vendor that over 75 jurisdictions have deemed untrustworthy, has facilitated data-sharing with federal immigration authorities, and has not demonstrated either the technical capacity or will to adhere to Berkeley's data privacy standards.",
+        "quote": "Flock Safety \u2014 a vendor that over 75 jurisdictions have deemed untrustworthy, has facilitated data-sharing with federal immigration authorities, and has not demonstrated either the technical capacity or will to adhere to Berkeley's data privacy standards.",
         "paragraph_idx": 11
       },
       {
@@ -7572,7 +7572,7 @@
     "published_at": null,
     "fetched_at": "2026-05-07T17:59:34Z",
     "discovered_by": "rss:epic.org",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "4581ba3dd101cf6a7e4c29108d12105242cf82b30da0dff543eeae49d75cb81a",
     "paths": {
@@ -7630,7 +7630,7 @@
     "published_at": null,
     "fetched_at": "2026-05-08T19:06:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "e2ed0076fc5f789a2531770383e626e552bda66d3139e74517e872e321d6e53a",
     "paths": {
@@ -7794,7 +7794,7 @@
     "published_at": "2026-02-25T22:02:49.129Z",
     "fetched_at": "2026-05-08T19:06:57Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "7cf211fea6e786b47a3bfbc76ce836563bac58a5a02a6fca5e20656d6cf84fb3",
     "paths": {
@@ -7878,7 +7878,7 @@
     "published_at": "2026-02-25T01:12:23.544",
     "fetched_at": "2026-05-08T19:06:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 66 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 66 pts, HIGH/CRITICAL findings",
     "scanner_score": 66,
     "content_hash": "c8a237971554b4ddbd084e01517bda8ea6d8c47f6934ccdd15bb306ada8c6646",
     "paths": {
@@ -7964,7 +7964,7 @@
     "published_at": "2025-12-06T04:48:15.362",
     "fetched_at": "2026-05-08T19:07:37Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 23 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 23 pts, low/medium only",
     "scanner_score": 23,
     "content_hash": "be49d4ac86df9fa6912c390e5668386f4df18ff8e708340f82e38d1ec5ffd417",
     "paths": {
@@ -8102,7 +8102,7 @@
     "published_at": "6/4/2025 5:52:18 PM",
     "fetched_at": "2026-05-08T19:06:52Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 116 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 116 pts, HIGH/CRITICAL findings",
     "scanner_score": 116,
     "content_hash": "12c2931c36b1a977f26eec9d42993ca3094f35137572c7f99b9166e628bb6cb4",
     "paths": {
@@ -8166,12 +8166,12 @@
     "source_domain": "lookouteugene-springfield.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock activated camera during ‘pause,’ chief says, pushing city to axe contract",
+    "title": "Flock activated camera during \u2018pause,\u2019 chief says, pushing city to axe contract",
     "byline": "Jaime Adame",
     "published_at": "2025-12-10T02:25:55+00:00",
     "fetched_at": "2026-05-08T19:07:32Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 185 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 185 pts, HIGH/CRITICAL findings",
     "scanner_score": 185,
     "content_hash": "4b728fa9f6e4a95b230f8b97b604e1613e988c0a624e009975600ccb5d1c28e7",
     "paths": {
@@ -8283,7 +8283,7 @@
     "published_at": "2026-02-03T00:09:01+00:00",
     "fetched_at": "2026-05-08T19:06:14Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 131 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 131 pts, HIGH/CRITICAL findings",
     "scanner_score": 131,
     "content_hash": "311daa517137890a2a27e7b986789476ba126ea484d371cec4fdf76e3b9701ef",
     "paths": {
@@ -8450,7 +8450,7 @@
     "published_at": "2025-12-06",
     "fetched_at": "2026-05-08T19:06:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "52ce71b135890a2550154c2b1db4bc510a35568fe2c95ba7632e8dc5132edc08",
     "paths": {
@@ -8568,12 +8568,12 @@
     "source_domain": "skamaniasheriff.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock Cameras Disabled After Recent Court Decision – Skamania County Sheriff",
+    "title": "Flock Cameras Disabled After Recent Court Decision \u2013 Skamania County Sheriff",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-08T19:07:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "b7ddd987c48d594c79256ede23c209f925e3dba9836fa2afdb6a9d7efe8ccbe6",
     "paths": {
@@ -8626,7 +8626,7 @@
     "published_at": "2026-04-23T04:00:58.295131947Z",
     "fetched_at": "2026-05-08T19:06:20Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 71 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 71 pts, HIGH/CRITICAL findings",
     "scanner_score": 71,
     "content_hash": "083eb425ae85cabf02ff0955ab964bc650bbda4a96682e40086d94ad6a411400",
     "paths": {
@@ -8710,7 +8710,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "Smith said he was immediately advised by officers that Flock cameras create a “heat map,” directly refuting claims to the contrary from Flock Chief Information Security Officer Chris Castaldo.",
+        "quote": "Smith said he was immediately advised by officers that Flock cameras create a \u201cheat map,\u201d directly refuting claims to the contrary from Flock Chief Information Security Officer Chris Castaldo.",
         "paragraph_idx": 9
       },
       {
@@ -8739,7 +8739,7 @@
     "published_at": "2026-03-05T04:24:56.349",
     "fetched_at": "2026-05-08T19:07:25Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 24 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 24 pts, low/medium only",
     "scanner_score": 24,
     "content_hash": "0035688abceac22795e60710c31c695ad0219becbd22e08d5d3c28e7705193ef",
     "paths": {
@@ -8883,7 +8883,7 @@
     "published_at": "10/14/2025 6:56:33 PM",
     "fetched_at": "2026-05-08T20:21:51Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 116 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 116 pts, HIGH/CRITICAL findings",
     "scanner_score": 116,
     "content_hash": "7b0deaf45a1cbd285e2442932aed4f442f981d4e65664d7f1cc7597c1427862d",
     "paths": {
@@ -8958,11 +8958,11 @@
     "tier": 1,
     "stance": "unknown",
     "title": "Bend is the latest Oregon city to turn off Flock cameras",
-    "byline": "Kathryn Styer Martínez",
+    "byline": "Kathryn Styer Mart\u00ednez",
     "published_at": "2026-01-08",
     "fetched_at": "2026-05-08T22:16:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 13 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 13 pts, low/medium only",
     "scanner_score": 13,
     "content_hash": "587463a2dd5c765809a70856aca1ce04de780973e9cc0dac4d71cb68d37254fe",
     "paths": {
@@ -9032,12 +9032,12 @@
     "source_domain": "clickorlando.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "‘Shocking violation:’ Lake County commissioners order takedown of secret surveillance cameras",
+    "title": "\u2018Shocking violation:\u2019 Lake County commissioners order takedown of secret surveillance cameras",
     "byline": "Brian Didlake",
     "published_at": "2021-08-12T22:17:14.497Z",
     "fetched_at": "2026-05-09T00:13:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 104 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 104 pts, HIGH/CRITICAL findings",
     "scanner_score": 104,
     "content_hash": "bd920221837590e48d76be12de3afcdc1db2d0429c249ba99def4b1b2b3eb96d",
     "paths": {
@@ -9167,7 +9167,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:22:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 223 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 223 pts, HIGH/CRITICAL findings",
     "scanner_score": 223,
     "content_hash": "e50f07bb3a8c1b5b34772520721e263ddd1d63a8131218bb51102060e22072c5",
     "paths": {
@@ -9328,12 +9328,12 @@
     "source_domain": "shorewoodmn.gov",
     "tier": 2,
     "stance": "unknown",
-    "title": "Blog • Flock Safety Camera Turned Off",
+    "title": "Blog \u2022 Flock Safety Camera Turned Off",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T02:22:17Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 34 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 34 pts, HIGH/CRITICAL findings",
     "scanner_score": 34,
     "content_hash": "f6de9b7c0d6031d0e0f2dc113b2fc08aa375d6aafec0a37da069f5ec95665fb0",
     "paths": {
@@ -9382,7 +9382,7 @@
     "published_at": "2026-02-25T05:50:59Z",
     "fetched_at": "2026-05-09T02:42:09Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "148744b9158e8ffa4756584380c183ff92d48a1e588ee0e474ec1e4105b6c734",
     "paths": {
@@ -9530,7 +9530,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:41:13Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "7cfd9247f1207df4bb4a14610a219b763934126816b6045e55703c1906a909f8",
     "paths": {
@@ -9611,7 +9611,7 @@
     "published_at": "2025-09-19T22:12:00-0600",
     "fetched_at": "2026-05-09T02:41:42Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 303 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 303 pts, HIGH/CRITICAL findings",
     "scanner_score": 303,
     "content_hash": "b29d1ac250656c643008ea46d68b2365ad28f24d32f26d9fa6935a7bf2c006ea",
     "paths": {
@@ -9766,12 +9766,12 @@
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Big Brother or crime fighter? Elbert County says ‘no’ to license plate readers",
+    "title": "Big Brother or crime fighter? Elbert County says \u2018no\u2019 to license plate readers",
     "byline": null,
     "published_at": "2024-02-17T19:00:00+00:00",
     "fetched_at": "2026-05-09T02:40:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 197 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 197 pts, HIGH/CRITICAL findings",
     "scanner_score": 197,
     "content_hash": "951a1b348e70cf0f08a386f85c5c2ff464479cbb45a3dc6f28961e97cd0efd6f",
     "paths": {
@@ -9925,7 +9925,7 @@
     "published_at": "2025-12-05T18:26:00+00:00",
     "fetched_at": "2026-05-09T02:39:50Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "76ef6c18065fce5a634431ef5a929f9e0b99adefc0c5b726009cac0d45bb17ca",
     "paths": {
@@ -10052,7 +10052,7 @@
         "paragraph_idx": 11
       },
       {
-        "quote": "federal agencies — including U.S. Border Patrol and Homeland Security Investigations — gained access to multiple Flock networks in Snohomish County, often without police departments knowing.",
+        "quote": "federal agencies \u2014 including U.S. Border Patrol and Homeland Security Investigations \u2014 gained access to multiple Flock networks in Snohomish County, often without police departments knowing.",
         "paragraph_idx": 5
       }
     ],
@@ -10073,7 +10073,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:41:04Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 153 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 153 pts, HIGH/CRITICAL findings",
     "scanner_score": 153,
     "content_hash": "0f57e35a4c10640f246cdb97bd63c8639f27a716c4ae91e5e59585f7095162e9",
     "paths": {
@@ -10191,7 +10191,7 @@
     "published_at": "2026-02-03T23:53:37+00:00",
     "fetched_at": "2026-05-09T02:40:51Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 134 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 134 pts, HIGH/CRITICAL findings",
     "scanner_score": 134,
     "content_hash": "11b26c6f4f5350b098aeda9d1ff0ed4fa035e477ed571bdf05b70fe69ecf8beb",
     "paths": {
@@ -10237,7 +10237,7 @@
         ]
       }
     ],
-    "summary": "Brooklyn Park, MN police canceled its Flock Safety contract at the end of December, citing concerns over customer support and data-sharing protocols. The article also notes that Anoka County Sheriff's Office added new restrictions—removing two federal agencies from data access and filtering out immigration-related nationwide searches—amid concerns about federal immigration access to ALPR data.",
+    "summary": "Brooklyn Park, MN police canceled its Flock Safety contract at the end of December, citing concerns over customer support and data-sharing protocols. The article also notes that Anoka County Sheriff's Office added new restrictions\u2014removing two federal agencies from data access and filtering out immigration-related nationwide searches\u2014amid concerns about federal immigration access to ALPR data.",
     "key_quotes": [
       {
         "quote": "The city of Brooklyn Park canceled its contract with the company Flock Safety at the end of December.",
@@ -10270,7 +10270,7 @@
     "published_at": "2026-03-19T20:49:46.5",
     "fetched_at": "2026-05-09T02:41:27Z",
     "discovered_by": "manual:retag-2026-05-14-chief-meeting (was: termination-ledger-import)",
-    "scanner_verdict": "REVIEW REQUIRED — 30 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 30 pts, HIGH/CRITICAL findings",
     "scanner_score": 30,
     "content_hash": "8f3d617890984fc6e4ce78e9fd365a2c60843a95f830a76c05dfc19ad87f54b1",
     "paths": {
@@ -10415,7 +10415,7 @@
     "published_at": "2026-03-02T00:00:00Z",
     "fetched_at": "2026-05-09T02:43:40Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 16 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 16 pts, low/medium only",
     "scanner_score": 16,
     "content_hash": "0577836126816b47dbe6816e7f25299ada8e58dd6d9a6dee1058ba229a64b672",
     "paths": {
@@ -10469,12 +10469,12 @@
     "source_domain": "sanjosespotlight.com",
     "tier": 2,
     "stance": "neutral",
-    "title": "Fact Brief: Does Campbell have a partnership with Flock cameras? - San José Spotlight",
+    "title": "Fact Brief: Does Campbell have a partnership with Flock cameras? - San Jos\u00e9 Spotlight",
     "byline": "Donovan Farnham",
     "published_at": "2026-04-15T17:00:28+00:00",
     "fetched_at": "2026-05-09T02:41:50Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 88 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 88 pts, HIGH/CRITICAL findings",
     "scanner_score": 88,
     "content_hash": "f39bdd86ece9a4a2a86aafb6b7999813ae61fd6f820b3bfce7ed7f3a177ead46",
     "paths": {
@@ -10546,7 +10546,7 @@
     "published_at": "2026-03-23T17:48:00.000-04:00",
     "fetched_at": "2026-05-09T02:43:19Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 73 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 73 pts, HIGH/CRITICAL findings",
     "scanner_score": 73,
     "content_hash": "bb2ae1d22d4ca1fb61ac50f91e925388a4373ea3fb76c862d1132a21ba3c1d90",
     "paths": {
@@ -10594,7 +10594,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:40:18Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 38 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 38 pts, HIGH/CRITICAL findings",
     "scanner_score": 38,
     "content_hash": "e61245e1c15580c6bd3811ec43111a41339336cde579cf76bff0ab7e77b51fd8",
     "paths": {
@@ -10627,7 +10627,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T02:42:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 50 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 50 pts, HIGH/CRITICAL findings",
     "scanner_score": 50,
     "content_hash": "29a4c288464130e0c26073d268ed7754fa2da869cea4fbf967f4832b1457186a",
     "paths": {
@@ -10674,7 +10674,7 @@
     "published_at": "2/4/2026 6:27:08 PM",
     "fetched_at": "2026-05-09T02:40:03Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "2bee96e18e062257740b4f42d5b6549b20263f86130a21a4e780925fb6e9c1c1",
     "paths": {
@@ -10732,7 +10732,7 @@
     "published_at": "2025-11-12T00:30:09+00:00",
     "fetched_at": "2026-05-09T02:42:59Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 65 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 65 pts, HIGH/CRITICAL findings",
     "scanner_score": 65,
     "content_hash": "0f3f2c6986e5ed12cae94703e9ac38f9de527709c32292c60228c140b88ef7d3",
     "paths": {
@@ -10767,7 +10767,7 @@
     "published_at": "2025-12-16T15:44:05+00:00",
     "fetched_at": "2026-05-09T08:53:03Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 64 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 64 pts, HIGH/CRITICAL findings",
     "scanner_score": 64,
     "content_hash": "2f20b37a770145b63313fbbc13626504b714fe98f53bc22c7223b4de256071a7",
     "paths": {
@@ -10840,7 +10840,7 @@
     "published_at": "2025-07-23T09:00:00",
     "fetched_at": "2026-05-09T08:54:51Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 34 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 34 pts, low/medium only",
     "scanner_score": 34,
     "content_hash": "579a991d62ece6c8e79f2c99d14e8d4f070f45e15fb011ac15a337f91518cd9c",
     "paths": {
@@ -10931,7 +10931,7 @@
     "published_at": "2019-03-13T16:00:00+00:00",
     "fetched_at": "2026-05-09T10:22:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "5cc7d115b125a4e16e74cad4efff9d7f5794cc4d70822648d8e068117ad1f5a1",
     "paths": {
@@ -11020,7 +11020,7 @@
         "paragraph_idx": 15
       },
       {
-        "quote": "Some have already rejected contracts for license plate surveillance — like Alameda and Culver City in California.",
+        "quote": "Some have already rejected contracts for license plate surveillance \u2014 like Alameda and Culver City in California.",
         "paragraph_idx": 21
       },
       {
@@ -11046,7 +11046,7 @@
     "published_at": "2026-01-07T17:42:40+00:00",
     "fetched_at": "2026-05-09T10:17:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "e74581adf4e471948c97f730f2df2b31dfe9de462aa70abc88830c45da9799a9",
     "paths": {
@@ -11113,7 +11113,7 @@
     "published_at": "2024-04-02T17:50:04+00:00",
     "fetched_at": "2026-05-09T11:59:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "3bd5b6345d41767019a072baea7262a5255595e885733a9e50981c5a4bce893b",
     "paths": {
@@ -11149,11 +11149,11 @@
     "summary": "Charlottesville Police Chief Michael Kochis presented a proposal to City Council for a one-year pilot of 10 Flock Safety license-plate reader cameras at city entryways, funded by the Police Foundation. Kochis argued the cameras would aid in alerts (Amber, Silver, Blue) and in solving shootings, robberies, and stolen-vehicle cases, noting 85% of city gun violence involves a vehicle.",
     "key_quotes": [
       {
-        "quote": "Amber alert, Silver alert, Blue alert… when those alerts occur, out officers will be alerted immediately.",
+        "quote": "Amber alert, Silver alert, Blue alert\u2026 when those alerts occur, out officers will be alerted immediately.",
         "paragraph_idx": 4
       },
       {
-        "quote": "He says no one can be pulled on a Flock hit alone… there must be other ample evidence for that to happen.",
+        "quote": "He says no one can be pulled on a Flock hit alone\u2026 there must be other ample evidence for that to happen.",
         "paragraph_idx": 8
       }
     ],
@@ -11169,12 +11169,12 @@
     "source_domain": "cvillerightnow.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Flock CEO includes Charlottesville, Staunton in email blaming activists for cities dropping the company’s services - Cville Right Now",
+    "title": "Flock CEO includes Charlottesville, Staunton in email blaming activists for cities dropping the company\u2019s services - Cville Right Now",
     "byline": "Dori Zook",
     "published_at": "2025-12-30T14:58:23+00:00",
     "fetched_at": "2026-05-09T13:46:57Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 67 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 67 pts, HIGH/CRITICAL findings",
     "scanner_score": 67,
     "content_hash": "703e115f7c18b08a329cafbfe469a8dc38862f48df87c6711ac0e3806ca6cc31",
     "paths": {
@@ -11298,7 +11298,7 @@
         ]
       }
     ],
-    "summary": "Charlottesville Police Chief Michael Kochis criticized a mass email from Flock Safety CEO Garrett Langley that blamed activists for cities ending their Flock contracts. The article lists multiple cities — including Charlottesville, Staunton, Flagstaff, Cambridge, Eugene, and Springfield — that have dropped Flock, and references controversies including ICE data access and a Texas abortion-related ALPR search.",
+    "summary": "Charlottesville Police Chief Michael Kochis criticized a mass email from Flock Safety CEO Garrett Langley that blamed activists for cities ending their Flock contracts. The article lists multiple cities \u2014 including Charlottesville, Staunton, Flagstaff, Cambridge, Eugene, and Springfield \u2014 that have dropped Flock, and references controversies including ICE data access and a Texas abortion-related ALPR search.",
     "key_quotes": [
       {
         "quote": "I looked at it and just, honestly, chalked it up to an unprofessional email from a venting CEO.",
@@ -11331,7 +11331,7 @@
     "published_at": "2026-04-09T13:34:14Z",
     "fetched_at": "2026-05-09T13:53:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 46 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 46 pts, HIGH/CRITICAL findings",
     "scanner_score": 46,
     "content_hash": "fef40cd91f9c9c0032849fac774a618a5646f88036b4b03b87d95167329b155e",
     "paths": {
@@ -11386,7 +11386,7 @@
     "published_at": "2026-02-12T20:07:58.472",
     "fetched_at": "2026-05-09T13:48:55Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 34 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 34 pts, low/medium only",
     "scanner_score": 34,
     "content_hash": "f730b17a1c902605c2bcf553874b1e236eacb5a780959c27cc34e9908f193fd9",
     "paths": {
@@ -11501,7 +11501,7 @@
     "published_at": "2014-01-29T20:46:32+00:00",
     "fetched_at": "2026-05-09T15:09:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "fd7fc74cde661891815e76c85899a3be96e33c93419891a0cb1fa8184ad2f01c",
     "paths": {
@@ -11563,7 +11563,7 @@
     "published_at": "2026-04-22",
     "fetched_at": "2026-05-09T15:13:04Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "62e0848ad6c7483712917da3a0df594ac217d5ebcdb95fd754821982d286e433",
     "paths": {
@@ -11679,7 +11679,7 @@
     "published_at": "2025-07-09T17:15:55+00:00",
     "fetched_at": "2026-05-09T15:06:09Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 86 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 86 pts, HIGH/CRITICAL findings",
     "scanner_score": 86,
     "content_hash": "0570dd6fb73f082022e0aee06e467886348cac130c7cdd25c7e4f9e8524f9a94",
     "paths": {
@@ -11796,7 +11796,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:01:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "49de7effba0b3ce72fee0f86c23dcad61c4db20bbb7da60fd1b37dac3b0780c0",
     "paths": {
@@ -11871,7 +11871,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:03:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "473e4a42de2435afb51eb73b1446d679a2cb518b121655dfc057e79d6f7b17b4",
     "paths": {
@@ -11936,7 +11936,7 @@
     "published_at": "2025-12-05T18:01:14.000Z",
     "fetched_at": "2026-05-09T16:03:21Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "dfe10cc5e9d2fe6257c1544d600390d835501370b33657930f530c227d7f80f5",
     "paths": {
@@ -12071,7 +12071,7 @@
     "published_at": "2026-01-21",
     "fetched_at": "2026-05-09T16:02:59Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "28bde6b1ace02c03739a36f4cb76cb5312af45c0a5c59af28f3e15db79018b97",
     "paths": {
@@ -12235,7 +12235,7 @@
     "published_at": "2025-12-16T12:42:29+00:00",
     "fetched_at": "2026-05-09T16:01:26Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 54 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 54 pts, HIGH/CRITICAL findings",
     "scanner_score": 54,
     "content_hash": "0f6d48eb35b83f6bcd8bd99f438cd6bf758bf276f97687a4acc8617161f72328",
     "paths": {
@@ -12288,12 +12288,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Mayor extends Denver’s contract with Flock license-plate readers without council approval",
+    "title": "Mayor extends Denver\u2019s contract with Flock license-plate readers without council approval",
     "byline": "Elliott Wenzler",
     "published_at": "2025-10-22T16:11:37+00:00",
     "fetched_at": "2026-05-09T16:02:16Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "a767b7a117c60cb69338c42d7e678f4fd833a67923f072bda9062099fae5e9aa",
     "paths": {
@@ -12432,12 +12432,12 @@
     "source_domain": "fauquiernow.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "‘Not on our watch’: Warrenton Town Council reverses course on license plate readers",
+    "title": "\u2018Not on our watch\u2019: Warrenton Town Council reverses course on license plate readers",
     "byline": "Grace Schumacher | FauquierNow",
     "published_at": null,
     "fetched_at": "2026-05-09T16:03:39Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 137 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 137 pts, HIGH/CRITICAL findings",
     "scanner_score": 137,
     "content_hash": "c1a4dc6f22c90b58c993137a84b097691cfac0d785bc8f79b17735b0d3c9c344",
     "paths": {
@@ -12474,7 +12474,7 @@
     "published_at": "2025-09-10T21:13:00+00:00",
     "fetched_at": "2026-05-09T16:02:29Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "61af71c73b329132b1f582d0890584b667a4cce054839b9a2d48b255354ae242",
     "paths": {
@@ -12527,7 +12527,7 @@
     "published_at": "2026-02-23T21:41:09.756",
     "fetched_at": "2026-05-09T16:03:05Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 70 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 70 pts, HIGH/CRITICAL findings",
     "scanner_score": 70,
     "content_hash": "ec1c8bcda6385070ef659943b7b08a6fa45015d0a2b9f04fd0a1464f87d69764",
     "paths": {
@@ -12624,7 +12624,7 @@
     "published_at": "2026-04-07T18:08:01.363Z",
     "fetched_at": "2026-05-09T16:04:35Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "515d322bd0533966f0d03c1719fba90a01a7454aac7a611556b93effbf880be9",
     "paths": {
@@ -12722,7 +12722,7 @@
     "published_at": "2025-09-25T15:21:17.387",
     "fetched_at": "2026-05-09T16:02:47Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 37 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 37 pts, low/medium only",
     "scanner_score": 37,
     "content_hash": "81b160ab3e413fc51573565a42cf44a6e02f7423c5bd352e8cb196cc11e82729",
     "paths": {
@@ -12784,7 +12784,7 @@
     "published_at": "2025-09-10T17:08:18+00:00",
     "fetched_at": "2026-05-09T16:02:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "6c222090701019ef7f74f7ff29157659befb7e3a2784ef5d0ceca0c404b00e4f",
     "paths": {
@@ -12850,7 +12850,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:04:11Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 25 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 25 pts, low/medium only",
     "scanner_score": 25,
     "content_hash": "84ab7704a7a5fc55be244beae596f6dbc4a4bd61b0cbc1280b8b1323a26db52a",
     "paths": {
@@ -12896,7 +12896,7 @@
     "published_at": "2026-02-20T04:19:25.74Z",
     "fetched_at": "2026-05-09T16:03:49Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "abf93cb7ae5d5cab6a0ba63f9c3e46c54b0854ad5c73612c29eea0013faba507",
     "paths": {
@@ -12989,7 +12989,7 @@
     "published_at": null,
     "fetched_at": "2026-05-09T16:47:23Z",
     "discovered_by": "bing:alpr",
-    "scanner_verdict": "REVIEW REQUIRED — 197 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 197 pts, HIGH/CRITICAL findings",
     "scanner_score": 197,
     "content_hash": "2c49a6ef589f70cb5d4abe065be702067bd62834d60f12cc87c308c87cc9f59e",
     "paths": {
@@ -13125,7 +13125,7 @@
         "paragraph_idx": 6
       },
       {
-        "quote": "his department has also been receiving numerous open records requests regarding the Flock system – with the majority not being Monona from residents – and staff was spending an exorbitant amount of time fulfilling those requests",
+        "quote": "his department has also been receiving numerous open records requests regarding the Flock system \u2013 with the majority not being Monona from residents \u2013 and staff was spending an exorbitant amount of time fulfilling those requests",
         "paragraph_idx": 9
       },
       {
@@ -13150,7 +13150,7 @@
     "published_at": "2026-05-08T16:14:26-07:00",
     "fetched_at": "2026-05-09T16:47:02Z",
     "discovered_by": "rss:kqed.org",
-    "scanner_verdict": "REVIEW REQUIRED — 103 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 103 pts, HIGH/CRITICAL findings",
     "scanner_score": 103,
     "content_hash": "2a203f67929ca7390d870304c67e248b531654e3f79786b540b614ca59f1c4c4",
     "paths": {
@@ -13289,7 +13289,7 @@
     "published_at": "2026-04-29T23:31:41.164",
     "fetched_at": "2026-05-09T16:46:48Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 79 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 79 pts, HIGH/CRITICAL findings",
     "scanner_score": 79,
     "content_hash": "b2b3d241757ae3d1f588c5e89c8187e81c6c1ec212d86cbaa3369f941a79befd",
     "paths": {
@@ -13383,12 +13383,12 @@
     "source_domain": "aclunorcal.org",
     "tier": 2,
     "stance": "critical",
-    "title": "California Activists Sue Marin County Sheriff for Illegally Sharing Drivers’ License Plate Data With ICE, CBP and Other Out-of-State Agencies - ACLU of Northern California",
+    "title": "California Activists Sue Marin County Sheriff for Illegally Sharing Drivers\u2019 License Plate Data With ICE, CBP and Other Out-of-State Agencies - ACLU of Northern California",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T17:01:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "68b6e6e70b7837d84ad7df28c3d5c6f96b4a03470d01a8952854e68d58e4aecc",
     "paths": {
@@ -13492,7 +13492,7 @@
     "published_at": "2026-04-16T17:50:00-0400",
     "fetched_at": "2026-05-09T17:03:18Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 196 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 196 pts, HIGH/CRITICAL findings",
     "scanner_score": 196,
     "content_hash": "fbf386517006f5d6d8a8fe012d8588c214faed35585b1083f3996f5ea708b7d4",
     "paths": {
@@ -13625,11 +13625,11 @@
         "paragraph_idx": 7
       },
       {
-        "quote": "There is misinformation out there that Flock works with ICE… and it's simply not true",
+        "quote": "There is misinformation out there that Flock works with ICE\u2026 and it's simply not true",
         "paragraph_idx": 13
       },
       {
-        "quote": "There are ways this data can be accessed… sometimes off the books",
+        "quote": "There are ways this data can be accessed\u2026 sometimes off the books",
         "paragraph_idx": 17
       },
       {
@@ -13654,7 +13654,7 @@
     "published_at": "2025-02-05T13:36:03+00:00",
     "fetched_at": "2026-05-09T17:02:12Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 54 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 54 pts, HIGH/CRITICAL findings",
     "scanner_score": 54,
     "content_hash": "d6234f895af8512b63673a42dc93dcab858cd578be18653904354833875d0684",
     "paths": {
@@ -13707,12 +13707,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Pushback against Flock cameras comes to Denver suburb — the latest Colorado city to enter debate",
+    "title": "Pushback against Flock cameras comes to Denver suburb \u2014 the latest Colorado city to enter debate",
     "byline": "John Aguilar",
     "published_at": "2026-02-10T13:00:31+00:00",
     "fetched_at": "2026-05-09T17:02:35Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 148 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 148 pts, HIGH/CRITICAL findings",
     "scanner_score": 148,
     "content_hash": "5b0c892b967ef0cb7189027156bed45b16586530b9c6845a7a5c3f126c5e9837",
     "paths": {
@@ -13823,14 +13823,14 @@
         ]
       }
     ],
-    "summary": "Thornton, Colorado residents are debating the city's use of 16 Flock Safety ALPR cameras, with critics raising privacy and Fourth Amendment concerns while police defend the technology as a key crime-fighting tool. The article situates Thornton's debate within broader Colorado pushback — citing Denver's contract extension, Longmont's data-sharing pause, Louisville's removal, and Loveland's federal sharing — and pending state legislation (SB 70, SB 71) to restrict surveillance tech.",
+    "summary": "Thornton, Colorado residents are debating the city's use of 16 Flock Safety ALPR cameras, with critics raising privacy and Fourth Amendment concerns while police defend the technology as a key crime-fighting tool. The article situates Thornton's debate within broader Colorado pushback \u2014 citing Denver's contract extension, Longmont's data-sharing pause, Louisville's removal, and Loveland's federal sharing \u2014 and pending state legislation (SB 70, SB 71) to restrict surveillance tech.",
     "key_quotes": [
       {
         "quote": "Thornton's Flock camera data can be seen by more than 1,600 other law enforcement agencies across the country.",
         "paragraph_idx": 11
       },
       {
-        "quote": "Any situation I feel uncomfortable about or that might be in conflict with our policies or with Colorado law, I will revoke their access — no problem,",
+        "quote": "Any situation I feel uncomfortable about or that might be in conflict with our policies or with Colorado law, I will revoke their access \u2014 no problem,",
         "paragraph_idx": 27
       },
       {
@@ -13859,7 +13859,7 @@
     "published_at": "2026-04-24T21:45:04.85",
     "fetched_at": "2026-05-09T17:02:26Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "89346712f67ada4ca73a04c295c2f271145ebd42b01b57bc78d8d2a181f8f347",
     "paths": {
@@ -13922,7 +13922,7 @@
     "published_at": "2026-04-25T00:40:48.123",
     "fetched_at": "2026-05-09T17:02:51Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 139 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 139 pts, HIGH/CRITICAL findings",
     "scanner_score": 139,
     "content_hash": "a1978b9f6038fc7cd5d93069f409c9b41705ecccc2edbf6f557e8a03fd55e706",
     "paths": {
@@ -14081,7 +14081,7 @@
     "published_at": "2026-05-08T16:33:38.326",
     "fetched_at": "2026-05-09T17:01:25Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 79 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 79 pts, HIGH/CRITICAL findings",
     "scanner_score": 79,
     "content_hash": "2a072e37084a3b5117574a19396f1096a3ae3892cebe191182ebdfdbbf854ef3",
     "paths": {
@@ -14169,7 +14169,7 @@
     "published_at": "2026-04-01T00:07:35+00:00",
     "fetched_at": "2026-05-09T17:02:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 112 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 112 pts, HIGH/CRITICAL findings",
     "scanner_score": 112,
     "content_hash": "b621ac19b43a80e688ba22d02400d915e324f866a44d90cf0e929cdc06f180ed",
     "paths": {
@@ -14295,7 +14295,7 @@
     "published_at": "2026-04-08T05:00:00-07:00",
     "fetched_at": "2026-05-09T17:02:03Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "62b24cd9122ee41f35025256e635f4f4c4af1f8b307748cea18c8ac557cc682c",
     "paths": {
@@ -14435,7 +14435,7 @@
     "summary": "Puyallup's two-year Flock Safety ALPR contract has expired, and the city is deciding whether to renew amid Washington's new Driver's Privacy Act (SB 6002) signed March 30, 2026. The article details PPD's 39 fixed cameras, its disabling of mobile ALPR and the national lookup feature after a UW study found Border Patrol back-door access in other WA agencies, and ongoing review of three cameras that may violate the new law.",
     "key_quotes": [
       {
-        "quote": "Puyallup's two-year contract with the cameras' vendor, Flock Safety, recently expired — leaving the city at a crossroads on whether to renew it amid new legislation and an ongoing national debate about the implications of the technology.",
+        "quote": "Puyallup's two-year contract with the cameras' vendor, Flock Safety, recently expired \u2014 leaving the city at a crossroads on whether to renew it amid new legislation and an ongoing national debate about the implications of the technology.",
         "paragraph_idx": 6
       },
       {
@@ -14460,11 +14460,11 @@
     "tier": 1,
     "stance": "unknown",
     "title": "What to know about controversial automated license plate readers in WA",
-    "byline": "Catalina Gaitán, The Seattle Times",
+    "byline": "Catalina Gait\u00e1n, The Seattle Times",
     "published_at": "2026-02-23T06:37:48-08:00",
     "fetched_at": "2026-05-09T17:03:37Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "eaaac27aa29b914560a609b1a9bbe09d25ac813c733e7a344edcc76ba0738a36",
     "paths": {
@@ -14619,12 +14619,12 @@
     "source_domain": "aclunorcal.org",
     "tier": 2,
     "stance": "critical",
-    "title": "Lawsuit Challenges San Jose’s Warrantless ALPR Mass Surveillance - ACLU of Northern California",
+    "title": "Lawsuit Challenges San Jose\u2019s Warrantless ALPR Mass Surveillance - ACLU of Northern California",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-09T19:25:43Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "eb18af576c7b2088c08f4fd770c528ed033c34e61c8165309795304fbcf3311b",
     "paths": {
@@ -14698,7 +14698,7 @@
         "paragraph_idx": 4
       },
       {
-        "quote": "The San Jose Police Department has blanketed the city's roadways with nearly 500 ALPRs – indiscriminately collecting millions of records per month about people's movements – and keeps this data for an entire year.",
+        "quote": "The San Jose Police Department has blanketed the city's roadways with nearly 500 ALPRs \u2013 indiscriminately collecting millions of records per month about people's movements \u2013 and keeps this data for an entire year.",
         "paragraph_idx": 7
       },
       {
@@ -14723,7 +14723,7 @@
     "published_at": "2025-02-04T18:22:57+00:00",
     "fetched_at": "2026-05-09T19:22:40Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 64 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 64 pts, HIGH/CRITICAL findings",
     "scanner_score": 64,
     "content_hash": "a88e8e889a46c9355226bd6cd12dfb668994d1d0acc55ec54400b924daec6793",
     "paths": {
@@ -14791,7 +14791,7 @@
     "published_at": "2026-02-05T05:00:00-08:00",
     "fetched_at": "2026-05-09T19:24:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "e817d0f7aff5362a061108867f5cfab6563054101f2d450d80aeb158c39ba188",
     "paths": {
@@ -14905,7 +14905,7 @@
     "published_at": "2025-08-14T21:46:35+00:00",
     "fetched_at": "2026-05-09T21:02:41Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "1bdfc4547e989ad64ce0d8eec4f0b42f42685d82c9cb250f3f7402e0c6aba0f7",
     "paths": {
@@ -14958,7 +14958,7 @@
     "published_at": "2026-04-11T11:28:11-07:00",
     "fetched_at": "2026-05-09T21:01:00Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "41c55965b6527703634194e2da630010f3e238665d57eb612bfd7cb1aa64acba",
     "paths": {
@@ -15078,12 +15078,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for ‘this whole Flock era’",
+    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for \u2018this whole Flock era\u2019",
     "byline": "Elliott Wenzler",
     "published_at": "2026-03-30T12:00:52+00:00",
     "fetched_at": "2026-05-09T22:05:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "184bdb1f578f7231e8af66286f32294b317bc114c5f85605698badc701d8ef98",
     "paths": {
@@ -15135,7 +15135,7 @@
     "summary": "Denver City Council is set to vote on a one-year, $150,000 contract with Axon to replace its expiring Flock Safety ALPR program with 50 cameras at up to 20 intersections. Several council members are leaning against approval amid concerns over ICE access to Denver data and broader surveillance integration with Axon's Fusus system; if rejected, the program will end.",
     "key_quotes": [
       {
-        "quote": "If the council rejects the one-year contract — which would cost $150,000 and provide 50 cameras at a maximum of 20 intersections — Johnston's administration has said the program will shut down.",
+        "quote": "If the council rejects the one-year contract \u2014 which would cost $150,000 and provide 50 cameras at a maximum of 20 intersections \u2014 Johnston's administration has said the program will shut down.",
         "paragraph_idx": 7
       },
       {
@@ -15168,7 +15168,7 @@
     "published_at": "2025-08-21T19:58:36+00:00",
     "fetched_at": "2026-05-09T22:00:37Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 112 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 112 pts, HIGH/CRITICAL findings",
     "scanner_score": 112,
     "content_hash": "78dbe690ad6e7cafd08fbec49215e2619e4507133c9bb9c3b7600bc00c3d598f",
     "paths": {
@@ -15244,7 +15244,7 @@
     "published_at": "2023-12-15T05:30:00-08:00",
     "fetched_at": "2026-05-09T22:03:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "4447f49030005c79e4d205893608da5e04f4f4bcd1e6dbfc3098898c648b539e",
     "paths": {
@@ -15414,7 +15414,7 @@
     "published_at": "2026-04-02T11:03:42+00:00",
     "fetched_at": "2026-05-10T00:06:16Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "3976c87bc76780f1cf4b2471b354146b4a3b206798ec7c5b51e3389c6bd02952",
     "paths": {
@@ -15497,7 +15497,7 @@
     "published_at": "2025-08-30T07:02:00+00:00",
     "fetched_at": "2026-05-10T00:02:48Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 114 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 114 pts, HIGH/CRITICAL findings",
     "scanner_score": 114,
     "content_hash": "f3505b1c3f70c480627e125f2b9dd496ae60109d47b2b45743fe3972123b5811",
     "paths": {
@@ -15582,12 +15582,12 @@
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for ‘this whole Flock era'",
+    "title": "As Denver council faces vote on new license plate cameras contract, distaste lingers for \u2018this whole Flock era'",
     "byline": " Elliott Wenzler, The Denver Post ",
     "published_at": "2026-03-30T11:35:59-07:00",
     "fetched_at": "2026-05-10T00:08:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "9e2c72c341ccb151044ecae6c165dcd325902b21debcc327e058a2104f697461",
     "paths": {
@@ -15662,12 +15662,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver’s City Council rejected Flock surveilance, but Axon is just as bad (Opinion)",
+    "title": "Denver\u2019s City Council rejected Flock surveilance, but Axon is just as bad (Opinion)",
     "byline": "Jennifer Piper",
     "published_at": "2026-03-23T15:36:37+00:00",
     "fetched_at": "2026-05-10T04:14:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "4705cf1fb8d69a338bac3be284a38551b819c2ed795370e1afe265ebd4581d0b",
     "paths": {
@@ -15739,12 +15739,12 @@
     "source_domain": "redrocknews.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Coconino County Sheriff’s Office installs Flock Cameras - Sedona Red Rock News",
+    "title": "Coconino County Sheriff\u2019s Office installs Flock Cameras - Sedona Red Rock News",
     "byline": "Joseph K Giddens",
     "published_at": "2025-09-08T13:37:00+00:00",
     "fetched_at": "2026-05-10T04:11:02Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "205325432128bf381204113b65491494b780cfb95c96261695692580b52c741e",
     "paths": {
@@ -15902,7 +15902,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T04:09:02Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 245 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 245 pts, HIGH/CRITICAL findings",
     "scanner_score": 245,
     "content_hash": "d8044a3c92980dc29f05f9c0880b1c74744b4b890db1c227d49813b561790d40",
     "paths": {
@@ -16059,7 +16059,7 @@
     "published_at": "2/24/2026 10:12:32 AM",
     "fetched_at": "2026-05-10T07:39:56Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "f1c7432dc58a48aeeaf650ab2a4755bf45c0d523d267ad588992b50530baf1dc",
     "paths": {
@@ -16129,7 +16129,7 @@
     "published_at": "2026-02-24T17:12:04+00:00",
     "fetched_at": "2026-05-10T07:35:27Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 145 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 145 pts, HIGH/CRITICAL findings",
     "scanner_score": 145,
     "content_hash": "8c51667ad06da13fdd7f0933cd11b035ee98018811d0d28d885c03437894e2ca",
     "paths": {
@@ -16190,7 +16190,7 @@
         "paragraph_idx": 8
       },
       {
-        "quote": "The new deal will also have a shorter retention policy for the photos the cameras snap — 21 days instead of 30 days under Flock.",
+        "quote": "The new deal will also have a shorter retention policy for the photos the cameras snap \u2014 21 days instead of 30 days under Flock.",
         "paragraph_idx": 11
       },
       {
@@ -16210,12 +16210,12 @@
     "source_domain": "redrocknews.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Watchdog eyes Sedona’s ALPR cameras - Sedona Red Rock News",
+    "title": "Watchdog eyes Sedona\u2019s ALPR cameras - Sedona Red Rock News",
     "byline": "Christopher Fox Graham",
     "published_at": "2025-07-20T13:54:00+00:00",
     "fetched_at": "2026-05-10T07:37:18Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 114 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 114 pts, HIGH/CRITICAL findings",
     "scanner_score": 114,
     "content_hash": "c25d2252f2c9e28db266e6dbd6b8b60b9338b413ba65685bbb8ed0996989115f",
     "paths": {
@@ -16300,7 +16300,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T09:54:15Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 16 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 16 pts, HIGH/CRITICAL findings",
     "scanner_score": 16,
     "content_hash": "0d4c4bd4c7a1ad6dc17ecc9ee2692ef6bea6eb25a4d7950576b8f25392e4acb7",
     "paths": {
@@ -16376,7 +16376,7 @@
     "published_at": "2026-01-14T03:15:19+00:00",
     "fetched_at": "2026-05-10T09:47:37Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 139 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 139 pts, HIGH/CRITICAL findings",
     "scanner_score": 139,
     "content_hash": "1246e23fc82cb654f6aa6153847de4a106016c551e4bdb390aa82eb4b056d846",
     "paths": {
@@ -16485,7 +16485,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T09:46:18Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 239 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 239 pts, HIGH/CRITICAL findings",
     "scanner_score": 239,
     "content_hash": "8cb4be3952abb172e4a1a54697f85dcbe9cf76f93cec0822cb627c78c92ba647",
     "paths": {
@@ -16646,7 +16646,7 @@
     "published_at": "2026-04-15T16:47:03-07:00",
     "fetched_at": "2026-05-10T09:51:19Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "fe050ab331b27823178ee4410331977a6aafcc97ae504a768cccdd63ebf384e0",
     "paths": {
@@ -16801,7 +16801,7 @@
     "published_at": "2025-05-15T10:04:08Z",
     "fetched_at": "2026-05-10T11:11:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 73 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 73 pts, HIGH/CRITICAL findings",
     "scanner_score": 73,
     "content_hash": "3d5749d3871987c2ad9d3a695ea15d14db36e8f85fb597f5c951d132e3ff76f1",
     "paths": {
@@ -16947,7 +16947,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T11:15:08Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "CLEAN — no findings",
+    "scanner_verdict": "CLEAN \u2014 no findings",
     "scanner_score": 0,
     "content_hash": "e8845dd235ccba766afddb67a1c5641d2fcb5bd8e6816c3e7ed9129af53bbebd",
     "paths": {
@@ -16981,7 +16981,7 @@
     "published_at": "2026-02-16T09:55:38-08:00",
     "fetched_at": "2026-05-10T11:17:08Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "43d01e36684821ba17b9786eb4ef64de283fa245ab5bc2d7e16ec60cf462d728",
     "paths": {
@@ -17054,12 +17054,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver considers kicking out Flock — but still using license plate cameras",
+    "title": "Denver considers kicking out Flock \u2014 but still using license plate cameras",
     "byline": "Elliott Wenzler",
     "published_at": "2026-02-16T20:39:03+00:00",
     "fetched_at": "2026-05-10T13:55:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 146 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 146 pts, HIGH/CRITICAL findings",
     "scanner_score": 146,
     "content_hash": "19cf8f6b63d64b134060f8c4d614c8a89ee0ff9a7910a80a70da7cedee696689",
     "paths": {
@@ -17108,7 +17108,7 @@
         ]
       }
     ],
-    "summary": "Denver is soliciting new bids for license plate reader services as its Flock contract ends March 31, potentially replacing Flock while continuing to use ALPR technology. The mayor's office cited community feedback and concerns over data sharing — including 1,400+ immigration-related searches of Denver data — as reasons for considering a new provider.",
+    "summary": "Denver is soliciting new bids for license plate reader services as its Flock contract ends March 31, potentially replacing Flock while continuing to use ALPR technology. The mayor's office cited community feedback and concerns over data sharing \u2014 including 1,400+ immigration-related searches of Denver data \u2014 as reasons for considering a new provider.",
     "key_quotes": [
       {
         "quote": "We are currently fielding bids for license plate reader services",
@@ -17140,7 +17140,7 @@
     "published_at": "2025-11-18T17:25:51+00:00",
     "fetched_at": "2026-05-10T13:53:28Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "caa6cf9f54281a13addb37cbc2ebad97a492f4f19e3ada43dbdc77849c997e14",
     "paths": {
@@ -17265,10 +17265,10 @@
         ]
       }
     ],
-    "summary": "Multiple Washington state police agencies — including Stanwood, Sedro-Woolley, Redmond, Lynnwood, and Skamania County — have turned off their Flock Safety ALPR cameras around the time of a Skagit County Superior Court ruling that ALPR images and data are public records subject to disclosure under Washington's Public Records Act. The article also notes Border Patrol searches of Flock data at 18 WA agencies and an ICE-related incident in Redmond.",
+    "summary": "Multiple Washington state police agencies \u2014 including Stanwood, Sedro-Woolley, Redmond, Lynnwood, and Skamania County \u2014 have turned off their Flock Safety ALPR cameras around the time of a Skagit County Superior Court ruling that ALPR images and data are public records subject to disclosure under Washington's Public Records Act. The article also notes Border Patrol searches of Flock data at 18 WA agencies and an ICE-related incident in Redmond.",
     "key_quotes": [
       {
-        "quote": "The Flock images generated by the Flock cameras … are public records",
+        "quote": "The Flock images generated by the Flock cameras \u2026 are public records",
         "paragraph_idx": 7
       },
       {
@@ -17295,7 +17295,7 @@
     "published_at": "2026-02-19T00:00:02Z",
     "fetched_at": "2026-05-10T13:56:41Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 141 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 141 pts, HIGH/CRITICAL findings",
     "scanner_score": 141,
     "content_hash": "29105c459dc612c875a20de5aa6d1d8c5d22ce9539c09c42f877b533d2c164f9",
     "paths": {
@@ -17370,7 +17370,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T15:11:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 185 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 185 pts, HIGH/CRITICAL findings",
     "scanner_score": 185,
     "content_hash": "485ddec34b8bf0e8a9c8eebf04b72d4e1f906f9b48e766587e8231efd28e3f06",
     "paths": {
@@ -17501,7 +17501,7 @@
     "summary": "The Walla Walla Police Department shut down its Flock Safety ALPR program after a Washington court ruling made the camera images subject to public records disclosure. Officials cited an overwhelming volume of disclosure requests, legal liability from the 30-day auto-deletion, and safety concerns that stalkers or PIs could obtain victims' location data.",
     "key_quotes": [
       {
-        "quote": "So our cameras are not active — they are not taking pictures — and at some point Flock is going to show up and take their cameras back",
+        "quote": "So our cameras are not active \u2014 they are not taking pictures \u2014 and at some point Flock is going to show up and take their cameras back",
         "paragraph_idx": 11
       },
       {
@@ -17521,12 +17521,12 @@
     "source_domain": "denverpost.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver’s new license plate reader deal is for 50 cameras — less than half as many as Flock has now",
+    "title": "Denver\u2019s new license plate reader deal is for 50 cameras \u2014 less than half as many as Flock has now",
     "byline": "Elliott Wenzler",
     "published_at": "2026-03-11T22:45:10+00:00",
     "fetched_at": "2026-05-10T15:12:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "cee454f7963c1ce1de989f38ca08d7e8d1e0b3afd398b826a508911b16bd7733",
     "paths": {
@@ -17610,7 +17610,7 @@
     "published_at": "4/1/2026 5:24:20 PM",
     "fetched_at": "2026-05-10T15:14:16Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 158 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 158 pts, HIGH/CRITICAL findings",
     "scanner_score": 158,
     "content_hash": "8d165b1d113b037acce426a8b7a332d9d30792855fd027c9b10f6cd4227eb29c",
     "paths": {
@@ -17693,7 +17693,7 @@
     "published_at": "2025-12-16T22:04:50+00:00",
     "fetched_at": "2026-05-10T16:09:47Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 35 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 35 pts, HIGH/CRITICAL findings",
     "scanner_score": 35,
     "content_hash": "580587fae693aef658a7ded1b871846853609dada697c0b6e32d0f7cd0779322",
     "paths": {
@@ -17747,12 +17747,12 @@
     "source_domain": "kiro7.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Pierce County Sheriff’s Office deactivates its automated license plate readers",
+    "title": "Pierce County Sheriff\u2019s Office deactivates its automated license plate readers",
     "byline": "KIRO 7 News Staff",
     "published_at": "2026-03-31T02:02:59.261Z",
     "fetched_at": "2026-05-10T16:14:22Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "8e1a0e8123b70a3ec8a132549a5824ad1b30554089d7290b3054d4b9c0223dcd",
     "paths": {
@@ -17826,7 +17826,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T16:08:09Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 189 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 189 pts, HIGH/CRITICAL findings",
     "scanner_score": 189,
     "content_hash": "b3e424063c94f2dce0954349d8f7898244c356272ca3b6715a402b8296b4a5e5",
     "paths": {
@@ -17965,7 +17965,7 @@
     "published_at": "2026-04-21T23:13:30.215",
     "fetched_at": "2026-05-10T16:12:43Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 104 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 104 pts, HIGH/CRITICAL findings",
     "scanner_score": 104,
     "content_hash": "a9f8dcc8ce760071a0a4ecdbb94e8fc8e19223f9f97ef946f7c96e0f7c436b03",
     "paths": {
@@ -18047,12 +18047,12 @@
     "source_domain": "theolympian.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Olympia council hears privacy concerns about license plate cameras. What’s next?",
+    "title": "Olympia council hears privacy concerns about license plate cameras. What\u2019s next?",
     "byline": "Ty Vinson",
     "published_at": "2025-11-24T08:38:44-08:00",
     "fetched_at": "2026-05-10T16:11:11Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "c4763988dfdcfc0d6af3405abfaddb04c773728f652e6f79a1582ac106bb3209",
     "paths": {
@@ -18213,7 +18213,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T17:13:39Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "fd39d235d89dc9b1c331f67aca98dfd1665b0a5fa0bbc7863f18278d04c39c3c",
     "paths": {
@@ -18352,7 +18352,7 @@
     "published_at": "2025-06-18T17:55:13+00:00",
     "fetched_at": "2026-05-10T17:11:43Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 83 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 83 pts, HIGH/CRITICAL findings",
     "scanner_score": 83,
     "content_hash": "2c39c0f1a77ba81080c4fd82cd152e4a5bd0f2b84cc5fbd3d1a9e58c743dd311",
     "paths": {
@@ -18415,7 +18415,7 @@
     "published_at": "2025-02-06T18:55:19.431",
     "fetched_at": "2026-05-10T17:19:07Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "065c7d03cd3b78f9d565877e4ad5dd5b413a3af57f04fc8a91bd9c2272cbc7c3",
     "paths": {
@@ -18519,7 +18519,7 @@
     "published_at": "2025-06-04T14:45:48.039",
     "fetched_at": "2026-05-10T17:17:19Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 22 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 22 pts, low/medium only",
     "scanner_score": 22,
     "content_hash": "140d383370d48dd488f8f6238d693014d94f61e01dfc8dc08ec0ee156263aa8a",
     "paths": {
@@ -18591,7 +18591,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T17:15:31Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 8 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 8 pts, HIGH/CRITICAL findings",
     "scanner_score": 8,
     "content_hash": "9b8bf4dd3102caa40045b3fb539bb30b72c13c474186e76f9fa84c9b6b7f8bff",
     "paths": {
@@ -18619,12 +18619,12 @@
     "source_domain": "heraldnet.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Automated license plate reader bill heads to governor’s desk - HeraldNet.com",
+    "title": "Automated license plate reader bill heads to governor\u2019s desk - HeraldNet.com",
     "byline": "Jenna Peterson",
     "published_at": "2026-03-12T08:30:00+00:00",
     "fetched_at": "2026-05-10T19:20:40Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 52 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 52 pts, HIGH/CRITICAL findings",
     "scanner_score": 52,
     "content_hash": "08a9226dc21e28148257309c4aebcfb2739bc148179256bb7157588f9f2225e6",
     "paths": {
@@ -18737,7 +18737,7 @@
         "paragraph_idx": 18
       },
       {
-        "quote": "federal agencies — including U.S. Customs and Border Protection — accessed several Flock networks in the county without police departments' knowledge",
+        "quote": "federal agencies \u2014 including U.S. Customs and Border Protection \u2014 accessed several Flock networks in the county without police departments' knowledge",
         "paragraph_idx": 7
       }
     ],
@@ -18756,7 +18756,7 @@
     "published_at": "2026-05-08T16:14:26-07:00",
     "fetched_at": "2026-05-10T19:19:22Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 102 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 102 pts, HIGH/CRITICAL findings",
     "scanner_score": 102,
     "content_hash": "752f0fb089231bd92d653f077ca3d02865ca1aa8b95db22effe1bdce287a9b90",
     "paths": {
@@ -18889,12 +18889,12 @@
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Did new law shut down Pierce County license-plate readers? Here’s what we know",
+    "title": "Did new law shut down Pierce County license-plate readers? Here\u2019s what we know",
     "byline": "Shea Johnson",
     "published_at": "2026-04-10T05:00:00-07:00",
     "fetched_at": "2026-05-10T19:26:14Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "f8b43b19a2d45b72c3416123f68bb2d071cca9137bf12a2f994d576fec68d3fb",
     "paths": {
@@ -19002,7 +19002,7 @@
         ]
       }
     ],
-    "summary": "After Washington Gov. Ferguson signed SB 6002 (the Driver Privacy Act), several Pierce County-area law enforcement agencies — including the Pierce County Sheriff's Office, Tacoma PD, and Puyallup PD — deactivated their mobile dashboard-mounted ALPRs, saying they can't comply with the law's location restrictions in real time. The bill's sponsor, Sen. Yasmin Trudeau, says the law permits ALPR use with guardrails and that agencies chose to pause on their own; Stanwood reactivated its Flock system after a compliance review.",
+    "summary": "After Washington Gov. Ferguson signed SB 6002 (the Driver Privacy Act), several Pierce County-area law enforcement agencies \u2014 including the Pierce County Sheriff's Office, Tacoma PD, and Puyallup PD \u2014 deactivated their mobile dashboard-mounted ALPRs, saying they can't comply with the law's location restrictions in real time. The bill's sponsor, Sen. Yasmin Trudeau, says the law permits ALPR use with guardrails and that agencies chose to pause on their own; Stanwood reactivated its Flock system after a compliance review.",
     "key_quotes": [
       {
         "quote": "The Pierce County Sheriff's Office recently deactivated more than 250 license-plate readers, declaring that a new state law made it legally risky, at least right now, to maintain the technology equipped in all of its patrol vehicles.",
@@ -19039,7 +19039,7 @@
     "published_at": "2018-02-07T22:31:46+00:00",
     "fetched_at": "2026-05-10T21:09:15Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 2 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 2 pts, low/medium only",
     "scanner_score": 2,
     "content_hash": "1ba8b22490b3ef26adc63c178d51d1209b2d17b8979b6c9004d787908253ee19",
     "paths": {
@@ -19116,7 +19116,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T21:02:39Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 161 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 161 pts, HIGH/CRITICAL findings",
     "scanner_score": 161,
     "content_hash": "9cc096a68d63172bf1caca734d30cf353c130ed27442c6144296a469fdcc4c51",
     "paths": {
@@ -19214,7 +19214,7 @@
     "published_at": "2026-04-02T23:41:27-07:00",
     "fetched_at": "2026-05-10T21:05:55Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "0c03259893a4839894595724615f48a4ed30ec97328612d84c9a4539c130a69e",
     "paths": {
@@ -19344,7 +19344,7 @@
     "published_at": "2025-11-10T04:59:45",
     "fetched_at": "2026-05-10T21:03:59Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 5 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 5 pts, low/medium only",
     "scanner_score": 5,
     "content_hash": "0bcda0ac93e94e1d00b2861bd6342bedb84aee3ee68cb78697c49e9c066fbcc2",
     "paths": {
@@ -19400,7 +19400,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T22:02:30Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 49 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 49 pts, HIGH/CRITICAL findings",
     "scanner_score": 49,
     "content_hash": "d2db2e949556dd98b2390b21132dbd755fabee9f6c15299d1bf6f11a74c96391",
     "paths": {
@@ -19459,7 +19459,7 @@
     "published_at": null,
     "fetched_at": "2026-05-10T22:01:08Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 169 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 169 pts, HIGH/CRITICAL findings",
     "scanner_score": 169,
     "content_hash": "a14afb9fa705ee26922ddead237216820a85e9c06c09de95dc322c7427ffffec",
     "paths": {
@@ -19536,7 +19536,7 @@
     "published_at": "2026-04-10",
     "fetched_at": "2026-05-10T23:09:49Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "402a76d8eb5f47a277c41c867ff0d3ab7f0f49e7bc72f601a0dcf1663d14cef3",
     "paths": {
@@ -19679,7 +19679,7 @@
     "published_at": "2026-03-13T05:15:00-07:00",
     "fetched_at": "2026-05-10T23:02:23Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "cdeff918b506ce97d534a7d9d60044a99a4bf5f764cdd67e0182dd1f98439238",
     "paths": {
@@ -19804,7 +19804,7 @@
     "published_at": "2026-02-05T05:00:00-08:00",
     "fetched_at": "2026-05-10T23:06:01Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "a8eef2a5cb44b38b9eaf30f0d2fff7d320a4157713c817e4d7be5cd3783498c3",
     "paths": {
@@ -19912,7 +19912,7 @@
     "published_at": null,
     "fetched_at": "2026-05-11T00:11:40Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 239 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 239 pts, HIGH/CRITICAL findings",
     "scanner_score": 239,
     "content_hash": "40a0c43fe6626caedeb1bc620101a0d66e1e93291a7f53ebe78c2245450d1c34",
     "paths": {
@@ -20048,12 +20048,12 @@
     "source_domain": "chronline.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "A new Oregon law regulates police use of license plate readers. Here’s how it works - The Daily Chronicle",
+    "title": "A new Oregon law regulates police use of license plate readers. Here\u2019s how it works - The Daily Chronicle",
     "byline": "Shaanth Nanguneri / Oregon Capital Chronicle",
     "published_at": "2026-04-23",
     "fetched_at": "2026-05-11T00:10:22Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 4 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 4 pts, low/medium only",
     "scanner_score": 4,
     "content_hash": "327df261f3243fe4731a456542a6094a8dbae19b44e73437f4815d01cfa7cba1",
     "paths": {
@@ -20212,7 +20212,7 @@
     "published_at": null,
     "fetched_at": "2026-05-11T00:05:17Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "8dd7b55318f4ee6e1bc476a78e461281b24eefd09d396cc172c17c867a20f4ab",
     "paths": {
@@ -20369,7 +20369,7 @@
     "published_at": "2026-05-08T07:06:02-07:00",
     "fetched_at": "2026-05-11T00:03:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 20 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 20 pts, HIGH/CRITICAL findings",
     "scanner_score": 20,
     "content_hash": "864d666dc146c8b232eafbf856160423a1b681be108766f9eb3f7d6d48c98ad4",
     "paths": {
@@ -20464,12 +20464,12 @@
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Pierce County Sheriff’s Office to deactivate its license-plate reader cameras",
+    "title": "Pierce County Sheriff\u2019s Office to deactivate its license-plate reader cameras",
     "byline": "Puneet Bsanti",
     "published_at": "2026-03-31T09:55:29-07:00",
     "fetched_at": "2026-05-11T04:24:48Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "73f671dd4adfa4b1671fbcce5e38041f123e85cce3d3ac9551a0e3e0ca4c3b67",
     "paths": {
@@ -20507,7 +20507,7 @@
         ]
       }
     ],
-    "summary": "The Pierce County Sheriff's Office announced it will deactivate its Flock ALPR cameras after Washington Gov. Bob Ferguson signed SB 6002 (the Driver Privacy Act), which restricts ALPR data retention, bans cameras near sensitive locations like schools and hospitals, and prohibits ALPR use for immigration enforcement. Sheriff Keith Swank said compliance risk—including gross misdemeanor liability—drove the decision and warned solve rates will drop.",
+    "summary": "The Pierce County Sheriff's Office announced it will deactivate its Flock ALPR cameras after Washington Gov. Bob Ferguson signed SB 6002 (the Driver Privacy Act), which restricts ALPR data retention, bans cameras near sensitive locations like schools and hospitals, and prohibits ALPR use for immigration enforcement. Sheriff Keith Swank said compliance risk\u2014including gross misdemeanor liability\u2014drove the decision and warned solve rates will drop.",
     "key_quotes": [
       {
         "quote": "The Sheriff's Office said in a news release the continued use of the ALPR system, or Flock cameras, would place deputies at risk of unintentionally violating the new state law.",
@@ -20537,7 +20537,7 @@
     "published_at": "2025-10-23T18:48:55+00:00",
     "fetched_at": "2026-05-11T22:25:53Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 132 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 132 pts, HIGH/CRITICAL findings",
     "scanner_score": 132,
     "content_hash": "f8f77c18f2f5544d88e2feee98cc35cecec727858d37aaae978964194ee22fae",
     "paths": {
@@ -20573,7 +20573,7 @@
     "published_at": "2025-11-20T00:03:04+00:00",
     "fetched_at": "2026-05-11T22:17:36Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 161 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 161 pts, HIGH/CRITICAL findings",
     "scanner_score": 161,
     "content_hash": "24c70da28734635fbbf06c1b0081e98e0f21c9edd1facf542c16221e3fb70bdf",
     "paths": {
@@ -20734,7 +20734,7 @@
     "published_at": null,
     "fetched_at": "2026-05-11T22:22:39Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "b40fb232ad63afb7c282a3c975f2ab108b04d406001bc4910384727e583b00d0",
     "paths": {
@@ -20882,7 +20882,7 @@
     "published_at": "2025-03-23T05:00:00-07:00",
     "fetched_at": "2026-05-11T22:19:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "0d997772d6f548de63e2a258d4d6dc30f4825e747af33d7098fcd77b039bd196",
     "paths": {
@@ -20998,7 +20998,7 @@
     "published_at": "2026-04-11T11:28:11-07:00",
     "fetched_at": "2026-05-11T22:24:07Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 6 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 6 pts, low/medium only",
     "scanner_score": 6,
     "content_hash": "c85c7aeeee657a7c2d52ddd1195e4c498d9f2ccab634badaea3017e8a0dd1234",
     "paths": {
@@ -21109,7 +21109,7 @@
     "published_at": "2025-09-24T07:29:47+00:00",
     "fetched_at": "2026-05-11T23:24:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 205 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 205 pts, HIGH/CRITICAL findings",
     "scanner_score": 205,
     "content_hash": "7638cc37bb5b19134aed6111a5673c408da9e64321d06b6c28568aa1632ba0c0",
     "paths": {
@@ -21211,7 +21211,7 @@
     "published_at": "2026-01-20T18:40:14+00:00",
     "fetched_at": "2026-05-11T23:25:04Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "c5aefb5da8e02e238267f094b4a6e4940d9ed12d7f8d0d26bfe3b1238c4d9495",
     "paths": {
@@ -21338,12 +21338,12 @@
     "source_domain": "thenewstribune.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "License plate cameras are controversial. Here’s what one Pierce County city decided",
+    "title": "License plate cameras are controversial. Here\u2019s what one Pierce County city decided",
     "byline": "Julia Park",
     "published_at": "2025-03-26T09:54:30-07:00",
     "fetched_at": "2026-05-11T23:24:24Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "WARNINGS — 7 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 7 pts, low/medium only",
     "scanner_score": 7,
     "content_hash": "21a6f35db06148760f24ac911ebc09b3d3313a051aa96712a7841d322f000f82",
     "paths": {
@@ -21447,7 +21447,7 @@
     "published_at": "2026-05-08T07:06:02-07:00",
     "fetched_at": "2026-05-11T23:24:49Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 19 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 19 pts, HIGH/CRITICAL findings",
     "scanner_score": 19,
     "content_hash": "913f96ad5bf6595db0eb3b2cbb4af1a7be8e4a73f7e8024977d2a8d550b3a658",
     "paths": {
@@ -21540,7 +21540,7 @@
     "published_at": "2024-01-02T23:09:26+00:00",
     "fetched_at": "2026-05-12T00:09:29Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 141 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 141 pts, HIGH/CRITICAL findings",
     "scanner_score": 141,
     "content_hash": "1bab592d7afd4558d7ce4b632245b0ea3db16313bd0bb2c77a5c9b4a620207b0",
     "paths": {
@@ -21601,12 +21601,12 @@
     "source_domain": "oaklandside.org",
     "tier": 2,
     "stance": "neutral",
-    "title": "CHP to control Oakland’s 300-camera vehicle surveillance network",
+    "title": "CHP to control Oakland\u2019s 300-camera vehicle surveillance network",
     "byline": "Eli Wolfe",
     "published_at": "2024-02-08T23:16:37+00:00",
     "fetched_at": "2026-05-12T00:14:31Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 164 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 164 pts, HIGH/CRITICAL findings",
     "scanner_score": 164,
     "content_hash": "40f389a3c439303cf837e837542ea1578ce66fa7556e58dbdc34ecc9c4c9575f",
     "paths": {
@@ -21763,7 +21763,7 @@
     "published_at": "2025-09-02T17:57:35+00:00",
     "fetched_at": "2026-05-12T00:12:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "e5d72dc49656a105b2121c56fbd5fc38d14fd6b395b4dc02a69d69b063061a8b",
     "paths": {
@@ -21899,7 +21899,7 @@
     "published_at": null,
     "fetched_at": "2026-05-12T00:16:13Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "4b48dcc2bf10c92a8a45bfec2e14a80c8f58e591a4a51f4d265c3de213728ba7",
     "paths": {
@@ -21933,7 +21933,7 @@
     "published_at": null,
     "fetched_at": "2026-05-12T00:07:58Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "3065e7ac029212d6f00a1801473db88150fd1cb315e6cb45c50855e8d71af663",
     "paths": {
@@ -22092,7 +22092,7 @@
     "published_at": "2024-03-01T22:00:00+00:00",
     "fetched_at": "2026-05-12T04:53:19Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 123 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 123 pts, HIGH/CRITICAL findings",
     "scanner_score": 123,
     "content_hash": "3568f14f674ca2051478a4865b452d45804aed1b64efa9d10953294cff78869b",
     "paths": {
@@ -22193,7 +22193,7 @@
     "published_at": "2023-05-11T19:40:57.992Z",
     "fetched_at": "2026-05-12T04:51:49Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "679408239b25ae8ad605cf625ba4922f378569795076ffe8e41299bcfa146904",
     "paths": {
@@ -22269,7 +22269,7 @@
     "published_at": "2026-04-02T21:21:41.876Z",
     "fetched_at": "2026-05-12T04:48:18Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "7bcfaaa4bed42a3be6b476a2a1a4f4ab52d841acdf95140fdd43c14e2c64202b",
     "paths": {
@@ -22361,7 +22361,7 @@
     "published_at": "10/25/2025 8:43:21 AM",
     "fetched_at": "2026-05-12T04:50:00Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 124 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 124 pts, HIGH/CRITICAL findings",
     "scanner_score": 124,
     "content_hash": "68bc2c1d4e5b52c2a3e4d05588f162d049086358f053fd22149f72d99c6df295",
     "paths": {
@@ -22416,7 +22416,7 @@
     "published_at": "2025-12-04",
     "fetched_at": "2026-05-12T04:46:28Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 15 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 15 pts, low/medium only",
     "scanner_score": 15,
     "content_hash": "57db636de09f2b3cceb5d3fbc6da3e58df45cccc6ec004f533d91d08c4bb483a",
     "paths": {
@@ -22489,7 +22489,7 @@
     "published_at": "2025-09-24T17:23:32.577Z",
     "fetched_at": "2026-05-12T07:52:22Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "6d0d9dbe47b91d1773b6aaf423ca37eb1a488c1a21f52334243cdbd02667929c",
     "paths": {
@@ -22580,7 +22580,7 @@
     "published_at": "2026-04-22T21:23:50.075Z",
     "fetched_at": "2026-05-12T07:58:30Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "ab5e85fad94de01c13118dd60653b0de882c2550da5b243e64dbd44cce9705f4",
     "paths": {
@@ -22660,7 +22660,7 @@
     "published_at": "11/6/2025 6:52:04 PM",
     "fetched_at": "2026-05-12T07:55:22Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 140 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 140 pts, HIGH/CRITICAL findings",
     "scanner_score": 140,
     "content_hash": "bbd0455d51ccb02a2d8bc27717de28543089f01e011ffe6bd0b78b94d3a7ec9d",
     "paths": {
@@ -22816,7 +22816,7 @@
     "published_at": "6/3/2025 9:42:13 PM",
     "fetched_at": "2026-05-12T07:56:59Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "daa86a38baea6fc55cebd19cba740cd49f8a43740e34e92c3d6a58cd02db69e0",
     "paths": {
@@ -22887,12 +22887,12 @@
     "source_domain": "opb.org",
     "tier": 1,
     "stance": "unknown",
-    "title": "A new Oregon law regulates police use of license plate readers. Here’s how it works",
+    "title": "A new Oregon law regulates police use of license plate readers. Here\u2019s how it works",
     "byline": "Shaanth Nanguneri",
     "published_at": "2026-04-23",
     "fetched_at": "2026-05-12T07:53:53Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 26 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 26 pts, HIGH/CRITICAL findings",
     "scanner_score": 26,
     "content_hash": "b704c32f0f9aaba33e8db5f1918f306ac73c20b4eabdcb93c91a62a129846e64",
     "paths": {
@@ -23024,7 +23024,7 @@
     "published_at": null,
     "fetched_at": "2026-05-12T08:00:36Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 3 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 3 pts, low/medium only",
     "scanner_score": 3,
     "content_hash": "f22c95d4a2dadb566957bf1a3fb3f2aa8c50f03eb7624b4a0a76c8faa9a77f43",
     "paths": {
@@ -23058,7 +23058,7 @@
     "published_at": "2025-09-18T14:27:54+00:00",
     "fetched_at": "2026-05-12T10:47:55Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 61 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 61 pts, HIGH/CRITICAL findings",
     "scanner_score": 61,
     "content_hash": "b30ad71c8c0c3dd1b79c238b78c1df8facd3bf7283effd0e3fb6b5f9c9612223",
     "paths": {
@@ -23154,7 +23154,7 @@
     "published_at": "2023-12-07T02:00:00+00:00",
     "fetched_at": "2026-05-12T10:40:31Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 115 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 115 pts, HIGH/CRITICAL findings",
     "scanner_score": 115,
     "content_hash": "5be2391221447799eff328f7cfb529f6705011292b85761ff7126b58c3447292",
     "paths": {
@@ -23293,7 +23293,7 @@
     "published_at": "2025-12-12T18:06:25.329Z",
     "fetched_at": "2026-05-12T10:42:17Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 26 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 26 pts, HIGH/CRITICAL findings",
     "scanner_score": 26,
     "content_hash": "8d8ae639bc791cd64a8c3a0dfc8c5a309ebf5323bcd8cb11ab2cd92df938666a",
     "paths": {
@@ -23368,12 +23368,12 @@
     "source_domain": "kiro7.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Redmond Police temporarily shut down ‘Flock’ license plate reader program",
+    "title": "Redmond Police temporarily shut down \u2018Flock\u2019 license plate reader program",
     "byline": "Frank Lenzi",
     "published_at": "2025-11-06T13:50:29.316Z",
     "fetched_at": "2026-05-12T10:44:58Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "1166e1a37b3e762b279a7389c96698c487d988f5f6be876facb687f4d27f3bc9",
     "paths": {
@@ -23462,7 +23462,7 @@
     "published_at": "2025-01-27T23:38:56.03Z",
     "fetched_at": "2026-05-12T10:46:18Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "0b0c5712bee4c631b2245aae44cab811aa1d6a21e9113e627b6059b87b026bc6",
     "paths": {
@@ -23541,7 +23541,7 @@
     "published_at": "2024-05-15T22:25:00+00:00",
     "fetched_at": "2026-05-12T13:10:43Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 123 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 123 pts, HIGH/CRITICAL findings",
     "scanner_score": 123,
     "content_hash": "dbe885c0c3a1bc560f57f28ee3e4be24af66011e5758ccdd8160ae66365219bb",
     "paths": {
@@ -23596,7 +23596,7 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": "New York State's Division of Criminal Justice Services awarded roughly $450,000 to several Tompkins County–area law enforcement agencies for technology upgrades, part of a $127 million statewide grant program. Over half of statewide funding will go toward license plate readers, body/vehicle cameras, and public safety camera systems; local recipients plan to spend funds on 3D crime scanners, radios, in-car systems, and (for Trumansburg) a license plate reader.",
+    "summary": "New York State's Division of Criminal Justice Services awarded roughly $450,000 to several Tompkins County\u2013area law enforcement agencies for technology upgrades, part of a $127 million statewide grant program. Over half of statewide funding will go toward license plate readers, body/vehicle cameras, and public safety camera systems; local recipients plan to spend funds on 3D crime scanners, radios, in-car systems, and (for Trumansburg) a license plate reader.",
     "key_quotes": [
       {
         "quote": "The department has been without technologies most departments would consider essential since Nelson became chief about five years ago, such as a license plate reader and functioning portable radios.",
@@ -23621,7 +23621,7 @@
     "published_at": "2024-12-10T06:39:32.548Z",
     "fetched_at": "2026-05-12T13:16:59Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "1fb7b3dff1d686770f4ef64ff364224de957814a49ece630575d6cb48da80c85",
     "paths": {
@@ -23694,7 +23694,7 @@
     "published_at": "1/20/2026 5:15:34 PM",
     "fetched_at": "2026-05-12T13:12:39Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 124 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 124 pts, HIGH/CRITICAL findings",
     "scanner_score": 124,
     "content_hash": "be39304049ba6eeff4ee374750d0d7be511f1f4c20f1d17ad986c5ef9a1dab35",
     "paths": {
@@ -23838,7 +23838,7 @@
     "published_at": null,
     "fetched_at": "2026-05-12T13:18:48Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 200 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 200 pts, HIGH/CRITICAL findings",
     "scanner_score": 200,
     "content_hash": "a69c0b5506f152b99da0baee82ece06c4c82ce90df770a70b9fecbc7e64d8a49",
     "paths": {
@@ -23978,7 +23978,7 @@
     "published_at": "2025-07-19T12:00:00+00:00",
     "fetched_at": "2026-05-12T16:31:26Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 227 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 227 pts, HIGH/CRITICAL findings",
     "scanner_score": 227,
     "content_hash": "5a58f4c98c538748388af3edb9930cd135e46d0de7355c0f07c970b8cb612fc1",
     "paths": {
@@ -24155,7 +24155,7 @@
     "published_at": "2025-06-13T13:27:48+00:00",
     "fetched_at": "2026-05-12T16:37:11Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 159 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 159 pts, HIGH/CRITICAL findings",
     "scanner_score": 159,
     "content_hash": "23d7d70ac0fa01756bd933272ef6d6b0a3d885903e3223a66c872f5827fce711",
     "paths": {
@@ -24292,7 +24292,7 @@
       "4a1c911b-5e90-53fd-805e-3b55f344434d",
       "ba107933-2f9d-5af5-836f-72a35dd288ba"
     ],
-    "summary": "Illinois Secretary of State Alexi Giannoulias ordered a statewide audit of Flock Safety license plate readers after 404 Media reported that out-of-state police used the network to search Illinois data—including Mount Prospect and Danville—for abortion and immigration-related investigations, in possible violation of a 2023 state law. Flock revoked access for 46 out-of-state agencies. The article details Evanston's 18 Flock cameras, its $242,500 five-year renewal, and EPD's stated policies barring immigration and reproductive-health uses.",
+    "summary": "Illinois Secretary of State Alexi Giannoulias ordered a statewide audit of Flock Safety license plate readers after 404 Media reported that out-of-state police used the network to search Illinois data\u2014including Mount Prospect and Danville\u2014for abortion and immigration-related investigations, in possible violation of a 2023 state law. Flock revoked access for 46 out-of-state agencies. The article details Evanston's 18 Flock cameras, its $242,500 five-year renewal, and EPD's stated policies barring immigration and reproductive-health uses.",
     "key_quotes": [
       {
         "quote": "the Mount Prospect Police Department was included in a May 9 search by the Johnson County (Texas) Sheriff's Office looking for a woman who it said had a self-administered abortion",
@@ -24325,7 +24325,7 @@
     "published_at": "2025-06-13T17:20:00+00:00",
     "fetched_at": "2026-05-12T16:39:02Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 123 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 123 pts, HIGH/CRITICAL findings",
     "scanner_score": 123,
     "content_hash": "794007889413e392dd47c89122d95a000e0ea062647967bb677dd80586a578a8",
     "paths": {
@@ -24415,7 +24415,7 @@
     "published_at": "2025-11-26T03:07:37.25Z",
     "fetched_at": "2026-05-12T16:33:14Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "a5307ffd4500d43ac06e8b3aaa609c8572c9cb3cf12f2c2902591741dbee58cd",
     "paths": {
@@ -24476,7 +24476,7 @@
     "summary": "The Coralville city council voted to amend its ALPR policy, clarifying when officers can act on Flock camera alerts and expanding data sharing with North Liberty PD and University of Iowa PD. Council members remain divided over the 30-day data retention window, with some worried about potential ICE access.",
     "key_quotes": [
       {
-        "quote": "the council clarified when officers can take action based on alerts from the Flock cameras and expanded data sharing with other agencies that already use the technology in Johnson County — North Liberty and the University of Iowa Police Department.",
+        "quote": "the council clarified when officers can take action based on alerts from the Flock cameras and expanded data sharing with other agencies that already use the technology in Johnson County \u2014 North Liberty and the University of Iowa Police Department.",
         "paragraph_idx": 4
       },
       {
@@ -24498,7 +24498,7 @@
     "published_at": "2025-12-07T05:41:30.533Z",
     "fetched_at": "2026-05-12T16:35:20Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 27 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 27 pts, low/medium only",
     "scanner_score": 27,
     "content_hash": "20b17147f6e9a76ace4e050e289a9a83e4fcf87eb6bc83c4c0f4e20d23c4fca5",
     "paths": {
@@ -24660,7 +24660,7 @@
     "published_at": "2025-12-22T15:35:11Z",
     "fetched_at": "2026-05-12T16:29:51Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 37 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 37 pts, HIGH/CRITICAL findings",
     "scanner_score": 37,
     "content_hash": "cf25965231585b5fc42fafb59928f8bf723a078a625ee7ac1a9e8b4ff8581e50",
     "paths": {
@@ -24727,7 +24727,7 @@
     "published_at": "2025-07-16T20:22:00+00:00",
     "fetched_at": "2026-05-12T19:10:52Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 193 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 193 pts, HIGH/CRITICAL findings",
     "scanner_score": 193,
     "content_hash": "d77f28e2475040bf41e81c24aa0605ce6646f8beec0de2696084bb10f10802e9",
     "paths": {
@@ -24834,7 +24834,7 @@
     "published_at": "2017-09-02T04:08:31Z",
     "fetched_at": "2026-05-12T19:05:34Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 26 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 26 pts, HIGH/CRITICAL findings",
     "scanner_score": 26,
     "content_hash": "9ea0af61b8ef45786918e993f0e599a24f9b7ca75b796583379403ca6f90793f",
     "paths": {
@@ -24898,7 +24898,7 @@
     "published_at": "2024-06-13T16:42:39.872Z",
     "fetched_at": "2026-05-12T19:08:44Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "a413c1b6da3904e5557bf991b1aa8225b36b2bdd9e46ade013fa95f58ae4bf01",
     "paths": {
@@ -24974,7 +24974,7 @@
     "published_at": "6/2/2025 10:14:58 PM",
     "fetched_at": "2026-05-12T19:13:58Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 155 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 155 pts, HIGH/CRITICAL findings",
     "scanner_score": 155,
     "content_hash": "a3d0a3e7081e7b10f46bae3411ce398ea366ed37cfb613d36ee1152b66d4efb9",
     "paths": {
@@ -25113,7 +25113,7 @@
     "published_at": "2025-07-29T18:19:06+00:00",
     "fetched_at": "2026-05-12T19:12:32Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "483b724381840b19efb1ee027b85ab1b3479ef3711c5208a9c3b8090c0c7af52",
     "paths": {
@@ -25219,7 +25219,7 @@
     "published_at": "2025-02-04T20:16:59.194Z",
     "fetched_at": "2026-05-12T19:06:55Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "1cae05d91ad2c432e22917f0377c0a1c1abef8dfedfb9a5ac6b31c27c7b297a3",
     "paths": {
@@ -25306,7 +25306,7 @@
     "published_at": "2026-04-01T01:44:25+00:00",
     "fetched_at": "2026-05-12T20:48:56Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "c266c253c72231a90b5166dc7c60971c390cae70dfc179497e45800827ab8e91",
     "paths": {
@@ -25371,7 +25371,7 @@
         "paragraph_idx": 2
       },
       {
-        "quote": "with these strengthened privacy and data protections, we are ensuring that no federal agency or federal agent can access this data—now or ever.",
+        "quote": "with these strengthened privacy and data protections, we are ensuring that no federal agency or federal agent can access this data\u2014now or ever.",
         "paragraph_idx": 5
       },
       {
@@ -25393,7 +25393,7 @@
     "published_at": "2025-08-28T13:38:34+00:00",
     "fetched_at": "2026-05-12T20:52:29Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 148 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 148 pts, HIGH/CRITICAL findings",
     "scanner_score": 148,
     "content_hash": "1f10e8c68b58fb984d7f09c5020b6cc7bf5e4f107fc5edcf9844e8ee3b26a747",
     "paths": {
@@ -25477,7 +25477,7 @@
     "published_at": "2024-05-14T15:40:05.384Z",
     "fetched_at": "2026-05-12T20:54:16Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "bba02f2dd436c6e49667fde91d3d484e7bd018c59c287839942b920abbc90c06",
     "paths": {
@@ -25552,7 +25552,7 @@
     "published_at": null,
     "fetched_at": "2026-05-12T20:56:22Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 271 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 271 pts, HIGH/CRITICAL findings",
     "scanner_score": 271,
     "content_hash": "1d951554372010163f8e67f26a4db96d98eaf64bc598bb123a5462ac554c6220",
     "paths": {
@@ -25697,7 +25697,7 @@
     "published_at": "2022-02-04T18:16:50",
     "fetched_at": "2026-05-12T20:50:37Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 36 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 36 pts, low/medium only",
     "scanner_score": 36,
     "content_hash": "497ddd82a837242f1b06339413e65ab12fd7993f67bf5b7bb001b8cc61e25d62",
     "paths": {
@@ -25821,12 +25821,12 @@
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver mayor extends Flock camera contract against council’s wishes",
+    "title": "Denver mayor extends Flock camera contract against council\u2019s wishes",
     "byline": null,
     "published_at": "2025-10-22T18:27:34+00:00",
     "fetched_at": "2026-05-12T22:21:12Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "bcc441d2713aee1aca9ae331ead85cbedaa196c8da79c0b4d64013fad266c0bc",
     "paths": {
@@ -25969,7 +25969,7 @@
     "published_at": "2026-04-21T18:24:39.532Z",
     "fetched_at": "2026-05-12T22:22:31Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 28 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 28 pts, low/medium only",
     "scanner_score": 28,
     "content_hash": "c77e58d10932bdc8a2f58b1670a73fcd2ee72c2a13c1d9aa80d73c6a1126416a",
     "paths": {
@@ -26121,7 +26121,7 @@
     "published_at": "10/10/2025 2:09:31 PM",
     "fetched_at": "2026-05-12T22:28:53Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "a85613f43b5776a3cb5739608a9c1825c364ee63a21377bbb3b50b10377b98f9",
     "paths": {
@@ -26210,7 +26210,7 @@
     "published_at": "2025-08-07T21:52:42+00:00",
     "fetched_at": "2026-05-12T22:27:02Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "41de4eb35f0b98961f6aaf8f769d6ebd9b7b63ece2d7de29be750dc310cf7f4c",
     "paths": {
@@ -26352,7 +26352,7 @@
     "published_at": "2025-07-22T18:28:41",
     "fetched_at": "2026-05-12T22:23:49Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 35 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 35 pts, low/medium only",
     "scanner_score": 35,
     "content_hash": "ab6b5cb8f71a3fb8301b6802e00d33ac4ff8792252edca335d4cd8fd2bbd0171",
     "paths": {
@@ -26454,7 +26454,7 @@
     "published_at": "2026-03-24T02:48:41+00:00",
     "fetched_at": "2026-05-13T00:11:52Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "50e0ac0aa50c81e33a911a52832fc70f31af3c9a2a842ff6edfdef56158e82c8",
     "paths": {
@@ -26553,7 +26553,7 @@
     "published_at": "2026-04-23T20:46:21.186Z",
     "fetched_at": "2026-05-13T00:13:29Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "WARNINGS — 26 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 26 pts, low/medium only",
     "scanner_score": 26,
     "content_hash": "9ad3f1df6376de47552d9be3a9b30a72a9163e9f91967ab67f7405512d2179b5",
     "paths": {
@@ -26660,7 +26660,7 @@
     "published_at": "11/19/2025 9:14:08 PM",
     "fetched_at": "2026-05-13T00:17:06Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 124 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 124 pts, HIGH/CRITICAL findings",
     "scanner_score": 124,
     "content_hash": "2bd674cbaeeae3be0c97b44d72dbf2fd12aa6901afb33774539d39a8e9c12cd6",
     "paths": {
@@ -26822,7 +26822,7 @@
     "published_at": "6/13/2025 12:54:28 PM",
     "fetched_at": "2026-05-13T00:15:04Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 121 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 121 pts, HIGH/CRITICAL findings",
     "scanner_score": 121,
     "content_hash": "c1204e1873894302554fdc357c6bc7976b054fd2ee06a24e01992fa50c8c613d",
     "paths": {
@@ -26898,7 +26898,7 @@
     "published_at": null,
     "fetched_at": "2026-05-13T00:20:26Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 263 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 263 pts, HIGH/CRITICAL findings",
     "scanner_score": 263,
     "content_hash": "7112f5460808a93b4aee0840bc1b0262bc510d92c16888fc15dd1822a0bab8cd",
     "paths": {
@@ -27045,7 +27045,7 @@
     "published_at": "2026-03-27T19:01:25+00:00",
     "fetched_at": "2026-05-13T04:56:51Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "ca7bae76523e7fb4b8d8da189674512df1b7faf95c6c8a01ecff6cc14d38efa7",
     "paths": {
@@ -27108,7 +27108,7 @@
         "paragraph_idx": 3
       },
       {
-        "quote": "The city’s agreement with Flock ends March 31.",
+        "quote": "The city\u2019s agreement with Flock ends March 31.",
         "paragraph_idx": 3
       }
     ],
@@ -27126,7 +27126,7 @@
     "published_at": "2025-09-25T21:46:46+00:00",
     "fetched_at": "2026-05-13T05:05:42Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 185 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 185 pts, HIGH/CRITICAL findings",
     "scanner_score": 185,
     "content_hash": "3739eebf355d22e87ebb2b7712805634a48b867a576812050ec8b5fd7b53d2ee",
     "paths": {
@@ -27203,7 +27203,7 @@
     "published_at": "2025-12-10T15:00:12.649Z",
     "fetched_at": "2026-05-13T04:58:46Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "8e8dedea20c16f76bce2313ee4746d74181db75bb4f90b5b1f0962309500a29b",
     "paths": {
@@ -27343,7 +27343,7 @@
     "published_at": "2/18/2026 6:16:50 PM",
     "fetched_at": "2026-05-13T05:04:20Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 137 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 137 pts, HIGH/CRITICAL findings",
     "scanner_score": 137,
     "content_hash": "a7d40953f9459e66d2d0e32afb892cc0ca7a92f407ddb0df3f40010830dd38ca",
     "paths": {
@@ -27432,7 +27432,7 @@
     "published_at": null,
     "fetched_at": "2026-05-13T05:02:18Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 255 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 255 pts, HIGH/CRITICAL findings",
     "scanner_score": 255,
     "content_hash": "e1b3f49bc0bd1f37a724a3f07e8f37e97f4c54a07ca33dd0da8ed13f4ad45eed",
     "paths": {
@@ -27573,12 +27573,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Oak Park board divided on  license plate reading tech - Wednesday Journal",
+    "title": "Oak Park board divided on\u00a0 license plate reading tech - Wednesday Journal",
     "byline": "Stacey Sheridan",
     "published_at": "2022-03-22T20:17:48+00:00",
     "fetched_at": "2026-05-13T05:00:31Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "1f5f2c46183ff971fc82a34057220af0f651d661882f3461d4c0de795b51222f",
     "paths": {
@@ -27697,7 +27697,7 @@
     "published_at": "2024-06-05T16:00:00+00:00",
     "fetched_at": "2026-05-13T08:07:51Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "3c9dc37dbb1456b9a777f0c54685d3a4d201daa70e59d183ddcf448cee74c95f",
     "paths": {
@@ -27779,7 +27779,7 @@
     "published_at": "2023-08-08T04:31:34.615Z",
     "fetched_at": "2026-05-13T08:09:39Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "eb062a5476a6713966f7e40f84c4d165078404220ccd629df461b5e441fcccc7",
     "paths": {
@@ -27855,7 +27855,7 @@
     "published_at": "5/17/2023 10:34:26 PM",
     "fetched_at": "2026-05-13T08:11:00Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 155 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 155 pts, HIGH/CRITICAL findings",
     "scanner_score": 155,
     "content_hash": "85fe2b0f0a2e73d8ae1fdc8176856af25b514ab79562a40dff35bc8f521debc9",
     "paths": {
@@ -27920,12 +27920,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Don’t throw Flock out with the bath water - Wednesday Journal",
+    "title": "Don\u2019t throw Flock out with the bath water - Wednesday Journal",
     "byline": "Rhoda Bernstein",
     "published_at": "2025-08-19T18:32:42+00:00",
     "fetched_at": "2026-05-13T08:12:30Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 89 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 89 pts, HIGH/CRITICAL findings",
     "scanner_score": 89,
     "content_hash": "fe36e9d319ade40ac4d395e594bd28bb01b6d9c9a1e3c3ca698af0be2453e8d7",
     "paths": {
@@ -28036,12 +28036,12 @@
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Denver mayor’s office requests delay on Axon ALPR contract vote",
+    "title": "Denver mayor\u2019s office requests delay on Axon ALPR contract vote",
     "byline": null,
     "published_at": "2026-03-11T19:20:59+00:00",
     "fetched_at": "2026-05-13T11:37:36Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "f4977fa83b78e63d6467087dad2966d8dfdd6235fa253ec421b3a3306bfcd34a",
     "paths": {
@@ -28143,7 +28143,7 @@
     "published_at": "2025-08-27T02:28:01+00:00",
     "fetched_at": "2026-05-13T11:44:28Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 216 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 216 pts, HIGH/CRITICAL findings",
     "scanner_score": 216,
     "content_hash": "7ca7451ab45c0aca0d2fb84d0e1541db7d9f2ff305a2754e2eb073a2b3471080",
     "paths": {
@@ -28257,7 +28257,7 @@
     "published_at": "2025-01-10T23:07:17.031Z",
     "fetched_at": "2026-05-13T11:39:11Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 28 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 28 pts, HIGH/CRITICAL findings",
     "scanner_score": 28,
     "content_hash": "6822db3bc9bd8d6f9e16b524f59c62f0cdc6b6273f3ff4a1d0795f5e86434c72",
     "paths": {
@@ -28344,7 +28344,7 @@
     "published_at": "6/3/2025 5:22:32 PM",
     "fetched_at": "2026-05-13T11:36:11Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 155 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 155 pts, HIGH/CRITICAL findings",
     "scanner_score": 155,
     "content_hash": "fdcb2e5db12002bd36199a039b8f8ab7ea6e3a30d883bb9ebe3bdfeaec32b072",
     "paths": {
@@ -28428,12 +28428,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "New reports emerge on Border Patrol use of Flock cameras  - Wednesday Journal",
+    "title": "New reports emerge on Border Patrol use of Flock cameras\u00a0 - Wednesday Journal",
     "byline": "Brendan Heffernan",
     "published_at": "2025-12-02T21:18:04+00:00",
     "fetched_at": "2026-05-13T11:42:56Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 89 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 89 pts, HIGH/CRITICAL findings",
     "scanner_score": 89,
     "content_hash": "31b6e27ef19f66a2b4ad898480f40c38b632a34c974a676ce6263efdd9da7296",
     "paths": {
@@ -28573,7 +28573,7 @@
     "published_at": "2026-02-23T06:00:00-08:00",
     "fetched_at": "2026-05-13T11:40:49Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 82 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 82 pts, HIGH/CRITICAL findings",
     "scanner_score": 82,
     "content_hash": "50d97406a904b6543edf36ef9eee0e85bafce415c5d77b8f1716c5b518c9ecf7",
     "paths": {
@@ -28711,7 +28711,7 @@
     "summary": "A Seattle Times explainer on automated license plate readers in Washington state, describing how ALPRs work, their proliferation via state grants, controversies including federal access to data, a Skagit County ruling making footage public, and pending state legislation that would set the first WA-wide ALPR regulations. The piece notes multiple WA cities have turned off cameras and mentions Lynnwood's upcoming vote on terminating its Flock contract.",
     "key_quotes": [
       {
-        "quote": "University of Washington researchers published a report showing U.S. Border Patrol had searched the Flock Safety databases of at least 18 police departments in the state — often without their knowledge.",
+        "quote": "University of Washington researchers published a report showing U.S. Border Patrol had searched the Flock Safety databases of at least 18 police departments in the state \u2014 often without their knowledge.",
         "paragraph_idx": 26
       },
       {
@@ -28736,12 +28736,12 @@
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Big Brother or crime fighter? Elbert County says ‘no’ to license plate readers",
+    "title": "Big Brother or crime fighter? Elbert County says \u2018no\u2019 to license plate readers",
     "byline": null,
     "published_at": "2024-02-17T19:00:00+00:00",
     "fetched_at": "2026-05-13T14:57:50Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 197 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 197 pts, HIGH/CRITICAL findings",
     "scanner_score": 197,
     "content_hash": "61df575455af8e0545ce2b6da770c47b1c2f16fbf12fe928577e64b028bd3c6c",
     "paths": {
@@ -28896,7 +28896,7 @@
     "published_at": "2025-08-18T21:24:46.137",
     "fetched_at": "2026-05-13T15:03:53Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "658ba5608847220efe478367129aa083fad14aefb013b1d7ffbe3fa91c4e383d",
     "paths": {
@@ -29022,7 +29022,7 @@
     "published_at": "2025-08-21T03:15:45.486Z",
     "fetched_at": "2026-05-13T14:59:29Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "16d9df69f9451782e1ce1c5e47b7740e12315e43180e6f7307b430c0bf038016",
     "paths": {
@@ -29128,7 +29128,7 @@
     "published_at": "8/25/2025 5:46:45 PM",
     "fetched_at": "2026-05-13T14:56:14Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 155 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 155 pts, HIGH/CRITICAL findings",
     "scanner_score": 155,
     "content_hash": "6ae92fb8eaad0f0cc1aa97eaa6c9271a06888d54f668b4d8e2fedbeaa9669dbc",
     "paths": {
@@ -29185,7 +29185,7 @@
     "published_at": "2026-04-27T23:06:07.221",
     "fetched_at": "2026-05-13T15:02:16Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 79 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 79 pts, HIGH/CRITICAL findings",
     "scanner_score": 79,
     "content_hash": "71f8ea2a5e3c0ca690a83e47a07eb7789ab825d54c902fd5da7cb3a0dc6d5752",
     "paths": {
@@ -29299,12 +29299,12 @@
     "source_domain": "denvergazette.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "Council panel insists on more robust discussion on Denver’s Flock dealings",
+    "title": "Council panel insists on more robust discussion on Denver\u2019s Flock dealings",
     "byline": null,
     "published_at": "2025-10-29T23:13:00+00:00",
     "fetched_at": "2026-05-13T17:22:47Z",
     "discovered_by": "backfill:google-search-2026-05-11",
-    "scanner_verdict": "REVIEW REQUIRED — 187 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 187 pts, HIGH/CRITICAL findings",
     "scanner_score": 187,
     "content_hash": "aefc88f1d5da7927e4608f81badbc4b7688efa39148c4ab423f368b467c94675",
     "paths": {
@@ -29448,7 +29448,7 @@
     "published_at": "2026-04-09T16:33:09.776",
     "fetched_at": "2026-05-13T17:24:38Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "93c1c9ef42f19b32681393953ea76e11a2c6e03bc15527ec33aefee3aa310726",
     "paths": {
@@ -29592,7 +29592,7 @@
     "summary": "More than 180 Michigan law enforcement agencies now use Flock Safety ALPR technology, up from about 60 in 2022, prompting privacy concerns and a bipartisan state bill (HB 5492/5493) that would require data deletion after 14 days (likely amended to 30) and quarterly transparency reports. The article surveys deployments in Waterford Township, Detroit, Grand Rapids, Warren, and Oakland County, and examines concerns about ICE access to LPR data.",
     "key_quotes": [
       {
-        "quote": "Statewide, more than 180 law enforcement agencies ― nearly a third of all agencies in Michigan ― now use Flock Safety technology",
+        "quote": "Statewide, more than 180 law enforcement agencies \u2015 nearly a third of all agencies in Michigan \u2015 now use Flock Safety technology",
         "paragraph_idx": 7
       },
       {
@@ -29617,12 +29617,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Consultant tells Oak Park to hire full-time police oversight staffer  - Wednesday Journal",
+    "title": "Consultant tells Oak Park to hire full-time police oversight staffer\u00a0 - Wednesday Journal",
     "byline": "Brendan Heffernan",
     "published_at": "2025-09-11T19:42:49+00:00",
     "fetched_at": "2026-05-13T17:30:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 89 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 89 pts, HIGH/CRITICAL findings",
     "scanner_score": 89,
     "content_hash": "73bbd10394797eca57be449c43da0a9639db5e8b561503b82fe39de01bf6a566",
     "paths": {
@@ -29739,7 +29739,7 @@
     "summary": "A consulting firm, Pivot, recommended that Oak Park hire a full-time staffer to support its Citizen Police Oversight Committee (CPOC), modeled on Cambridge, MA's oversight board. The recommendations follow the village board's recent vote to cancel its Flock Safety ALPR contract over immigration enforcement concerns, and include standardizing CPOC's role in reviewing new police surveillance technology.",
     "key_quotes": [
       {
-        "quote": "The set of recommendations comes after the village board voted to cancel the department's contract with Flock Safety — turning off the eight license plate reading cameras the company operated in town citing concerns that the cameras helped aid federal immigration enforcement.",
+        "quote": "The set of recommendations comes after the village board voted to cancel the department's contract with Flock Safety \u2014 turning off the eight license plate reading cameras the company operated in town citing concerns that the cameras helped aid federal immigration enforcement.",
         "paragraph_idx": 17
       },
       {
@@ -29761,7 +29761,7 @@
     "published_at": "2025-10-29T19:21:11+00:00",
     "fetched_at": "2026-05-13T20:11:25Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 134 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 134 pts, HIGH/CRITICAL findings",
     "scanner_score": 134,
     "content_hash": "cae5c155a95fa927ec5f8f9fed7269d3c24acd7fc16b638661d6bb52fc0772c2",
     "paths": {
@@ -29835,7 +29835,7 @@
     "published_at": "2025-12-17T19:53:18+00:00",
     "fetched_at": "2026-05-13T20:10:10Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 157 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 157 pts, HIGH/CRITICAL findings",
     "scanner_score": 157,
     "content_hash": "9a37f6d6907bf84d1c23c15d4b1e7cc0d50ba2af4b66e449158b360da0780026",
     "paths": {
@@ -29981,7 +29981,7 @@
     "published_at": "2026-04-29T18:30:00",
     "fetched_at": "2026-05-13T21:43:46Z",
     "discovered_by": "inglewood-outbound-drop research",
-    "scanner_verdict": "REVIEW REQUIRED — 78 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 78 pts, HIGH/CRITICAL findings",
     "scanner_score": 78,
     "content_hash": "afc467b92ff75e92c1435d2d4224e8cf51ee1be6b4430ff6f1e0d07003a5bab7",
     "paths": {
@@ -30058,7 +30058,7 @@
     "published_at": "2026-01-28T20:56:11+00:00",
     "fetched_at": "2026-05-13T21:51:33Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 56 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 56 pts, HIGH/CRITICAL findings",
     "scanner_score": 56,
     "content_hash": "49bbd3505f58684d85c00bd284f72ed88bf5263ed7f1770b62a7f1aeaef5f6a9",
     "paths": {
@@ -30104,7 +30104,7 @@
     "published_at": "2024-03-29T17:57:12+00:00",
     "fetched_at": "2026-05-13T21:48:17Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 151 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 151 pts, HIGH/CRITICAL findings",
     "scanner_score": 151,
     "content_hash": "4de2f6808d2c8db6bb9e29ef1b3a0feeb9813c949d453b8baf70ca47f70312a2",
     "paths": {
@@ -30257,7 +30257,7 @@
     "published_at": null,
     "fetched_at": "2026-05-13T21:46:22Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "57f281f80b7d0e207c01f13aeb11c9b6ff19d713f9ba025082b53991e39c160f",
     "paths": {
@@ -30390,7 +30390,7 @@
     "summary": "The Half Moon Bay City Council discussed whether to install automated license plate readers, with a majority expressing interest pending more information on efficacy, privacy, and peer-city policies. The council had previously declined ALPRs in 2019, and the ACLU sent a letter warning of misuse, while business representatives supported installing cameras downtown.",
     "key_quotes": [
       {
-        "quote": "The City Council originally declined the use of ALPRs in 2019 pending a state audit into their usage — which found that the technology often lacked sufficient policy and audit oversight, according to a staff report.",
+        "quote": "The City Council originally declined the use of ALPRs in 2019 pending a state audit into their usage \u2014 which found that the technology often lacked sufficient policy and audit oversight, according to a staff report.",
         "paragraph_idx": 4
       },
       {
@@ -30420,7 +30420,7 @@
     "published_at": null,
     "fetched_at": "2026-05-13T23:17:15Z",
     "discovered_by": "inglewood-outbound-drop research",
-    "scanner_verdict": "REVIEW REQUIRED — 40 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 40 pts, HIGH/CRITICAL findings",
     "scanner_score": 40,
     "content_hash": "07442e9f555091e00549b2dabdf48d931e0d21c2453b5f31db5389dd64c00a24",
     "paths": {
@@ -30552,12 +30552,12 @@
     "source_domain": "oaklandside.org",
     "tier": 2,
     "stance": "neutral",
-    "title": "Sheriff’s deputies thought they'd stopped a criminal. But license plate cameras led them to the wrong person",
+    "title": "Sheriff\u2019s deputies thought they'd stopped a criminal. But license plate cameras led them to the wrong person",
     "byline": "Eli Wolfe",
     "published_at": "2026-03-23T17:12:17+00:00",
     "fetched_at": "2026-05-13T23:21:56Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 167 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 167 pts, HIGH/CRITICAL findings",
     "scanner_score": 167,
     "content_hash": "d0638134dfe77bdfbf7d053c15c4538491aa0df996223bd5f7f8d2fdb647bec0",
     "paths": {
@@ -30714,12 +30714,12 @@
     "source_domain": "oaklandside.org",
     "tier": 2,
     "stance": "neutral",
-    "title": "2 Oakland privacy commissioners resign: ‘I felt like nothing I was doing mattered’",
+    "title": "2 Oakland privacy commissioners resign: \u2018I felt like nothing I was doing mattered\u2019",
     "byline": "Roselyn Romero",
     "published_at": "2025-11-13T00:55:44+00:00",
     "fetched_at": "2026-05-14T04:09:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 161 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 161 pts, HIGH/CRITICAL findings",
     "scanner_score": 161,
     "content_hash": "5ade939cebddf3af975b8f9a080515e469755e57d1613488682f8cb63f6703ad",
     "paths": {
@@ -30840,7 +30840,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T04:15:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "2db6f6ac33cf5ac1c6e858ae4f085741b817d216c449b4170b212e10747e8feb",
     "paths": {
@@ -31005,7 +31005,7 @@
     "published_at": "2025-08-12T18:47:46+00:00",
     "fetched_at": "2026-05-14T07:57:46Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 89 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 89 pts, HIGH/CRITICAL findings",
     "scanner_score": 89,
     "content_hash": "30d3874001e93fadd3fd8441fd7779ea073138b1751bfc4b2b056bc2613e363e",
     "paths": {
@@ -31105,7 +31105,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T07:56:33Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "50d3087936e1db11170fe07e4d2c7853812c73f1f08a1ce8e2e3de4d5788a5ef",
     "paths": {
@@ -31262,12 +31262,12 @@
     "source_domain": "epic.org",
     "tier": 2,
     "stance": "critical",
-    "title": "EPIC Encourages CalPrivacy to Enact Independent Testing and Inspection Requirements for Data Broker Audits",
+    "title": "EPIC\u00a0Encourages\u00a0CalPrivacy\u00a0to Enact\u00a0Independent Testing\u00a0and Inspection Requirements\u00a0for Data Broker Audits",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-14T10:31:41Z",
     "discovered_by": "rss:epic.org",
-    "scanner_verdict": "REVIEW REQUIRED — 19 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 19 pts, HIGH/CRITICAL findings",
     "scanner_score": 19,
     "content_hash": "5d9440d9c144b836d83aea9e485a367d533f70056688062bd012e85f3fa21b6f",
     "paths": {
@@ -31322,7 +31322,7 @@
     "published_at": "2026-02-11T17:41:39+00:00",
     "fetched_at": "2026-05-14T10:34:32Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 151 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 151 pts, HIGH/CRITICAL findings",
     "scanner_score": 151,
     "content_hash": "21ba6237a819a5f55ee255da116b0d10ec8e29160d0d9641aa0c20ea9c323087",
     "paths": {
@@ -31481,7 +31481,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T10:30:04Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 8 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 8 pts, HIGH/CRITICAL findings",
     "scanner_score": 8,
     "content_hash": "9b8bf4dd3102caa40045b3fb539bb30b72c13c474186e76f9fa84c9b6b7f8bff",
     "paths": {
@@ -31514,7 +31514,7 @@
     "published_at": "2025-06-24T09:20:19+00:00",
     "fetched_at": "2026-05-14T13:09:42Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 155 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 155 pts, HIGH/CRITICAL findings",
     "scanner_score": 155,
     "content_hash": "0236abf94a014d83bb5b2a04cae8d08639e7f8f8757e0a644be80bc709aa6d47",
     "paths": {
@@ -31637,7 +31637,7 @@
     "published_at": "2024-03-27T22:31:55+00:00",
     "fetched_at": "2026-05-14T13:06:25Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 163 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 163 pts, HIGH/CRITICAL findings",
     "scanner_score": 163,
     "content_hash": "821c67f68b7096f37ca974a1c60110c7827be9842216303627c2891250a2a201",
     "paths": {
@@ -31807,7 +31807,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T13:01:43Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "134c58688ffde5fb200ab69f302d16d13f8f8996b20028ace800d4281c3d6af2",
     "paths": {
@@ -31965,7 +31965,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T13:07:56Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 18 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 18 pts, HIGH/CRITICAL findings",
     "scanner_score": 18,
     "content_hash": "1013dd44ac807a2ac4264d77000d5c92cd4fe36f5d36fdd62f884b1e1a67f1e2",
     "paths": {
@@ -32012,7 +32012,7 @@
       }
     ],
     "primary_subject_agency_ids": [],
-    "summary": "Seattle Mayor Katie Wilson paused expansion of police surveillance cameras—installing but not activating 26 new cameras south of downtown—and commissioned an NYU Policing Project privacy and data governance audit. She also ordered SPD to switch off ALPR systems on 400 patrol cars and 6 parking enforcement vehicles, citing a new state law prohibiting ALPR use near schools, courthouses, and other locations.",
+    "summary": "Seattle Mayor Katie Wilson paused expansion of police surveillance cameras\u2014installing but not activating 26 new cameras south of downtown\u2014and commissioned an NYU Policing Project privacy and data governance audit. She also ordered SPD to switch off ALPR systems on 400 patrol cars and 6 parking enforcement vehicles, citing a new state law prohibiting ALPR use near schools, courthouses, and other locations.",
     "key_quotes": [
       {
         "quote": "the Mayor ordered the Seattle Police Department (\"SPD\") to switch off its Automated License Plate Reader (\"ALPR\") systems installed on 400 patrol cars and 6 parking enforcement vehicles",
@@ -32041,7 +32041,7 @@
     "published_at": "2025-07-03T05:43:41+00:00",
     "fetched_at": "2026-05-14T15:30:24Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 143 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 143 pts, HIGH/CRITICAL findings",
     "scanner_score": 143,
     "content_hash": "ec7f265e6665f539dd5108384500a59ec2a1065873f2fdec24760805a75cd421",
     "paths": {
@@ -32124,12 +32124,12 @@
     "source_domain": "lookouteugene-springfield.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Lane County Sheriff’s Office suspends Flock Safety contract",
+    "title": "Lane County Sheriff\u2019s Office suspends Flock Safety contract",
     "byline": "Jaime Adame",
     "published_at": "2025-12-10T23:51:26+00:00",
     "fetched_at": "2026-05-14T15:36:56Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 179 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 179 pts, HIGH/CRITICAL findings",
     "scanner_score": 179,
     "content_hash": "354ba012c3dce500a454730e3032b670de2254445fbb1121517049b3fd3401e0",
     "paths": {
@@ -32259,12 +32259,12 @@
     "source_domain": "mlive.com",
     "tier": 1,
     "stance": "unknown",
-    "title": "4 key takeaways from Oakland County’s Flock Safety drone program",
+    "title": "4 key takeaways from Oakland County\u2019s Flock Safety drone program",
     "byline": "Advance Local Express Desk",
     "published_at": "2026-04-23T13:38:34.235Z",
     "fetched_at": "2026-05-14T15:32:05Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "WARNINGS — 9 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 9 pts, low/medium only",
     "scanner_score": 9,
     "content_hash": "b0d5d2e4a243176896c8b8b95b63555e8985ef4f9a4cec77a603158166761e82",
     "paths": {
@@ -32418,7 +32418,7 @@
     "published_at": "2026-03-13T19:12:03+00:00",
     "fetched_at": "2026-05-14T15:33:34Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 173 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 173 pts, HIGH/CRITICAL findings",
     "scanner_score": 173,
     "content_hash": "8958444d44476f70b57f4c8e5e39cc195c80afa3b9788c0efda0e567f1d1364b",
     "paths": {
@@ -32566,7 +32566,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T15:28:31Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "3e821c47153a698b242385e21d41e122ac309ba33784624fce20db7c0b8b4988",
     "paths": {
@@ -32723,7 +32723,7 @@
     "published_at": "2025-11-04T18:10:06+00:00",
     "fetched_at": "2026-05-14T18:12:44Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 128 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 128 pts, HIGH/CRITICAL findings",
     "scanner_score": 128,
     "content_hash": "1fbe04fcac421aeacd7fc2c5fb2eb13a6164985a9450c60d2cce3aa094f13a93",
     "paths": {
@@ -32769,7 +32769,7 @@
     "published_at": "2026-02-27T23:14:32+00:00",
     "fetched_at": "2026-05-14T18:06:03Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 170 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 170 pts, HIGH/CRITICAL findings",
     "scanner_score": 170,
     "content_hash": "c72888d1ddd606102606b7622b85fa9a710ea71e64006b3922d181a0552df29f",
     "paths": {
@@ -32901,7 +32901,7 @@
     "published_at": "2025-11-18T16:50:00Z",
     "fetched_at": "2026-05-14T18:13:57Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "WARNINGS — 11 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 11 pts, low/medium only",
     "scanner_score": 11,
     "content_hash": "71ddcc669d839fb6a3986589961381236ce857c022cb0a76dc440e7c45ca1b76",
     "paths": {
@@ -33055,7 +33055,7 @@
     "published_at": "2025-11-20T23:11:00+00:00",
     "fetched_at": "2026-05-14T18:07:46Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 161 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 161 pts, HIGH/CRITICAL findings",
     "scanner_score": 161,
     "content_hash": "d03f463fe03d0c4d84a1f47e504a7e9651acc0a8eb8c5404aaff6fa8967c1be6",
     "paths": {
@@ -33214,7 +33214,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T20:07:07Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 199 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 199 pts, HIGH/CRITICAL findings",
     "scanner_score": 199,
     "content_hash": "32122241f5623e2efd0d016839a2ef022a371feffc74183c62fe1ae3027be34d",
     "paths": {
@@ -33353,7 +33353,7 @@
     "published_at": "2025-09-03T08:37:27+00:00",
     "fetched_at": "2026-05-14T20:00:50Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 204 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 204 pts, HIGH/CRITICAL findings",
     "scanner_score": 204,
     "content_hash": "6e8d0ec59f7cebecca184f2a3ccbc78096a8fc5096c86a4654069025de04d3bc",
     "paths": {
@@ -33472,7 +33472,7 @@
     "published_at": "2025-10-10T13:00:00+00:00",
     "fetched_at": "2026-05-14T21:21:57Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 142 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 142 pts, HIGH/CRITICAL findings",
     "scanner_score": 142,
     "content_hash": "a61b00c2c57e989534277aa1e146665266785c127932c51223af07c3177b795e",
     "paths": {
@@ -33511,7 +33511,7 @@
         "paragraph_idx": 20
       },
       {
-        "quote": "I am very concerned that someone driving by Chestnut Hill Realty properties … could get tagged, not see the sign and that we could be facilitating abuses",
+        "quote": "I am very concerned that someone driving by Chestnut Hill Realty properties \u2026 could get tagged, not see the sign and that we could be facilitating abuses",
         "paragraph_idx": 25
       }
     ],
@@ -33529,7 +33529,7 @@
     "published_at": "2026-03-27T23:04:50+00:00",
     "fetched_at": "2026-05-14T21:28:22Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 331 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 331 pts, HIGH/CRITICAL findings",
     "scanner_score": 331,
     "content_hash": "f4f0b17fc5acaa9d753c43fd88b9e8ec82349242b058edf1fc901d215a0ee726",
     "paths": {
@@ -33651,7 +33651,7 @@
     "published_at": "2025-10-14T20:09:49+00:00",
     "fetched_at": "2026-05-14T23:15:09Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 127 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 127 pts, HIGH/CRITICAL findings",
     "scanner_score": 127,
     "content_hash": "ee0334dcf2b61282b909c9c4e8a35f4ec88096c90c81ee2152cca05e865ae481",
     "paths": {
@@ -33698,7 +33698,7 @@
     "published_at": "2026-04-15T16:00:00+00:00",
     "fetched_at": "2026-05-14T23:13:34Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 138 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 138 pts, HIGH/CRITICAL findings",
     "scanner_score": 138,
     "content_hash": "b105902ec37bc16d8e2233287cb4c027b706d1429560013ec2584656161a0b88",
     "paths": {
@@ -33795,7 +33795,7 @@
     "published_at": "2025-12-06T05:24:00+00:00",
     "fetched_at": "2026-05-14T23:11:42Z",
     "discovered_by": "termination-ledger-import",
-    "scanner_verdict": "REVIEW REQUIRED — 179 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 179 pts, HIGH/CRITICAL findings",
     "scanner_score": 179,
     "content_hash": "d52b1f2f355345aeae8fa1e6f9fca899bf23dfc02a70e6a62871b551a9602b98",
     "paths": {
@@ -33916,7 +33916,7 @@
     "published_at": "2025-07-15T20:06:35+00:00",
     "fetched_at": "2026-05-14T23:10:04Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 151 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 151 pts, HIGH/CRITICAL findings",
     "scanner_score": 151,
     "content_hash": "c6562a5cd858a25722ef5b0152ea060d8ad7508eb4fa480313dcf1324e379897",
     "paths": {
@@ -34086,7 +34086,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T23:08:23Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 237 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 237 pts, HIGH/CRITICAL findings",
     "scanner_score": 237,
     "content_hash": "8e2a419f99ace8dd88891779d32058f31513838c920e8ce28112ed0db9050a53",
     "paths": {
@@ -34245,7 +34245,7 @@
     "published_at": "2025-06-16T13:29:24+00:00",
     "fetched_at": "2026-05-15T04:22:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 163 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 163 pts, HIGH/CRITICAL findings",
     "scanner_score": 163,
     "content_hash": "e873970e626ac6b22e36b1cba9ba73883afff8c5b9f5bc2b17fe9c969b6e23b0",
     "paths": {
@@ -34406,7 +34406,7 @@
     "published_at": "2025-11-18T22:12:46+00:00",
     "fetched_at": "2026-05-15T04:20:57Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 159 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 159 pts, HIGH/CRITICAL findings",
     "scanner_score": 159,
     "content_hash": "8be71b48587e26bd7b265a5c9c8dfdcd2717c1cf2c6f7d085faeef0ea9de758e",
     "paths": {
@@ -34552,12 +34552,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "RF chief stands by license plate tech but not Flock camera system  - Wednesday Journal",
+    "title": "RF chief stands by license plate tech but not Flock camera system\u00a0 - Wednesday Journal",
     "byline": "Robert J. Lifka",
     "published_at": "2025-09-02T14:43:35+00:00",
     "fetched_at": "2026-05-15T04:16:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 90 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 90 pts, HIGH/CRITICAL findings",
     "scanner_score": 90,
     "content_hash": "3b63e012861113e4924d9908ce89010844a053b9f2119350fa8b73863bbb3e11",
     "paths": {
@@ -34704,7 +34704,7 @@
     "published_at": "2026-03-05T00:55:08+00:00",
     "fetched_at": "2026-05-15T04:17:46Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 175 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 175 pts, HIGH/CRITICAL findings",
     "scanner_score": 175,
     "content_hash": "8574da8c0f9c9fb7aad2ecb42619908860eb7d02bd1581ea20da1d854bef6813",
     "paths": {
@@ -34844,7 +34844,7 @@
     "summary": "Richmond, CA City Council ran out of time to vote on whether to reactivate Flock ALPR cameras that were turned off late 2025 after a data-sharing vulnerability was discovered. Police Chief Timothy Simmons urged reinstatement, citing a 33% rise in vehicle thefts and an active trafficking case, while opponents raised data-sharing and ICE-cooperation concerns. The article also notes El Cerrito's federal-access audit and Flock's recent compliance changes.",
     "key_quotes": [
       {
-        "quote": "The Flock automated license plate reader (ALPR) system was taken offline late last year after Police Chief Timothy Simmons discovered that a back-end software feature left the data potentially accessible via a \"national lookup\" capability, creating a reciprocal data-sharing arrangement that meant outside agencies could access Richmond's data — a violation of city policy and California law.",
+        "quote": "The Flock automated license plate reader (ALPR) system was taken offline late last year after Police Chief Timothy Simmons discovered that a back-end software feature left the data potentially accessible via a \"national lookup\" capability, creating a reciprocal data-sharing arrangement that meant outside agencies could access Richmond's data \u2014 a violation of city policy and California law.",
         "paragraph_idx": 7
       },
       {
@@ -34874,7 +34874,7 @@
     "published_at": "2026-05-18T18:19:45.000Z",
     "fetched_at": "2026-05-19T10:10:03Z",
     "discovered_by": "rss:404media.co",
-    "scanner_verdict": "REVIEW REQUIRED — 43 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 43 pts, HIGH/CRITICAL findings",
     "scanner_score": 43,
     "content_hash": "68222efcedb1850f1148e09c636acd3ef9860894c38ad7cf46c6604406734dec",
     "paths": {
@@ -34900,7 +34900,7 @@
     "summary": "FBI procurement records reviewed by 404 Media show the bureau is seeking to purchase nationwide access to automated license plate reader data, which would enable warrantless tracking of vehicle movements across the country. The article notes only a few vendors, likely Flock and Motorola, could fulfill the request.",
     "key_quotes": [
       {
-        "quote": "The FBI wants to buy access to automated license plate readers (ALPRs) nationwide, which would likely allow the agency to track the movements of vehicles—and by extension people—across the country without a warrant, according to FBI procurement records reviewed by 404 Media.",
+        "quote": "The FBI wants to buy access to automated license plate readers (ALPRs) nationwide, which would likely allow the agency to track the movements of vehicles\u2014and by extension people\u2014across the country without a warrant, according to FBI procurement records reviewed by 404 Media.",
         "paragraph_idx": 3
       },
       {
@@ -34922,7 +34922,7 @@
     "published_at": "2024-07-24T21:04:42.336",
     "fetched_at": "2026-05-19T10:05:10Z",
     "discovered_by": "bing:alpr",
-    "scanner_verdict": "REVIEW REQUIRED — 38 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 38 pts, HIGH/CRITICAL findings",
     "scanner_score": 38,
     "content_hash": "f0014d3a25d43bd1880918092d9a2392a3a94cdd87c480a224e791c61e874e76",
     "paths": {
@@ -35044,7 +35044,7 @@
     "published_at": null,
     "fetched_at": "2026-05-19T10:03:28Z",
     "discovered_by": "bing:alpr",
-    "scanner_verdict": "REVIEW REQUIRED — 209 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 209 pts, HIGH/CRITICAL findings",
     "scanner_score": 209,
     "content_hash": "ef32a199e5a486aa81e27b0aff13ad4a572fd0dc92b8b625a65172170b4001b4",
     "paths": {
@@ -35200,7 +35200,7 @@
     "published_at": null,
     "fetched_at": "2026-05-19T10:11:37Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 245 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 245 pts, HIGH/CRITICAL findings",
     "scanner_score": 245,
     "content_hash": "845a2bc278e6c6ef253146b4103bc355bd0b62eb430f86bc041d5e070896c97a",
     "paths": {
@@ -35359,7 +35359,7 @@
     "published_at": "2026-05-19T21:29:33+00:00",
     "fetched_at": "2026-05-20T11:56:20Z",
     "discovered_by": "rss:arstechnica.com",
-    "scanner_verdict": "REVIEW REQUIRED — 70 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 70 pts, HIGH/CRITICAL findings",
     "scanner_score": 70,
     "content_hash": "7567482c905c67a9d04a1da6ba35d86eb0d64866581556e5ae3b64790410553a",
     "paths": {
@@ -35445,7 +35445,7 @@
     "published_at": "2026-05-20T02:07:26.122Z",
     "fetched_at": "2026-05-20T12:01:08Z",
     "discovered_by": "rss:kiro7.com",
-    "scanner_verdict": "WARNINGS — 29 pts, low/medium only",
+    "scanner_verdict": "WARNINGS \u2014 29 pts, low/medium only",
     "scanner_score": 29,
     "content_hash": "02c171d1a03ee8571caadca56dabe5367002d43d9c8a550b0f2f9c9e06109588",
     "paths": {
@@ -35491,7 +35491,7 @@
     "published_at": "5/19/2026 3:20:34 PM",
     "fetched_at": "2026-05-20T11:59:08Z",
     "discovered_by": "rss:kvue.com",
-    "scanner_verdict": "REVIEW REQUIRED — 137 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 137 pts, HIGH/CRITICAL findings",
     "scanner_score": 137,
     "content_hash": "306aa686ba27186fdad697402430d3335ca92ee07399954be4af3d71053f4e32",
     "paths": {
@@ -35578,7 +35578,7 @@
     "published_at": null,
     "fetched_at": "2026-05-20T12:03:59Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 239 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 239 pts, HIGH/CRITICAL findings",
     "scanner_score": 239,
     "content_hash": "443a7da13dc324a765bf44e1f28d7caee417b74b2bbeab6850af9489f77ce264",
     "paths": {
@@ -35732,7 +35732,7 @@
     "published_at": "2026-05-12T17:55:38.596",
     "fetched_at": "2026-05-26T04:26:48Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 80 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 80 pts, HIGH/CRITICAL findings",
     "scanner_score": 80,
     "content_hash": "a043d96c031b4e447dbaf2107f860a65bbd018774751b75f4f2799eff082b73e",
     "paths": {
@@ -35888,7 +35888,7 @@
     "published_at": "5/22/2026 4:24:02 PM",
     "fetched_at": "2026-05-26T04:25:17Z",
     "discovered_by": "rss:kvue.com",
-    "scanner_verdict": "REVIEW REQUIRED — 137 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 137 pts, HIGH/CRITICAL findings",
     "scanner_score": 137,
     "content_hash": "f8296672263808d5dc4b2622cbf8196d86800aad337d52bdf654340c455fa33e",
     "paths": {
@@ -35978,12 +35978,12 @@
     "source_domain": "oaklandside.org",
     "tier": 2,
     "stance": "neutral",
-    "title": "Oakland’s license plate readers have been off for months, so why does the city want more?",
+    "title": "Oakland\u2019s license plate readers have been off for months, so why does the city want more?",
     "byline": "Eli Wolfe",
     "published_at": "2023-08-17T16:00:00+00:00",
     "fetched_at": "2026-05-26T04:29:42Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 157 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 157 pts, HIGH/CRITICAL findings",
     "scanner_score": 157,
     "content_hash": "a89b7b8332f9e69477776da3af955f87abe19cb4495c98bce3727e2e006b4eea",
     "paths": {
@@ -36093,12 +36093,12 @@
     "source_domain": "wired.com",
     "tier": 2,
     "stance": "neutral",
-    "title": "The FBI Wants ‘Near Real-Time’ Access to US License Plate Readers",
+    "title": "The FBI Wants \u2018Near Real-Time\u2019 Access to US License Plate Readers",
     "byline": "Matt Burgess,Dell Cameron,Andrew Couts",
     "published_at": "2026-05-23T10:30:00.000Z",
     "fetched_at": "2026-05-26T04:23:52Z",
     "discovered_by": "rss:wired.com",
-    "scanner_verdict": "REVIEW REQUIRED — 97 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 97 pts, HIGH/CRITICAL findings",
     "scanner_score": 97,
     "content_hash": "059bfc697c04ac288d64e8cbea71a9dc320c379938abbce3d8c1795b6640cc2a",
     "paths": {
@@ -36192,7 +36192,7 @@
     "published_at": "2026-02-05T18:02:06.067",
     "fetched_at": "2026-05-26T08:40:54Z",
     "discovered_by": "bing:alpr",
-    "scanner_verdict": "REVIEW REQUIRED — 62 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 62 pts, HIGH/CRITICAL findings",
     "scanner_score": 62,
     "content_hash": "ecdaf817ffa783aa4e28b9f87e5b2ce04ed952f1c21667d2678fb2bd16204345",
     "paths": {
@@ -36313,12 +36313,12 @@
     "source_domain": "oakpark.com",
     "tier": 2,
     "stance": "unknown",
-    "title": "Police oversight committee seeks more data on Flock camera use  - Wednesday Journal",
+    "title": "Police oversight committee seeks more data on Flock camera use\u00a0 - Wednesday Journal",
     "byline": "Brendan Heffernan",
     "published_at": "2025-05-20T19:53:48+00:00",
     "fetched_at": "2026-05-26T08:45:29Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 92 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 92 pts, HIGH/CRITICAL findings",
     "scanner_score": 92,
     "content_hash": "fde13e0bbd65cfe18fccfae7efa0674667e5fdfeba4aae47a1c7938887d24330",
     "paths": {
@@ -36463,7 +36463,7 @@
     "published_at": "2026-03-19T00:33:26+00:00",
     "fetched_at": "2026-05-26T08:46:55Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 177 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 177 pts, HIGH/CRITICAL findings",
     "scanner_score": 177,
     "content_hash": "5c84dc17c602fd652e8a7811e4274d4eb626d1f3dc4a1b94b379b83bd3122f8a",
     "paths": {
@@ -36632,7 +36632,7 @@
     "published_at": null,
     "fetched_at": "2026-05-26T17:00:13Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 203 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 203 pts, HIGH/CRITICAL findings",
     "scanner_score": 203,
     "content_hash": "83294d23577f31274e6d1f3a522bcdd6ce399e0e8e28e615d56b6334838b4004",
     "paths": {
@@ -36771,7 +36771,7 @@
     "published_at": "2025-01-06T22:32:37+00:00",
     "fetched_at": "2026-05-26T16:53:25Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 92 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 92 pts, HIGH/CRITICAL findings",
     "scanner_score": 92,
     "content_hash": "09dba97e005b8a1f5fd97b58e01d2bced094b401fba45cfaea74c23ef848c749",
     "paths": {
@@ -36897,7 +36897,7 @@
     "published_at": null,
     "fetched_at": "2026-05-26T19:29:45Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 227 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 227 pts, HIGH/CRITICAL findings",
     "scanner_score": 227,
     "content_hash": "e7180d55d3e6c690c9c27d397ea1861c88a1e48cd4112b560700d9bffe7ff8fe",
     "paths": {
@@ -37042,7 +37042,7 @@
         "paragraph_idx": 7
       },
       {
-        "quote": "Staff will draw up a contract with Flock Safety — an ALPR company used by other cities in San Mateo County — and return to the City Council for final approval",
+        "quote": "Staff will draw up a contract with Flock Safety \u2014 an ALPR company used by other cities in San Mateo County \u2014 and return to the City Council for final approval",
         "paragraph_idx": 14
       }
     ],
@@ -37060,7 +37060,7 @@
     "published_at": null,
     "fetched_at": "2026-05-27T08:52:07Z",
     "discovered_by": "manual-seed-batch-2026-05-08",
-    "scanner_verdict": "REVIEW REQUIRED — 243 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 243 pts, HIGH/CRITICAL findings",
     "scanner_score": 243,
     "content_hash": "cc9f53f86a3931d20fd48c326d905bda90535e9d48c387f9035dc6a4023f7ba5",
     "paths": {
@@ -37191,7 +37191,7 @@
     "summary": "Half Moon Bay will bring its Flock Safety ALPR contract back to the City Council for review after residents raised concerns about data sharing with federal agencies, particularly given the city's large Latino and farmworker population. The reconsideration comes as nearby Bay Area cities like Mountain View and Santa Cruz have terminated their Flock contracts over unauthorized access and immigration enforcement concerns.",
     "key_quotes": [
       {
-        "quote": "We have a large Latino community here, and a large farmworker community — some in Half Moon Bay, some in the county. We want to look out for the most vulnerable people, as well as everybody else.",
+        "quote": "We have a large Latino community here, and a large farmworker community \u2014 some in Half Moon Bay, some in the county. We want to look out for the most vulnerable people, as well as everybody else.",
         "paragraph_idx": 3
       },
       {
@@ -37217,7 +37217,7 @@
     "published_at": "2026-05-26T14:23:43-07:00",
     "fetched_at": "2026-05-27T12:30:30Z",
     "discovered_by": "rss:eff.org",
-    "scanner_verdict": "REVIEW REQUIRED — 31 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 31 pts, HIGH/CRITICAL findings",
     "scanner_score": 31,
     "content_hash": "38220f61db95e9359817aef9b96f1fc753d5913b31309635e811aca244a03471",
     "paths": {
@@ -37386,12 +37386,12 @@
     "source_domain": "opb.org",
     "tier": 1,
     "stance": "unknown",
-    "title": "Albany City Council will decide whether to turn the city’s Flock camera back on",
+    "title": "Albany City Council will decide whether to turn the city\u2019s Flock camera back on",
     "byline": "Macy Moore",
     "published_at": "2026-05-26",
     "fetched_at": "2026-05-27T12:31:54Z",
     "discovered_by": "rss:opb.org",
-    "scanner_verdict": "REVIEW REQUIRED — 29 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 29 pts, HIGH/CRITICAL findings",
     "scanner_score": 29,
     "content_hash": "e3e1964767d56eb3e64450e3113c56ff92027cc33448db939c7bed2f3130c9aa",
     "paths": {
@@ -37507,7 +37507,7 @@
     "published_at": null,
     "fetched_at": "2026-05-27T12:33:40Z",
     "discovered_by": "bing:flock",
-    "scanner_verdict": "REVIEW REQUIRED — 175 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 175 pts, HIGH/CRITICAL findings",
     "scanner_score": 175,
     "content_hash": "892682a207ad9d1deba17c5b26c40b237bc901ad26457ec08da4ebb24e8a97bd",
     "paths": {
@@ -37646,7 +37646,7 @@
     "published_at": null,
     "fetched_at": "2026-05-28T12:45:40Z",
     "discovered_by": "rss:epic.org",
-    "scanner_verdict": "REVIEW REQUIRED — 19 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 19 pts, HIGH/CRITICAL findings",
     "scanner_score": 19,
     "content_hash": "914566cac673080257000cfbec08af8e159066092ac2e8ac56168347b5d02cf7",
     "paths": {
@@ -37688,12 +37688,12 @@
     "source_domain": "epic.org",
     "tier": 2,
     "stance": "critical",
-    "title": "EPIC Encourages CalPrivacy to Prohibit Dark Patterns in Privacy Policies",
+    "title": "EPIC Encourages CalPrivacy to\u00a0Prohibit Dark Patterns in Privacy\u00a0Policies",
     "byline": null,
     "published_at": null,
     "fetched_at": "2026-05-28T12:43:59Z",
     "discovered_by": "rss:epic.org",
-    "scanner_verdict": "REVIEW REQUIRED — 19 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 19 pts, HIGH/CRITICAL findings",
     "scanner_score": 19,
     "content_hash": "39db1b78645900921de2b609139c9bfbb7e38e95a225cf647effc457582eacaf",
     "paths": {
@@ -37747,7 +37747,7 @@
     "published_at": "2026-05-27T08:30:00+00:00",
     "fetched_at": "2026-05-28T12:42:11Z",
     "discovered_by": "rss:heraldnet.com",
-    "scanner_verdict": "REVIEW REQUIRED — 163 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 163 pts, HIGH/CRITICAL findings",
     "scanner_score": 163,
     "content_hash": "bb0ca17dad148b73e4dd7e1b2c3d4b1390a2a7e6b266199223cdbfb8b06e3ce8",
     "paths": {
@@ -37885,7 +37885,7 @@
     "published_at": "2026-05-28T16:18:52.000Z",
     "fetched_at": "2026-05-28T23:40:16Z",
     "discovered_by": "rss:404media.co",
-    "scanner_verdict": "REVIEW REQUIRED — 43 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 43 pts, HIGH/CRITICAL findings",
     "scanner_score": 43,
     "content_hash": "599e22bdbc804a681fab4265fffb7c4a605a537f1ba392b49ae05e393aded8e3",
     "paths": {
@@ -38010,7 +38010,7 @@
     "published_at": "2025-07-24T15:42:00-0400",
     "fetched_at": "2026-05-28T23:43:16Z",
     "discovered_by": "bing:lpr",
-    "scanner_verdict": "REVIEW REQUIRED — 218 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 218 pts, HIGH/CRITICAL findings",
     "scanner_score": 218,
     "content_hash": "607dd4e5200e06a7a7cd47d321f1febabb0ff669729b8ce4619f96e6cb391812",
     "paths": {
@@ -38070,7 +38070,7 @@
         "state": "NM",
         "score": 3.767,
         "matched_forms": [
-          "Española"
+          "Espa\u00f1ola"
         ]
       },
       {
@@ -38145,7 +38145,7 @@
     "published_at": "2026-05-28T18:03:38+00:00",
     "fetched_at": "2026-05-28T23:42:02Z",
     "discovered_by": "rss:oaklandside.org",
-    "scanner_verdict": "REVIEW REQUIRED — 173 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 173 pts, HIGH/CRITICAL findings",
     "scanner_score": 173,
     "content_hash": "f5d0b2eae92d4338099559453105dda3623ba38bb3b994cb9a7be793d738afaf",
     "paths": {
@@ -38283,7 +38283,7 @@
     "published_at": null,
     "fetched_at": "2026-05-14T22:37:38Z",
     "discovered_by": "manual: chief-meeting evidence",
-    "scanner_verdict": "REVIEW REQUIRED — 91 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 91 pts, HIGH/CRITICAL findings",
     "scanner_score": 91,
     "content_hash": "c41ce7a6ce42a03e7f45cbad3b8d182c29e2acc72e83136fa581443f343d71e2",
     "paths": {
@@ -38446,7 +38446,7 @@
     "published_at": "2026-04-14T18:06:00-0700",
     "fetched_at": "2026-05-14T22:37:00Z",
     "discovered_by": "manual: chief-meeting evidence",
-    "scanner_verdict": "REVIEW REQUIRED — 235 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 235 pts, HIGH/CRITICAL findings",
     "scanner_score": 235,
     "content_hash": "4aea3bab3f30978971921a09e59e9061e6602482b63ee21efb37d9e5e68f5ee4",
     "paths": {
@@ -38600,7 +38600,7 @@
     "published_at": "2026-02-26T00:21:04.000Z",
     "fetched_at": "2026-05-14T22:37:14Z",
     "discovered_by": "manual: chief-meeting evidence",
-    "scanner_verdict": "REVIEW REQUIRED — 141 pts, HIGH/CRITICAL findings",
+    "scanner_verdict": "REVIEW REQUIRED \u2014 141 pts, HIGH/CRITICAL findings",
     "scanner_score": 141,
     "content_hash": "5d759935ac00cddb28ec4407a7cc79ae7fdf0ba3d501eed5abb1bd2b6e4ad03c",
     "paths": {

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T08:50:04Z"
+  "last_run": "2026-05-29T12:25:33Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T12:25:33Z"
+  "last_run": "2026-05-29T16:52:27Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T04:38:13Z"
+  "last_run": "2026-05-29T08:50:04Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 345
- Curation: enriched: 286 · mechanical: 41 · needs_review: 18
- Scanner: REVIEW REQUIRED: 231 · WARNINGS: 112 · CLEAN: 2
- Wayback: saved: 147 · submit-failed: 95 · poll-failed: 89 · existing: 7 · save-failed: 7
- PDF: rendered: 288 · skipped-curl-fallback: 57
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 1 auto = 1

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
