### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -373,5 +373,5 @@
     "https://www.chicagotribune.com/2025/06/12/license-plate-reader-audito-ordered/",
     "https://www.officer.com/command-hq/technology/computers-software/investigation-software/press-release/12322253/vigilant-solutions-a-part-of-motorola-solutions-inc-new-vigilant-solutions-channel-program-offers-incentives-including-discounts-and-share-of-recurring-revenue-for-distribution-partners"
   ],
-  "last_run": "2026-05-30T18:12:26Z"
+  "last_run": "2026-05-30T20:15:29Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 372
- Curation: enriched: 301 · mechanical: 48 · needs_review: 23
- Scanner: REVIEW REQUIRED: 254 · WARNINGS: 116 · CLEAN: 2
- Wayback: saved: 160 · submit-failed: 104 · poll-failed: 92 · save-failed: 9 · existing: 7
- PDF: rendered: 312 · skipped-curl-fallback: 60
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
