### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -376,5 +376,5 @@
     "https://hoodline.com/2026/05/uc-license-plates-border-patrol-pings-campus-data-trail-rattles-students/",
     "https://www.daytondailynews.com/local/area-police-share-license-plate-reader-data-for-immigration-unstated-reasons-records-show/article_45511d7d-c316-5d41-9391-a54d196aa2b1.html"
   ],
-  "last_run": "2026-06-01T18:46:43Z"
+  "last_run": "2026-06-01T22:15:42Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -376,5 +376,5 @@
     "https://hoodline.com/2026/05/uc-license-plates-border-patrol-pings-campus-data-trail-rattles-students/",
     "https://www.daytondailynews.com/local/area-police-share-license-plate-reader-data-for-immigration-unstated-reasons-records-show/article_45511d7d-c316-5d41-9391-a54d196aa2b1.html"
   ],
-  "last_run": "2026-06-01T12:47:47Z"
+  "last_run": "2026-06-01T18:46:43Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 375
- Curation: enriched: 301 · mechanical: 51 · needs_review: 23
- Scanner: REVIEW REQUIRED: 257 · WARNINGS: 116 · CLEAN: 2
- Wayback: saved: 161 · submit-failed: 105 · poll-failed: 92 · save-failed: 10 · existing: 7
- PDF: rendered: 315 · skipped-curl-fallback: 60
- Top sources: eff.org (26), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
