### PR TITLE
fix(articles): mint article_id from URL hash, not sequential counter

### DIFF
--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -33,6 +33,7 @@ runs over everything since it's free.
 
 import argparse
 import functools
+import hashlib
 import json
 import os
 import re
@@ -81,14 +82,22 @@ def now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def next_article_id(registry: list[dict]) -> str:
-    """Sequential art_NNN; lint_articles enforces uniqueness across PRs."""
-    used: set[int] = set()
-    for e in registry:
-        m = re.match(r"^art_(\d+)$", e.get("article_id", ""))
-        if m:
-            used.add(int(m.group(1)))
-    return f"art_{(max(used) + 1) if used else 1:03d}"
+def article_id_for_url(url: str) -> str:
+    """Stable, collision-free article id derived from the URL.
+
+    Hash-based rather than a max(n)+1 counter: every branch derives the
+    SAME id for a given URL and DIFFERENT ids for different URLs, so two
+    PRs curating concurrently can't mint the same id the way the sequential
+    counter did (each branch read the same max from its own snapshot, picked
+    the same next number, and merged without a git conflict — the collision
+    only surfaced in lint after the fact). Also idempotent: re-crawling a
+    URL reuses its id instead of spawning a second entry. Mirrors the
+    sha256(url)[:8] filename convention in scripts/article_crawl.py
+    (url_filename); 12 hex chars (~48 bits) keep birthday-collision odds
+    negligible at corpus scale. Legacy art_NNN ids are grandfathered by
+    lint_articles.ARTICLE_ID_RE — minting changes, existing ids don't.
+    """
+    return "art_" + hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
 
 
 # ───────────────────────── HTML metadata extraction ─────────────────────────
