### PR TITLE
fix(geocoding): resolve 158 recipient agencies missing coordinates (#447)

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -6825,7 +6825,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "2541200",
+      "name": "Milford",
+      "state": "MA",
+      "lat": 42.150664,
+      "lng": -71.517783
+    }
   },
   {
     "agency_id": "cbe60ab8-3f22-59ae-9e72-989ac99a1e75",
@@ -6887,7 +6894,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3651000",
+      "name": "New York",
+      "state": "NY",
+      "lat": 40.662712,
+      "lng": -73.938677
+    }
   },
   {
     "agency_id": "1eaafe48-4ea2-574c-b86e-a8a0452194bb",
@@ -7924,8 +7938,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3673000",
+      "name": "Syracuse",
+      "state": "NY",
+      "lat": 43.040998,
+      "lng": -76.143554
     }
   },
   {
@@ -7945,8 +7963,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3611000",
+      "name": "Buffalo",
+      "state": "NY",
+      "lat": 42.892492,
+      "lng": -78.859686
     }
   },
   {
@@ -7966,8 +7988,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3629542",
+      "name": "Goshen",
+      "state": "NY",
+      "lat": 41.401647,
+      "lng": -74.326855
     }
   },
   {
@@ -7987,8 +8013,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3663000",
+      "name": "Rochester",
+      "state": "NY",
+      "lat": 43.169927,
+      "lng": -77.616891
     }
   },
   {
@@ -8008,8 +8038,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3651055",
+      "name": "Niagara Falls",
+      "state": "NY",
+      "lat": 43.092841,
+      "lng": -79.014743
     }
   },
   {
@@ -8029,8 +8063,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3606607",
+      "name": "Binghamton",
+      "state": "NY",
+      "lat": 42.101331,
+      "lng": -75.909369
     }
   },
   {
@@ -8076,8 +8114,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3606711913",
+      "name": "Camillus",
+      "state": "NY",
+      "lat": 43.066191,
+      "lng": -76.313273
     }
   },
   {
@@ -8148,8 +8190,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CT"
+      "kind": "place",
+      "fips": "0950370",
+      "name": "New Britain",
+      "state": "CT",
+      "lat": 41.676555,
+      "lng": -72.786161
     }
   },
   {
@@ -8269,8 +8315,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3606715704",
+      "name": "Cicero",
+      "state": "NY",
+      "lat": 43.172142,
+      "lng": -76.056249
     }
   },
   {
@@ -9012,8 +9062,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4234064",
+      "name": "Hermitage",
+      "state": "PA",
+      "lat": 41.229552,
+      "lng": -80.440704
     }
   },
   {
@@ -9185,8 +9239,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3638077",
+      "name": "Ithaca",
+      "state": "NY",
+      "lat": 42.443937,
+      "lng": -76.503055
     }
   },
   {
@@ -9381,8 +9439,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3611942136",
+      "name": "Lewisboro",
+      "state": "NY",
+      "lat": 41.266143,
+      "lng": -73.588296
     }
   },
   {
@@ -9702,8 +9764,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NJ"
+      "kind": "cousub",
+      "fips": "3402347280",
+      "name": "Monroe",
+      "state": "NJ",
+      "lat": 40.319482,
+      "lng": -74.428785
     }
   },
   {
@@ -9748,8 +9814,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3952052",
+      "name": "Moreland Hills",
+      "state": "OH",
+      "lat": 41.441836,
+      "lng": -81.435735
     }
   },
   {
@@ -10007,8 +10077,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MA"
+      "kind": "place",
+      "fips": "2546598",
+      "name": "North Attleborough Town",
+      "state": "MA",
+      "lat": 41.970454,
+      "lng": -71.33493
     }
   },
   {
@@ -10052,7 +10126,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3653682",
+      "name": "North Tonawanda",
+      "state": "NY",
+      "lat": 43.049157,
+      "lng": -78.871224
+    }
   },
   {
     "agency_id": "616c3761-ec1f-5bc3-b494-8c0759fb7be5",
@@ -11122,8 +11203,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MA"
+      "kind": "place",
+      "fips": "2567000",
+      "name": "Springfield",
+      "state": "MA",
+      "lat": 42.115454,
+      "lng": -72.539978
     }
   },
   {
@@ -11265,8 +11350,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3673000",
+      "name": "Syracuse",
+      "state": "NY",
+      "lat": 43.040998,
+      "lng": -76.143554
     }
   },
   {
@@ -11362,8 +11451,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CT"
+      "kind": "cousub",
+      "fips": "0918043230",
+      "name": "Lisbon",
+      "state": "CT",
+      "lat": 41.602766,
+      "lng": -72.012261
     }
   },
   {
@@ -13388,8 +13481,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4819000",
+      "name": "Dallas",
+      "state": "TX",
+      "lat": 32.793333,
+      "lng": -96.766513
     }
   },
   {
@@ -13696,7 +13793,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4874144",
+      "name": "Tyler",
+      "state": "TX",
+      "lat": 32.317258,
+      "lng": -95.305886
+    }
   },
   {
     "agency_id": "7c846159-92c5-5a52-a994-3c431aa12522",
@@ -14088,8 +14192,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48157",
+      "name": "Fort Bend",
+      "state": "TX",
+      "lat": 29.526602,
+      "lng": -95.771015
     }
   },
   {
@@ -14110,8 +14218,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48157",
+      "name": "Fort Bend",
+      "state": "TX",
+      "lat": 29.526602,
+      "lng": -95.771015
     }
   },
   {
@@ -14675,8 +14787,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4835000",
+      "name": "Houston",
+      "state": "TX",
+      "lat": 29.785743,
+      "lng": -95.388806
     }
   },
   {
@@ -14928,7 +15044,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "county",
+      "fips": "48257",
+      "name": "Kaufman",
+      "state": "TX",
+      "lat": 32.598944,
+      "lng": -96.288377
+    }
   },
   {
     "agency_id": "50397353-6995-5ea3-8d79-b780271c4317",
@@ -15139,8 +15262,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4840984",
+      "name": "Lakeway",
+      "state": "TX",
+      "lat": 30.354982,
+      "lng": -97.986269
     }
   },
   {
@@ -15236,8 +15363,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4807000",
+      "name": "Beaumont",
+      "state": "TX",
+      "lat": 30.084912,
+      "lng": -94.14533
     }
   },
   {
@@ -15638,8 +15769,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4833068",
+      "name": "Hedwig Village",
+      "state": "TX",
+      "lat": 29.779884,
+      "lng": -95.51926
     }
   },
   {
@@ -15684,8 +15819,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4848096",
+      "name": "Midlothian",
+      "state": "TX",
+      "lat": 32.469436,
+      "lng": -96.99067
     }
   },
   {
@@ -15976,8 +16115,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4819000",
+      "name": "Dallas",
+      "state": "TX",
+      "lat": 32.793333,
+      "lng": -96.766513
     }
   },
   {
@@ -16157,7 +16300,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
+    }
   },
   {
     "agency_id": "c8c1183c-3d0d-549c-8cdf-bdef931c4b7f",
@@ -17213,8 +17363,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4845000",
+      "name": "Lubbock",
+      "state": "TX",
+      "lat": 33.561901,
+      "lng": -101.888883
     }
   },
   {
@@ -17605,8 +17759,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4870208",
+      "name": "Stephenville",
+      "state": "TX",
+      "lat": 32.214544,
+      "lng": -98.219885
     }
   },
   {
@@ -17697,7 +17855,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4841464",
+      "name": "Laredo",
+      "state": "TX",
+      "lat": 27.560379,
+      "lng": -99.489181
+    }
   },
   {
     "agency_id": "bfa5836d-05c5-5e97-9eed-99222743f826",
@@ -17717,8 +17882,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4827000",
+      "name": "Fort Worth",
+      "state": "TX",
+      "lat": 32.781954,
+      "lng": -97.348573
     }
   },
   {
@@ -17762,7 +17931,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4805000",
+      "name": "Austin",
+      "state": "TX",
+      "lat": 30.298622,
+      "lng": -97.754134
+    }
   },
   {
     "agency_id": "ebcdf29d-6668-5325-8597-46bbd036c716",
@@ -17937,8 +18113,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4805000",
+      "name": "Austin",
+      "state": "TX",
+      "lat": 30.298622,
+      "lng": -97.754134
     }
   },
   {
@@ -17984,8 +18164,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4802272",
+      "name": "Alvin",
+      "state": "TX",
+      "lat": 29.424772,
+      "lng": -95.224432
     }
   },
   {
@@ -18532,8 +18716,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4806128",
+      "name": "Baytown",
+      "state": "TX",
+      "lat": 29.76478,
+      "lng": -94.967457
     }
   },
   {
@@ -18976,8 +19164,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4835000",
+      "name": "Houston",
+      "state": "TX",
+      "lat": 29.785743,
+      "lng": -95.388806
     }
   },
   {
@@ -18998,8 +19190,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4835000",
+      "name": "Houston",
+      "state": "TX",
+      "lat": 29.785743,
+      "lng": -95.388806
     }
   },
   {
@@ -19097,7 +19293,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4853388",
+      "name": "Odessa",
+      "state": "TX",
+      "lat": 31.880461,
+      "lng": -102.345314
+    }
   },
   {
     "agency_id": "851dd88b-b44b-55cb-86a2-7aa90e0b3a57",
@@ -19328,8 +19531,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4876864",
+      "name": "Weatherford",
+      "state": "TX",
+      "lat": 32.75319,
+      "lng": -97.771944
     }
   },
   {
@@ -19395,8 +19602,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1754144",
+      "name": "North Riverside",
+      "state": "IL",
+      "lat": 41.846142,
+      "lng": -87.826283
     }
   },
   {
@@ -20015,8 +20226,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0465350",
+      "name": "Sedona",
+      "state": "AZ",
+      "lat": 34.858517,
+      "lng": -111.793057
     }
   },
   {
@@ -20453,8 +20668,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0423620",
+      "name": "Flagstaff",
+      "state": "AZ",
+      "lat": 35.185212,
+      "lng": -111.620698
     }
   },
   {
@@ -20893,8 +21112,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0453700",
+      "name": "Payson",
+      "state": "AZ",
+      "lat": 34.243841,
+      "lng": -111.318964
     }
   },
   {
@@ -20965,8 +21188,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0477000",
+      "name": "Tucson",
+      "state": "AZ",
+      "lat": 32.153036,
+      "lng": -110.870773
     }
   },
   {
@@ -21086,8 +21313,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4843132",
+      "name": "Livingston",
+      "state": "TX",
+      "lat": 30.710043,
+      "lng": -94.93793
     }
   },
   {
@@ -21500,8 +21731,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MN"
+      "kind": "cousub",
+      "fips": "2716554556",
+      "name": "Riverdale",
+      "state": "MN",
+      "lat": 44.06432,
+      "lng": -94.557632
     }
   },
   {
@@ -21593,8 +21828,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "place",
+      "fips": "5509025",
+      "name": "Bowler",
+      "state": "WI",
+      "lat": 44.862729,
+      "lng": -88.981379
     }
   },
   {
@@ -22153,7 +22392,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "5315115",
+      "name": "Coulee Dam",
+      "state": "WA",
+      "lat": 47.968511,
+      "lng": -118.97628
+    }
   },
   {
     "agency_id": "def23147-b644-5501-b150-9d113ac1f900",
@@ -22545,8 +22791,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48157",
+      "name": "Fort Bend",
+      "state": "TX",
+      "lat": 29.526602,
+      "lng": -95.771015
     }
   },
   {
@@ -22666,8 +22916,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4848072",
+      "name": "Midland",
+      "state": "TX",
+      "lat": 32.024642,
+      "lng": -102.113467
     }
   },
   {
@@ -22688,8 +22942,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3734300",
+      "name": "Jamestown",
+      "state": "NC",
+      "lat": 35.998445,
+      "lng": -79.934601
     }
   },
   {
@@ -24158,7 +24416,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4835000",
+      "name": "Houston",
+      "state": "TX",
+      "lat": 29.785743,
+      "lng": -95.388806
+    }
   },
   {
     "agency_id": "2d026c3d-0e71-5f6e-b82a-19965bca3701",
@@ -25151,7 +25416,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1775185",
+      "name": "Thornton",
+      "state": "IL",
+      "lat": 41.574149,
+      "lng": -87.6193
+    }
   },
   {
     "agency_id": "619d3ba1-3fa1-5276-80af-df929b431a6a",
@@ -25371,8 +25643,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1765000",
+      "name": "Rockford",
+      "state": "IL",
+      "lat": 42.258836,
+      "lng": -89.064553
     }
   },
   {
@@ -25417,7 +25693,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1704845",
+      "name": "Belleville",
+      "state": "IL",
+      "lat": 38.515973,
+      "lng": -89.989779
+    }
   },
   {
     "agency_id": "53b26353-9e01-52db-98c7-fcd28774d88a",
@@ -26512,8 +26795,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "WI"
+      "kind": "place",
+      "fips": "5535150",
+      "name": "Hobart",
+      "state": "WI",
+      "lat": 44.495441,
+      "lng": -88.155601
     }
   },
   {
@@ -27452,8 +27739,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SD"
+      "kind": "place",
+      "fips": "4659260",
+      "name": "Sisseton",
+      "state": "SD",
+      "lat": 45.662499,
+      "lng": -97.045293
     }
   },
   {
@@ -28105,8 +28396,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4738320",
+      "name": "Johnson City",
+      "state": "TN",
+      "lat": 36.342325,
+      "lng": -82.380915
     }
   },
   {
@@ -28726,8 +29021,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3644710",
+      "name": "Malone",
+      "state": "NY",
+      "lat": 44.848221,
+      "lng": -74.28958
     }
   },
   {
@@ -29163,8 +29462,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -29534,8 +29837,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2919252",
+      "name": "De Soto",
+      "state": "MO",
+      "lat": 38.141066,
+      "lng": -90.560834
     }
   },
   {
@@ -29676,7 +29983,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "cousub",
+      "fips": "3402719210",
+      "name": "East Hanover",
+      "state": "NJ",
+      "lat": 40.818553,
+      "lng": -74.363742
+    }
   },
   {
     "agency_id": "8a66299b-4bb5-51fd-85e7-a93ab3b02446",
@@ -30039,8 +30353,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -30385,8 +30703,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3640937",
+      "name": "Lake Success",
+      "state": "NY",
+      "lat": 40.763883,
+      "lng": -73.711112
     }
   },
   {
@@ -30632,8 +30954,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3959416",
+      "name": "Painesville",
+      "state": "OH",
+      "lat": 41.721635,
+      "lng": -81.258357
     }
   },
   {
@@ -30954,8 +31280,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "place",
+      "fips": "2609180",
+      "name": "Bloomfield Hills",
+      "state": "MI",
+      "lat": 42.581359,
+      "lng": -83.246418
     }
   },
   {
@@ -31519,8 +31849,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3952052",
+      "name": "Moreland Hills",
+      "state": "OH",
+      "lat": 41.441836,
+      "lng": -81.435735
     }
   },
   {
@@ -32136,8 +32470,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2938000",
+      "name": "Kansas City",
+      "state": "MO",
+      "lat": 39.122361,
+      "lng": -94.555117
     }
   },
   {
@@ -32407,8 +32745,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3975098",
+      "name": "Strongsville",
+      "state": "OH",
+      "lat": 41.312955,
+      "lng": -81.83169
     }
   },
   {
@@ -32478,8 +32820,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3901000",
+      "name": "Akron",
+      "state": "OH",
+      "lat": 41.080456,
+      "lng": -81.521429
     }
   },
   {
@@ -32499,8 +32845,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3654705",
+      "name": "Old Westbury",
+      "state": "NY",
+      "lat": 40.786543,
+      "lng": -73.597508
     }
   },
   {
@@ -32720,8 +33070,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3611175935",
+      "name": "Ulster",
+      "state": "NY",
+      "lat": 41.970995,
+      "lng": -74.004746
     }
   },
   {
@@ -33041,8 +33395,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2938000",
+      "name": "Kansas City",
+      "state": "MO",
+      "lat": 39.122361,
+      "lng": -94.555117
     }
   },
   {
@@ -33542,8 +33900,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3604198",
+      "name": "Baldwinsville",
+      "state": "NY",
+      "lat": 43.159706,
+      "lng": -76.338464
     }
   },
   {
@@ -34215,8 +34577,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3676540",
+      "name": "Utica",
+      "state": "NY",
+      "lat": 43.096382,
+      "lng": -75.225983
     }
   },
   {
@@ -34762,8 +35128,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -34783,8 +35153,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -35155,8 +35529,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3606720478",
+      "name": "De Witt",
+      "state": "NY",
+      "lat": 43.053886,
+      "lng": -76.071794
     }
   },
   {
@@ -35403,8 +35781,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4253920",
+      "name": "New Oxford",
+      "state": "PA",
+      "lat": 39.863001,
+      "lng": -77.055477
     }
   },
   {
@@ -35449,8 +35831,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3728080",
+      "name": "Greenville",
+      "state": "NC",
+      "lat": 35.596431,
+      "lng": -77.375256
     }
   },
   {
@@ -35793,8 +36179,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3921000",
+      "name": "Dayton",
+      "state": "OH",
+      "lat": 39.784743,
+      "lng": -84.199632
     }
   },
   {
@@ -36164,8 +36554,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3606728519",
+      "name": "Geddes",
+      "state": "NY",
+      "lat": 43.076667,
+      "lng": -76.224544
     }
   },
   {
@@ -37664,8 +38058,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4575850",
+      "name": "West Columbia",
+      "state": "SC",
+      "lat": 33.99013,
+      "lng": -81.099354
     }
   },
   {
@@ -38337,8 +38735,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3949098",
+      "name": "Mentor-on-the-Lake",
+      "state": "OH",
+      "lat": 41.715129,
+      "lng": -81.363467
     }
   },
   {
@@ -39392,8 +39794,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4242352",
+      "name": "Leesport",
+      "state": "PA",
+      "lat": 40.444433,
+      "lng": -75.967191
     }
   },
   {
@@ -39610,8 +40016,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3915000",
+      "name": "Cincinnati",
+      "state": "OH",
+      "lat": 39.140183,
+      "lng": -84.505829
     }
   },
   {
@@ -39682,7 +40092,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
+    }
   },
   {
     "agency_id": "3ae3ebc6-f651-5660-bd47-d18c0e38330b",
@@ -39700,7 +40117,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
+    }
   },
   {
     "agency_id": "468280a9-d8c9-5b5a-924b-1c44a913cde1",
@@ -39763,8 +40187,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OK"
+      "kind": "place",
+      "fips": "4073250",
+      "name": "The Village",
+      "state": "OK",
+      "lat": 35.570276,
+      "lng": -97.557499
     }
   },
   {
@@ -39784,7 +40212,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4055000",
+      "name": "Oklahoma City",
+      "state": "OK",
+      "lat": 35.467079,
+      "lng": -97.513657
+    }
   },
   {
     "agency_id": "41abbff5-3105-58e1-b98c-aab53fcc8e56",
@@ -39854,7 +40289,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4055000",
+      "name": "Oklahoma City",
+      "state": "OK",
+      "lat": 35.467079,
+      "lng": -97.513657
+    }
   },
   {
     "agency_id": "86ba8880-1c14-50ee-a9cb-52854bbe21f0",
@@ -39992,8 +40434,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OK"
+      "kind": "place",
+      "fips": "4062650",
+      "name": "Red Rock",
+      "state": "OK",
+      "lat": 36.460071,
+      "lng": -97.179608
     }
   },
   {
@@ -40393,8 +40839,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MD"
+      "kind": "place",
+      "fips": "2445825",
+      "name": "Largo",
+      "state": "MD",
+      "lat": 38.88035,
+      "lng": -76.829266
     }
   },
   {
@@ -40414,8 +40864,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3977000",
+      "name": "Toledo",
+      "state": "OH",
+      "lat": 41.664071,
+      "lng": -83.581861
     }
   },
   {
@@ -40988,8 +41442,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4575850",
+      "name": "West Columbia",
+      "state": "SC",
+      "lat": 33.99013,
+      "lng": -81.099354
     }
   },
   {
@@ -41259,8 +41717,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0467800",
+      "name": "Snowflake",
+      "state": "AZ",
+      "lat": 34.521459,
+      "lng": -110.091182
     }
   },
   {
@@ -41280,8 +41742,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4567435",
+      "name": "Society Hill",
+      "state": "SC",
+      "lat": 34.509815,
+      "lng": -79.853535
     }
   },
   {
@@ -41577,8 +42043,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3901000",
+      "name": "Akron",
+      "state": "OH",
+      "lat": 41.080456,
+      "lng": -81.521429
     }
   },
   {
@@ -41674,8 +42144,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3606607",
+      "name": "Binghamton",
+      "state": "NY",
+      "lat": 42.101331,
+      "lng": -75.909369
     }
   },
   {
@@ -41696,8 +42170,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "place",
+      "fips": "3673000",
+      "name": "Syracuse",
+      "state": "NY",
+      "lat": 43.040998,
+      "lng": -76.143554
     }
   },
   {
@@ -41793,8 +42271,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4827000",
+      "name": "Fort Worth",
+      "state": "TX",
+      "lat": 32.781954,
+      "lng": -97.348573
     }
   },
   {
@@ -42140,7 +42622,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1050670",
+      "name": "Newark",
+      "state": "DE",
+      "lat": 39.677649,
+      "lng": -75.757479
+    }
   },
   {
     "agency_id": "958cd633-368c-5ebd-84e8-7b06a7ead8ff",
@@ -42160,8 +42649,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3711800",
+      "name": "Chapel Hill",
+      "state": "NC",
+      "lat": 35.928328,
+      "lng": -79.041375
     }
   },
   {
@@ -42358,8 +42851,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5126496",
+      "name": "Fairfax",
+      "state": "VA",
+      "lat": 38.853183,
+      "lng": -77.299025
     }
   },
   {
@@ -42451,8 +42948,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3600777255",
+      "name": "Vestal",
+      "state": "NY",
+      "lat": 42.049395,
+      "lng": -76.017594
     }
   },
   {
@@ -42571,7 +43072,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "5167000",
+      "name": "Richmond",
+      "state": "VA",
+      "lat": 37.531399,
+      "lng": -77.476009
+    }
   },
   {
     "agency_id": "e986f42c-79e5-5a03-b7e6-6ffa9f828b96",
@@ -42660,8 +43168,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3755000",
+      "name": "Raleigh",
+      "state": "NC",
+      "lat": 35.831868,
+      "lng": -78.641042
     }
   },
   {
@@ -44035,8 +44547,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1748021",
+      "name": "Mechanicsburg",
+      "state": "IL",
+      "lat": 39.797238,
+      "lng": -89.410749
     }
   },
   {
@@ -45054,8 +45570,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3607118916",
+      "name": "Crawford",
+      "state": "NY",
+      "lat": 41.571408,
+      "lng": -74.315705
     }
   },
   {
@@ -45175,8 +45695,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4831592",
+      "name": "Gun Barrel City",
+      "state": "TX",
+      "lat": 32.328248,
+      "lng": -96.131762
     }
   },
   {
@@ -45296,8 +45820,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "08103",
+      "name": "Rio Blanco",
+      "state": "CO",
+      "lat": 39.972622,
+      "lng": -108.200716
     }
   },
   {
@@ -45757,8 +46285,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3602902000",
+      "name": "Amherst",
+      "state": "NY",
+      "lat": 43.011639,
+      "lng": -78.757148
     }
   },
   {
@@ -46874,7 +47406,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1714026",
+      "name": "Chicago Heights",
+      "state": "IL",
+      "lat": 41.510685,
+      "lng": -87.634672
+    }
   },
   {
     "agency_id": "76622e0b-9321-5532-8678-f9dad9596bd2",
@@ -48244,8 +48783,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4561405",
+      "name": "Rock Hill",
+      "state": "SC",
+      "lat": 34.938216,
+      "lng": -81.019177
     }
   },
   {
@@ -49285,8 +49828,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1735879",
+      "name": "Homewood",
+      "state": "IL",
+      "lat": 41.559422,
+      "lng": -87.662025
     }
   },
   {
@@ -49483,8 +50030,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3918000",
+      "name": "Columbus",
+      "state": "OH",
+      "lat": 39.983938,
+      "lng": -82.984882
     }
   },
   {
@@ -49504,8 +50055,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1836003",
+      "name": "Indianapolis city (balance)",
+      "state": "IN",
+      "lat": 39.776664,
+      "lng": -86.145935
     }
   },
   {
@@ -50634,7 +51189,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1735879",
+      "name": "Homewood",
+      "state": "IL",
+      "lat": 41.559422,
+      "lng": -87.662025
+    }
   },
   {
     "agency_id": "154c4162-f9c9-58dd-b549-f6d230542f6b",
@@ -50703,7 +51265,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3962848",
+      "name": "Piqua",
+      "state": "OH",
+      "lat": 40.145865,
+      "lng": -84.243506
+    }
   },
   {
     "agency_id": "64748831-d865-5be2-978e-2052d47acd0e",
@@ -51173,8 +51742,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NY"
+      "kind": "cousub",
+      "fips": "3602924801",
+      "name": "Evans",
+      "state": "NY",
+      "lat": 42.654805,
+      "lng": -79.004975
     }
   },
   {
@@ -51667,8 +52240,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1722164",
+      "name": "East Peoria",
+      "state": "IL",
+      "lat": 40.673377,
+      "lng": -89.541764
     }
   },
   {
@@ -53091,8 +53668,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4232800",
+      "name": "Harrisburg",
+      "state": "PA",
+      "lat": 40.275891,
+      "lng": -76.88502
     }
   },
   {
@@ -54807,8 +55388,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "place",
+      "fips": "2605920",
+      "name": "Battle Creek",
+      "state": "MI",
+      "lat": 42.299176,
+      "lng": -85.229267
     }
   },
   {
@@ -54902,7 +55487,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "2128900",
+      "name": "Frankfort",
+      "state": "KY",
+      "lat": 38.194966,
+      "lng": -84.865877
+    }
   },
   {
     "agency_id": "527214f8-a375-5eec-8c56-7fa73b8f2906",
@@ -55294,8 +55886,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2143480",
+      "name": "La Grange",
+      "state": "KY",
+      "lat": 38.397251,
+      "lng": -85.376804
     }
   },
   {
@@ -55465,8 +56061,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1842246",
+      "name": "La Porte",
+      "state": "IN",
+      "lat": 41.606072,
+      "lng": -86.713679
     }
   },
   {
@@ -56561,7 +57161,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4254264",
+      "name": "Newtown",
+      "state": "PA",
+      "lat": 40.653216,
+      "lng": -76.345568
+    }
   },
   {
     "agency_id": "fd0594f2-7dad-50d7-8079-ae14bdea2db4",
@@ -56605,8 +57212,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3988000",
+      "name": "Youngstown",
+      "state": "OH",
+      "lat": 41.099095,
+      "lng": -80.645902
     }
   },
   {
@@ -59024,8 +59635,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "manual",
+      "name": "Wexford",
+      "state": "PA",
+      "lat": 40.647,
+      "lng": -80.059
     }
   },
   {
@@ -59718,8 +60332,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3943554",
+      "name": "Lima",
+      "state": "OH",
+      "lat": 40.740679,
+      "lng": -84.112091
     }
   },
   {
@@ -59764,8 +60382,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3977000",
+      "name": "Toledo",
+      "state": "OH",
+      "lat": 41.664071,
+      "lng": -83.581861
     }
   },
   {
@@ -59860,8 +60482,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3975602",
+      "name": "Sunbury",
+      "state": "OH",
+      "lat": 40.249405,
+      "lng": -82.880199
     }
   },
   {
@@ -59957,8 +60583,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3912000",
+      "name": "Canton",
+      "state": "OH",
+      "lat": 40.80765,
+      "lng": -81.367228
     }
   },
   {
@@ -59978,8 +60608,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3914184",
+      "name": "Chillicothe",
+      "state": "OH",
+      "lat": 39.340502,
+      "lng": -82.996102
     }
   },
   {
@@ -60067,7 +60701,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3944674",
+      "name": "London",
+      "state": "OH",
+      "lat": 39.892845,
+      "lng": -83.438875
+    }
   },
   {
     "agency_id": "c33881fc-332e-50fa-b582-a7174f0c5637",
@@ -60085,7 +60726,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "3966390",
+      "name": "Reynoldsburg",
+      "state": "OH",
+      "lat": 39.961302,
+      "lng": -82.788939
+    }
   },
   {
     "agency_id": "27c6bcca-5e43-5066-bf86-4526ffd0984f",
@@ -62769,8 +63417,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4253368",
+      "name": "New Castle",
+      "state": "PA",
+      "lat": 40.995617,
+      "lng": -80.345807
     }
   },
   {
@@ -62940,8 +63592,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3941720",
+      "name": "Lancaster",
+      "state": "OH",
+      "lat": 39.725228,
+      "lng": -82.605246
     }
   },
   {
@@ -63360,7 +64016,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "county",
+      "fips": "39151",
+      "name": "Stark",
+      "state": "OH",
+      "lat": 40.814131,
+      "lng": -81.365667
+    }
   },
   {
     "agency_id": "d1b85c6a-72e1-50a0-ad30-5e24c7c1d906",
@@ -64029,8 +64692,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2973618",
+      "name": "Town and Country",
+      "state": "MO",
+      "lat": 38.630602,
+      "lng": -90.477191
     }
   },
   {
@@ -64505,8 +65172,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OH"
+      "kind": "place",
+      "fips": "3916000",
+      "name": "Cleveland",
+      "state": "OH",
+      "lat": 41.478462,
+      "lng": -81.679435
     }
   },
   {
@@ -64553,8 +65224,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "place",
+      "fips": "2603000",
+      "name": "Ann Arbor",
+      "state": "MI",
+      "lat": 42.276147,
+      "lng": -83.73086
     }
   },
   {
@@ -64575,8 +65250,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3712000",
+      "name": "Charlotte",
+      "state": "NC",
+      "lat": 35.209045,
+      "lng": -80.83099
     }
   },
   {
@@ -64597,8 +65276,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IN"
+      "kind": "place",
+      "fips": "1871000",
+      "name": "South Bend",
+      "state": "IN",
+      "lat": 41.676643,
+      "lng": -86.268809
     }
   },
   {
@@ -64794,8 +65477,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1740793",
+      "name": "La Grange Park",
+      "state": "IL",
+      "lat": 41.830778,
+      "lng": -87.872274
     }
   },
   {
@@ -67229,8 +67916,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3707080",
+      "name": "Boone",
+      "state": "NC",
+      "lat": 36.213842,
+      "lng": -81.665197
     }
   },
   {
@@ -67325,8 +68016,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AZ"
+      "kind": "place",
+      "fips": "0473000",
+      "name": "Tempe",
+      "state": "AZ",
+      "lat": 33.388414,
+      "lng": -111.931782
     }
   },
   {
@@ -67346,8 +68041,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "county",
+      "fips": "13059",
+      "name": "Clarke",
+      "state": "GA",
+      "lat": 33.952185,
+      "lng": -83.367152
     }
   },
   {
@@ -67542,8 +68241,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "DFW Airport",
+      "state": "TX",
+      "lat": 32.8998,
+      "lng": -97.0403
     }
   },
   {
@@ -114544,7 +115246,15 @@
       "needs-review",
       "public"
     ],
