### PR TITLE
fix(ci): open FBI refresh PR via REFRESH_PAT so CI runs

### DIFF
--- a/.github/workflows/refresh-fbi-data.yml
+++ b/.github/workflows/refresh-fbi-data.yml
@@ -91,7 +91,11 @@ jobs:
       - name: Create PR
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (if set) so the PR is opened by a human identity and therefore
+          # triggers CI — PRs opened by GITHUB_TOKEN don't, by GitHub's
+          # anti-recursion rule. Matches refresh-flock-data. Falls back to
+          # GITHUB_TOKEN when the PAT isn't configured.
+          GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The chore PR had "no checks reported" because `gh pr create` used GITHUB_TOKEN, and PRs opened by GITHUB_TOKEN don't trigger workflows (anti-recursion). Open it with `secrets.REFRESH_PAT || secrets.GITHUB_TOKEN`, matching refresh-flock-data. One-line.