@@ -323,7 +332,7 @@ def run_phase1(registry: list[dict], *, tags_data: dict,
             continue
         if entry is None:
             continue
-        entry["article_id"] = next_article_id(registry)
+        entry["article_id"] = article_id_for_url(entry["url"])
         registry.append(entry)
         seen.add(entry["url"])
         added += 1

--- a/scripts/lint_articles.py
+++ b/scripts/lint_articles.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Lint assets/article_registry.json for structural integrity.
 
-Parallel PRs adding article entries can collide on art_NNN IDs without
-touching the same line. CI runs this on every PR. The same shape as
+article_id is now hashed from the URL (collision-free by construction —
+see scripts/article_curate.py:article_id_for_url), so parallel PRs can no
+longer mint the same new id. This lint stays as defense-in-depth: it still
+guards the legacy art_NNN ids, hand-edits, URL uniqueness, and the other
+structural invariants. CI runs it on every PR. Same shape as
 scripts/lint_findings.py — fail closed on any error, list every error,
 exit 1.
 
 Checks (errors — exit 1):
-  - article_id format (art_NNN) and uniqueness
+  - article_id format (art_NNN legacy or art_<hex>) and uniqueness
   - URL uniqueness
   - source_domain present and listed in assets/sources.json
   - agencies[] entries resolve to assets/agency_registry.json agency_ids
@@ -39,7 +42,10 @@ SOURCES = ROOT / "assets" / "sources.json"
 TAGS = ROOT / "assets" / "tags.json"
 AGENCY_REGISTRY = ROOT / "assets" / "agency_registry.json"
 
-ARTICLE_ID_RE = re.compile(r"^art_\d{3,}$")
+# art_NNN (legacy sequential) or art_<hex> (current, hashed from the URL —
+# see scripts/article_curate.py:article_id_for_url). Decimal digits are a
+# subset of hex, so one pattern accepts both.
+ARTICLE_ID_RE = re.compile(r"^art_[0-9a-f]{3,}$")
 KNOWN_STATUSES = {"mechanical", "enriched", "needs_review"}
 
 # Word-boundary regex hits suggesting the article reports a contract
@@ -128,7 +134,8 @@ def main() -> int:
         if not aid:
             errors.append(f"{prefix}: missing article_id")
         elif not ARTICLE_ID_RE.match(aid):
-            errors.append(f"{prefix}: article_id {aid!r} doesn't match art_NNN")
+            errors.append(
+                f"{prefix}: article_id {aid!r} doesn't match art_<digits-or-hex>")
         elif aid in seen_ids:
             errors.append(
                 f"{prefix}: duplicate article_id (also at entry[{seen_ids[aid]}])"

--- a/tests/test_article_curate.py
+++ b/tests/test_article_curate.py
@@ -1,0 +1,33 @@
+"""Tests for scripts/article_curate.py — article_id minting.
+
+article_id_for_url replaced a max(n)+1 counter so parallel PRs can't mint
+colliding ids; these lock in the properties that makes possible.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import article_curate  # noqa: E402
+
+
+def test_article_id_is_deterministic():
+    url = "https://example.org/news/license-plate-readers"
+    assert (article_curate.article_id_for_url(url)
+            == article_curate.article_id_for_url(url))
+
+
+def test_article_id_format_matches_lint():
+    aid = article_curate.article_id_for_url("https://example.org/x")
+    assert aid.startswith("art_")
+    hexpart = aid[len("art_"):]
+    assert len(hexpart) == 12
+    assert all(c in "0123456789abcdef" for c in hexpart)
+
+
+def test_distinct_urls_get_distinct_ids():
+    a = article_curate.article_id_for_url("https://example.org/a")
+    b = article_curate.article_id_for_url("https://example.org/b")
+    assert a != b

--- a/tests/test_lint_articles.py
+++ b/tests/test_lint_articles.py
@@ -96,6 +96,17 @@ def test_lint_passes_on_valid_entries(tmp_path):
     assert rc == 0, err
 
 
+def test_lint_accepts_hashed_article_id(tmp_path):
+    # Current minting is art_<12 hex> (article_curate.article_id_for_url);
+    # legacy art_NNN must keep validating alongside the new hashed form.
+    repo, _ = _make_repo(tmp_path, registry=[
+        _good_entry("art_a1b2c3d4e5f6"),
+        _good_entry("art_001", url="https://eff.org/legacy"),
+    ])
+    rc, out, err = _run(repo)
+    assert rc == 0, err
+
+
 # ── Failure cases ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Parallel article PRs collide on `art_NNN` ids. `next_article_id()` mints with `max(n)+1` — a shared counter each branch computes from its own snapshot of the registry. Two PRs adding articles at the same time both read the same max, pick the same next number, and merge cleanly (different lines, no git conflict). The dup only surfaces in `lint_articles.py` after the fact, requiring a manual renumber.

## Fix

Replace the counter with `article_id_for_url()`: `art_<sha256(url)[:12]>`.

- **Collision-free by construction** — the id derives from the URL, not a counter, so every branch mints the same id for a given URL and different ids for different URLs. Concurrent PRs can't dup.
- **Idempotent** — re-crawling a URL reuses its id instead of spawning a second entry. (UUID4 would also avoid collisions but is random — it loses this, orphaning the old entry on re-crawl.)
- Mirrors the `sha256(url)[:8]` filename convention already in `article_crawl.url_filename`.

## Compatibility

- **Existing `art_NNN` ids are not renumbered** — they're referenced by merged PRs, the findings viewer, and `contracts.js`. Only minting changes; numeric and hashed ids coexist.
- `lint_articles` `ARTICLE_ID_RE` widens `^art_\d{3,}$` → `^art_[0-9a-f]{3,}$` (decimal digits ⊂ hex), so both forms validate. The uniqueness check stays as defense-in-depth.
- Verified no consumer parses the numeric part of the id (only one lexicographic string sort in `article_pr_body.py`).

## Tests

- `tests/test_article_curate.py` (new): determinism, format-matches-lint, distinct-urls-distinct-ids.
- `tests/test_lint_articles.py`: new case asserting hashed ids validate alongside legacy `art_NNN`.
- Full lint still passes on the live 345-entry registry.