### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1991,7 +1991,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T20:39:14.433160+00:00",
+      "last_probed": "2026-05-30T21:45:15.026808+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2021,6 +2021,7 @@
         "-beverlyhills-ca-ps": "http_403",
         "-beverlyhills-pd-ca": "http_404",
         "-beverlyhills-po-ca": "http_404",
+        "-beverlyhills-police-ca": "http_404",
         "-beverlyhills-police-department-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
@@ -2559,6 +2560,14 @@
       "last_probed": "2026-05-10T21:34:55.107391+00:00",
       "tried": {
         "west-saint-paul-mn-pd": "http_200"
+      }
+    },
+    "877a3737-0a7b-588b-a1ab-09901c0ad645": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T21:45:03.028996+00:00",
+      "tried": {
+        "tahlequah-ok-pd": "http_403"
       }
     },
     "87a1c161-c069-5a52-aa60-2a9a899efb89": {
@@ -4419,6 +4428,14 @@
         "la-grange-mo-pd": "http_404"
       }
     },
+    "eec5c484-c3df-5f3d-8434-00561fc760da": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T21:45:09.347614+00:00",
+      "tried": {
+        "magnolia-tx-pd": "http_404"
+      }
+    },
     "eef11480-824c-5b76-9049-541470c862b1": {
       "exhausted": false,
       "found": null,
@@ -4758,6 +4775,6 @@
       }
     }
   },
-  "updated": "2026-05-30T20:39:14.473692+00:00",
+  "updated": "2026-05-30T21:45:15.064407+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -349,6 +349,14 @@
         "kern-county-ca-sheriffs-office": "http_404"
       }
     },
+    "142f7c1a-5353-5dce-8d38-3312bd7803ad": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T23:44:21.178989+00:00",
+      "tried": {
+        "lamar-county-ms-so": "http_404"
+      }
+    },
     "1430e4e5-d018-50ab-9b4a-d347c319e73e": {
       "exhausted": false,
       "found": null,
@@ -1999,7 +2007,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T22:42:42.132089+00:00",
+      "last_probed": "2026-05-30T23:44:25.345670+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2027,6 +2035,7 @@
         "-beverlyhills-ca-police": "http_404",
         "-beverlyhills-ca-police-department": "http_404",
         "-beverlyhills-ca-ps": "http_403",
+        "-beverlyhills-pd": "http_404",
         "-beverlyhills-pd-ca": "http_404",
         "-beverlyhills-po-ca": "http_404",
         "-beverlyhills-police-ca": "http_404",
@@ -2714,6 +2723,14 @@
       "last_probed": "2026-05-17T08:01:58.586086+00:00",
       "tried": {
         "athens-clarke-county-ga-pd": "http_404"
+      }
+    },
+    "8f552811-dba7-5474-b67e-c64a8449b1d5": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T23:44:16.007465+00:00",
+      "tried": {
+        "nassau-county-ny-pd": "http_403"
       }
     },
     "8f99f695-5554-5fd5-9b6c-63a683f21d55": {
@@ -4792,6 +4809,6 @@
       }
     }
   },
-  "updated": "2026-05-30T22:42:42.170928+00:00",
+  "updated": "2026-05-30T23:44:25.383487+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1031,6 +1031,14 @@
         "portland-tn-pd": "http_404"
       }
     },
+    "380f3c07-683a-5f86-8cc4-042c2db249d7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T22:42:30.347921+00:00",
+      "tried": {
+        "sag-harbor-village-ny-pd": "http_403"
+      }
+    },
     "39054b43-7c24-5b8f-a4ca-266e742af0d4": {
       "exhausted": false,
       "found": null,
@@ -1991,7 +1999,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T21:45:15.026808+00:00",
+      "last_probed": "2026-05-30T22:42:42.132089+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2023,6 +2031,7 @@
         "-beverlyhills-po-ca": "http_404",
         "-beverlyhills-police-ca": "http_404",
         "-beverlyhills-police-department-ca": "http_404",
+        "-beverlyhills-ps-ca": "http_404",
         "beverly-hills": "http_404",
         "beverly-hills-ca": "http_404",
         "beverly-hills-ca-po": "http_404",
@@ -2846,6 +2855,14 @@
       "last_probed": "2026-05-09T16:36:35.500578+00:00",
       "tried": {
         "fort-bend-county-tx-district-attorneys-office-tx-pd": "http_404"
+      }
+    },
+    "97b4da7d-f1b2-520c-b0b0-d2b1c546090d": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-30T22:42:35.607442+00:00",
+      "tried": {
+        "fox-point-wi-pd": "http_404"
       }
     },
     "97c37376-ac7e-5fa1-ba14-3a6e3c2f3fdb": {
@@ -4775,6 +4792,6 @@
       }
     }
   },
