### PR TITLE
make build/test targets; CI reuses make build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,15 +174,10 @@ jobs:
           exit 0
 
       - name: Build sharing graph, audit log, map, scoreboard, report data, justifications, and findings PDF
-        run: |
-          uv run python scripts/build_sharing_graph.py
-          uv run python scripts/build_history.py
-          uv run python scripts/build_audit_log.py
-          uv run python scripts/build_map.py
-          uv run python scripts/build_scoreboard.py
-          uv run python scripts/build_report_data.py
-          uv run python scripts/build_justifications.py
-          uv run python scripts/md_to_pdf.py
+        # Canonical generator list lives in the Makefile (`make build`) so local
+        # `make test` and CI build the same artifacts in the same order. Keep
+        # this in sync by editing the Makefile, not by re-inlining commands here.
+        run: make build
 
       - name: Run smoke tests
         run: uv run pytest tests/test_map_smoke.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.pyc
 .claude/
+# `make build` success stamp; `make test` rebuilds when it's absent.
+.make/
 .DS_Store
 .env*
 outputs/pii_scan_results.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # CLAUDE.md
 
+## Running Tests
+
+Run the suite with `make test`, not bare `pytest`. Several tests read
+gitignored site/data artifacts (`docs/sharing_map.html`, `docs/js/map.js`,
+`docs/data/*.json`, `docs/data/audit/`, `docs/data/history/`), so a fresh
+worktree has none of them and a bare `pytest` reports dozens of environmental
+failures. `make test` builds those artifacts first, but only when they're
+missing — repeat runs skip straight to the tests.
+
+- `make build` — force a full rebuild of all artifacts (run after editing a
+  generator script; `make test` will not pick up generator changes on its own).
+- `make clean` — remove the generated artifacts so the next `make test` rebuilds.
+
+The generator list lives in `make build` and is reused by CI (`.github/workflows/ci.yml`),
+so the two never drift. Edit the Makefile, not the CI step, to change it.
+
 ## Security: Scraped Data is Untrusted
 
 Scraped third-party content lives under two paths and could be manipulated to

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 #
 #   make help            Show this list.
 #
+# Testing:
+#   make test            Build site/data artifacts if missing, then run pytest.
+#                        Bare `pytest` fails in a fresh worktree because the
+#                        site/data artifacts it reads are gitignored; this
+#                        builds them first.
+#   make build           Force a full rebuild of all site/data artifacts and
+#                        the findings PDF (run after editing a generator).
+#
 # Daily PRA workflow:
 #   make pra-update      Pull new portal activity, OCR sidecars, seed stubs,
 #                        and rebuild the registry. The one-shot you usually want.
@@ -17,15 +25,54 @@
 #   make serve-public    Serve docs/ on all interfaces (LAN-visible)
 #
 # Hygiene:
-#   make clean           Remove generated docs/data artifacts.
+#   make clean           Remove generated site/data artifacts (forces the next
+#                        `make build` / `make test` to rebuild from scratch).
 
-.PHONY: help pra-update pra-scrape pra-scrape-one pra-ocr pra-init pra-build \
-        serve serve-public clean
+.PHONY: help build test pra-update pra-scrape pra-scrape-one pra-ocr pra-init \
+        pra-build serve serve-public clean
+
+# Gitignored artifacts produced by `make build` and read by the test suite.
+# `make build` regenerates exactly these; `make clean` removes exactly these
+# (plus the stamp), so `make clean test` is a guaranteed-fresh run.
+BUILD_FILES := \
+	docs/sharing_map.html \
+	docs/js/map.js \
+	docs/data/map_data.json \
+	docs/data/scoreboard_data.json \
+	docs/data/report_data.json \
+	docs/data/justifications.json \
+	docs/data/agency_changelog.json \
+	assets/transparency.flocksafety.com/.sharing_graph_full.json
+BUILD_DIRS := docs/data/audit docs/data/history
+# Touched on a successful `make build`. `make test` depends on it, so the
+# build runs only when the stamp is absent (fresh worktree or after clean) —
+# not on every test run. Edit a generator? Run `make build` to force a rebuild.
+BUILD_STAMP := .make/build.stamp
 
 help:
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} \
 	      /^[a-zA-Z_-]+:.*?##/ {printf "  %-22s %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
 	      2>/dev/null || sed -n '2,/^$$/p' Makefile | sed 's/^# \{0,1\}//'
+
+build: ## Force-rebuild all site/data artifacts + findings PDF
+	uv run python scripts/build_sharing_graph.py
+	uv run python scripts/build_history.py
+	uv run python scripts/build_audit_log.py
+	uv run python scripts/build_map.py
+	uv run python scripts/build_scoreboard.py
+	uv run python scripts/build_report_data.py
+	uv run python scripts/build_justifications.py
+	uv run python scripts/md_to_pdf.py
+	@mkdir -p $(dir $(BUILD_STAMP))
+	@touch $(BUILD_STAMP)
+
+# Real-file target with no prerequisites: Make runs its recipe only when the
+# stamp is missing. That recipe rebuilds everything (and re-touches the stamp).
+$(BUILD_STAMP):
+	@$(MAKE) build
+
+test: $(BUILD_STAMP) ## Build artifacts if missing, then run the full test suite
+	uv run pytest
 
 pra-update: pra-scrape pra-ocr pra-init pra-build ## Full local PRA refresh
 	@echo ""
@@ -56,6 +103,9 @@ serve: ## Serve docs/ locally on http://127.0.0.1:8765
 serve-public: ## Serve docs/ on all interfaces (LAN-visible)
 	cd docs && python3 -m http.server 8765
 
-clean: ## Remove generated docs/data artifacts
-	rm -f docs/data/pra_registry.json docs/data/pra_productivity.json
-	@echo "Removed PRA build artifacts. Run 'make pra-build' to regenerate."
+clean: ## Remove generated site/data + PRA artifacts
+	rm -f $(BUILD_FILES) $(BUILD_STAMP) \
+	      docs/data/pra_registry.json docs/data/pra_productivity.json
+	rm -rf $(BUILD_DIRS)
+	@echo "Removed generated artifacts. 'make build' rebuilds the site/data;"
+	@echo "'make pra-build' rebuilds the PRA registry."


### PR DESCRIPTION
## Why

Bare `pytest` fails in a fresh worktree: several tests read site/data artifacts (`docs/sharing_map.html`, `docs/js/map.js`, `docs/data/*.json`, `docs/data/audit/`, `docs/data/history/`) that are gitignored, so a clean checkout reports dozens of environmental failures that have nothing to do with the code under change. This came up repeatedly.

## What

- **`make test`** — builds the artifacts **only if missing** (a `.make/build.stamp` gate), then runs the full suite. A cold worktree pays the ~50s build once; every run after skips straight to pytest.
- **`make build`** — force-rebuilds all 8 generators + the findings PDF. Run after editing a generator (`make test` won't pick up generator changes on its own).
- **`make clean`** — removes the generated artifacts + stamp, so `make clean test` is a guaranteed-fresh run.
- **CI** — the inline 8-command build step is now `run: make build`. The generator list now has a single source of truth, so local `make test` and CI can't drift.

The 8 generators in `make build` are exactly what CI already ran, and are sufficient for the full 588-test suite (the contract-map test self-builds a `tmp_path` fixture; nothing hard-requires articles_data/pra_registry). So the CI change is a zero-behavior-change refactor.

## Validation

- Cold `make clean && make test` (build from nothing): **588 passed** in 2:36.
- Warm `make test`: skips build, pytest only.
- `make build`: always rebuilds regardless of stamp.
- `.make/` is gitignored; no artifacts committed.