-    "flags": []
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4807192",
+      "name": "Beeville",
+      "state": "TX",
+      "lat": 28.405244,
+      "lng": -97.748931
+    }
   },
   {
     "agency_id": "67cf5190-2ae6-577a-9cba-8a23246426a2",
@@ -117097,8 +117807,12 @@
       "public"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4834832",
+      "name": "Horizon City",
+      "state": "TX",
+      "lat": 31.679648,
+      "lng": -106.191055
     },
     "flags": []
   },
@@ -122990,8 +123704,12 @@
       "needs-review"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4819000",
+      "name": "Dallas",
+      "state": "TX",
+      "lat": 32.793333,
+      "lng": -96.766513
     },
     "flags": []
   },
@@ -127442,7 +128160,15 @@
     "tags": [
       "needs-review"
     ],
-    "flags": []
+    "flags": [],
+    "geo": {
+      "kind": "place",
+      "fips": "4835000",
+      "name": "Houston",
+      "state": "TX",
+      "lat": 29.785743,
+      "lng": -95.388806
+    }
   },
   {
     "agency_id": "030b796b-eb59-5d03-8f7f-b1d5ce1a005c",

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -257,6 +257,61 @@ STATE_CITY_ALIASES = {
     ("Marta", "GA"): "Atlanta",  # MARTA is the Atlanta transit authority
     ("Wyandotte Nation", "OK"): "Wyandotte",
     ("Port of Seattle", "WA"): "Seattle",
+
+    # Single-campus colleges/universities → campus city (issue #447).
+    ("ASU", "AZ"): "Tempe",
+    ("Central Connecticut State University", "CT"): "New Britain",
+    ("Guilford Technical Community College", "NC"): "Jamestown",
+    ("Houston Christian University", "TX"): "Houston",
+    ("Ithaca College", "NY"): "Ithaca",
+    ("Kellogg Community College", "MI"): "Battle Creek",
+    ("Lamar University", "TX"): "Beaumont",
+    ("Northern Arizona University", "AZ"): "Flagstaff",
+    ("College of Mount St. Joseph", "OH"): "Cincinnati",
+    ("Oklahoma City Community College", "OK"): "Oklahoma City",
+    ("Prince George's Community College", "MD"): "Largo",
+    ("Rockhurst University", "MO"): "Kansas City",
+    ("SUNY Binghamton", "NY"): "Binghamton",
+    ("SUNY-Onondaga Community College", "NY"): "Syracuse",
+    ("SUNY Old Westbury", "NY"): "Old Westbury",
+    ("Southwestern Illinois College", "IL"): "Belleville",
+    ("Springfield College", "MA"): "Springfield",
+    ("Alvin College", "TX"): "Alvin",
+    ("Lee College", "TX"): "Baytown",
+    ("Tarleton State University", "TX"): "Stephenville",
+    ("Texas A&M International University", "TX"): "Laredo",
+    ("Texas Christian University", "TX"): "Fort Worth",
+    ("University Circle", "OH"): "Cleveland",
+    ("University of Arizona", "AZ"): "Tucson",
+    ("University of Delaware", "DE"): "Newark",
+    ("University of Houston Clear Lake", "TX"): "Houston",
+    ("University of Houston Downtown", "TX"): "Houston",
+    ("University of Michigan Ann Arbor", "MI"): "Ann Arbor",
+    ("University of North Carolina Chapel Hill", "NC"): "Chapel Hill",
+    ("University of North Carolina Charlotte", "NC"): "Charlotte",
+    ("University of Notre Dame", "IN"): "South Bend",
+    ("University of Texas Permian Basin", "TX"): "Odessa",
+    ("George Mason University", "VA"): "Fairfax",
+    ("Weatherford College", "TX"): "Weatherford",
+
+    # City-name spelling / suffix variants (issue #447). Census place
+    # names differ from the spelling Flock carries.
+    ("Desoto", "MO"): "De Soto",
+    ("Laporte", "IN"): "La Porte",
+    ("Gun Barrel", "TX"): "Gun Barrel City",
+    ("Horizon", "TX"): "Horizon City",
+    ("Town & Country", "MO"): "Town and Country",
+    ("Snowflake-Taylor", "AZ"): "Snowflake",   # twin towns; pick Snowflake
+    ("Hobart-Lawrence", "WI"): "Hobart",       # twin villages; pick Hobart
+    ("Mechanicsburg/Buffalo", "IL"): "Mechanicsburg",
+    ("Mentor on the Lake", "OH"): "Mentor-on-the-Lake",
+    ("Moorland Hills", "OH"): "Moreland Hills",
+    ("LaGrange", "KY"): "La Grange",
+    ("LaGrange Park", "IL"): "La Grange Park",
+    ("North Attleboro", "MA"): "North Attleborough",
+    ("Bloomfield", "MI"): "Bloomfield Hills",
+    ("The City of The Village", "OK"): "The Village",
+    ("Inc Village of Lake Success", "NY"): "Lake Success",
 }
 
 
@@ -602,7 +657,161 @@ MANUAL_OVERRIDES = {
         "kind": "manual", "name": "Cape Girardeau", "state": "MO",
         "lat": 37.3059, "lng": -89.5181,
     },
+    # Dallas/Fort Worth International Airport PD — the airport straddles
+    # Irving/Grapevine/Euless; no single Census place centroid fits, so
+    # pin to the airport itself (issue #447).
+    "95421760-604f-57cd-88e7-40055f0e1529": {
+        "kind": "manual", "name": "DFW Airport", "state": "TX",
+        "lat": 32.8998, "lng": -97.0403,
+    },
+    # Northern Regional PD (Allegheny County PA) — HQ in Wexford, a CDP
+    # the Census places gazetteer doesn't index; serves the northern
+    # Allegheny suburbs (issue #447).
+    "08440ba2-9d22-5fef-8f08-bec451284e95": {
+        "kind": "manual", "name": "Wexford", "state": "PA",
+        "lat": 40.6470, "lng": -80.0590,
+    },
 }
