### PR TITLE
Allow-list 17 outlets from discover-run rejections; queue their ALPR articles

### DIFF
--- a/assets/articles/queue/05ddad05.json
+++ b/assets/articles/queue/05ddad05.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.daytondailynews.com/local/flock-cameras-how-they-work-and-why-some-are-concerned/article_a22b4f47-aac0-5be1-b9c9-cbf325def6e5.html",
+  "source_domain": "daytondailynews.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/0b4156be.json
+++ b/assets/articles/queue/0b4156be.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://timesofsandiego.com/crime/2025/11/14/mayor-todd-gloria-backs-sdpds-use-of-alpr-technology/",
+  "source_domain": "timesofsandiego.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/153a76e5.json
+++ b/assets/articles/queue/153a76e5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.kmbc.com/article/license-plate-reader-cameras-find-missing-liberty-man/69148165",
+  "source_domain": "kmbc.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/1bd3c395.json
+++ b/assets/articles/queue/1bd3c395.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.law.com/radar/card/likeness-data-v-vigilant-solutions-inc-et-al-48923446-0/",
+  "source_domain": "law.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/2c27e27e.json
+++ b/assets/articles/queue/2c27e27e.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://hoodline.com/2026/05/bay-area-cops-coached-on-how-to-pitch-flock-cameras-to-city-hall/",
+  "source_domain": "hoodline.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/3af5c670.json
+++ b/assets/articles/queue/3af5c670.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.timescall.com/2026/04/19/letters-use-of-license-plate-reader-technology-helps-crime-victims/",
+  "source_domain": "timescall.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/4267134c.json
+++ b/assets/articles/queue/4267134c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wgal.com/article/carroll-township-implement-license-plate-reader-system/69548180",
+  "source_domain": "wgal.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/5cfcce66.json
+++ b/assets/articles/queue/5cfcce66.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://augustafreepress.com/news/staunton-police-chief-flock-safety-cameras-no-longer-accessible-to-officers/",
+  "source_domain": "augustafreepress.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/71cf91f5.json
+++ b/assets/articles/queue/71cf91f5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.securitysystemsnews.com/article/flock-safety-engages-bishop-fox-to-bolster-cybersecurity-for-public-safety-platform",
+  "source_domain": "securitysystemsnews.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/7b75e4b3.json
+++ b/assets/articles/queue/7b75e4b3.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.khq.com/national/amazons-ring-ends-partnership-with-flock-safety-amid-surveillance-concerns/article_3ebc3aad-4026-4a49-9538-100e545ad49f.html",
+  "source_domain": "khq.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/8716b96a.json
+++ b/assets/articles/queue/8716b96a.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.nwaonline.com/news/2025/aug/03/springdale-buying-license-plate-reader-cameras/",
+  "source_domain": "nwaonline.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/8bbcc687.json
+++ b/assets/articles/queue/8bbcc687.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.securitysystemsnews.com/article/amazon-ring-and-flock-safety-cancel-partnership",
+  "source_domain": "securitysystemsnews.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/aa3fe2dd.json
+++ b/assets/articles/queue/aa3fe2dd.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.wowt.com/2025/12/10/alpr-cameras-track-iowa-drivers-with-few-regulations-aclu-report-finds/",
+  "source_domain": "wowt.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/ac39c0e9.json
+++ b/assets/articles/queue/ac39c0e9.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.chicagotribune.com/2025/08/28/homer-glen-license-plate-reader-cameras/",
+  "source_domain": "chicagotribune.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/aff60ada.json
+++ b/assets/articles/queue/aff60ada.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.azfamily.com/2025/12/20/flagstaff-cancels-controversial-contract-flock-safety-cameras/",
+  "source_domain": "azfamily.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/b6b8bae5.json
+++ b/assets/articles/queue/b6b8bae5.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.nydailynews.com/2026/02/13/ring-flock-safety-doorbell-camera-deal-canceled/",
+  "source_domain": "nydailynews.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/c23a364c.json
+++ b/assets/articles/queue/c23a364c.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.miaminewtimes.com/news/vigilant-solutions-coral-gables-license-plate-reader-company-shares-info-with-ice-10373144/",
+  "source_domain": "miaminewtimes.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/e086eac7.json
+++ b/assets/articles/queue/e086eac7.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.daytondailynews.com/local/city-covers-all-flock-cameras-amid-program-suspension/article_01aa7687-f68e-5443-b102-d98dd38ed9b6.html",
+  "source_domain": "daytondailynews.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/articles/queue/e1dffebb.json
+++ b/assets/articles/queue/e1dffebb.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.chicagotribune.com/2025/06/12/license-plate-reader-audito-ordered/",
+  "source_domain": "chicagotribune.com",
+  "discovered_at": "2026-05-30T06:20:25Z",
+  "discovered_by": "bing-reject-backfill"
+}

