### PR TITLE
feat(ingest): integrity fingerprint on ingested audit JSONs

### DIFF
--- a/scripts/diff_scrapes.py
+++ b/scripts/diff_scrapes.py
@@ -11,7 +11,10 @@ from lib import portal_jsons
 DATA_DIR = Path("assets/transparency.flocksafety.com")
 
 # Fields to skip in diffs (always change between scrapes)
-SKIP_FIELDS = {"archived_date"}
+# `integrity` is a structural fingerprint of the audit CSV (row_count, date
+# resets, span) — it moves every scrape and isn't portal "content", so diffing
+# it would bury the real changes in noise.
+SKIP_FIELDS = {"archived_date", "integrity"}
 
 # Fields where we show set diffs instead of full values
 # Support both old and new field names during transition

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -51,7 +51,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from lib import (
     BASE_URL, FAILED_FILE, USER_AGENT,
-    dedupe, load_json, save_json,
+    audit_integrity, dedupe, load_json, save_json,
     portal_jsons, portal_txts, resolve_agency,
 )
 
@@ -1079,6 +1079,24 @@ def extract_csvs_from_html(html_text):
     return results
 
 
+def attach_csv_integrity(portal_data):
+    """Add an `integrity` fingerprint per embedded *_csv table.
+
+    We store the CSV rows in their as-delivered order (no sort on ingest), and
+    this records the structural properties of that order — row_count, date_resets,
+    duplicate_ids, date_span — so anomalies (e.g. a portal that ever ships rows
+    grouped by user instead of by date) are visible in the JSON we read instead
+    of needing a re-parse of the raw HTML. Excluded from diff_scrapes.SKIP_FIELDS:
+    these move every scrape and aren't portal "content"."""
+    blocks = {
+        key: audit_integrity(val)
+        for key, val in portal_data.items()
+        if key.endswith("_csv") and isinstance(val, list) and val
+    }
+    if blocks:
+        portal_data["integrity"] = blocks
+
+
 # ═══════════════════════════════════════════════════════════
 # Crawl: fetch pages, save .txt + .pdf
 # ═══════════════════════════════════════════════════════════
@@ -1167,6 +1185,7 @@ def archive_agency(page, slug, data_dir, force=False, hashes=None, progress=""):
         field = csv_name.replace(".csv", "").replace("-", "_") + "_csv"
         portal_data[field] = csv_rows
         print(f"    extracted {csv_name}: {len(csv_rows)} rows")