-  "updated": "2026-05-30T21:45:15.064407+00:00",
+  "updated": "2026-05-30T22:42:42.170928+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -2007,7 +2007,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-30T23:44:25.345670+00:00",
+      "last_probed": "2026-05-31T01:54:31.465894+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2037,6 +2037,7 @@
         "-beverlyhills-ca-ps": "http_403",
         "-beverlyhills-pd": "http_404",
         "-beverlyhills-pd-ca": "http_404",
+        "-beverlyhills-po": "http_404",
         "-beverlyhills-po-ca": "http_404",
         "-beverlyhills-police-ca": "http_404",
         "-beverlyhills-police-department-ca": "http_404",
@@ -2787,9 +2788,10 @@
     "9079f9e0-e3c2-5611-8f09-a0276b7911f8": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-04-26T08:45:38.324251+00:00",
+      "last_probed": "2026-05-31T01:54:27.623875+00:00",
       "tried": {
         "california-state-university-long-beach-campus-ca-pd": "http_404",
+        "california-state-university-long-beach-campus-ca-police": "http_404",
         "california-state-university-long-beach-campus-ca-ps": "http_404"
       }
     },
@@ -4750,6 +4752,14 @@
         "springfield-il-pd": "http_403"
       }
     },
+    "fbb44875-d16a-5dfd-a9eb-e185878f06f7": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-31T01:54:22.827274+00:00",
+      "tried": {
+        "new-london-oh-pd": "http_404"
+      }
+    },
     "fc97bf62-065b-507f-a327-4fd4c94453c6": {
       "exhausted": false,
       "found": null,
@@ -4809,6 +4819,6 @@
       }
     }
   },
-  "updated": "2026-05-30T23:44:25.383487+00:00",
+  "updated": "2026-05-31T01:54:31.495703+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1458,6 +1458,14 @@
         "lakeport-ca-police-department": "http_404"
       }
     },
+    "4e3f6084-585f-58ac-b00a-3b21f8b5d200": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-31T06:43:44.961116+00:00",
+      "tried": {
+        "stark-county-oh-so": "http_404"
+      }
+    },
     "4e5ef2cb-d1e8-5393-8d5f-e614a6d230c3": {
       "exhausted": false,
       "found": null,
@@ -2007,7 +2015,7 @@
     "6b18acc6-e4b8-5f72-97e5-9942b2582e96": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-31T01:54:31.465894+00:00",
+      "last_probed": "2026-05-31T06:43:51.289645+00:00",
       "tried": {
         "-beverly-hills": "http_404",
         "-beverly-hills-ca": "http_404",
@@ -2040,6 +2048,7 @@
         "-beverlyhills-po": "http_404",
         "-beverlyhills-po-ca": "http_404",
         "-beverlyhills-police-ca": "http_404",
+        "-beverlyhills-police-department": "http_404",
         "-beverlyhills-police-department-ca": "http_404",
         "-beverlyhills-ps-ca": "http_404",
         "beverly-hills": "http_404",
@@ -3766,6 +3775,14 @@
         "university-of-the-pacific-ca-pd": "http_404"
       }
     },
+    "c443930e-e0d2-5ffd-9416-bb08f9fbbee3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-05-31T06:43:38.557649+00:00",
+      "tried": {
+        "diboll-tx-pd": "http_404"
+      }
+    },
     "c57c612b-30e6-57fd-a677-ab1b3f1ea095": {
       "exhausted": false,
       "found": null,
@@ -4819,6 +4836,6 @@
       }
     }
   },
-  "updated": "2026-05-31T01:54:31.495703+00:00",
+  "updated": "2026-05-31T06:43:51.326177+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.