+
+
+# Gazetteer-resolved overrides for agencies whose physical location is a
+# Census place/county/cousub but whose *name* can't be auto-extracted
+# (hospital systems, park districts, transit authorities, ISDs, regional
+# task forces, state-agency HQ cities, etc.). Keyed by agency_id; resolved
+# against the gazetteer at geocode time so the coords stay in sync (and are
+# validated by tests/test_geo_cache.py) rather than being frozen here.
+# Value is (kind, name, state) or (kind, name, state, county_hint) where
+# kind is "place" | "county" | "cousub". Entries whose location genuinely
+# can't be pinned down (multi-county task forces with no base, bare TX
+# constable precincts, cryptic portal names) are deliberately omitted —
+# they stay flagged by scripts/check_recipient_coords.py.
+GAZ_OVERRIDES = {
+    # place overrides (issue #447)
+    "bb9193bd-a05e-5a85-8442-0500a92e5345": ("place", "Johnson City", "TN"),  # 1st Judicial District DTF
+    "10319f36-e697-550c-8201-d4b1aa641813": ("place", "Livingston", "TX"),  # Alabama-Coushatta Tribe
+    "04cea6da-d564-5393-9c2b-e6954ab126d7": ("place", "Boone", "NC"),  # Appalachian Regional Healthcare System
+    "578144cb-7f6b-5893-8d43-0fd67b01543b": ("place", "Baldwinsville", "NY"),  # Baldwinsville Central School District
+    "fcdbe24d-aac3-5056-8085-e6ee55c61448": ("place", "Chicago Heights", "IL"),  # Bloom Township HS District 206
+    "a94e8041-ab2e-58e7-90e8-09218338b9dd": ("place", "Syracuse", "NY"),  # CAC - Central NY
+    "d9b3e9f0-3081-5459-b234-39e4bc23ee0d": ("place", "Buffalo", "NY"),  # CAC - Erie
+    "d803558a-de4c-56cd-8e59-ea5e06e7bc93": ("place", "Goshen", "NY"),  # CAC - Hudson Valley
+    "2f033355-e355-5db0-b779-0f1f2b45cc2b": ("place", "Utica", "NY"),  # CAC - Mohawk Valley
+    "af4247e1-9428-5fff-bbeb-de37252f7e13": ("place", "Rochester", "NY"),  # CAC - Monroe
+    "e790abe7-04a0-5480-9b1f-2a6f75d4ad65": ("place", "Niagara Falls", "NY"),  # CAC - Niagara
+    "e5a4e334-e976-5d15-a5ca-5ddfb0d324ff": ("place", "Malone", "NY"),  # CAC - North Country
+    "7e6433bc-b57a-54b6-b375-fb838605e473": ("place", "Binghamton", "NY"),  # CAC - Southern Tier
+    "1fd26e6a-2b09-53ac-8f8e-fe4226969049": ("place", "Homewood", "IL"),  # CN Railroad PD (US HQ)
+    "1e65fcf9-b399-5e54-9cd4-6f68c9824fa8": ("place", "Rock Hill", "SC"),  # Catawba Nation
+    "112cf1f2-b628-5a03-b02a-63169d752db1": ("place", "Cleveland", "OH"),  # Cleveland Clinic
+    "2f781e64-cdac-50f8-87b5-907c9049ed95": ("place", "Cleveland", "OH"),  # Cleveland Metro Schools
+    "4f49b561-9ed3-5576-9576-145702229258": ("place", "Cleveland", "OH"),  # Cleveland Metroparks
+    "fb1b3ad0-6321-5316-8995-1309ed1f2e3d": ("place", "Beeville", "TX"),  # Coastal Bend College
+    "74a9fbc7-1d82-5628-aee5-e2938510d86c": ("place", "West Columbia", "SC"),  # Columbia Metro Airport
+    "14068524-23ad-5f61-be7a-ed7de5135595": ("place", "Columbus", "OH"),  # Columbus Regional Airport Authority
+    "7b710523-06a2-5f2e-948e-41a18aa58fec": ("place", "Indianapolis city (balance)", "IN"),  # Community Health Network
+    "27bbf971-facc-5637-8b79-7d2d16893da1": ("place", "Coulee Dam", "WA"),  # Coulee Dam PD
+    "76010eb9-473b-5f1d-84fe-5329196b72ba": ("place", "Dallas", "TX"),  # Dallas Area Rapid Transit
+    "bd9b53d4-d38f-50b9-90d1-15684578c915": ("place", "Greenville", "NC"),  # ECU Health
+    "28bf3b02-2dcd-5e12-98e0-0a5f3ea066a1": ("place", "Homewood", "IL"),  # ECom911 (south Cook County dispatch)
+    "7071c666-10c3-5626-9d40-7899bbaad3df": ("place", "Tyler", "TX"),  # East Texas Auto Theft Task Force
+    "54d1bc80-a170-513b-861c-79400c9cb8c1": ("place", "New Oxford", "PA"),  # Eastern Adams Regional PD
+    "9dc99f88-1f3e-572a-8f92-0c12d47f9b8f": ("place", "Piqua", "OH"),  # Edison State Community College
+    "16899400-f5d1-5e53-b38c-9890dc1d9048": ("place", "Dayton", "OH"),  # Five Rivers MetroParks
+    "f740adf6-7787-5a57-959c-83eabad5d032": ("place", "East Peoria", "IL"),  # Fon du Lac Park District
+    "efc5c6ce-a8ae-5855-8764-bb4ef22e6e05": ("place", "Cleveland", "OH"),  # Greater Cleveland RTA
+    "994cafa6-360c-5767-b9bb-1778b2182bc7": ("place", "Midland", "TX"),  # Greenwood ISD
+    "0bacfde0-4cc1-5aa2-8959-c24fc15e98c6": ("place", "Harrisburg", "PA"),  # Harrisburg Bureau of Police
+    "46448aa2-3292-5837-af4a-55a94ad6b52a": ("place", "Hermitage", "PA"),  # Hermitage PD
+    "cdf53878-f007-5349-82c3-c198d69e4737": ("place", "Houston", "TX"),  # Houston METRO transit
+    "0eee95cd-e37a-5dfc-b370-3745ed279b97": ("place", "Thornton", "IL"),  # Illinois Statewide Auto Theft TF
+    "799ad8b7-438d-5086-a14c-d396754a5644": ("place", "Lima", "OH"),  # Johnny Appleseed Metro Park District
+    "c5cde259-f76e-50ed-87c9-6b4dc48f9cf3": ("place", "Frankfort", "KY"),  # Kentucky AG
+    "85363fab-8619-55e4-aa45-15949bb864d2": ("place", "Painesville", "OH"),  # Lake Metroparks Rangers
+    "6202f013-25eb-518a-b460-2c6bd405d044": ("place", "Lakeway", "TX"),  # Lake Travis ISD
+    "04cf4606-6e6f-59ce-b518-1c9cdde0c183": ("place", "West Columbia", "SC"),  # Lexington Medical Center
+    "954e73b9-7cf7-5c4f-b490-a65a1a9cc357": ("place", "Milford", "MA"),  # Massachusetts Dept of Correction
+    "e6113b72-79ed-5300-834b-f749e617f7be": ("place", "Newtown", "PA"),  # MAGLOCLEN RISS center
+    "710baca5-ca63-52f4-925d-9cdfa9917c61": ("place", "Youngstown", "OH"),  # Mahoning Valley LE Task Force
+    "95c199f9-534a-585e-a7e9-4983399855bb": ("place", "Hedwig Village", "TX"),  # Memorial Villages PD
+    "c0667123-d485-5710-923a-dbf817b0f99c": ("place", "Midlothian", "TX"),  # Methodist Midlothian Medical Center
+    "ca1760c3-29de-5a02-be23-502ff58b205b": ("place", "Toledo", "OH"),  # Metroparks Toledo
+    "6f7dca30-e826-53d5-bb7a-33a8e21a85ef": ("place", "New York", "NY"),  # NYC Dept of Environmental Protection
+    "7ea3e352-7c88-5b18-88cb-964542ce0796": ("place", "Dallas", "TX"),  # North TX Anti-Gang Center
+    "d1c45457-4bc4-5858-a874-158dcc960ef1": ("place", "North Tonawanda", "NY"),  # North Tonawanda City PD
+    "a203ad54-323b-54d9-9a8a-94c1cbe609ee": ("place", "Leesport", "PA"),  # Northern Berks Regional PD
+    "0be79128-e1ed-5a3c-a57c-75cfd1ee2406": ("place", "Chillicothe", "OH"),  # U.S. 23 Major Crimes Task Force
+    "2d246354-acd9-5314-a529-cdb88d36e50b": ("place", "Oklahoma City", "OK"),  # Oklahoma State Bureau of Investigation
+    "01d3d28e-4e7f-5b42-8e1e-d68741684c46": ("place", "London", "OH"),  # Ohio Bureau of Criminal Investigation
+    "fe8cfc6d-73db-56ef-bb9d-4d1a4432be35": ("place", "Columbus", "OH"),  # Ohio Bureau of Motor Vehicles
+    "350b3dc3-f357-59ea-9ce1-91f5c4fbb9e8": ("place", "Columbus", "OH"),  # Ohio DPS
+    "a483e698-31f9-5d06-8f8e-973537e839a6": ("place", "Moreland Hills", "OH"),  # Ohio Drug TF (Moreland Hills)
+    "c33881fc-332e-50fa-b582-a7174f0c5637": ("place", "Reynoldsburg", "OH"),  # Ohio State Fire Marshal
+    "3ae3ebc6-f651-5660-bd47-d18c0e38330b": ("place", "Columbus", "OH"),  # Ohio Bureau of Workers' Compensation
+    "42353055-bd16-5954-87dd-ce3ce3f5d572": ("place", "Red Rock", "OK"),  # Otoe-Missouria Tribe
+    "6600f2e5-4aa7-57ba-bfc6-94434b7e40b8": ("place", "Sunbury", "OH"),  # Preservation Parks of Delaware County
+    "05f3a58d-3072-5fa9-aac2-85fefe863065": ("place", "Toledo", "OH"),  # ProMedica
+    "127b98cf-5af4-5ae9-a955-db6f2d5cade8": ("place", "Rockford", "IL"),  # Rockford Park District
+    "ea85dbdd-5957-5508-9a72-bf380ecd103d": ("place", "Sisseton", "SD"),  # Lake Traverse Reservation
+    "00404003-7cbf-5393-b423-b14d38d6fce5": ("place", "Strongsville", "OH"),  # Southwest Emergency Dispatch Center
+    "0ef3b226-05d1-577d-a97b-3b9f48bf6a19": ("place", "Sedona", "AZ"),  # Sedona PD (deactivated)
+    "0a271d12-f706-5482-bf9a-1324a3150525": ("place", "New Castle", "PA"),  # Shenango Township PD (Lawrence Co.)
+    "82ae4281-d565-5965-ae53-06f2ec921757": ("place", "Society Hill", "SC"),  # Society Hill PD
+    "df21aae3-5581-58b8-b5d2-3b81c0d2b668": ("place", "Lancaster", "OH"),  # South Central OH Major Crimes Unit
+    "f4cde793-b9ca-5de9-a379-27026fb407fd": ("place", "Lubbock", "TX"),  # South Plains Auto Theft Task Force
+    "16fd9939-edcc-5adc-8dcf-939d662158fc": ("place", "Canton", "OH"),  # Stark Parks Public Safety
+    "0b1f7152-0bf0-57e7-a020-bf9794a5bed0": ("place", "Bowler", "WI"),  # Stockbridge-Munsee Community
+    "6175cc72-e59f-509d-9bac-fc2c762895a5": ("place", "Akron", "OH"),  # Summa Health
+    "2fcedc2f-f6e5-579a-846b-8868befbeff2": ("place", "Akron", "OH"),  # Summit Metro Parks
+    "fd94ae2d-2dbc-51e9-839d-a05b87c478a3": ("place", "Syracuse", "NY"),  # Syracuse-Hancock Intl Airport
+    "f77f3cb5-93ee-52fb-9f54-223682704d1d": ("place", "Austin", "TX"),  # TX Alcoholic Beverage Commission
+    "8020a5ed-a254-5ff7-b195-d0f086713829": ("place", "Austin", "TX"),  # Texas Dept of Transportation
+    "6370abfb-0b2d-5be3-8a5d-28be2f4d14de": ("place", "Fort Worth", "TX"),  # Tarrant Regional Water District
+    "11aab840-0087-5abc-b328-35a2619958bc": ("place", "Houston", "TX"),  # Texas Medical Center
+    "77d0e5dd-585e-5feb-9574-ca7c4c3dc66f": ("place", "Payson", "AZ"),  # Tonto Apache Tribe
+    "eab53746-9866-59f2-b0a5-313f2dd081f0": ("place", "Dallas", "TX"),  # UT Southwestern Medical Center
+    "5a2c7e66-cd79-5606-8385-a761dcf9dc22": ("place", "Richmond", "VA"),  # VA Dept of Wildlife Resources
+    "50246cdc-d525-5adb-857b-642bb801df47": ("place", "Raleigh", "NC"),  # WakeMed
+    "818b8252-e20f-5986-bb60-32d66972f28d": ("place", "North Riverside", "IL"),  # West Central Consolidated Comms
+    "1b63402e-4767-5115-a837-f6c148290248": ("place", "Kansas City", "MO"),  # Westport Regional Business League
+    # county overrides (issue #447)
+    "8e84238f-abb9-5a87-a619-52905c0a2821": ("county", "Clarke", "GA"),  # Athens-Clarke County PD
+    "fde92938-d9fc-5d64-ad1a-cf0239b2ee13": ("county", "Fort Bend", "TX"),  # Fort Bend County Constable Pct 1
+    "4c590b32-1aff-5185-a6fb-c6f583505349": ("county", "Fort Bend", "TX"),  # Fort Bend County Constable Pct 4
+    "5855a3bb-f4b8-5104-92f6-512f92a16c42": ("county", "Fort Bend", "TX"),  # Fort Bend County Environmental Health
+    "c680b273-977e-5d06-a26c-c635701a4510": ("county", "Kaufman", "TX"),  # Kaufman County Constable Pct 2
+    "8d9679c1-25c2-5625-afd2-7a014384dc6f": ("county", "Rio Blanco", "CO"),  # Rio Blanco County SO
+    "4e3f6084-585f-58ac-b00a-3b21f8b5d200": ("county", "Stark", "OH"),  # Stark County SO
+    # county-subdivision (cousub) overrides (issue #447)
+    "fdf3939a-6ec5-5236-9186-f86cc9e627e7": ("cousub", "De Witt", "NY"),  # DeWitt town (Onondaga Co.)
+    "592bf6b8-db27-5a54-8802-34d5b841b2ba": ("cousub", "East Hanover", "NJ"),  # East Hanover Twp (Morris Co.)
+    "c639c3ab-f1e6-504c-baed-b5ed04d33181": ("cousub", "Monroe", "NJ", "34023"),  # Monroe Twp (Middlesex Co.)
+    "ec54b02b-0101-59bc-a7a0-27cc6f96accc": ("cousub", "Lisbon", "CT"),  # Town of Lisbon (resident troopers)
+}
+
+
+def _gaz_override_geo(spec):
+    """Resolve a GAZ_OVERRIDES spec into a geo block, or None.
+
+    spec is (kind, name, state) or (kind, name, state, county_hint).
+    """
+    kind, name, state = spec[0], spec[1], spec[2]
+    hint = spec[3] if len(spec) > 3 else None
+    if kind == "place":
+        p = lookup_place(name, state)
+        if p:
+            return {"kind": "place", "fips": p["fips"], "name": p["name"],
+                    "state": state, "lat": p["lat"], "lng": p["lng"]}
+    elif kind == "county":
+        c = lookup_county(name, state)
+        if c:
+            return {"kind": "county", "fips": c["fips"], "name": c["bare_name"],
+                    "state": state, "lat": c["lat"], "lng": c["lng"]}
+    elif kind == "cousub":
+        cs = lookup_cousub(name, state, county_hint=hint)
+        if cs:
+            return {"kind": "cousub", "fips": cs["fips"], "name": cs["bare_name"],
+                    "state": state, "lat": cs["lat"], "lng": cs["lng"]}
+    return None
 
 
 def geocode_entry(entry):
