### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/queue/0e02a375.json
+++ b/assets/articles/queue/0e02a375.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.berkeleyscanner.com/2026/05/12/community/berkeley-extends-flock-camera-contract-drones-postponed/",
+  "source_domain": "berkeleyscanner.com",
+  "discovered_at": "2026-05-30T05:10:48Z",
+  "discovered_by": "rss:berkeleyscanner.com"
+}

--- a/assets/articles/queue/2d2632c5.json
+++ b/assets/articles/queue/2d2632c5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.whsv.com/2026/05/29/elkton-police-defends-use-flock-cameras-residents-question-transparency/",
+  "source_domain": "whsv.com",
+  "discovered_at": "2026-05-30T05:11:36Z",
+  "discovered_by": "rss:whsv.com"
+}

--- a/assets/articles/queue/965a3e81.json
+++ b/assets/articles/queue/965a3e81.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.rwcpulse.com/police/2026/05/29/man-arrested-in-fatal-redwood-city-hit-and-run/",
+  "source_domain": "rwcpulse.com",
+  "discovered_at": "2026-05-30T05:11:03Z",
+  "discovered_by": "rss:rwcpulse.com"
+}

--- a/assets/articles/queue/cfb09b64.json
+++ b/assets/articles/queue/cfb09b64.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://padailypost.com/2026/05/29/hit-and-run-kills-woman-police-seeking-the-driver/",
+  "source_domain": "padailypost.com",
+  "discovered_at": "2026-05-30T05:11:02Z",
+  "discovered_by": "rss:padailypost.com"
+}

--- a/assets/articles/queue/da5afd2c.json
+++ b/assets/articles/queue/da5afd2c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.sfgate.com/news/bayarea/article/berkeley-city-council-votes-to-extend-contract-22255538.php",
+  "source_domain": "sfgate.com",
+  "discovered_at": "2026-05-30T05:11:37Z",
+  "discovered_by": "bing:flock"
+}


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 345
- Curation: enriched: 296 · mechanical: 26 · needs_review: 23
- Scanner: REVIEW REQUIRED: 231 · WARNINGS: 112 · CLEAN: 2
- Wayback: saved: 147 · submit-failed: 95 · poll-failed: 89 · existing: 7 · save-failed: 7
- PDF: rendered: 288 · skipped-curl-fallback: 57
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 1 priority + 5 auto = 6

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
