### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1981,7 +1981,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T11:58:56.052507+00:00",
+      "last_probed": "2026-05-30T14:19:28.111666+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2007,6 +2007,7 @@
         "-beverlyhills-ca-po": "http_404",
         "-beverlyhills-ca-police": "http_404",
         "-beverlyhills-ca-police-department": "http_404",
+        "-beverlyhills-ca-ps": "http_403",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -4594,6 +4595,14 @@
         "ada-county-id-sd": "http_404"
       }
     },
+    "fa76668b-f6e2-5703-850a-724a856e27e8": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T14:19:21.918185+00:00",
+      "tried": {
+        "lee-county-ga-so": "http_403"
+      }
+    },
     "fad50c3f-54b7-5bac-9093-b41b977dac71": {
       "exhausted": false,
       "found": null,
@@ -4634,6 +4643,14 @@
       "last_probed": "2026-05-10T05:23:54.460198+00:00",
       "tried": {
         "madison-in-pd": "http_404"
+      }
+    },
+    "fba15b64-1a12-5f54-8002-3e730717fd99": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T14:19:18.257409+00:00",
+      "tried": {
+        "springfield-il-pd": "http_403"
       }
     },
     "fc97bf62-065b-507f-a327-4fd4c94453c6": {
@@ -4687,6 +4704,6 @@
       }
     }
   },
-  "updated": "2026-05-30T11:58:56.095952+00:00",
+  "updated": "2026-05-30T14:19:28.185621+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1981,7 +1981,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T10:29:59.619344+00:00",
+      "last_probed": "2026-05-30T11:58:56.052507+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2005,6 +2005,7 @@
         "-beverly-hills-psca": "http_404",
         "-beverlyhills-ca-pd": "http_404",
         "-beverlyhills-ca-po": "http_404",
+        "-beverlyhills-ca-police": "http_404",
         "-beverlyhills-ca-police-department": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -2451,6 +2452,14 @@
       "last_probed": "2026-05-12T11:06:05.456347+00:00",
       "tried": {
         "oxford-ms-pd": "http_404"
+      }
+    },
+    "8383db21-74c6-5054-a618-f23bc75390ac": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T11:58:46.268239+00:00",
+      "tried": {
+        "louisville-airport-ky-pd": "http_403"
       }
     },
     "83b5db01-b5ce-5b18-94a4-f5d8c875e5d1": {
@@ -4022,6 +4031,14 @@
         "brunswick-county-va-so": "http_404"
       }
     },
+    "dc9f487a-e4ef-54cb-aa98-402c66a516c0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T11:58:50.676641+00:00",
+      "tried": {
+        "russell-county-al-so": "http_404"
+      }
+    },
     "dcf451eb-a2f0-5b00-b77e-34275821760b": {
       "exhausted": false,
       "found": null,
@@ -4670,6 +4687,6 @@
       }
     }
   },
-  "updated": "2026-05-30T10:29:59.662180+00:00",
+  "updated": "2026-05-30T11:58:56.095952+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1990,7 +1990,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T17:47:33.590204+00:00",
+      "last_probed": "2026-05-30T18:53:01.982885+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2019,6 +2019,7 @@
         "-beverlyhills-ca-police-department": "http_404",
         "-beverlyhills-ca-ps": "http_403",
         "-beverlyhills-pd-ca": "http_404",
+        "-beverlyhills-po-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -3059,6 +3060,14 @@
       "last_probed": "2026-05-20T16:40:52.395922+00:00",
       "tried": {
         "haywood-county-nc-so": "http_404"
+      }
+    },
+    "a0b054c4-fd13-52f4-9b23-4d4e5188532e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T18:52:52.351665+00:00",
+      "tried": {
+        "northport-ny-pd": "http_404"
       }
     },
     "a17a8e7d-6ebb-50e2-ad83-14ecd689e810": {
@@ -4351,6 +4360,14 @@
         "beverly-hills-mi-pd": "http_404"
       }
     },
+    "ec62b92f-8175-540c-b2c2-24467240567f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T18:52:57.600474+00:00",
+      "tried": {
+        "gering-ne-pd": "http_404"
+      }
+    },
     "ec938401-adce-513f-a651-b52d3f8387b5": {
       "exhausted": false,
       "found": null,
@@ -4731,6 +4748,6 @@
       }
     }
   },
-  "updated": "2026-05-30T17:47:33.623281+00:00",
+  "updated": "2026-05-30T18:53:02.023955+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -272,6 +272,14 @@
         "kingsburg-ca-po": "http_404"
       }
     },
+    "10077de6-6b5b-5aed-80e9-3bd5943177f6": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T10:29:54.606146+00:00",
+      "tried": {
+        "bryan-oh-pd": "http_404"
+      }
+    },
     "10a2a498-db9d-56c0-a06d-8f3a667b6632": {
       "exhausted": false,
       "found": null,
@@ -959,9 +967,10 @@
     "3605ccef-4c03-5aeb-9dd6-8c4408f99752": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-13T08:27:08.390389+00:00",
+      "last_probed": "2026-05-30T10:29:50.429819+00:00",
       "tried": {
-        "beech-grove-in-pd": "http_404"
+        "beech-grove-in-pd": "http_404",
+        "beech-grove-in-po": "http_403"
       }
     },
     "365adb5d-03ad-55ca-bfdd-fea851bc2525": {
@@ -1972,7 +1981,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T08:10:33.640759+00:00",
+      "last_probed": "2026-05-30T10:29:59.619344+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -1996,6 +2005,7 @@
         "-beverly-hills-psca": "http_404",
         "-beverlyhills-ca-pd": "http_404",
         "-beverlyhills-ca-po": "http_404",
+        "-beverlyhills-ca-police-department": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -4660,6 +4670,6 @@
       }
     }
   },
