### PR TITLE
Flag audit-vs-disclosure discrepancies on per-city report

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1453,8 +1453,86 @@
     // show agencies that pass every heuristic signal while having
     // substantial compliance gaps.
     html += `<p class="legal-note" style="border-left: 3px solid var(--warn-border); background: var(--warn-bg); color: #78350f; margin: 6px 0 10px 0"><strong>Surface-signal checks only.</strong> A green check means the signal appears on the transparency page &mdash; not that the agency substantively complies. A posted policy may be stale, an &ldquo;audit process&rdquo; may not be executed, a clean sharing list may include unvetted recipients. Starting point for questions, not a compliance certification.</p>`;
+    html += renderInboundAuditDiscrepancy(report);
     html += renderChecklistItems(items, { report: report });
     return html;
+  }
+
+  // Flag box: the agency publishes a search audit, and its
+  // per-query networkCount tells a story the transparency portal
+  // doesn't. Three cases in priority order:
+  //   (1) Inbound published, audit routinely exceeds it. Strongest —
+  //       agency's own numbers don't add up.
+  //   (2) No inbound published, audit reaches > 100 networks. The
+  //       audit is the only evidence of operational scope.
+  //   (3) Outbound published, audit routinely exceeds it. Softer —
+  //       agency pulls broader than it pushes; not a discrepancy
+  //       per se, but useful context.
+  function renderInboundAuditDiscrepancy(report) {
+    const avi = report.audit_vs_inbound;
+    if (!avi) return "";
+
+    // Case 1: strong — inbound exists and audit exceeds it routinely.
+    if (avi.exceeding_inbound_pct != null && avi.exceeding_inbound_pct >= 10) {
+      let html = '<div class="flag-section">';
+      html += `<strong>Search audit reaches beyond the published inbound sharing list</strong>`;
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `Published inbound sharing list: <strong>${fmtInt(avi.inbound_count)}</strong> agencies. `;
+      html += `Search audit shows <strong>${avi.exceeding_inbound_pct}%</strong> of queries `;
+      html += `(${fmtInt(avi.exceeding_inbound_count)} of ${fmtInt(avi.rows_analyzed)}) `;
+      html += `reached more agency networks than that &mdash; at least one query reached `;
+      html += `<strong>${fmtInt(avi.max_network_count)}</strong> networks.`;
+      html += '</div>';
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `This implies use of Flock&rsquo;s statewide or nationwide lookup features &mdash; access that bilateral sharing relationships do not grant. The inbound list on the transparency page does not reflect the actual scope of data this agency reaches.`;
+      html += '</div>';
+      html += '</div>';
+      return html;
+    }
+
+    // Case 2: strong — no inbound published, but audit shows
+    // meaningful reach. 100-network floor filters out agencies that
+    // run only a handful of local-only queries.
+    if (avi.inbound_count == null && avi.max_network_count > 100) {
+      let html = '<div class="flag-section">';
+      html += `<strong>No inbound sharing list published &mdash; audit shows broad reach anyway</strong>`;
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `This agency&rsquo;s transparency portal does not publish an inbound sharing list. `;
+      html += `Its search audit shows queries reaching up to `;
+      html += `<strong>${fmtInt(avi.max_network_count)}</strong> agency networks `;
+      html += `across ${fmtInt(avi.rows_analyzed)} audited searches.`;
+      html += '</div>';
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `Reaching hundreds of networks per query indicates use of Flock&rsquo;s statewide or nationwide lookup features. Without a published inbound list, residents cannot see which agencies&rsquo; camera data appears in those results.`;
+      html += '</div>';
+      html += '</div>';
+      return html;
+    }
+
+    // Case 3: soft — audit reaches beyond outbound. Softer wording
+    // because the agency may simply consume a broader network than
+    // it contributes to, which isn't a disclosure failure on its
+    // face. Useful as context for the asymmetry.
+    if (avi.exceeding_outbound_pct != null
+        && avi.exceeding_outbound_pct >= 10
+        && avi.outbound_count != null) {
+      let html = '<div class="flag-section" style="border-left-color:#9ca3af">';
+      html += `<strong>For context: search reach exceeds the agency&rsquo;s own sharing footprint</strong>`;
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `This agency shares its ALPR data with <strong>${fmtInt(avi.outbound_count)}</strong> other agencies. `;
+      html += `Its search audit shows <strong>${avi.exceeding_outbound_pct}%</strong> of queries `;
+      html += `(${fmtInt(avi.exceeding_outbound_count)} of ${fmtInt(avi.rows_analyzed)}) `;
+      html += `reached more agency networks than that &mdash; up to `;
+      html += `<strong>${fmtInt(avi.max_network_count)}</strong> networks per query.`;
+      html += '</div>';
+      html += '<div style="margin-top:6px;font-size:10pt">';
+      html += `The agency draws data from a much broader set than it contributes to. Not by itself a disclosure failure, but useful context for understanding the asymmetry between what this agency pushes out and what it pulls in.`;
+      html += '</div>';
+      html += '</div>';
+      return html;
+    }
+
+    return "";
   }
 
   function renderTransparencyChecklist(report, meta) {
@@ -2681,7 +2759,7 @@
     // question relies on the agency's own numbers not adding up;
     // cross-portal inference would weaken that claim.
     const avi = report.audit_vs_inbound;
-    if (avi && avi.exceeding_inbound_pct >= 10) {
+    if (avi && avi.exceeding_inbound_pct != null && avi.exceeding_inbound_pct >= 10) {
       add(90,
         `${Dept}'s published search audit shows searches reaching more agency ` +
         `networks than ${deptShort}'s transparency portal lists as sharing data inbound &mdash; ` +

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -508,30 +508,32 @@ def _audit_searches_30d(audit):
     }
 
 
-def _audit_vs_inbound(audit, direct_inbound):
-    """Compare audit-log row networkCounts against the agency's own
-    published inbound list size.
+def _audit_vs_inbound(audit, direct_inbound, outbound_count):
+    """Summarize audit-log networkCounts against the agency's own
+    published inbound and outbound list sizes.
 
     A search row's networkCount is how many agency networks that one
-    query touched. If networkCount routinely exceeds the agency's
-    own published inbound list, the agency is using Flock's
-    statewide / nationwide lookup features — capabilities not granted
-    by bilateral sharing. That's the disclosure question.
+    query touched. Three discrepancies are worth surfacing:
 
-    We only compare against the agency's DIRECT inbound (the count
-    published on its own transparency portal), not against inferred
-    inbound from peer outbound lists. The question's bite is that the
-    agency's own numbers don't add up; pulling in cross-portal
-    inference would make us assert a number the department itself
-    didn't publish, which weakens the question. The cost is that this
-    only fires for agencies that publish both an inbound list and a
-    search audit (about half a dozen CA agencies as of writing).
+      1. networkCount routinely exceeds the agency's published inbound
+         list — agency is using statewide/nationwide lookup beyond what
+         bilateral sharing grants. (`exceeding_inbound_*` populated.)
+      2. agency publishes no inbound list at all, but audit shows broad
+         reach — residents have no published baseline to evaluate.
+         (`inbound_count` is None.)
+      3. networkCount exceeds the agency's outbound list — the agency
+         pulls data from a much broader set than it pushes to. Softer
+         finding; useful context. (`exceeding_outbound_*` populated.)
 
-    Returns None if no usable rows or direct_inbound is zero/missing.
+    We only compare against DIRECT inbound (published on the agency's
+    own portal), not inferred-from-peer-outbound. The question's bite
+    is that the agency's own numbers don't add up; pulling in
+    cross-portal inference would make us assert a number the
+    department itself didn't publish, which weakens the question.
+
+    Returns None only if the audit log has zero usable rows.
     """
     rows = audit.get("rows") or []
-    if not direct_inbound:
-        return None
     network_counts = []
     for r in rows:
         nc = r.get("networkCount")
@@ -544,17 +546,28 @@ def _audit_vs_inbound(audit, direct_inbound):
     if not network_counts:
         return None
     total = len(network_counts)
-    over = sum(1 for x in network_counts if x > direct_inbound)
-    return {
+    result = {
         "rows_analyzed": total,
         "max_network_count": max(network_counts),
         "median_network_count": int(sorted(network_counts)[total // 2]),
-        "exceeding_inbound_count": over,
-        "exceeding_inbound_pct": round(100.0 * over / total, 1),
-        "inbound_count": direct_inbound,
+        "inbound_count": direct_inbound if direct_inbound else None,
+        "exceeding_inbound_count": None,
+        "exceeding_inbound_pct": None,
+        "outbound_count": outbound_count if outbound_count else None,
+        "exceeding_outbound_count": None,
+        "exceeding_outbound_pct": None,
         "search_date_min": audit.get("search_date_min"),
         "search_date_max": audit.get("search_date_max"),
     }
+    if direct_inbound:
+        over_i = sum(1 for x in network_counts if x > direct_inbound)
+        result["exceeding_inbound_count"] = over_i
+        result["exceeding_inbound_pct"] = round(100.0 * over_i / total, 1)
+    if outbound_count:
+        over_o = sum(1 for x in network_counts if x > outbound_count)
+        result["exceeding_outbound_count"] = over_o
+        result["exceeding_outbound_pct"] = round(100.0 * over_o / total, 1)
+    return result
 
 
 # ── Geography ──
@@ -1729,23 +1742,24 @@ def main():
         )
 
         # ── Audit-log derived fields ──
-        # If the agency publishes a search audit (or we've imported one
-        # via PRA), surface two derived signals:
-        #   1. audit_vs_inbound: per-search networkCount vs the agency's
-        #      own published inbound list size — searches touching more
-        #      networks than the agency receives from imply use of
-        #      Flock's statewide/nationwide lookup features.
-        #   2. searches_30d_audit: a trailing 30-day count anchored to
-        #      the latest searchDate in the union log. Lets agencies
-        #      that publish the CSV but not a top-line "searches in the
-        #      last 30 days" stat still get a number in the report.
+        # If the agency publishes a search audit, summarize the
+        # per-search networkCount distribution and compare against
+        # both the published inbound and outbound list sizes.
+        # Searches that touch more networks than the agency receives
+        # data from imply use of Flock's statewide/nationwide lookup
+        # features. Fires even when inbound is unpublished (the audit
+        # alone reveals the actual reach).
+        # searches_30d_audit is a trailing 30-day count anchored to
+        # the latest searchDate in the union log, for agencies that
+        # publish the CSV but no top-line 30-day stat.
         audit_vs_inbound = None
         searches_30d_audit = None
         if crawled:
             audit_json = _load_audit_json(reg)
             if audit_json:
-                if inbound_count:
-                    audit_vs_inbound = _audit_vs_inbound(audit_json, inbound_count)
+                audit_vs_inbound = _audit_vs_inbound(
+                    audit_json, inbound_count, outbound_count
+                )
                 searches_30d_audit = _audit_searches_30d(audit_json)
 
         # ── Inferred inbound (for uncrawled agencies mostly) ──


### PR DESCRIPTION
## Summary
- Adds a discrepancy flag box to the SB 34 Compliance Concerns section of the per-city report
- Fires when an agency's published search audit reveals reach beyond what its transparency portal discloses
- Three priority-ordered cases with different wording for each: inbound exceeded, no inbound published, or outbound exceeded

## What changes for readers
For agencies that publish a search audit, the report now surfaces a visible discrepancy badge when the audit's per-query `networkCount` exceeds what the agency itself publishes as inbound or outbound sharing. Previously this finding was tucked into a single council-to-PD question paragraph and only fired for agencies that published both an inbound list AND a search audit.

Three cases the box handles:

1. **Strong (inbound published, audit exceeds it)** — e.g. Oceanside publishes 270 inbound agencies but 52.6% of audited queries reached more networks than that, with at least one reaching 959. Implies use of Flock's statewide / nationwide lookup features.
2. **Strong (no inbound published, audit shows broad reach)** — e.g. SMPD publishes no inbound list, but its audit shows queries reaching up to 914 networks across 19,966 searches. Without an inbound list residents have no published baseline to evaluate.
3. **Soft (audit > outbound)** — softer framing for the asymmetry between push and pull reach. No current agencies hit this case without also hitting case 1; logic in place for future data.

## Implementation
- `scripts/build_report_data.py` — `_audit_vs_inbound()` now runs whenever audit data exists (previously gated on inbound also being published). Returns a richer payload that includes outbound-comparison stats alongside the existing inbound ones.
- `docs/js/report.js` — new `renderInboundAuditDiscrepancy()` slotted into `renderSB34Checklist` between the disclaimer and the checklist items. Picks one of three wordings based on which fields are populated.
- Existing `renderQuestions` audit-vs-inbound question hardened against the new null fields.

The box is currently scoped to CA only because it lives inside the CA-only SB 34 section. Out-of-state audit-publishing agencies (e.g. Pawnee KS, Webster Groves MO in the nationwide-lookup cluster) won't render it yet — separate change if we want to broaden state coverage.

## Test plan
- [ ] Verify Oceanside report shows the case-1 wording with correct stats
- [ ] Verify SMPD report shows the case-2 wording with 914 networks / 19,966 searches
- [ ] Verify agencies with no audit (e.g., a typical SMPD-peer city) show no box
- [ ] Verify agencies with audit but low exceedance (e.g., Livingston at 5%) show no box
- [ ] Spot-check that the existing renderQuestions audit-vs-inbound prompt still renders for case-1 agencies