--- a/assets/sources.json
+++ b/assets/sources.json
@@ -66,7 +66,7 @@
       "name": "The Almanac",
       "stance": "neutral",
       "last_reviewed": "2026-05-29",
-      "notes": "Menlo Park / Atherton / Woodside / Portola Valley (San Mateo County). Embarcadero Media Foundation network; shares one RSS with rwcpulse/paloaltoonline/mv-voice — rwcpulse.com is the network feed-bearer, so this entry is feedless to avoid 4x duplicate crawls of shared stories."
+      "notes": "Menlo Park / Atherton / Woodside / Portola Valley (San Mateo County). Embarcadero Media Foundation network; shares one RSS with rwcpulse/paloaltoonline/mv-voice \u2014 rwcpulse.com is the network feed-bearer, so this entry is feedless to avoid 4x duplicate crawls of shared stories."
     },
     {
       "domain": "apnews.com",
@@ -102,6 +102,15 @@
       "notes": ""
     },
     {
+      "domain": "augustafreepress.com",
+      "tier": 2,
+      "name": "Augusta Free Press",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.augustafreepress.com/feed/",
+      "notes": "Staunton / Augusta County VA local news; Flock/ALPR coverage."
+    },
+    {
       "domain": "axon.com",
       "tier": 2,
       "name": "Axon (vendor)",
@@ -118,13 +127,22 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "azfamily.com",
+      "tier": 2,
+      "name": "Arizona's Family (KTVK/KPHO)",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.azfamily.com/arc/outboundfeeds/rss/?outputType=xml",
+      "notes": "Phoenix AZ TV news; Flock contract-cancellation coverage."
+    },
+    {
       "domain": "berkeleyscanner.com",
       "tier": 2,
       "name": "The Berkeley Scanner",
       "stance": "neutral",
       "last_reviewed": "2026-05-29",
       "feed_url": "https://www.berkeleyscanner.com/feed/",
-      "notes": "Berkeley police-beat newsroom; crime/policing focus — high signal for ALPR/surveillance coverage."
+      "notes": "Berkeley police-beat newsroom; crime/policing focus \u2014 high signal for ALPR/surveillance coverage."
     },
     {
       "domain": "berkeleyside.org",
@@ -193,6 +211,14 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "chicagotribune.com",
+      "tier": 1,
+      "name": "Chicago Tribune",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Major metro daily; ALPR/Flock coverage in Chicago and suburbs. No simple public RSS \u2014 Bing + manual discovery."
+    },
+    {
       "domain": "chronline.com",
       "tier": 2,
       "name": "chronline.com",
@@ -232,6 +258,14 @@
       "last_reviewed": "2026-05-11",
       "feed_url": "https://cvillerightnow.com/feed/",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "daytondailynews.com",
+      "tier": 2,
+      "name": "Dayton Daily News",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Dayton OH daily (Cox); Flock program-suspension coverage. Bing + manual discovery."
     },
     {
       "domain": "denvergazette.com",
@@ -367,6 +401,15 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "hoodline.com",
+      "tier": 2,
+      "name": "Hoodline",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.hoodline.com/rss",
+      "notes": "San Francisco / Bay Area hyperlocal; covers how police pitch Flock/ALPR to city hall."
+    },
+    {
       "domain": "ithacavoice.org",
       "tier": 2,
       "name": "ithacavoice.org",
@@ -393,6 +436,14 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "khq.com",
+      "tier": 2,
+      "name": "KHQ",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Spokane WA TV news. Bing + manual discovery."
+    },
+    {
       "domain": "kiro7.com",
       "tier": 2,
       "name": "kiro7.com",
@@ -408,6 +459,14 @@
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "kmbc.com",
+      "tier": 2,
+      "name": "KMBC",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Kansas City MO TV news (Hearst). Bing + manual discovery."
     },
     {
       "domain": "koamnewsnow.com",
@@ -505,6 +564,14 @@
       "notes": "California desk feed."
     },
     {
+      "domain": "law.com",
+      "tier": 2,
+      "name": "Law.com (ALM)",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Legal-industry news and dockets; ALPR litigation (e.g. v. Vigilant Solutions). Bing + manual discovery."
+    },
+    {
       "domain": "localnewsmatters.org",
       "tier": 2,
       "name": "Local News Matters (Bay City News)",
@@ -544,7 +611,7 @@
       "name": "Marin Independent Journal",
       "stance": "neutral",
       "last_reviewed": "2026-05-29",
-      "notes": "Marin County daily (MediaNews Group). Feed returns HTTP 403 to bots — Bing + manual discovery only, same as mercurynews.com / eastbaytimes.com."
+      "notes": "Marin County daily (MediaNews Group). Feed returns HTTP 403 to bots \u2014 Bing + manual discovery only, same as mercurynews.com / eastbaytimes.com."
     },
     {
       "domain": "mercurynews.com",
@@ -553,6 +620,15 @@
       "stance": "neutral",
       "last_reviewed": "2026-04-27",
       "notes": "MediaNews Group; direct feed blocked (403). Discoverable via search mode."
+    },
+    {
+      "domain": "miaminewtimes.com",
+      "tier": 2,
+      "name": "Miami New Times",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.miaminewtimes.com/feed/",
+      "notes": "Miami alt-weekly; investigative ALPR / ICE data-sharing coverage."
     },
     {
       "domain": "missionlocal.org",
@@ -640,6 +716,22 @@
       "notes": ""
     },
     {
+      "domain": "nwaonline.com",
+      "tier": 2,
+      "name": "NW Arkansas Democrat-Gazette",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Northwest Arkansas daily (WEHCO); LPR-purchase coverage. Bing + manual discovery."
+    },
+    {
+      "domain": "nydailynews.com",
+      "tier": 1,
+      "name": "New York Daily News",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Major metro daily; Ring/Flock coverage. Bing + manual discovery."
+    },
+    {
       "domain": "nytimes.com",
       "tier": 1,
       "name": "The New York Times",
@@ -664,6 +756,14 @@
       "last_reviewed": "2026-05-11",
       "feed_url": "https://www.oakpark.com/feed/",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "officer.com",
+      "tier": 2,
+      "name": "Officer.com",
+      "stance": "supportive",
+      "last_reviewed": "2026-05-29",
+      "notes": "Law-enforcement trade publication (Endeavor B2B); vendor/LE-side ALPR coverage. Peer to police1.com. Bing + manual discovery."
     },
     {
       "domain": "opb.org",
@@ -697,7 +797,7 @@
       "name": "Palo Alto Online",
       "stance": "neutral",
       "last_reviewed": "2026-05-29",
-      "notes": "Palo Alto / Peninsula. Embarcadero Media Foundation network; shares one RSS with rwcpulse (the feed-bearer) — feedless here to avoid duplicate crawls of shared stories."
+      "notes": "Palo Alto / Peninsula. Embarcadero Media Foundation network; shares one RSS with rwcpulse (the feed-bearer) \u2014 feedless here to avoid duplicate crawls of shared stories."
     },
     {
       "domain": "patch.com",
@@ -825,6 +925,14 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "securitysystemsnews.com",
+      "tier": 2,
+      "name": "Security Systems News",
+      "stance": "industry",
+      "last_reviewed": "2026-05-29",
+      "notes": "Security-industry trade; ALPR vendor/partnership news (e.g. Ring/Flock). RSS feed 403s our research-bot UA, so Bing + manual discovery only."
+    },
+    {
       "domain": "sfchronicle.com",
       "tier": 1,
       "name": "San Francisco Chronicle",
@@ -932,6 +1040,23 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "timescall.com",
+      "tier": 2,
+      "name": "Longmont Times-Call",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Longmont CO daily (MediaNews); LPR coverage. Bing + manual (MediaNews feeds 403 bots)."
+    },
+    {
+      "domain": "timesofsandiego.com",
+      "tier": 2,
+      "name": "Times of San Diego",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.timesofsandiego.com/feed/",
+      "notes": "San Diego CA digital daily; ALPR / SDPD coverage."
+    },
+    {
       "domain": "timesunion.com",
       "tier": 1,
       "name": "timesunion.com",
@@ -997,6 +1122,14 @@
       "notes": "auto-added from termination_ledger import; review tier/stance"
     },
     {
+      "domain": "wgal.com",
+      "tier": 2,
+      "name": "WGAL",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "notes": "Lancaster / Harrisburg PA TV news (Hearst). Bing + manual discovery."
+    },
+    {
       "domain": "whsv.com",
       "tier": 2,
       "name": "whsv.com",
@@ -1029,6 +1162,15 @@
       "stance": "unknown",
       "last_reviewed": "2026-05-08",
       "notes": "auto-added from termination_ledger import; review tier/stance"
+    },
+    {
+      "domain": "wowt.com",
+      "tier": 2,
+      "name": "WOWT",
+      "stance": "neutral",
+      "last_reviewed": "2026-05-29",
+      "feed_url": "https://www.wowt.com/arc/outboundfeeds/rss/?outputType=xml",
+      "notes": "Omaha NE TV news (Gray); ALPR / ACLU-report coverage."
     },
     {
       "domain": "wpri.com",


### PR DESCRIPTION
## Why

The daily discover run ([job 78625902999](https://github.com/none-below/sm-alpr/actions/runs/26675340941/job/78625902999)) rejected **38 Bing hits** as off-allowlist. Triaging them by topic:

- **~half are aggregators / PR wires** — `msn`, `yahoo`, `aol`, `markets.businessinsider`, `prnewswire.co.uk`, `bolsamania` (+ old/off-topic `upi`/`edn`/`bizjournals`). These **stay rejected**: they republish other outlets' work or are vendor marketing, so the allowlist is doing its job.
- **The rest are legit outlets with real ALPR/Flock coverage** being lost — including `hoodline.com`'s *"Bay Area cops coached on how to pitch Flock cameras to city hall."*

## Sources (+17)

`hoodline` (SF/Bay Area), `timesofsandiego` (CA), `chicagotribune`, `nydailynews`, `miaminewtimes`, `daytondailynews`, `azfamily`, `kmbc`, `khq`, `wowt`, `wgal`, `nwaonline`, `augustafreepress`, `timescall`, `law.com`, `securitysystemsnews` (industry stance), `officer.com` (supportive stance, peer to `police1.com`).

**6 have working RSS feeds**, validated against the *pipeline's research-bot UA* (not just a browser UA): `hoodline`, `timesofsandiego`, `miaminewtimes`, `augustafreepress`, `azfamily`, `wowt`. `securitysystemsnews` 403s the bot UA, so it's feed-less (Bing/manual) — flagged in its notes.

## Queued articles (+19)

Re-fed every rejected URL back through `article_queue_add.py`: the 17 new domains now pass, aggregators/PR-wires stay rejected. Queued **19** of the actual articles (e.g. Flagstaff/Dayton Flock cancellations, Miami New Times' ICE-data-sharing investigation, the SDPD ALPR story). Dropped 2 `officer.com` Vigilant channel-program PR pieces by hand.

## Notes for review

- `sources.json` diff shows 4 "deletions" — those are my own PR #500 notes getting normalized from a literal `—` to `—`, the file's established escaping convention. No content change.