### PR TITLE
Schedule the meeting watcher + PR-based ALPR/Flock alerts

### DIFF
--- a/.github/workflows/meeting-watch.yml
+++ b/.github/workflows/meeting-watch.yml
@@ -1,0 +1,130 @@
+name: Watch ALPR/Flock Meeting Agendas
+
+# Polls the agenda portals in assets/meeting_portals.json and flags upcoming +
+# recent council/committee meetings whose agendas mention ALPR/Flock, writing
+# one finding per flagged meeting under assets/meetings/. CA's Brown Act posts
+# agendas >=72h before a regular meeting, so a daily run catches items a few
+# days before the vote.
+#
+# Findings are idempotent (meeting_watch.py only rewrites on a genuine change),
+# so this commits to the meeting-watch-bot branch and opens/updates ONE PR only
+# when something is actually new or changed. The PR body IS the alert — upcoming
+# flagged meetings are listed first, and GitHub emails you when it opens/updates.
+
+on:
+  schedule:
+    - cron: '23 13 * * *'   # daily ~06:23 America/Los_Angeles (after overnight agenda posts)
+  workflow_dispatch:
+    inputs:
+      past_days:
+        description: 'How many days back to include'
+        default: '21'
+      platforms:
+        description: 'Comma list to limit (primegov,legistar,civicclerk,granicus-viewpublisher,selfhosted-webapps,selfhosted-pdf)'
+        default: ''
+
+concurrency:
+  group: meeting-watch
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0   # full history so the bot-branch rebase finds a common ancestor
+          token: ${{ secrets.REFRESH_PAT || github.token }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up long-lived bot branch
+        run: |
+          git fetch origin meeting-watch-bot || true
+          if git rev-parse --verify origin/meeting-watch-bot >/dev/null 2>&1; then
+            git checkout meeting-watch-bot
+            # Never auto-reset to main on rebase failure — it would destroy
+            # accumulated, not-yet-merged findings. Leave the branch untouched.
+            git rebase origin/main || {
+              git rebase --abort
+              echo "::error::rebase against origin/main conflicts. Bot branch left untouched — resolve manually."
+              exit 1
+            }
+          else
+            git checkout -b meeting-watch-bot
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium
+
+      - name: Install Chromium for Playwright
+        run: uv run playwright install chromium
+
+      - name: Run the watcher
+        run: |
+          ARGS="--past-days ${{ inputs.past_days || '21' }} --emit-new /tmp/new.json"
+          if [ -n "${{ inputs.platforms }}" ]; then
+            ARGS="$ARGS --platforms ${{ inputs.platforms }}"
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/meeting_watch.py $ARGS
+
+      - name: Commit findings
+        id: commit
+        run: |
+          git add assets/meetings 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No new/changed findings"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          git commit -m "chore: ALPR/Flock meeting-agenda findings ($(date -u +%Y-%m-%d))"
+          git push --force-with-lease origin meeting-watch-bot
+
+      - name: Build alert / PR body
+        if: steps.commit.outputs.has_changes == 'true'
+        run: |
+          NEW=$(jq 'length' /tmp/new.json 2>/dev/null || echo 0)
+          {
+            echo "## 🚨 ALPR / Flock on meeting agendas"
+            echo
+            echo "**${NEW} newly-flagged meeting(s)** this run. Upcoming items are time-sensitive — CA's Brown Act posts agendas ~72h before a meeting, so act on them now."
+            echo
+            uv run python scripts/meeting_watch.py report --past-days "${{ inputs.past_days || '21' }}" --md
+          } > /tmp/body.md
+
+      - name: Open or update the alert PR
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.REFRESH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --head meeting-watch-bot --state open --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --title "🚨 ALPR/Flock meeting-agenda findings" \
+              --body-file /tmp/body.md \
+              --head meeting-watch-bot \
+              --base main
+          else
+            gh pr edit "$existing" --body-file /tmp/body.md
+          fi

--- a/scripts/meeting_watch.py
+++ b/scripts/meeting_watch.py
@@ -572,15 +572,24 @@ def finding_path(gov_id, platform, meeting_id):
     return MEETINGS_DIR / gov_id / f"{platform}-{meeting_id}.json"
 
 
+def _core(rec):
+    """A finding's content minus the volatile timestamp, for change detection."""
+    return {k: v for k, v in rec.items() if k != "last_checked"}
+
+
 def write_finding(portal, meeting, matches, source, dry_run):
+    """Write/refresh a finding. Idempotent: if the flagged content is unchanged
+    from what's on disk, the file is left untouched (no last_checked churn) so a
+    daily cron only produces a git diff when something genuinely changed.
+    Returns (record, is_new, is_changed)."""
     path = finding_path(portal["id"], portal["platform"], meeting["meeting_id"])
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    first_seen = now_iso
+    existing = None
     if path.exists():
         try:
-            first_seen = json.loads(path.read_text()).get("first_seen", now_iso)
+            existing = json.loads(path.read_text())
         except Exception:
-            pass
+            existing = None
     rec = {
         "gov_id": portal["id"],
         "gov_name": portal["city"],
@@ -595,13 +604,17 @@ def write_finding(portal, meeting, matches, source, dry_run):
         "matched_terms": [m["term"] for m in matches],
         "matches": matches,
         "source": source,
-        "first_seen": first_seen,
+        "first_seen": (existing or {}).get("first_seen", now_iso),
         "last_checked": now_iso,
     }
-    if not dry_run:
+    is_new = existing is None
+    is_changed = existing is not None and _core(existing) != _core(rec)
+    if not dry_run and (is_new or is_changed):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(rec, indent=2) + "\n")
-    return rec
+    elif existing is not None:
+        rec = existing  # unchanged — keep the file (and its last_checked) as-is
+    return rec, is_new, is_changed
 
 
 def load_findings():
