### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1006,6 +1006,14 @@
         "mauldin-sc-pd": "http_404"
       }
     },
+    "3adb1453-b196-5bc4-82c1-37c97be1f645": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T12:37:06.002748+00:00",
+      "tried": {
+        "sugarcreek-township-oh-pd": "http_404"
+      }
+    },
     "3b8360eb-fbdf-5233-b419-5b92124c764e": {
       "exhausted": false,
       "found": null,
@@ -1908,7 +1916,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-29T08:58:45.306357+00:00",
+      "last_probed": "2026-05-29T12:37:10.947922+00:00",
       "tried": {
         "-beverly-hills-ca": "http_404",
         "-beverly-hills-ca-pd": "http_404",
@@ -1920,6 +1928,7 @@
         "-beverly-hills-pd-ca": "http_404",
         "-beverly-hills-po": "http_404",
         "-beverly-hills-po-ca": "http_404",
+        "-beverly-hills-police": "http_404",
         "-beverly-hills-police-ca": "http_404",
         "-beverly-hills-police-department": "http_404",
         "-beverly-hills-police-department-ca": "http_404",
@@ -4058,6 +4067,14 @@
         "jasper-ga-pd": "http_404"
       }
     },
+    "e67b2296-f7a6-5fcd-96d8-ea4b91c8c534": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T12:37:00.857152+00:00",
+      "tried": {
+        "jonesboro-ar-pd": "http_404"
+      }
+    },
     "e714b834-a444-5310-b637-f50715b85d67": {
       "exhausted": false,
       "found": null,
@@ -4531,6 +4548,6 @@
       }
     }
   },
-  "updated": "2026-05-29T08:58:45.347629+00:00",
+  "updated": "2026-05-29T12:37:10.983671+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1805,6 +1805,14 @@
         "el-dorado-county-ca-sd": "http_404"
       }
     },
+    "64f3e786-cdc0-575d-ad89-b15f8695ebe8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T16:31:32.276425+00:00",
+      "tried": {
+        "redmond-wa-pd": "http_404"
+      }
+    },
     "650ab346-a013-56f6-a970-1bf8a61acb18": {
       "exhausted": false,
       "found": null,
@@ -1916,7 +1924,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-29T12:37:10.947922+00:00",
+      "last_probed": "2026-05-29T16:31:38.385088+00:00",
       "tried": {
         "-beverly-hills-ca": "http_404",
         "-beverly-hills-ca-pd": "http_404",
@@ -1932,6 +1940,7 @@
         "-beverly-hills-police-ca": "http_404",
         "-beverly-hills-police-department": "http_404",
         "-beverly-hills-police-department-ca": "http_404",
+        "-beverly-hills-ps": "http_404",
         "-beverly-hills-ps-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -2651,6 +2660,14 @@
       "tried": {
         "california-state-university-long-beach-campus-ca-pd": "http_404",
         "california-state-university-long-beach-campus-ca-ps": "http_404"
+      }
+    },
+    "9101d68e-8ac1-5315-b6ad-785913ec5343": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T16:31:27.167194+00:00",
+      "tried": {
+        "richland-hills-tx-pd": "http_404"
       }
     },
     "925ee626-f5b9-5fa4-b079-55cb545544e8": {
@@ -4548,6 +4565,6 @@
       }
     }
   },
-  "updated": "2026-05-29T12:37:10.983671+00:00",
+  "updated": "2026-05-29T16:31:38.421113+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1708,6 +1708,14 @@
         "overland-park-ks-pd": "http_404"
       }
     },
+    "60ade978-1e97-5677-bf87-f6016f4a1dd1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T08:58:37.001097+00:00",
+      "tried": {
+        "shrewsbury-mo-pd": "http_403"
+      }
+    },
     "6184b16e-aefb-5c87-9eac-ff7428124cf2": {
       "exhausted": false,
       "found": null,
@@ -1900,7 +1908,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-27T11:24:50.083072+00:00",
+      "last_probed": "2026-05-29T08:58:45.306357+00:00",
       "tried": {
         "-beverly-hills-ca": "http_404",
         "-beverly-hills-ca-pd": "http_404",
@@ -1913,6 +1921,7 @@
         "-beverly-hills-po": "http_404",
         "-beverly-hills-po-ca": "http_404",
         "-beverly-hills-police-ca": "http_404",
+        "-beverly-hills-police-department": "http_404",
         "-beverly-hills-police-department-ca": "http_404",
         "-beverly-hills-ps-ca": "http_404",
         "beverly-hills": "http_404",
@@ -3405,6 +3414,14 @@
         "markle-in-pd": "http_404"
       }
     },
+    "bbfcb003-91ba-5770-8129-c8dc5d0e7775": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T08:58:41.124370+00:00",
+      "tried": {
+        "wynne-ar-pd": "http_404"
+      }
+    },
     "bc05c669-7bc4-557f-8639-322574d87d4d": {
       "exhausted": false,
       "found": null,
@@ -4514,6 +4531,6 @@
       }
     }
   },
-  "updated": "2026-05-29T05:02:04.910293+00:00",
+  "updated": "2026-05-29T08:58:45.347629+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.