### PR TITLE
slug_probe: back off on 403 instead of burning candidates

### DIFF
--- a/scripts/slug_probe.py
+++ b/scripts/slug_probe.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
 """
 Slug probe crawler — find the Flock transparency portal slug for agencies
 where our guess 404'd.
@@ -266,12 +268,24 @@ PORTAL_MARKERS = [
 
 WAIT_MS = 5000  # matches flock_transparency.py — let SPA hydrate
 
+# A 403 from Flock's edge is a bot-challenge, not a real answer about the
+# slug — the same block the module dodges with Chromium, leaking through
+# intermittently. They arrive in bursts once the session is fingerprinted,
+# so we back off (exponential, jittered, capped) instead of plowing through
+# and burning candidates as permanent misses, and bail the run entirely
+# after this many consecutive 403s.
+MAX_CONSECUTIVE_FORBIDDEN = 3
+FORBIDDEN_COOLDOWN_CAP = 120  # seconds — ceiling on per-strike backoff
+
 
 def probe(page, slug, timeout_ms=30000):
     """Probe a candidate slug via playwright.
 
     Flock blocks non-browser clients at the edge (403 on curl/urllib), so we
-    need a real Chromium. Returns ("hit"|"miss"|"rate_limited"|"error", detail).
+    need a real Chromium. Even then the edge bot-challenges a fraction of our
+    requests with a 403 — that's a "we flagged you," NOT a "this slug is dead,"
+    so it's reported distinctly from a genuine 404/4xx miss.
+    Returns ("hit"|"miss"|"forbidden"|"rate_limited"|"error", detail).
     """
     url = f"{BASE_URL}/{slug}"
     try:
@@ -283,6 +297,8 @@ def probe(page, slug, timeout_ms=30000):
         return "error", "no_response"
     if response.status == 429:
         return "rate_limited", "http_429"
+    if response.status == 403:
+        return "forbidden", "http_403"
     if response.status == 404:
         return "miss", "http_404"
     if response.status >= 400:
@@ -506,6 +522,7 @@ def main():
     print(f"Budget split: tier A = {a_budget}, tier B = {b_budget}")
 
     probes_done = 0
+    consecutive_forbidden = 0  # carried across both tiers — the edge flag is session-wide
     hits = []
 
     # Authoritative-hint lookup: an external crawler (eyesonflock.com)
@@ -584,7 +601,7 @@ def main():
         # against separate queues with separate budgets. Return value is
         # whether we hit a rate_limit and should stop the whole run.
         def run_tier(queues, budget, label):
-            nonlocal probes_done
+            nonlocal probes_done, consecutive_forbidden
             q_idx = 0
             consumed = 0
             while consumed < budget and queues:
@@ -605,6 +622,8 @@ def main():
                 st["last_probed"] = datetime.now(timezone.utc).isoformat()
                 probes_done += 1
                 consumed += 1
+                if result != "forbidden":
+                    consecutive_forbidden = 0
 
                 if result == "hit":
                     print(f"    HIT ({detail}) — promoting to registry")
@@ -638,6 +657,28 @@ def main():
                     probes_done -= 1
                     consumed -= 1
                     return True  # signal: stop the whole run
+                elif result == "forbidden":
+                    # Edge bot-challenge, not a real answer. Roll it back like a
+                    # rate-limit (don't burn the candidate — it regenerates next
+                    # run) and don't charge it against the probe budget. Then
+                    # slow down: 403s come serially once the session is flagged,
+                    # so back off before the next try and bail if they persist.
+                    st["tried"].pop(candidate, None)
+                    probes_done -= 1
+                    consumed -= 1
+                    consecutive_forbidden += 1
+                    if consecutive_forbidden >= MAX_CONSECUTIVE_FORBIDDEN:
+                        print(f"    FORBIDDEN x{consecutive_forbidden} — edge is "
+                              f"blocking us, stopping this run")
+                        return True  # signal: stop the whole run
+                    cooldown = min(args.delay * 2 ** consecutive_forbidden,
+                                   FORBIDDEN_COOLDOWN_CAP) * random.uniform(0.7, 1.3)
+                    print(f"    forbidden (http_403) — backing off {cooldown:.0f}s "
+                          f"(strike {consecutive_forbidden}/{MAX_CONSECUTIVE_FORBIDDEN})")
+                    save_state(data_dir, state)
+                    time.sleep(cooldown)
+                    q_idx += 1
+                    continue  # skip the normal save + inter-probe sleep tail
                 else:  # error
                     print(f"    error ({detail}) — leaving as tried to avoid retry loops")
                     q_idx += 1

--- a/tests/test_slug_probe.py
+++ b/tests/test_slug_probe.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
 """Tests for the slug probe candidate generator.
 
 The generator is the load-bearing part: if it doesn't produce the right