+    attach_csv_integrity(portal_data)
 
     cdp = page.context.new_cdp_session(page)
     result = cdp.send("Page.printToPDF", {
@@ -1541,6 +1560,7 @@ def cmd_parse(args):
                     field = csv_name.replace(".csv", "").replace("-", "_") + "_csv"
                     portal_data[field] = csv_rows
                     print(f"    extracted {csv_name}: {len(csv_rows)} rows")
+            attach_csv_integrity(portal_data)
 
             json_path.write_text(json.dumps(portal_data, indent=2) + "\n")
             cameras = portal_data.get("camera_count") or "?"

--- a/scripts/import_pra_audit.py
+++ b/scripts/import_pra_audit.py
@@ -108,11 +108,18 @@ def main() -> int:
     normalized = [normalize_row(r) for r in raw_rows]
     normalized.sort(key=lambda r: (r["searchDate"], r["id"]))
 
+    # Carry the raw-order integrity forward from parse_pra_audit. search_audit_csv
+    # below is re-sorted by date (to merge with portal scrapes), so the per-user
+    # block structure only survives in this block's per-file date_resets — keep it
+    # visible in the file we actually read, not just the PRA folder's audit_rows.
+    out = {}
+    if payload.get("integrity"):
+        out["integrity"] = {**payload["integrity"], "files": payload.get("files", [])}
+    out["search_audit_csv"] = normalized
+
     request_id = request_id_from_folder(folder)
     out_path = portal_dir / f"pra-{request_id}.json"
-    out_path.write_text(
-        json.dumps({"search_audit_csv": normalized}, indent=2) + "\n"
-    )
+    out_path.write_text(json.dumps(out, indent=2) + "\n")
 
     dates = [r["searchDate"][:10] for r in normalized]
     print(f"wrote {out_path}")

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -8,6 +8,7 @@ lookup helpers against the registry.
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 
 REGISTRY_PATH = Path("assets/agency_registry.json")
@@ -56,6 +57,117 @@ def portal_txts(slug_dir):
 def portal_jsons(slug_dir):
     """Sorted YYYY-MM-DD.json portal parses in a slug dir (excludes sidecar artifacts)."""
     return sorted(p for p in slug_dir.iterdir() if _PORTAL_JSON_RE.match(p.name))
+
+
+# ── Ingest integrity ──────────────────────────────────────────────────────
+# When we convert ingested data (HTML/PDF → JSON) the row array can be sorted,
+# deduped or otherwise normalized, which silently destroys signals that only
+# live in the as-delivered order — e.g. the PRA audit's userId-then-date blocks,
+# whose date "resets" reveal distinct (redacted) users. We read the JSON, not
+# the raw artifact, so those signals must be surfaced as *fields*. audit_integrity
+# computes that structural fingerprint on the rows in the order given.
+
+# Flock PRA PDF export datetime, e.g. "01/23/2023, 06:15:22 PM UTC".
+_PRA_DATETIME_RE = re.compile(
+    r"^(\d{2})/(\d{2})/(\d{4}),\s+(\d{2}):(\d{2}):(\d{2})\s+(AM|PM)\s+UTC$"
+)
+
+
+def parse_iso_dt(s):
+    """Tolerant ISO-8601 parse (handles a trailing Z). None on miss/non-str."""
+    if not isinstance(s, str) or not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_pra_datetime(s):
+    """Tolerant parse of the PRA PDF datetime format. None on miss.
+
+    Diagnostic sibling of import_pra_audit.to_iso_utc — that one RAISES on drift
+    (a normalizer should be loud); this one stays quiet (a fingerprint shouldn't
+    crash the ingest)."""
+    if not isinstance(s, str):
+        return None
+    m = _PRA_DATETIME_RE.match(s.strip())
+    if not m:
+        return None
+    mm, dd, yyyy, h, mi, ss, ampm = m.groups()
+    h = int(h)
+    if ampm == "PM" and h != 12:
+        h += 12
+    elif ampm == "AM" and h == 12:
+        h = 0
+    return datetime(int(yyyy), int(mm), int(dd), h, int(mi), int(ss))
+
+
+def audit_integrity(rows, date_key="searchDate", id_key="id", to_dt=None):
+    """Structural fingerprint of an as-ingested audit-row list.
+
+    Surfaces the properties that sorting/normalization would otherwise hide, so a
+    discrepancy is a *visible field* in the JSON we read — not something you only
+    catch by re-parsing the raw artifact. Computed on ``rows`` IN THE ORDER GIVEN:
+    pass the as-delivered order to capture it.
+
+    date_resets counts positions where the date column steps backwards. 0 means
+    the rows are already in date order (e.g. the Flock portal CSV); a positive
+    count means an outer sort key groups them — the PRA's userId-then-date blocks
+    produce ~one reset per user boundary — or the data is unordered. date_ordering
+    summarizes this: ascending / descending / grouped / constant.
+
+    to_dt parses the date STRING at date_key into a comparable value (default:
+    ISO-8601). Pass parse_pra_datetime for the PRA PDF format.
+    """
+    to_dt = to_dt or parse_iso_dt
+    dts, unparsed, seen, dups = [], 0, set(), 0
+    for r in rows:
+        rid = r.get(id_key)
+        if rid in seen:
+            dups += 1
+        else:
+            seen.add(rid)
+        d = to_dt(r.get(date_key))
+        if d is None:
+            unparsed += 1
+        dts.append(d)
+
+    def cmp(i):  # comparison of consecutive parsed dates, else None
+        a, b = dts[i - 1], dts[i]
+        return None if a is None or b is None else (b > a) - (b < a)
+
+    steps = [cmp(i) for i in range(1, len(dts))]
+    resets = steps.count(-1)
+    ascents = steps.count(1)
+    if resets and ascents:
+        ordering = "grouped"          # both directions => outer sort key present
+    elif ascents:
+        ordering = "ascending"
+    elif resets:
+        ordering = "descending"
+    else:
+        ordering = "constant"         # all equal, or <2 comparable dates
+
+    known = [d for d in dts if d is not None]
+    span = None
+    if known:
+        span = {
+            "first": dts[0].isoformat() if dts[0] is not None else None,
+            "last": dts[-1].isoformat() if dts[-1] is not None else None,
+            "min": min(known).isoformat(),
+            "max": max(known).isoformat(),
+        }
+    out = {
+        "row_count": len(rows),
+        "date_resets": resets,
+        "date_ordering": ordering,
+        "duplicate_ids": dups,
+        "date_span": span,
+    }
+    if unparsed:
+        out["unparsed_dates"] = unparsed
+    return out
 
 
 _registry_cache = None

--- a/scripts/parse_pra_audit.py
+++ b/scripts/parse_pra_audit.py
@@ -36,6 +36,9 @@ from pathlib import Path
 
 import fitz  # pymupdf
 
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import audit_integrity, parse_pra_datetime
+
 UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
@@ -117,9 +120,17 @@ def main() -> int:
 
     by_id: dict[str, dict] = {}
     per_file: list[dict] = []
+    rows_in = 0
     for pdf in pdfs:
         rows = parse_pdf(pdf)
-        per_file.append({"file": pdf.name, "row_count": len(rows)})
+        rows_in += len(rows)
+        # integrity is computed on the PDF's AS-DELIVERED order (userId-then-date)
+        # BEFORE the merge/sort below erases it — date_resets ≈ distinct users − 1.
+        per_file.append({
+            "file": pdf.name,
+            "row_count": len(rows),
+            "integrity": audit_integrity(rows, to_dt=parse_pra_datetime),
+        })
         for r in rows:
             existing = by_id.get(r["id"])
             if existing is None:
@@ -135,9 +146,22 @@ def main() -> int:
     rows = sorted(by_id.values(),
                   key=lambda r: (r.get("searchDate", ""), r.get("id", "")))
 
+    integrity = {
+        "note": ("per-file integrity reflects each PDF's raw userId-then-date "
+                 "order; the merged/sorted row array is re-ordered by "
+                 "(searchDate, id) into a canonical timeline, which erases the "
+                 "per-user grouping. To recover users, read per-file date_resets, "
+                 "not the sorted rows."),
+        "source_pdfs": len(pdfs),
+        "rows_in": rows_in,
+        "rows_unique": len(by_id),
+        "duplicate_ids_merged": rows_in - len(by_id),
+    }
+
     payload = {
         "source": "PRA-produced PDF exports of Flock search audit log",
         "pra_folder": folder.name,
+        "integrity": integrity,
         "files": per_file,
         "row_count": len(rows),
         "rows": rows,

--- a/tests/test_audit_integrity.py
+++ b/tests/test_audit_integrity.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for the ingest-integrity fingerprint in scripts/lib.py.
+
+The whole point of the block is to make the as-delivered row order legible from
+the JSON we read: a date-sorted CSV (portal) vs. a userId-then-date one (PRA)
+must produce visibly different fingerprints.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lib import audit_integrity, parse_iso_dt, parse_pra_datetime
+
+
+def _rows(dates, ids=None):
+    ids = ids or [f"id{i}" for i in range(len(dates))]
+    return [{"id": i, "searchDate": d} for i, d in zip(ids, dates)]
+
+
+class TestAuditIntegrity:
+    def test_date_sorted_portal_has_no_resets(self):
+        rows = _rows([
+            "2026-04-27T00:27:25Z",
+            "2026-04-27T00:28:42Z",
+            "2026-05-01T10:00:00Z",
+        ])
+        r = audit_integrity(rows)
+        assert r["date_resets"] == 0
+        assert r["date_ordering"] == "ascending"
+        assert r["row_count"] == 3
+        assert r["date_span"]["min"] == r["date_span"]["first"]
+        assert r["date_span"]["max"] == r["date_span"]["last"]
+
+    def test_userid_grouped_pra_shows_resets(self):
+        # three user blocks, each internally date-ascending; the two block
+        # boundaries step backwards -> 2 resets, and ordering is "grouped".
+        rows = _rows([
+            "2023-01-01T01:00:00Z", "2023-01-01T02:00:00Z", "2023-01-01T03:00:00Z",
+            "2023-01-01T01:30:00Z", "2023-01-01T02:30:00Z",
+            "2023-01-01T00:30:00Z", "2023-01-01T05:00:00Z",
+        ])
+        r = audit_integrity(rows)
+        assert r["date_resets"] == 2
+        assert r["date_ordering"] == "grouped"
+
+    def test_descending(self):
+        rows = _rows([
+            "2026-05-03T00:00:00Z", "2026-05-02T00:00:00Z", "2026-05-01T00:00:00Z",
+        ])
+        r = audit_integrity(rows)
+        assert r["date_ordering"] == "descending"
+        assert r["date_resets"] == 2
+
+    def test_duplicate_ids(self):
+        rows = _rows(
+            ["2026-05-01T00:00:00Z", "2026-05-02T00:00:00Z", "2026-05-03T00:00:00Z"],
+            ids=["a", "a", "b"],
+        )
+        assert audit_integrity(rows)["duplicate_ids"] == 1
+
+    def test_unparsed_dates_counted_not_fatal(self):
+        rows = _rows(["2026-05-01T00:00:00Z", "not-a-date", "2026-05-03T00:00:00Z"])
+        r = audit_integrity(rows)
+        assert r["unparsed_dates"] == 1
+        assert r["row_count"] == 3
+
+    def test_empty_is_constant(self):
+        r = audit_integrity([])
+        assert r["row_count"] == 0
+        assert r["date_resets"] == 0
+        assert r["date_ordering"] == "constant"
+        assert r["date_span"] is None
+
+    def test_custom_to_dt_for_pra_format(self):
+        rows = [
+            {"id": "a", "searchDate": "01/01/2023, 01:00:00 AM UTC"},
+            {"id": "b", "searchDate": "01/01/2023, 02:00:00 AM UTC"},
+            {"id": "c", "searchDate": "01/01/2023, 01:30:00 AM UTC"},  # reset
+        ]
+        r = audit_integrity(rows, to_dt=parse_pra_datetime)
+        assert r["date_resets"] == 1
+        assert "unparsed_dates" not in r  # all parsed cleanly
+
+
+class TestDateParsers:
+    def test_iso_with_millis_and_z(self):
+        assert parse_iso_dt("2026-04-27T00:27:25.717Z") == datetime.fromisoformat(
+            "2026-04-27T00:27:25.717+00:00")
+
+    def test_iso_bad_and_empty(self):
+        assert parse_iso_dt("") is None
+        assert parse_iso_dt(None) is None
+        assert parse_iso_dt("nope") is None
+
+    def test_pra_pm_am_noon_midnight(self):
+        assert parse_pra_datetime("01/23/2023, 06:15:22 PM UTC") == datetime(2023, 1, 23, 18, 15, 22)
+        assert parse_pra_datetime("12/01/2023, 12:05:00 AM UTC") == datetime(2023, 12, 1, 0, 5, 0)
+        assert parse_pra_datetime("12/01/2023, 12:05:00 PM UTC") == datetime(2023, 12, 1, 12, 5, 0)
+
+    def test_pra_bad(self):
+        assert parse_pra_datetime("2023-01-01T00:00:00Z") is None
+        assert parse_pra_datetime(None) is None

--- a/tests/test_diff_scrapes.py
+++ b/tests/test_diff_scrapes.py
@@ -142,3 +142,17 @@ class TestDiffAgency:
         slug_dir = tmp_path / "empty-agency"
         slug_dir.mkdir()
         assert diff_agency(slug_dir) == []
+
+    def test_integrity_block_not_diffed(self, tmp_path):
+        # The audit-CSV integrity fingerprint moves every scrape; it must not
+        # surface as a change (it lives in SKIP_FIELDS).
+        slug_dir = tmp_path / "test-agency"
+        _write_json(slug_dir / "2026-03-27.json", {
+            "slug": "test-agency", "archived_date": "2026-03-27",
+            "integrity": {"search_audit_csv": {"row_count": 100, "date_resets": 0}},
+        })
+        _write_json(slug_dir / "2026-04-03.json", {
+            "slug": "test-agency", "archived_date": "2026-04-03",
+            "integrity": {"search_audit_csv": {"row_count": 142, "date_resets": 0}},
+        })
+        assert diff_agency(slug_dir) == []


### PR DESCRIPTION
## Why

Ingest converts raw artifacts (portal HTML, PRA PDFs) into JSON, and the row array gets sorted/deduped on the way in — silently destroying signals that only live in the **as-delivered order**. The case that motivated this: the PRA audit PDF is `userId`-then-date, and our pipeline re-sorts it into a date timeline, erasing the per-user block boundaries (the date "resets" that reveal distinct, redacted users). We read the JSON, not the raw artifact — so those signals have to be surfaced as fields.

## What

`audit_integrity()` (`scripts/lib.py`) records `{row_count, date_resets, date_ordering, duplicate_ids, date_span}` on the rows in the order given. `date_resets` = backward steps in that order: `0` = date-sorted (portal), `>0` = grouped by an outer key (the PRA's user blocks).

Wired into both producers:
- **Portal scrape** (`flock_transparency.py`) — per `*_csv`, in both crawl and parse paths.
- **PRA audit** (`parse_pra_audit.py` → `import_pra_audit.py`) — per-PDF, computed on the **raw pre-sort order**, carried into the user-facing `pra-*.json`.

**Don't diff on it:** `integrity` is in `diff_scrapes.SKIP_FIELDS` — it moves every scrape and isn't portal content. Crawl skip-logic is unaffected (it hashes the raw `.txt`, not the JSON).

## Validation
- On the W012541 PRA, per-PDF `date_resets + 1` reproduces the known per-month user counts **exactly** (e.g. Oct'25 235→236, Dec'25 205→206; split months sum cleanly).
- Surfaced a previously-invisible discrepancy: **78 duplicate ids inside the Jan 2023 PDF**.
- Portal block reads `date_resets: 0, ascending`; regenerated PRA rows are byte-identical (block-only addition).
- New `tests/test_audit_integrity.py` (9) + a diff-skip test; both green.

## Scope
Applies to **future ingests only** — existing JSONs are not reparsed.