### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -437,6 +437,14 @@
         "whittier-ca-po": "http_404"
       }
     },
+    "1a317e3d-40ce-5c15-abfb-5f033a2f8cb7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T08:10:21.330098+00:00",
+      "tried": {
+        "glenpool-ok-pd": "http_404"
+      }
+    },
     "1aa44a1e-bfc7-509f-87f9-a6bb0a951727": {
       "exhausted": false,
       "found": null,
@@ -1623,6 +1631,14 @@
         "glen-carbon-il-pd": "http_404"
       }
     },
+    "59970831-4f53-57f5-876c-78db7e83bfac": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T08:10:27.010379+00:00",
+      "tried": {
+        "elizabeth-co-pd": "http_404"
+      }
+    },
     "59b1f730-2412-5790-92fd-a707e3ac23cd": {
       "exhausted": false,
       "found": null,
@@ -1956,7 +1972,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T05:36:25.629130+00:00",
+      "last_probed": "2026-05-30T08:10:33.640759+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -1979,6 +1995,7 @@
         "-beverly-hills-ps-ca": "http_404",
         "-beverly-hills-psca": "http_404",
         "-beverlyhills-ca-pd": "http_404",
+        "-beverlyhills-ca-po": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -4643,6 +4660,6 @@
       }
     }
   },
-  "updated": "2026-05-30T05:36:25.667038+00:00",
+  "updated": "2026-05-30T08:10:33.674498+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.