### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T23:25:43Z"
+  "last_run": "2026-05-30T04:13:27Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T16:52:27Z"
+  "last_run": "2026-05-29T23:18:18Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -346,5 +346,5 @@
     "https://www.wkow.com/news/fitchburg-common-council-votes-to-end-flock-safety-camera-contact/article_d86e071f-51dd-4c33-9907-bb0e388a2b6d.html",
     "https://www.wskg.org/regional-news/2026-03-04/ithaca-common-council-votes-to-end-contract-with-flock-safety"
   ],
-  "last_run": "2026-05-29T23:18:18Z"
+  "last_run": "2026-05-29T23:25:43Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 345
- Curation: enriched: 296 · mechanical: 26 · needs_review: 23
- Scanner: REVIEW REQUIRED: 231 · WARNINGS: 112 · CLEAN: 2
- Wayback: saved: 147 · submit-failed: 95 · poll-failed: 89 · existing: 7 · save-failed: 7
- PDF: rendered: 288 · skipped-curl-fallback: 57
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