@@ -614,6 +823,10 @@ def geocode_entry(entry):
     aid = entry.get("agency_id")
     if aid in MANUAL_OVERRIDES:
         return dict(MANUAL_OVERRIDES[aid])
+    if aid in GAZ_OVERRIDES:
+        geo = _gaz_override_geo(GAZ_OVERRIDES[aid])
+        if geo:
+            return geo
 
     name = agency_display_name(entry)
     state = agency_state(entry) or infer_state_from_name(name)
@@ -787,6 +1000,23 @@ def geocode_entry(entry):
     # Try as a place (city/town)
     candidate = extract_place_candidate(name, state)
     if candidate:
+        # New England / NY style "X Town", "X Town/Village", "X Village":
+        # the Census indexes these as county subdivisions (towns), not
+        # incorporated places. Strip the trailing town-type word and look
+        # up the cousub first (e.g. "Amherst Town NY PD" -> Amherst town).
+        tm = re.search(r"\s+(?:Town/Village|Town|Village)$", candidate)
+        if tm:
+            bare = candidate[: tm.start()].strip()
+            town = lookup_cousub(bare, state)
+            if town:
+                return {
+                    "kind": "cousub",
+                    "fips": town["fips"],
+                    "name": town["bare_name"],
+                    "state": state,
+                    "lat": town["lat"],
+                    "lng": town["lng"],
+                }
         place = lookup_place(candidate, state)
         if place:
             return {


### PR DESCRIPTION
Closes #447.

Takes the missing-recipient-coordinates gap from **166 → 8**. All additions are gazetteer-backed and validated by `tests/test_geo_cache.py` (no frozen coordinates except two true sub-place points).

## Mechanisms (in `scripts/geocode_agencies.py`)

- **`STATE_CITY_ALIASES` (+50)** — single-campus colleges/universities mapped to their campus city (ASU→Tempe, Lamar→Beaumont, Notre Dame→South Bend, UNC Charlotte→Charlotte, …), plus city-name spelling/suffix variants (De Soto, La Porte, Gun Barrel City, North Attleborough, Mentor-on-the-Lake, …).
- **`GAZ_OVERRIDES` (new table)** — `agency_id → (place | county | cousub, name, state)`, resolved against the Census gazetteer at geocode time, for agencies whose physical location is a Census place/county but whose *name* can't be auto-extracted: hospital systems, park districts, transit/airport authorities, ISDs, regional task forces, state-agency HQ cities, NY Crime Analysis Centers, tribal HQs, etc. Coords stay in sync with the gazetteer rather than being frozen.
- **NY / New-England "X Town" / "X Village" heuristic** — the Census indexes these as county subdivisions (towns), not incorporated places; strip the town-type word and look up the cousub. Generalizes to future town/village PDs (e.g. Amherst, Cicero, Vestal).
- **Two explicit `kind=manual` points** — DFW Airport (straddles several municipalities) and Northern Regional PD (HQ in the Wexford CDP, not in the places gazetteer).

## Remaining 8 (left flagged by CI on purpose)

Genuinely un-pinnable: no state (`1st Judicial District`), multi-county task forces with no base (`Alabama Drug Enforcement Task Force Region G`, `Regional Vehicle Burglary Suppression Taskforce TX`), bare TX constable precincts whose senders are scattered out-of-state (`Precinct 3/4 (TX)`), a `DO NOT USE` portal, and cryptic names (`OK - 477`, `Elm Ridge TX PD`).

## Verification

- `scripts/check_recipient_coords.py`: 166 → 8.
- `scripts/geocode_agencies.py --apply`: 159 entries geocoded (136 place, 14 cousub, 7 county, 2 manual).
- Full suite green: `pytest` 529 passed (geo-cache, gazetteer, map smoke, scoreboard, etc.).