### PR TITLE
Queue bare-"Flock" headlines; add curator off_topic verdict

### DIFF
--- a/scripts/article_curate.py
+++ b/scripts/article_curate.py
@@ -351,6 +351,8 @@ CURATION_SCHEMA = {
     "properties": {
         "refusal": {"type": "boolean"},
         "refusal_reason": {"type": ["string", "null"]},
+        "off_topic": {"type": "boolean"},
+        "off_topic_reason": {"type": ["string", "null"]},
         "summary": {"type": "string"},
         "key_quotes": {
             "type": "array",
@@ -376,8 +378,9 @@ CURATION_SCHEMA = {
         },
     },
     "required": [
-        "refusal", "refusal_reason", "summary", "key_quotes",
-        "topic_tags", "genre", "primary_subject_agency_ids",
+        "refusal", "refusal_reason", "off_topic", "off_topic_reason",
+        "summary", "key_quotes", "topic_tags", "genre",
+        "primary_subject_agency_ids",
     ],
     "additionalProperties": False,
 }
@@ -499,9 +502,25 @@ fields are:
   Return an empty list for national, vendor-focused, or legal-doctrine
   pieces with no specific agency subjects.
 
-If you cannot complete the task — paywalled stub, language you can't
-read, content that turned out not to be about ALPR — set refusal=true
-and provide refusal_reason. Otherwise refusal=false, refusal_reason=null.
+Two distinct escape hatches:
+
+- refusal — you CANNOT evaluate the article: paywalled stub, truncated
+  or empty body, a language you can't read. Set refusal=true with a
+  refusal_reason. These go to a human review queue.
+
+- off_topic — you CAN read it, but it simply isn't about ALPR /
+  license-plate readers / police surveillance cameras at all. The
+  discovery filter now queues any article naming "Flock," which
+  occasionally catches an unrelated use — a literal flock of birds,
+  Flock Freight (the trucking company), a church congregation, the Flock
+  messaging app, etc. Set off_topic=true with a brief off_topic_reason.
+  off_topic articles are DROPPED from the public viewer, so reserve it
+  for genuinely unrelated content — not for on-topic articles you merely
+  find thin or tangential. When unsure whether a surveillance-camera
+  story counts, treat it as on-topic (off_topic=false).
+
+When neither applies: refusal=false, refusal_reason=null, off_topic=false,
+off_topic_reason=null.
 
 Controlled topic tag vocabulary (apply only these IDs):
 
@@ -690,6 +709,18 @@ def run_phase2(registry: list[dict], *, tags_data: dict,
             entry["curation_status"] = "needs_review"
             entry["curation_error"] = f"refusal: {data.get('refusal_reason')}"
             print(f"phase2: refused {entry['article_id']} ({data.get('refusal_reason')})")
+            continue
+        if data.get("off_topic"):
+            # Terminal, not a review queue: the curator read it and it's
+            # simply not about ALPR (a literal flock of birds, Flock Freight,
+            # etc. that the loosened keyword gate let through). The entry
+            # stays in the registry as a tombstone so article_queue_add's URL
+            # dedup never re-queues it (one crawl + one curation, ever), and
+            # build_articles_data drops it from the viewer.
+            entry["curation_status"] = "off_topic"
+            entry["curation_error"] = f"off_topic: {data.get('off_topic_reason')}"
+            entry["curated_at"] = now_iso()
+            print(f"phase2: off_topic {entry['article_id']} ({data.get('off_topic_reason')})")
             continue
         ok, err = validate_curation_output(data, entry, tags_data)
         if not ok:

--- a/scripts/build_articles_data.py
+++ b/scripts/build_articles_data.py
@@ -44,6 +44,12 @@ def main() -> int:
     tag_counts: dict[str, int] = {}
 
     for entry in registry:
+        # Off-topic entries (the curator's not-about-ALPR verdict) stay in
+        # the registry as dedup tombstones but never reach the public viewer
+        # — skip them here so they're absent from the article list, tag/
+        # source counts, and the per-agency index alike.
+        if entry.get("curation_status") == "off_topic":
+            continue
         agencies = []
         for aid in entry.get("agencies") or []:
             ag = reg_by_id.get(aid)

--- a/scripts/discover_articles.py
+++ b/scripts/discover_articles.py
@@ -61,9 +61,13 @@ USER_AGENT_BROWSER = (
 )
 
 # Substrings we look for (case-insensitive) in feed-item title or
-# summary. Keep "flock" out of the bare list — it's too generic
-# (covers flocks of birds, demographic flocking, etc.). Require a
-# disambiguating second word.
+# summary. Most entries are plain substrings; the bare "flock" sentinel
+# at the end is special-cased in _keyword_hit to match on a word boundary,
+# so a headline that names the company only as "Flock" ("Palo Alto
+# considers ditching Flock") still queues while common-noun inflections
+# ("flocking", "flocks of geese") don't. The looser bare-"flock" recall is
+# backstopped by the curator's off_topic verdict, which drops the rare
+# bird / Flock-Freight / congregation false positive from display.
 KEYWORDS = [
     "alpr",
     "license plate reader",
@@ -92,6 +96,10 @@ KEYWORDS = [
     "fusus",
     "street camera",
     "public safety camera",
+    # Bare company name, word-boundary matched (see _keyword_hit). Listed
+    # last so the qualified "flock safety"/"flock camera" forms win the
+    # label when present. Kept safe by the curator's off_topic backstop.
+    "flock",
 ]
 
 # Bing News RSS search queries. Bing doesn't support quoted OR (e.g.
@@ -109,13 +117,31 @@ SEARCH_QUERIES = [
 ]
 
 
+_BARE_FLOCK_RE = re.compile(r"\bflock\b", re.IGNORECASE)
+
+
+def _keyword_hit(kw: str, text: str, low: str) -> bool:
+    """True if ``kw`` matches ``text``.
+
+    Most keywords are plain case-insensitive substrings. The bare "flock"
+    sentinel is the exception: it matches only on a word boundary, so the
+    company name in a headline like "…ditching Flock" counts while
+    common-noun inflections ("flocking", "flocks of geese") don't. Treating
+    it as a sentinel (rather than a substring or an unconditional fallback)
+    keeps custom --keywords lists unaffected unless they opt in to "flock".
+    """
+    if kw == "flock":
+        return _BARE_FLOCK_RE.search(text) is not None
+    return kw in low
+
+
 def matches_keywords(text: str, kws: list[str]) -> str | None:
     """Return the first matching keyword (lowercased), or None."""
     if not text:
         return None
     low = text.lower()
     for kw in kws:
-        if kw in low:
+        if _keyword_hit(kw, text, low):
             return kw
     return None
 

--- a/scripts/lint_articles.py
+++ b/scripts/lint_articles.py
@@ -48,7 +48,7 @@ AGENCY_REGISTRY = ROOT / "assets" / "agency_registry.json"
 # see scripts/article_curate.py:article_id_for_url). Decimal digits are a
 # subset of hex, so one pattern accepts both.
 ARTICLE_ID_RE = re.compile(r"^art_[0-9a-f]{3,}$")
-KNOWN_STATUSES = {"mechanical", "enriched", "needs_review"}
+KNOWN_STATUSES = {"mechanical", "enriched", "needs_review", "off_topic"}
 
 # Word-boundary regex hits suggesting the article reports a contract
 # action — terminating, turning off, pausing, declining renewal, etc.

--- a/tests/test_article_curate.py
+++ b/tests/test_article_curate.py
@@ -31,3 +31,60 @@ def test_distinct_urls_get_distinct_ids():
     a = article_curate.article_id_for_url("https://example.org/a")
     b = article_curate.article_id_for_url("https://example.org/b")
     assert a != b
+
+
+# ── Phase 2 routing: off_topic vs enriched ───────────────────────
+
+
+def _phase2_once(tmp_path, monkeypatch, verdict):
+    """Drive run_phase2 over a single eligible 'mechanical' entry with a
+    stubbed curator verdict. Returns the entry after processing."""
+    monkeypatch.setattr(article_curate, "ROOT", tmp_path)
+    (tmp_path / "a.txt").write_text("article body text")
+    entry = {
+        "article_id": "art_aaaaaaaaaaaa",
+        "url": "https://eff.org/x",
+        "tier": 2,
+        "scanner_verdict": "CLEAN — no findings",
+        "curation_status": "mechanical",
+        "discovered_by": "bing:flock",
+        "paths": {"txt": "a.txt"},
+        "tags": [],
+        "agencies": [],
+        "agency_candidates": [],
+    }
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr(article_curate, "call_claude_for_curation",
+                        lambda *a, **k: (verdict, "raw"))
+    article_curate.run_phase2(
+        [entry], tags_data={"topics": {}, "editorial": {}},
+        limit=5, model="x", dry_run=False,
+    )
+    return entry
+
+
+def test_phase2_routes_off_topic_to_terminal_status(tmp_path, monkeypatch):
+    """off_topic verdict → curation_status 'off_topic' (terminal tombstone),
+    not 'needs_review' and not 'enriched'."""
+    verdict = {
+        "refusal": False, "refusal_reason": None,
+        "off_topic": True, "off_topic_reason": "a flock of birds, not ALPR",
+        "summary": "", "key_quotes": [], "topic_tags": [],
+        "genre": "explainer", "primary_subject_agency_ids": [],
+    }
+    entry = _phase2_once(tmp_path, monkeypatch, verdict)
+    assert entry["curation_status"] == "off_topic"
+    assert "off_topic" in entry["curation_error"]
+
+
+def test_phase2_enriches_on_topic_entry(tmp_path, monkeypatch):
+    """The off_topic branch must not swallow a normal on-topic article."""
+    verdict = {
+        "refusal": False, "refusal_reason": None,
+        "off_topic": False, "off_topic_reason": None,
+        "summary": "Real ALPR story.", "key_quotes": [], "topic_tags": [],
+        "genre": "investigative", "primary_subject_agency_ids": [],
+    }
+    entry = _phase2_once(tmp_path, monkeypatch, verdict)
+    assert entry["curation_status"] == "enriched"
+    assert entry["summary"] == "Real ALPR story."

--- a/tests/test_discover_articles.py
+++ b/tests/test_discover_articles.py
@@ -38,12 +38,22 @@ def test_matches_keywords(text, expected):
     assert got == expected
 
 
-def test_matches_keywords_skips_bare_flock():
-    """We deliberately excluded bare 'flock' from the keyword list —
-    it's too generic (flocks of birds, etc.). 'flock safety' or
-    'flock cameras' must appear to match."""
-    assert da.matches_keywords("A flock of geese flew overhead.", da.KEYWORDS) is None
+def test_matches_bare_flock_word_boundary():
+    """A bare standalone 'Flock' now matches — the company is frequently
+    named only as 'Flock' in headlines ('…ditching Flock'), which carry no
+    qualified keyword. The residual false positive (a literal flock of
+    birds, Flock Freight, a congregation) is dropped downstream by the
+    curator's off_topic verdict, so we accept it here for recall. Inflected
+    common-noun forms stay excluded via the word boundary."""
+    # Standalone token → matches (curator backstops the bird/Freight case).
+    assert da.matches_keywords("Palo Alto considers ditching Flock", da.KEYWORDS) == "flock"
+    assert da.matches_keywords("Evanston orders Flock to remove cameras", da.KEYWORDS) == "flock"
+    assert da.matches_keywords("A flock of geese flew overhead.", da.KEYWORDS) == "flock"
+    # Qualified forms still win the (more specific) label.
+    assert da.matches_keywords("Flock Safety launches product", da.KEYWORDS) == "flock safety"
+    # Inflected forms are not a standalone 'flock' token → no match.
     assert da.matches_keywords("Bird flocking behavior in winter", da.KEYWORDS) is None
+    assert da.matches_keywords("Shoppers arrived in their flocks", da.KEYWORDS) is None
 
 
 def test_matches_keywords_empty_input():

--- a/tests/test_lint_articles.py
+++ b/tests/test_lint_articles.py
@@ -225,6 +225,14 @@ def test_lint_rejects_unknown_curation_status(tmp_path):
     assert "unknown curation_status" in err
 
 
+def test_lint_accepts_off_topic_status(tmp_path):
+    """off_topic is a terminal verdict (curator: not about ALPR); the entry
+    stays in the registry as a dedup tombstone, so lint must accept it."""
+    repo, _ = _make_repo(tmp_path, registry=[_good_entry(curation_status="off_topic")])
+    rc, out, err = _run(repo)
+    assert rc == 0, err
+
+
 def test_lint_rejects_missing_paths(tmp_path):
     repo, _ = _make_repo(tmp_path, registry=[_good_entry(
         paths={"html": "assets/articles/eff.org/missing.html"},


### PR DESCRIPTION
## Why

A reader-flagged headline ("Palo Alto considers ditching Flock") never auto-discovered. The domain was already allow-listed by #(4db6d181), but that commit deliberately kept bare `flock` out of the keyword list ("too generic"), and added euphemism terms (`street camera`, `public safety camera`, `fusus`) instead. A headline that names the company only as **"Flock"** — no "Flock Safety/camera/contract" — still matches no keyword and slips the gate.

This queues those headlines, and moves the precision call from the keyword gate to the curator.

## What

- **`discover_articles.py`** — bare `flock` is now a keyword, **word-boundary matched** via `_keyword_hit` so `flocking` / `flocks of geese` don't trip it. Implemented as a sentinel, so custom `--keywords` lists are unaffected unless they opt in to `flock`.
- **`article_curate.py`** — new **`off_topic`** verdict, distinct from `refusal`. `refusal` = "I couldn't evaluate it" (paywall/truncation → `needs_review`). `off_topic` = "I read it and it's simply not about ALPR" (a literal flock of birds, Flock Freight, a congregation) → terminal `curation_status: "off_topic"`.
- **`build_articles_data.py`** — `off_topic` entries are dropped from the public viewer (article list, tag/source counts, per-agency index).
- **`lint_articles.py`** — `off_topic` added to `KNOWN_STATUSES`.

## Cost is bounded

The `off_topic` entry **stays in the registry as a tombstone**, so `article_queue_add`'s existing URL dedup never re-queues it — **one crawl + one curation per false positive, ever** (not per refresh). The domain allowlist already scopes discovery to surveillance-leaning publishers, so the false-positive volume is small to begin with.

## Note for review

This **reverses a deliberate choice** from #(4db6d181) (same author, parallel session) to keep bare `flock` out. The curator `off_topic` backstop is what makes that safe now — worth a glance in case that choice had a reason not captured in the commit.

## Tests

Flipped the old `skip_bare_flock` assertion to the new word-boundary behavior; added `off_topic` routing tests for the curator (`run_phase2`) and lint. Full suite green (633 passed) after `make build`.