@@ -640,6 +653,32 @@ def print_report(findings, past_days):
     print()
 
 
+def print_report_md(findings, past_days):
+    """Markdown variant for PR/issue bodies (clickable agenda links)."""
+    today = date.today().isoformat()
+    cutoff = (date.today() - timedelta(days=past_days)).isoformat()
+    upcoming = sorted((f for f in findings if f["meeting_date"] >= today),
+                      key=lambda f: f["meeting_date"])
+    past = sorted((f for f in findings if cutoff <= f["meeting_date"] < today),
+                  key=lambda f: f["meeting_date"], reverse=True)
+
+    def table(items):
+        if not items:
+            return "_none_"
+        head = "| Date | Government | Body | Terms | Agenda |\n|---|---|---|---|---|"
+        rows = [
+            f"| {f['meeting_date']} | {f['gov_name']} | {f.get('body', '')} | "
+            f"{', '.join(f.get('matched_terms') or [])} | [agenda]({f.get('agenda_url', '')}) |"
+            for f in items
+        ]
+        return "\n".join([head] + rows)
+
+    print(f"### ⏰ Upcoming flagged meetings ({len(upcoming)}) — act before the vote\n")
+    print(table(upcoming))
+    print(f"\n### 🗓️ Past {past_days}d flagged meetings ({len(past)})\n")
+    print(table(past))
+
+
 # ═══════════════════════════════════════════════════════════
 # Main
 # ═══════════════════════════════════════════════════════════
@@ -660,7 +699,7 @@ def run_watch(args):
           f"| window: {since_date.isoformat()} → future"
           + ("  [DRY RUN]" if args.dry_run else ""))
 
-    findings, hits, scanned = [], 0, 0
+    findings, new_findings, changed, hits, scanned = [], [], 0, 0, 0
     for p in portals:
         adapter = ADAPTERS.get(p["platform"])
         if not adapter:
@@ -676,20 +715,27 @@ def run_watch(args):
             matches = find_matches(m["agenda_text"]) if m["agenda_text"] else []
             if not matches:
                 continue
-            rec = write_finding(p, m, matches, f"{p['platform']}:watch", args.dry_run)
+            rec, is_new, is_changed = write_finding(p, m, matches, f"{p['platform']}:watch", args.dry_run)
             findings.append(rec)
+            if is_new:
+                new_findings.append(rec)
+            elif is_changed:
+                changed += 1
             hits += 1
             flagged_here += 1
         print(f"  {p['id']:<24} {len(meetings):>3} meetings in window, {flagged_here} flagged")
 
-    print(f"\nScanned {scanned} meetings across {len(portals)} governments → {hits} flagged.")
+    print(f"\nScanned {scanned} meetings across {len(portals)} governments → "
+          f"{hits} flagged ({len(new_findings)} new, {changed} changed).")
+    if args.emit_new:
+        Path(args.emit_new).write_text(json.dumps(new_findings, indent=2) + "\n")
     # Report uses freshly written findings plus anything already on disk.
     all_findings = load_findings() if not args.dry_run else findings
     print_report(all_findings, args.past_days)
 
 
 def run_report(args):
-    print_report(load_findings(), args.past_days)
+    (print_report_md if args.md else print_report)(load_findings(), args.past_days)
 
 
 def main():
@@ -700,6 +746,10 @@ def main():
     parser.add_argument("--platforms", default="", help="comma list to limit (primegov,legistar,civicclerk)")
     parser.add_argument("--gov", default="", help="limit to gov ids containing this substring")
     parser.add_argument("--dry-run", action="store_true", help="detect + report but write no files")
