### PR TITLE
fix(ci): use REFRESH_PAT for the FBI refresh push

### DIFF
--- a/.github/workflows/refresh-fbi-data.yml
+++ b/.github/workflows/refresh-fbi-data.yml
@@ -43,6 +43,12 @@ jobs:
     timeout-minutes: 350
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Use the REFRESH_PAT (if configured) so the chore-branch push is
+          # authed as the PAT owner — the default GITHUB_TOKEN is forbidden from
+          # pushing a branch that carries .github/workflows/ files. Same pattern
+          # as refresh-flock-data / article-registry. Falls back to github.token.
+          token: ${{ secrets.REFRESH_PAT || github.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
The chore-branch push was rejected because GITHUB_TOKEN can't push a branch that carries `.github/workflows/` files (which it does, and the workflow just changed). Auth the checkout with `secrets.REFRESH_PAT || github.token` — the same pattern the other push-bot workflows (refresh-flock-data, article-registry, …) already use. One-line, no logic change.