### PR TITLE
Add Bay Area hyperlocal sources; broaden ALPR discovery keywords

### DIFF
--- a/assets/articles/queue/priority/78f1b77b.json
+++ b/assets/articles/queue/priority/78f1b77b.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.rwcpulse.com/police/2026/02/24/redwood-city-to-review-street-camera-program-ahead-of-contract-renewal/",
+  "source_domain": "rwcpulse.com",
+  "discovered_at": "2026-05-30T00:09:51Z",
+  "discovered_by": "manual:rwc-street-camera-review"
+}

--- a/assets/sources.json
+++ b/assets/sources.json
@@ -61,6 +61,14 @@
       "notes": "Formerly aclunc.org; redirects to aclunorcal.org."
     },
     {
+      "domain": "almanacnews.com",
+      "tier": 2,
+      "name": "The Almanac",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Menlo Park / Atherton / Woodside / Portola Valley (San Mateo County). Embarcadero Media Foundation network; shares one RSS with rwcpulse/paloaltoonline/mv-voice — rwcpulse.com is the network feed-bearer, so this entry is feedless to avoid 4x duplicate crawls of shared stories."
+    },
+    {
       "domain": "apnews.com",
       "tier": 1,
       "name": "Associated Press",
@@ -108,6 +116,15 @@
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "berkeleyscanner.com",
+      "tier": 2,
+      "name": "The Berkeley Scanner",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.berkeleyscanner.com/feed/",
+      "notes": "Berkeley police-beat newsroom; crime/policing focus — high signal for ALPR/surveillance coverage."
     },
     {
       "domain": "berkeleyside.org",
@@ -334,6 +351,14 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "hmbreview.com",
+      "tier": 2,
+      "name": "Half Moon Bay Review",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "San Mateo County coastside (Half Moon Bay / Coastside). No usable RSS feed found (TownNews/BLOX platform); Bing + manual discovery only."
+    },
+    {
       "domain": "hngnews.com",
       "tier": 2,
       "name": "hngnews.com",
@@ -411,12 +436,30 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "kron4.com",
+      "tier": 2,
+      "name": "KRON4",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.kron4.com/feed/",
+      "notes": "Bay Area TV news (Nexstar)."
+    },
+    {
       "domain": "kstp.com",
       "tier": 2,
       "name": "kstp.com",
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "ktvu.com",
+      "tier": 2,
+      "name": "KTVU FOX 2",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.ktvu.com/rss/category/news.xml",
+      "notes": "Bay Area TV news (FOX)."
     },
     {
       "domain": "kut.org",
@@ -462,6 +505,15 @@
       "notes": "California desk feed."
     },
     {
+      "domain": "localnewsmatters.org",
+      "tier": 2,
+      "name": "Local News Matters (Bay City News)",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://localnewsmatters.org/feed/",
+      "notes": "Bay City News regional wire; broad Bay Area / Northern California coverage, syndicated to many local outlets."
+    },
+    {
       "domain": "lookouteugene-springfield.com",
       "tier": 2,
       "name": "lookouteugene-springfield.com",
@@ -485,6 +537,14 @@
       "last_reviewed": "2026-05-11",
       "feed_url": "https://madison.com/search/?f=rss&t=article&l=50&s=start_time&sd=desc&k%5B%5D=%23topstory",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "marinij.com",
+      "tier": 1,
+      "name": "Marin Independent Journal",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Marin County daily (MediaNews Group). Feed returns HTTP 403 to bots — Bing + manual discovery only, same as mercurynews.com / eastbaytimes.com."
     },
     {
       "domain": "mercurynews.com",
@@ -535,6 +595,15 @@
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "nbcbayarea.com",
+      "tier": 2,
+      "name": "NBC Bay Area",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.nbcbayarea.com/?rss=y",
+      "notes": "Bay Area TV news (NBC)."
     },
     {
       "domain": "news10.com",
@@ -614,12 +683,38 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "padailypost.com",
+      "tier": 2,
+      "name": "Palo Alto Daily Post",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://padailypost.com/feed/",
+      "notes": "Palo Alto / Peninsula daily."
+    },
+    {
+      "domain": "paloaltoonline.com",
+      "tier": 2,
+      "name": "Palo Alto Online",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Palo Alto / Peninsula. Embarcadero Media Foundation network; shares one RSS with rwcpulse (the feed-bearer) — feedless here to avoid duplicate crawls of shared stories."
+    },
+    {
       "domain": "patch.com",
       "tier": 2,
       "name": "patch.com",
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "peninsula360press.com",
+      "tier": 2,
+      "name": "Peninsula 360 Press",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://peninsula360press.com/feed/",
+      "notes": "Redwood City / Peninsula bilingual (English + Spanish) outlet; apex is peninsula360press.com (p360press.com is a short alias). Spanish-language items won't trip the English keyword list, but English ALPR coverage will."
     },
     {
       "domain": "police1.com",
@@ -679,6 +774,15 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "rwcpulse.com",
+      "tier": 2,
+      "name": "Redwood City Pulse",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.rwcpulse.com/rss",
+      "notes": "Redwood City (San Mateo County). Embarcadero Media Foundation network feed-bearer: this one RSS carries the shared network's stories (almanacnews/paloaltoonline/mv-voice publish the same items under their own domains), so only this domain polls the feed to avoid duplicate crawls."
+    },
+    {
       "domain": "sacbee.com",
       "tier": 1,
       "name": "Sacramento Bee",
@@ -727,6 +831,24 @@
       "stance": "neutral",
       "last_reviewed": "2026-04-27",
       "notes": "Hard paywall; no public RSS. Discoverable via search mode."
+    },
+    {
+      "domain": "sfgate.com",
+      "tier": 2,
+      "name": "SFGATE",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.sfgate.com/rss/feed/bay-area-news-429.php",
+      "notes": "Hearst Bay Area digital outlet (sister to sfchronicle.com); Bay Area News section feed."
+    },
+    {
+      "domain": "sfstandard.com",
+      "tier": 2,
+      "name": "The San Francisco Standard",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://sfstandard.com/feed/",
+      "notes": "San Francisco nonprofit newsroom; policing/surveillance coverage."
     },
     {
       "domain": "shorewoodmn.gov",

--- a/scripts/discover_articles.py
+++ b/scripts/discover_articles.py
@@ -79,6 +79,18 @@ KEYWORDS = [
     "flock surveillance",
     "vigilant solutions",
     "axon alpr",
+    # Municipal-program / real-time-crime-center framings. Local outlets
+    # often describe ALPR/Flock deployments euphemistically ("street
+    # camera program", "public safety cameras") rather than naming the
+    # vendor, so the headline alone carries no ALPR term. These broaden
+    # recall for that framing; "fusus"/"real-time crime center" cover the
+    # adjacent surveillance stack (see Axon Fusus). Modest false-positive
+    # cost is absorbed by the two PR-review gates before crawl/merge.
+    "real-time crime center",
+    "real time crime center",
+    "fusus",
+    "street camera",
+    "public safety camera",
 ]
 
 # Bing News RSS search queries. Bing doesn't support quoted OR (e.g.

--- a/tests/test_discover_articles.py
+++ b/tests/test_discover_articles.py
@@ -26,6 +26,10 @@ import discover_articles as da  # noqa: E402
     # appears earlier in the list than "automated license plate".
     ("Automated license plate recognition systems",  "license plate recognition"),
     ("FLOCK SAFETY launches new product",            "flock safety"),  # case-insensitive
+    # Municipal-program / euphemistic framings (headline names no vendor).
+    ("City to review its street camera program",     "street camera"),
+    ("Police roll out a Fusus integration",          "fusus"),
+    ("New public safety camera network goes live",   "public safety camera"),
     ("Unrelated story about politics",               None),
 ])
 def test_matches_keywords(text, expected):


