### PR TITLE
Reword searches-per-crime report card; drop ÷ notation

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -737,14 +737,14 @@
       const t30 = spc.trailing_30d;
       let caveat;
       if (spc.searches_source === "audit_month") {
-        caveat = `${fmtInt(spc.searches)} ALPR searches in ${escapeHtml(spc.month_label)} ÷ ${fmtInt(spc.crime_total)} Part 1 crimes reported to the FBI (${fmtInt(spc.crime_violent)} violent + ${fmtInt(spc.crime_property)} property).`;
+        caveat = `In ${escapeHtml(spc.month_label)}, ${escapeHtml(short)} ran ${fmtInt(spc.searches)} ALPR searches against the ${fmtInt(spc.crime_total)} Part 1 crimes it reported to the FBI (${fmtInt(spc.crime_violent)} violent + ${fmtInt(spc.crime_property)} property) — about ${fmtNum(spc.ratio, 1)} searches per crime.`;
       } else if (spc.searches_source === "audit_month_prorated") {
-        caveat = `<strong>Estimated.</strong> ${escapeHtml(short)} recorded ${fmtInt(spc.month_count)} searches over ${spc.month_covered_days} of ${spc.days_in_month} days in ${escapeHtml(spc.month_label)} (audit data begins ${spc.month_first}); scaled to a full month ≈ ${fmtInt(spc.searches)}. Denominator: ${fmtInt(spc.crime_total)} Part 1 crimes (${fmtInt(spc.crime_violent)} violent + ${fmtInt(spc.crime_property)} property).`;
-        if (t30) caveat += ` For reference, the trailing 30 days (${t30.window_start}–${t30.window_end}) hold ${fmtInt(t30.count)} searches.`;
+        caveat = `<strong>Estimated.</strong> ${escapeHtml(short)} ran about ${fmtInt(spc.searches)} ALPR searches in ${escapeHtml(spc.month_label)} against the ${fmtInt(spc.crime_total)} Part 1 crimes it reported to the FBI (${fmtInt(spc.crime_violent)} violent + ${fmtInt(spc.crime_property)} property) — roughly ${fmtNum(spc.ratio, 1)} searches per crime. That ${fmtInt(spc.searches)} extrapolates the ${fmtInt(spc.month_count)} searches logged over ${spc.month_covered_days} of the month’s ${spc.days_in_month} days (the log begins ${spc.month_first}) to a full month.`;
+        if (t30) caveat += ` The most recent 30 days (${t30.window_start}–${t30.window_end}) show ${fmtInt(t30.count)} searches.`;
       } else if (spc.searches_source === "audit_trailing_30d") {
-        caveat = `${fmtInt(spc.searches)} searches in the 30 days ending ${t30 ? t30.window_end : ""} ÷ ${fmtInt(spc.crime_total)} Part 1 crimes reported in ${escapeHtml(spc.month_label)} (most recent FBI data). The 30-day search window isn’t aligned to the crime month.`;
+        caveat = `${escapeHtml(short)} ran ${fmtInt(spc.searches)} ALPR searches in the 30 days ending ${t30 ? t30.window_end : ""} against the ${fmtInt(spc.crime_total)} Part 1 crimes it reported to the FBI in ${escapeHtml(spc.month_label)} — about ${fmtNum(spc.ratio, 1)} searches per crime. The 30-day search window isn’t aligned to the crime month (${escapeHtml(spc.month_label)} is the most recent FBI data).`;
       } else {
-        caveat = `${fmtInt(spc.searches)} searches (${escapeHtml(short)}’s self-reported last-30-days) ÷ ${fmtInt(spc.crime_total)} Part 1 crimes reported in ${escapeHtml(spc.month_label)}.`;
+        caveat = `${escapeHtml(short)} self-reports ${fmtInt(spc.searches)} ALPR searches over its last 30 days, set against the ${fmtInt(spc.crime_total)} Part 1 crimes it reported to the FBI in ${escapeHtml(spc.month_label)} — about ${fmtNum(spc.ratio, 1)} searches per crime. The two windows don’t line up exactly.`;
       }
       const ratioCell = statsCellHtml({
         cellClass: "raw",
@@ -755,8 +755,8 @@
       const mathCell = statsCellHtml({
         cellClass: "per-capita",
         label: spc.month_label,
-        value: `${fmtInt(spc.searches)} ÷ ${fmtInt(spc.crime_total)}`,
-        extrasHtml: `<div class="per-vehicle"><span class="muted">searches ÷ Part 1 crimes</span></div>`,
+        value: `${spc.estimated ? "≈" : ""}${fmtInt(spc.searches)} searches`,
+        extrasHtml: `<div class="per-vehicle"><span class="muted">for ${fmtInt(spc.crime_total)} Part 1 crimes</span></div>`,
       });
       html += metricBlockHtml({
         title: `${short}'s ALPR searches per reported crime`,


### PR DESCRIPTION
Reworks the per-city **ALPR searches per reported crime** card copy. Wording only — no data or compute changes (the metric still resolves the numerator build-side in `scripts/fbi_crime.py`).

### What changed
- **Prose → headline-first.** Leads with the searches-vs-crimes comparison and the ≈ratio, then explains how the estimate is derived. Drops the orphaned "scaled to … ≈ 764", the lab-ish "Denominator:", and "hold N searches".
- **Math cell → plain language.** `764 ÷ 112` becomes `≈764 searches` / "for 112 Part 1 crimes". The extrapolated numerator carries `≈` to match the `≈6.8` ratio (only fires on the prorated branch, where `estimated` is true).
- **Consistent voice across all four numerator branches** (exact-month, prorated, trailing-30, portal self-report) — the math cell is shared, so leaving the others with `÷` prose would clash.

### Before / after (San Mateo, live numbers)
**Before:** *Estimated. San Mateo recorded 509 searches over 20 of 30 days in April 2026 (audit data begins 2026-04-11); scaled to a full month ≈ 764. Denominator: 112 Part 1 crimes (7 violent + 105 property). For reference, the trailing 30 days … hold 624 searches.* — cell: `764 ÷ 112`

**After:** *Estimated. San Mateo ran about 764 ALPR searches in April 2026 against the 112 Part 1 crimes it reported to the FBI (7 violent + 105 property) — roughly 6.8 searches per crime. That 764 extrapolates the 509 searches logged over 20 of the month's 30 days (the log begins 2026-04-11) to a full month. The most recent 30 days (2026-04-27–2026-05-26) show 624 searches.* — cell: `≈764 searches` / for 112 Part 1 crimes

Verified locally by building `report_data.json` + the San Mateo audit log and rendering `report.html?agency=san-mateo-ca-pd`.