@@ -16,6 +18,7 @@ from slug_probe import (
     eyesonflock_hint,
     generate_candidates,
     normalize_name,
+    probe,
     select_targets,
 )
 
@@ -397,3 +400,67 @@ def test_eyesonflock_hint_returns_none_without_geo_block():
         {"agency_role": "police", "geo": {"kind": "place", "state": "CA"}},
         eof_index,
     ) is None
+
+
+# ── probe() HTTP-status outcome mapping ─────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status):
+        self.status = status
+
+
+class _FakePage:
+    """Minimal stand-in for a playwright Page. probe() only calls goto()
+    (returns a response with .status), and — on the 200 path — wait_for_timeout
+    and inner_text. The 403/404/429 paths return before those, so a fake is
+    enough to pin the status→outcome mapping without a real browser."""
+
+    def __init__(self, status, body=""):
+        self._status = status
+        self._body = body
+
+    def goto(self, url, wait_until=None, timeout=None):
+        return _FakeResponse(self._status) if self._status is not None else None
+
+    def wait_for_timeout(self, ms):
+        pass
+
+    def inner_text(self, selector):
+        return self._body
+
+
+def test_probe_403_is_forbidden_not_a_miss():
+    """A 403 is Flock's edge bot-challenge, NOT evidence the slug is dead.
+    It must be reported as 'forbidden' (distinct from a 404 'miss') so the
+    run loop backs off and rolls it back instead of burning the candidate
+    as a permanent tried-miss."""
+    assert probe(_FakePage(403), "anytown-ca-pd") == ("forbidden", "http_403")
+
+
+def test_probe_404_is_a_real_miss():
+    """404 reached the origin and means the slug genuinely doesn't exist —
+    a trustworthy answer, recorded as a permanent miss."""
+    assert probe(_FakePage(404), "anytown-ca-pd") == ("miss", "http_404")
+
+
+def test_probe_429_is_rate_limited():
+    assert probe(_FakePage(429), "anytown-ca-pd") == ("rate_limited", "http_429")
+
+
+def test_probe_other_4xx_is_miss():
+    """Any other 4xx (not 403/404/429) is a generic miss."""
+    assert probe(_FakePage(410), "anytown-ca-pd") == ("miss", "http_410")
+
+
+def test_probe_200_with_portal_marker_is_hit():
+    body = "Welcome. Provided by Flock Safety. Acceptable Use Policy ..."
+    assert probe(_FakePage(200, body=body), "anytown-ca-pd") == ("hit", "http_200")
+
+
+def test_probe_200_without_marker_is_miss():
+    """A 200 with no portal marker is an SPA shell / marketing page, not a
+    real portal."""
+    assert probe(
+        _FakePage(200, body="Page not found"), "anytown-ca-pd"
+    ) == ("miss", "http_200_no_marker")


### PR DESCRIPTION
## Why

Flock's edge bot-challenges a fraction of our Chromium probe requests with a **403** — the same block the module dodges with a real browser, leaking through intermittently. A 403 means *"the edge flagged us,"* not *"this slug is dead."* But the probe folded 403s into the generic `>= 400` miss and recorded them in `tried`, which **permanently excludes that candidate** from future runs (it might be a live portal). And because 403s arrive in bursts once the session is fingerprinted, a single run could burn several candidates serially.

Surfaced from the #518 state diff: same agency, `peru-in-pd` → 404 but `peru-in-po` → 403; 403s scattered across suffixes and the whole run window — consistent with random WAF challenges, not a structural "private portal" signal.

## What changed (`scripts/slug_probe.py`)

- `probe()` returns a distinct `("forbidden", "http_403")` instead of a generic miss.
- The run loop handles `forbidden` like the existing `rate_limited` path: **roll it back** — pop from `tried`, don't charge the probe budget — so the candidate regenerates next run instead of being burned.
- Then **slow down**: exponential, jittered, capped backoff before the next try (`delay·2^strike`, ×0.7–1.3 jitter, 120s ceiling → ~10s then ~20s at default `delay=5`).
- **Circuit-break** after `MAX_CONSECUTIVE_FORBIDDEN = 3` consecutive 403s — the session is flagged; continuing just produces more serial 403s. A successful get-through (even a 404) resets the counter, so sporadic one-off challenges cost only one short backoff.
- Counter is session-wide (carried across tier A → tier B), since the edge flag is per-session, not per-tier.

The loop still always terminates: candidates are popped every iteration, so worst case it drains the queue even if the breaker never trips.

## Tests

Added 6 cases pinning the HTTP-status → outcome mapping (403→forbidden, 404→miss, 429→rate_limited, other-4xx→miss, 200 ±portal-marker), using a fake page since the 4xx paths return before any browser-only calls. 39/39 pass.

## Not in this PR

The ~7 slugs already recorded as `http_403` in the committed state file (#518) stay burned. Scrubbing those for re-probe is a separate cleanup if wanted.