### PR DESCRIPTION
## Why

An rwcpulse.com Flock article — *"Redwood City to review street camera program ahead of contract renewal"* — never auto-discovered. Two gates closed it out: the domain wasn't in `sources.json`, and its euphemistic headline ("street camera program") matched none of the ALPR keywords. This fixes both classes of gap and adds Bay Area / San Mateo County coverage.

## Sources (+14)

**SMC / Peninsula:** `rwcpulse.com`, `almanacnews.com`, `paloaltoonline.com`, `padailypost.com`, `peninsula360press.com`, `hmbreview.com`
**Bay Area regional / TV:** `sfstandard.com`, `sfgate.com`, `localnewsmatters.org` (Bay City News wire), `berkeleyscanner.com`, `kron4.com`, `ktvu.com`, `nbcbayarea.com`, `marinij.com`

Notes on the design:
- **Embarcadero Media network** — `rwcpulse`/`almanacnews`/`paloaltoonline`/`mv-voice` publish *identical* stories under their *own* URLs. A feed on each would crawl every story 4×, so only `rwcpulse.com` bears the shared RSS feed; the siblings are feed-less allow-list entries (Bing/manual hits under those domains still pass).
- **Feed-less by necessity** — `marinij.com` (MediaNews Group 403s bots, same as the already-feedless `mercurynews`/`eastbaytimes`) and `hmbreview.com` (TownNews/BLOX, no usable RSS).
- All feed URLs validated with feedparser; berkeleyscanner + padailypost already matched ALPR items in a dry run.

## Keywords (+5)

`real-time crime center`, `real time crime center`, `fusus`, `street camera`, `public safety camera` — to catch municipal-program framings where the headline names no vendor. Modest false-positive cost is absorbed by the two existing PR-review gates (discovery PR → merge → crawl PR → merge). New test cases lock them in (`pytest` 15/15).

## Also

- Priority-queued the originating rwcpulse article so the crawler fetches it first once this merges.

## Known follow-up (not in this PR)

Peninsula outlets run **bilingual** coverage; the English-only keyword list skips Spanish-language law-enforcement items (e.g. the rwcpulse feed currently carries *"Una nueva ley de California prohíbe a las fuerzas del orden…"*). A Spanish keyword set would close that.