+    parser.add_argument("--emit-new", default="", metavar="PATH",
+                        help="write JSON of findings newly created this run to PATH (for alerting)")
+    parser.add_argument("--md", action="store_true",
+                        help="in report mode, render as markdown (for PR/issue bodies)")
     args = parser.parse_args()
 
     if not PORTALS_FILE.exists():

--- a/tests/test_meeting_watch.py
+++ b/tests/test_meeting_watch.py
@@ -133,3 +133,41 @@ def test_strip_html_drops_tags_and_unescapes():
     out = mw.strip_html("<p>Flock&nbsp;Safety</p><br><script>x</script>")
     assert "Flock" in out and "Safety" in out
     assert "<" not in out and "script" not in out
+
+
+# ── findings are idempotent (no churn on unchanged re-runs) ──
+
+
+class TestWriteFindingIdempotency:
+    PORTAL = {"id": "belmont-ca", "city": "Belmont", "state": "CA",
+              "county": "San Mateo", "platform": "granicus-viewpublisher"}
+    MEETING = {"meeting_id": "1139", "body": "Public Safety Committee",
+               "meeting_date": "2025-02-24", "meeting_datetime": "2025-02-24T00:00:00-08:00",
+               "agenda_url": "https://x/AgendaViewer.php?clip_id=1139"}
+
+    def test_new_then_unchanged_does_not_rewrite(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mw, "MEETINGS_DIR", tmp_path)
+        matches = [{"term": "license plate reader", "snippet": "automated license plate readers"}]
+        rec1, is_new, is_changed = mw.write_finding(self.PORTAL, self.MEETING, matches, "test", False)
+        assert is_new and not is_changed
+        path = mw.finding_path("belmont-ca", "granicus-viewpublisher", "1139")
+        on_disk = path.read_text()
+
+        rec2, is_new2, is_changed2 = mw.write_finding(self.PORTAL, self.MEETING, matches, "test", False)
+        assert not is_new2 and not is_changed2
+        assert path.read_text() == on_disk                     # file untouched -> no git churn
+        assert rec2["first_seen"] == rec1["first_seen"]         # first_seen preserved
+
+    def test_changed_terms_marks_changed_and_rewrites(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mw, "MEETINGS_DIR", tmp_path)
+        mw.write_finding(self.PORTAL, self.MEETING, [{"term": "lpr", "snippet": "a"}], "test", False)
+        _, is_new, is_changed = mw.write_finding(
+            self.PORTAL, self.MEETING, [{"term": "alpr", "snippet": "b"}], "test", False)
+        assert not is_new and is_changed
+
+    def test_dry_run_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mw, "MEETINGS_DIR", tmp_path)
+        _, is_new, _ = mw.write_finding(self.PORTAL, self.MEETING,
+                                        [{"term": "alpr", "snippet": "x"}], "test", True)
+        assert is_new
+        assert not mw.finding_path("belmont-ca", "granicus-viewpublisher", "1139").exists()


### PR DESCRIPTION
Builds on the merged watcher to make it **run on its own and alert you** — the forward-looking payoff.

## What
- **`.github/workflows/meeting-watch.yml`** — daily cron (~06:23 PT, after overnight agenda posts) + manual `workflow_dispatch`. Runs the watcher (with Playwright for the Redwood City PAC), commits findings to a `meeting-watch-bot` branch, and **opens/updates one PR** whose body lists **upcoming flagged meetings first**. GitHub emails you on the PR, so it doubles as the time-sensitive "act before the vote" alert. Mirrors the `discover-articles.yml` bot-branch + rebase pattern.
- **Idempotent findings** — `write_finding` no longer rewrites an unchanged finding, so the daily cron only produces a diff (and a PR update) when something is **genuinely new or changed**. No more `last_checked` churn. (This settles the findings-churn question from the last PR.)
- **`--emit-new`** dumps the run's newly-created findings as JSON; **`report --md`** renders the windows as markdown for the PR body.

## Tests
Added idempotency tests (no rewrite when unchanged, change detection on differing terms, dry-run writes nothing) — 24 tests total, all passing, wired into CI.

## Notes
- Cadence is daily; bump to `'23 13,1 * * *'` for twice-daily if you want to catch special meetings inside their 24h notice window.
- The PR is the alert surface (no separate issue) — consistent with the repo, no secrets needed.

## Out of scope (next)
Remaining council adapters (CivicPlus AgendaCenter RSS, OnBase council), and expanding the portal map beyond the county to SMPD's sharing partners.