### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1948,8 +1948,9 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-29T22:59:56.317086+00:00",
+      "last_probed": "2026-05-30T01:31:58.239966+00:00",
       "tried": {
+        "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
         "-beverly-hills-ca-pd": "http_404",
         "-beverly-hills-ca-po": "http_404",
@@ -4261,6 +4262,14 @@
         "ca-wasco-ca-pd": "http_404"
       }
     },
+    "ec4bad31-edce-5f57-9491-5351b3ff3ce0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T01:31:53.512585+00:00",
+      "tried": {
+        "beverly-hills-mi-pd": "http_404"
+      }
+    },
     "ec938401-adce-513f-a651-b52d3f8387b5": {
       "exhausted": false,
       "found": null,
@@ -4585,9 +4594,10 @@
     "fda043f8-008d-5ce2-a2bb-0d9b9cfbbba2": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-25T11:26:49.382798+00:00",
+      "last_probed": "2026-05-30T01:31:47.047478+00:00",
       "tried": {
         "sonoma-county-ca-sd": "http_404",
+        "sonoma-county-ca-sheriffs-department": "http_404",
         "sonoma-county-ca-sheriffs-office": "http_404"
       }
     },
@@ -4616,6 +4626,6 @@
       }
     }
   },
-  "updated": "2026-05-29T22:59:56.356312+00:00",
+  "updated": "2026-05-30T01:31:58.278750+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1005,6 +1005,14 @@
         "pulaski-county-in-so": "http_404"
       }
     },
+    "37bd6460-ffaa-57e3-9c7c-38dd04b363c3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T05:36:21.296215+00:00",
+      "tried": {
+        "portland-tn-pd": "http_404"
+      }
+    },
     "39054b43-7c24-5b8f-a4ca-266e742af0d4": {
       "exhausted": false,
       "found": null,
@@ -1948,7 +1956,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T01:31:58.239966+00:00",
+      "last_probed": "2026-05-30T05:36:25.629130+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -1970,6 +1978,7 @@
         "-beverly-hills-ps": "http_404",
         "-beverly-hills-ps-ca": "http_404",
         "-beverly-hills-psca": "http_404",
+        "-beverlyhills-ca-pd": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -2835,6 +2844,14 @@
       "tried": {
         "solano-county-special-investigations-bureau-ca-pd": "http_404",
         "solano-county-special-investigations-bureau-ca-po": "http_404"
+      }
+    },
+    "99fd1579-3e9b-58f7-9376-78edaacc408c": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T05:36:15.550823+00:00",
+      "tried": {
+        "graham-nc-pd": "http_404"
       }
     },
     "9a02b7a4-b078-5f90-9323-a684dcda6674": {
@@ -4626,6 +4643,6 @@
       }
     }
   },
-  "updated": "2026-05-30T01:31:58.278750+00:00",
+  "updated": "2026-05-30T05:36:25.667038+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -644,6 +644,14 @@
         "muskegon-mi-pd": "http_200"
       }
     },
+    "253379f6-8514-5e77-88ba-2b994ad6c041": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T22:59:47.232722+00:00",
+      "tried": {
+        "suny-onondaga-community-college-campus-ny-pd": "http_403"
+      }
+    },
     "2549113a-a3d1-5d5c-9a3c-98fe21f27b17": {
       "exhausted": false,
       "found": null,
@@ -890,6 +898,14 @@
       "last_probed": "2026-05-08T14:27:27.847392+00:00",
       "tried": {
         "kanabec-county-mn-so": "http_404"
+      }
+    },
+    "33d26eeb-df4e-5d73-9e6c-2986bd4bb645": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-29T22:59:51.288115+00:00",
+      "tried": {
+        "seguin-tx-pd": "http_404"
       }
     },
     "33f2410a-d3bc-59c8-9076-2f363c25b8ea": {
@@ -1932,7 +1948,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-29T21:29:56.836710+00:00",
+      "last_probed": "2026-05-29T22:59:56.317086+00:00",
       "tried": {
         "-beverly-hills-ca": "http_404",
         "-beverly-hills-ca-pd": "http_404",
@@ -1952,6 +1968,7 @@
         "-beverly-hills-police-department-ca": "http_404",
         "-beverly-hills-ps": "http_404",
         "-beverly-hills-ps-ca": "http_404",
+        "-beverly-hills-psca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -4599,6 +4616,6 @@
       }
     }
   },
-  "updated": "2026-05-29T21:29:56.897573+00:00",
+  "updated": "2026-05-29T22:59:56.356312+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.