-  "updated": "2026-05-30T08:10:33.674498+00:00",
+  "updated": "2026-05-30T10:29:59.662180+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -935,9 +935,10 @@
     "34034d82-8744-59d3-8910-ce3f386487c0": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-09T21:29:42.653652+00:00",
+      "last_probed": "2026-05-30T17:47:24.978835+00:00",
       "tried": {
-        "peru-in-pd": "http_404"
+        "peru-in-pd": "http_404",
+        "peru-in-po": "http_403"
       }
     },
     "34274c0f-3463-563f-82e5-b56843cd8dc3": {
@@ -1989,7 +1990,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T15:53:32.958493+00:00",
+      "last_probed": "2026-05-30T17:47:33.590204+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2017,6 +2018,7 @@
         "-beverlyhills-ca-police": "http_404",
         "-beverlyhills-ca-police-department": "http_404",
         "-beverlyhills-ca-ps": "http_403",
+        "-beverlyhills-pd-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -4696,6 +4698,14 @@
         "sonoma-county-ca-sheriffs-office": "http_404"
       }
     },
+    "fdf3939a-6ec5-5236-9186-f86cc9e627e7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T17:47:29.121593+00:00",
+      "tried": {
+        "dewitt-town-ny-pd": "http_404"
+      }
+    },
     "fe2ade2a-15d6-5074-8593-c2f5c8f2c590": {
       "exhausted": false,
       "found": "huffman-isd-tx-pd",
@@ -4721,6 +4731,6 @@
       }
     }
   },
-  "updated": "2026-05-30T15:53:32.994753+00:00",
+  "updated": "2026-05-30T17:47:33.623281+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1193,6 +1193,14 @@
         "yelm-wa-pd": "http_200"
       }
     },
+    "4109cb58-5415-50f6-a322-2bff979a4919": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T15:53:20.939922+00:00",
+      "tried": {
+        "river-rouge-mi-pd": "http_403"
+      }
+    },
     "410c43eb-92df-5183-bc30-02ee9b4eb7b9": {
       "exhausted": false,
       "found": null,
@@ -1981,7 +1989,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T14:19:28.111666+00:00",
+      "last_probed": "2026-05-30T15:53:32.958493+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2003,6 +2011,7 @@
         "-beverly-hills-ps": "http_404",
         "-beverly-hills-ps-ca": "http_404",
         "-beverly-hills-psca": "http_404",
+        "-beverlyhills-ca": "http_404",
         "-beverlyhills-ca-pd": "http_404",
         "-beverlyhills-ca-po": "http_404",
         "-beverlyhills-ca-police": "http_404",
@@ -3201,6 +3210,14 @@
       "last_probed": "2026-05-18T10:50:27.137410+00:00",
       "tried": {
         "apopka-fl-pd": "http_404"
+      }
+    },
+    "a84d1a3f-68f3-529c-9d11-8e1da89bd6ee": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T15:53:27.151766+00:00",
+      "tried": {
+        "alvin-tx-pd": "http_404"
       }
     },
     "aa1aa6e8-1827-5686-a60c-de76fb77aa78": {
@@ -4704,6 +4721,6 @@
       }
     }
   },
-  "updated": "2026-05-30T14:19:28.185621+00:00",
+  "updated": "2026-05-30T15:53:32.994753+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1464,9 +1464,10 @@
     "4e876f28-fcca-5c87-9e65-f0730980ea1d": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-05T01:21:17.699496+00:00",
+      "last_probed": "2026-05-30T20:39:10.101404+00:00",
       "tried": {
-        "corcoran-ca-po": "http_404"
+        "corcoran-ca-po": "http_404",
+        "corcoran-ca-police-department": "http_404"
       }
     },
     "4ec54275-baff-59d8-8b65-ab55b6ab864b": {
@@ -1990,7 +1991,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T18:53:01.982885+00:00",
+      "last_probed": "2026-05-30T20:39:14.433160+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2020,6 +2021,7 @@
         "-beverlyhills-ca-ps": "http_403",
         "-beverlyhills-pd-ca": "http_404",
         "-beverlyhills-po-ca": "http_404",
+        "-beverlyhills-police-department-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -3622,6 +3624,14 @@
         "creve-coeur-mo-pd": "http_404"
       }
     },
+    "bde50179-1511-5cde-a89b-c04228d0b2a9": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T20:39:04.024675+00:00",
+      "tried": {
+        "decatur-in-pd": "http_403"
+      }
+    },
     "be5124a8-2b29-578f-b2d7-b63b9947b18f": {
       "exhausted": false,
       "found": null,
@@ -4748,6 +4758,6 @@
       }
     }
   },
-  "updated": "2026-05-30T18:53:02.023955+00:00",
+  "updated": "2026-05-30T20:39:14.473692+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.