### PR TITLE
Add backlog dashboard (crawl + article pipeline status)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         run: make build
 
       - name: Run smoke tests
-        run: uv run pytest tests/test_map_smoke.py -v
+        run: uv run pytest tests/test_map_smoke.py tests/test_dashboard.py -v
 
       - name: Run meeting-watcher tests
         run: uv run pytest tests/test_meeting_watch.py -v

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
           uv run python scripts/build_contract_map.py &
           uv run python scripts/build_justifications.py &
           uv run python scripts/build_articles_data.py &
+          uv run python scripts/build_dashboard.py &
           uv run python scripts/md_to_pdf.py docs/SMPD_ALPR_Findings.md "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" &
           uv run python scripts/build_pra_registry.py
           uv run python scripts/build_pra_productivity.py &

--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -161,6 +161,7 @@ jobs:
           uv run python scripts/build_map.py &
           uv run python scripts/build_report_data.py &
           uv run python scripts/build_justifications.py &
+          uv run python scripts/build_dashboard.py &
           uv run python scripts/md_to_pdf.py &
           wait
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/data/agency_changelog.json
 docs/data/contract_map_data.json
 docs/data/justifications.json
 docs/data/articles_data.json
+docs/data/dashboard.json
 docs/js/map.js
 assets/transparency.flocksafety.com/.sharing_graph_full.json
 assets/**/_pending/

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ BUILD_FILES := \
 	docs/data/report_data.json \
 	docs/data/justifications.json \
 	docs/data/agency_changelog.json \
+	docs/data/dashboard.json \
 	assets/transparency.flocksafety.com/.sharing_graph_full.json
 BUILD_DIRS := docs/data/audit docs/data/history
 # Touched on a successful `make build`. `make test` depends on it, so the
@@ -62,6 +63,7 @@ build: ## Force-rebuild all site/data artifacts + findings PDF
 	uv run python scripts/build_scoreboard.py
 	uv run python scripts/build_report_data.py
 	uv run python scripts/build_justifications.py
+	uv run python scripts/build_dashboard.py
 	uv run python scripts/md_to_pdf.py
 	@mkdir -p $(dir $(BUILD_STAMP))
 	@touch $(BUILD_STAMP)

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://gc.zgo.at; connect-src 'self' https://gc.zgo.at https://none-below.goatcounter.com;">
+<link rel="stylesheet" href="css/shared.css">
+<title>Backlog Dashboard — California ALPR Network</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, system-ui, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+    min-height: 100vh;
+    line-height: 1.5;
+  }
+  .wrap { max-width: 1000px; margin: 0 auto; padding: 28px 20px 60px; }
+  h1 { font-size: 22px; margin-bottom: 4px; }
+  .lede { color: #94a3b8; font-size: 14px; max-width: 680px; }
+  .built { color: #64748b; font-size: 12px; margin-top: 8px; }
+  h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em;
+    color: #94a3b8; border-bottom: 1px solid #1e293b;
+    padding-bottom: 6px; margin: 34px 0 14px;
+  }
+
+  /* Summary stat cards */
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+  .stat {
+    background: #1e293b; border: 1px solid #334155; border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .stat .num { font-size: 28px; font-weight: 700; line-height: 1.1; }
+  .stat .label { font-size: 12px; color: #94a3b8; margin-top: 4px; }
+  .stat .sub { font-size: 11px; color: #64748b; margin-top: 2px; }
+  .stat.alert .num { color: #fca5a5; }
+  .stat.warn .num { color: #fcd34d; }
+  .stat.ok .num { color: #86efac; }
+
+  /* Controls */
+  .controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-bottom: 12px; }
+  .controls input[type=text] {
+    background: #1e293b; border: 1px solid #334155; color: #e2e8f0;
+    border-radius: 6px; padding: 6px 10px; font-size: 13px; min-width: 220px;
+  }
+  .controls label { font-size: 13px; color: #cbd5e1; display: flex; align-items: center; gap: 6px; cursor: pointer; }
+  .controls .count { font-size: 12px; color: #64748b; margin-left: auto; }
+
+  /* Table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 7px 10px; border-bottom: 1px solid #1e293b; }
+  th { color: #94a3b8; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: #16213a; }
+  .badge {
+    display: inline-block; padding: 1px 8px; border-radius: 10px;
+    font-size: 11px; font-weight: 600;
+  }
+  .badge.overdue { background: #450a0a; color: #fca5a5; }
+  .badge.due { background: #451a03; color: #fcd34d; }
+  .badge.fresh { background: #052e16; color: #86efac; }
+  .flag { color: #c4b5fd; font-size: 11px; margin-left: 6px; }
+  .empty { color: #64748b; font-size: 13px; padding: 16px 0; }
+
+  /* Article pipeline mini-grid */
+  .pipe { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+  .pipe .stat .num { font-size: 22px; }
+  a.src { color: #60a5fa; }
+
+  /* Pipeline-health layout: stat row + trend sparkline */
+  .health { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
+  .sparkwrap { background: #1e293b; border: 1px solid #334155; border-radius: 8px; padding: 14px 16px; margin-top: 12px; }
+  .sparkwrap .caption { font-size: 12px; color: #94a3b8; margin-bottom: 10px; }
+  .spark { display: flex; align-items: flex-end; gap: 3px; height: 52px; }
+  .spark .bar { flex: 1; background: #334155; border-radius: 2px 2px 0 0; min-height: 2px; }
+  .spark .bar.today { background: #60a5fa; }
+  .sparkwrap .axis { display: flex; justify-content: space-between; color: #64748b; font-size: 11px; margin-top: 6px; }
+
+  /* Quarantine callout */
+  .note { font-size: 12px; color: #94a3b8; margin-top: 10px; }
+  .note code { background: #1e293b; border: 1px solid #334155; border-radius: 4px; padding: 1px 5px; }
+  .badge.stuck { background: #3b0764; color: #d8b4fe; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <a class="back-link" href="index.html">&larr; Back to investigation</a>
+  <h1>Backlog Dashboard</h1>
+  <p class="lede">What's waiting to be picked up — transparency portals due for a re-crawl,
+    and where each news article sits in the curation pipeline. Staleness is recomputed in
+    your browser against the current time, so the "due" counts stay live between rebuilds.</p>
+  <div class="built" id="built"></div>
+
+  <h2>At a glance</h2>
+  <div class="stats" id="stats"><div class="empty">Loading…</div></div>
+
+  <h2>Pipeline health — crawl throughput</h2>
+  <div class="health" id="health"></div>
+  <div class="sparkwrap" id="sparkwrap"></div>
+
+  <h2>Stuck — quarantined portals</h2>
+  <div id="quarantined"></div>
+
+  <h2>Crawl backlog — transparency portals due for re-crawl</h2>
+  <div class="controls">
+    <input type="text" id="filter" placeholder="Filter by agency or state…">
+    <label><input type="checkbox" id="dueOnly" checked> Due only</label>
+    <span class="count" id="crawlCount"></span>
+  </div>
+  <div id="crawl"></div>
+
+  <h2>Article pipeline</h2>
+  <div class="pipe" id="articles"></div>
+</div>
+
+<script src="js/utils.js"></script>
+<script src="js/dashboard.js"></script>
+
+<script data-goatcounter="https://none-below.goatcounter.com/count"
+        async src="https://gc.zgo.at/count.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,6 +124,10 @@
     <h3><a href="justifications.html">Search Justifications</a></h3>
     <p>What people enter in the "reason" field when running ALPR searches, across every California agency that publishes its audit log.</p>
   </div>
+  <div class="card">
+    <h3><a href="dashboard.html">Backlog Dashboard</a> <span class="tag new">New</span></h3>
+    <p>Live status of the data pipeline: transparency portals due for a re-crawl (recomputed in your browser against the crawler's own timer) and where each news article sits in the curation queue.</p>
+  </div>
 </div>
 
 <h2>San Mateo PD investigation</h2>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 zero-below
+//
+// Backlog dashboard. Fetches data/dashboard.json (built by
+// scripts/build_dashboard.py) and renders crawl + article backlog. Staleness
+// is recomputed against the viewer's clock on load and on a slow interval, so
+// "days idle" / "due" counts advance between site rebuilds.
+
+var DAY = 86400000;
+var DATA = null;
+
+// Whole days since an ISO date (YYYY-MM-DD), or null. Date.parse on a bare
+// date is UTC midnight; good enough for day-granularity staleness.
+function daysSince(iso) {
+  if (!iso) return null;
+  var t = Date.parse(iso);
+  if (isNaN(t)) return null;
+  return Math.floor((Date.now() - t) / DAY);
+}
+
+function relAge(ms) {
+  var s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (s < 90) return s + 's ago';
+  var m = Math.round(s / 60);
+  if (m < 90) return m + 'm ago';
+  var h = Math.round(m / 60);
+  if (h < 36) return h + 'h ago';
+  return Math.round(h / 24) + 'd ago';
+}
+
+// Classify a portal by the same timer the crawler uses: due once the latest
+// *attempt* is >= refresh_max_age_days old, overdue at >= stale_days.
+function classify(agency, cfg) {
+  var age = daysSince(agency.last_attempt);
+  if (age === null || age >= cfg.stale_days) return 'overdue';
+  if (age >= cfg.refresh_max_age_days) return 'due';
+  return 'fresh';
+}
+
+function renderBuilt() {
+  var el = document.getElementById('built');
+  if (!DATA) return;
+  var built = Date.parse(DATA.generated_at);
+  el.textContent = 'Data built ' + relAge(built) + ' (' + formatDate(DATA.generated_at) +
+    ') · staleness recomputed live in your browser';
+}
+
+function statCard(num, label, sub, cls) {
+  var d = document.createElement('div');
+  d.className = 'stat' + (cls ? ' ' + cls : '');
+  var n = document.createElement('div'); n.className = 'num'; n.textContent = num; d.appendChild(n);
+  var l = document.createElement('div'); l.className = 'label'; l.textContent = label; d.appendChild(l);
+  if (sub) { var s = document.createElement('div'); s.className = 'sub'; s.textContent = sub; d.appendChild(s); }
+  return d;
+}
+
+function renderStats() {
+  var cfg = DATA.crawl;
+  var agencies = cfg.agencies;
+  var due = 0, overdue = 0, maxIdle = 0, stalest = null;
+  agencies.forEach(function (a) {
+    var c = classify(a, cfg);
+    if (c === 'due') due++;
+    if (c === 'overdue') overdue++;
+    var age = daysSince(a.last_attempt);
+    if (age !== null && age > maxIdle) { maxIdle = age; stalest = a; }
+  });
+
+  var art = DATA.articles;
+  var grid = document.getElementById('stats');
+  grid.innerHTML = '';
+  grid.appendChild(statCard(due + overdue, 'Portals due', 'of ' + cfg.total_agencies + ' tracked',
+    (due + overdue) ? 'warn' : 'ok'));
+  grid.appendChild(statCard(overdue, 'Overdue', '≥ ' + cfg.stale_days + ' days idle',
+    overdue ? 'alert' : 'ok'));
+  grid.appendChild(statCard(stalest ? maxIdle + 'd' : '—', 'Stalest portal',
+    stalest ? stalest.name : '', stalest && maxIdle >= cfg.stale_days ? 'alert' : ''));
+  var stuck = (cfg.quarantined || []).length;
+  grid.appendChild(statCard(stuck, 'Quarantined', 'skipped until retry', stuck ? 'alert' : 'ok'));
+  grid.appendChild(statCard(art.needs_review, 'Articles to review', 'curation flagged',
+    art.needs_review ? 'warn' : 'ok'));
+  grid.appendChild(statCard(art.failed_urls, 'Failed article URLs', 'fetch gave up',
+    art.failed_urls ? 'warn' : 'ok'));
+}
+
+function renderHealth() {
+  var cfg = DATA.crawl;
+  var t = cfg.throughput || {};
+  var health = document.getElementById('health');
+  health.innerHTML = '';
+  health.appendChild(statCard(t.mean_7d != null ? t.mean_7d : '—', 'Captures / day', '7-day average'));
+  var cycle = t.effective_cycle_days;
+  health.appendChild(statCard(cycle != null ? cycle + 'd' : '—', 'Effective cycle',
+    'to refresh all ' + cfg.total_agencies,
+    cycle != null && cycle > cfg.stale_days ? 'warn' : ''));
+  health.appendChild(statCard(cfg.total_captures, 'Total snapshots', 'all-time'));
+
+  // Trend sparkline: bar height ∝ that day's new-snapshot count.
+  var series = t.per_day || [];
+  var max = series.reduce(function (m, x) { return Math.max(m, x.captures); }, 0) || 1;
+  var bars = series.map(function (x, i) {
+    var pct = Math.max(Math.round((x.captures / max) * 100), 3);
+    var today = i === series.length - 1;
+    return '<div class="bar' + (today ? ' today' : '') + '" style="height:' + pct + '%" ' +
+      'title="' + escapeHtml(x.date) + ': ' + x.captures + ' captures"></div>';
+  }).join('');
+  var wrap = document.getElementById('sparkwrap');
+  if (!series.length) { wrap.innerHTML = ''; return; }
+  wrap.innerHTML =
+    '<div class="caption">New snapshots per day — last ' + series.length + ' days (a portal only writes one when its content changed)</div>' +
+    '<div class="spark">' + bars + '</div>' +
+    '<div class="axis"><span>' + escapeHtml(formatDate(series[0].date)) + '</span>' +
+    '<span>' + escapeHtml(formatDate(series[series.length - 1].date)) + ' (today)</span></div>';
+}
+
+function renderQuarantine() {
+  var q = DATA.crawl.quarantined || [];
+  var box = document.getElementById('quarantined');
+  if (!q.length) {
+    box.innerHTML = '<div class="empty">None — every previously-captured agency is still in rotation.</div>';
+    return;
+  }
+  var html = '<table><thead><tr>' +
+    '<th>Agency</th><th>Reason</th><th>Quarantined</th><th>Last capture</th><th class="num">Days idle</th>' +
+    '</tr></thead><tbody>';
+  q.forEach(function (a) {
+    var age = daysSince(a.last_capture);
+    html += '<tr>' +
+      '<td>' + escapeHtml(a.name) + ' <span class="badge stuck">stuck</span></td>' +
+      '<td>' + escapeHtml(a.reason || '—') + '</td>' +
+      '<td>' + (a.since ? formatDate(a.since) : '—') + '</td>' +
+      '<td>' + (a.last_capture ? formatDate(a.last_capture) : '—') + '</td>' +
+      '<td class="num">' + (age === null ? '—' : age) + '</td>' +
+      '</tr>';
+  });
+  html += '</tbody></table>' +
+    '<div class="note">Skipped on every run until a manual <code>crawl --retry-failed</code> ' +
+    '(or an explicit <code>--slugs</code> crawl). A 404 / not-a-portal reason usually means the ' +
+    'portal moved or was taken down.</div>';
+  box.innerHTML = html;
+}
+
+function renderCrawl() {
+  var cfg = DATA.crawl;
+  var q = document.getElementById('filter').value.trim().toLowerCase();
+  var dueOnly = document.getElementById('dueOnly').checked;
+
+  var rows = cfg.agencies.filter(function (a) {
+    if (q) {
+      var hay = (a.name + ' ' + (a.state || '') + ' ' + a.slug).toLowerCase();
+      if (hay.indexOf(q) === -1) return false;
+    }
+    if (dueOnly && classify(a, cfg) === 'fresh') return false;
+    return true;
+  });
+
+  document.getElementById('crawlCount').textContent =
+    rows.length + ' shown · ' + cfg.total_agencies + ' tracked · ' + cfg.total_captures + ' captures';
+
+  var box = document.getElementById('crawl');
+  if (!rows.length) {
+    box.innerHTML = '<div class="empty">Nothing matches — everything in view is fresh.</div>';
+    return;
+  }
+
+  var html = '<table><thead><tr>' +
+    '<th>Agency</th><th>State</th><th>Last capture</th>' +
+    '<th class="num">Days idle</th><th>Status</th>' +
+    '</tr></thead><tbody>';
+  rows.forEach(function (a) {
+    var cls = classify(a, cfg);
+    var age = daysSince(a.last_attempt);
+    // Last attempt newer than last successful capture → recent crawls aren't
+    // parsing into a snapshot.
+    var failing = a.last_capture && a.last_attempt && a.last_capture < a.last_attempt;
+    html += '<tr>' +
+      '<td>' + escapeHtml(a.name) +
+        (failing ? '<span class="flag" title="Recent crawl attempts did not parse into a snapshot">⚠ attempts not parsing</span>' : '') +
+      '</td>' +
+      '<td>' + escapeHtml(a.state || '—') + '</td>' +
+      '<td>' + (a.last_capture ? formatDate(a.last_capture) : '—') + '</td>' +
+      '<td class="num">' + (age === null ? '—' : age) + '</td>' +
+      '<td><span class="badge ' + cls + '">' + cls + '</span></td>' +
+      '</tr>';
+  });
+  html += '</tbody></table>';
+  box.innerHTML = html;
+}
+
+function renderArticles() {
+  var art = DATA.articles;
+  var box = document.getElementById('articles');
+  box.innerHTML = '';
+  box.appendChild(statCard(art.total, 'Total fetched', 'in registry'));
+  box.appendChild(statCard(art.enriched, 'Enriched', 'full curation', 'ok'));
+  box.appendChild(statCard(art.mechanical, 'Mechanical', 'no AI summary'));
+  box.appendChild(statCard(art.needs_review, 'Needs review', 'curation error', art.needs_review ? 'warn' : 'ok'));
+  box.appendChild(statCard(art.failed_urls, 'Failed URLs', 'fetch gave up', art.failed_urls ? 'warn' : 'ok'));
+  var last = statCard(art.last_crawl_run ? relAge(Date.parse(art.last_crawl_run)) : '—',
+    'Last discovery', art.last_crawl_run ? formatDate(art.last_crawl_run) : '');
+  box.appendChild(last);
+}
+
+function renderAll() {
+  if (!DATA) return;
+  renderBuilt();
+  renderStats();
+  renderHealth();
+  renderQuarantine();
+  renderCrawl();
+  renderArticles();
+}
+
+fetch('data/dashboard.json')
+  .then(function (r) { return r.json(); })
+  .then(function (data) {
+    DATA = data;
+    document.getElementById('filter').addEventListener('input', renderCrawl);
+    document.getElementById('dueOnly').addEventListener('change', renderCrawl);
+    renderAll();
+    // Keep "built ago" / staleness honest for a long-open tab.
+    setInterval(renderAll, 60000);
+  })
+  .catch(function () {
+    document.getElementById('stats').innerHTML =
+      '<div class="empty">Failed to load dashboard data.</div>';
+  });

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""
+Build the operations dashboard data: docs/data/dashboard.json.
+
+Surfaces the "backlog" worth acting on:
+
+  - crawl backlog — Flock transparency portals due for a re-crawl, judged by
+    the same staleness timer the crawler uses (latest .txt *attempt* older
+    than the refresh max-age). Per-agency capture/attempt dates are emitted
+    raw; dashboard.js recomputes age against the viewer's current date, so the
+    staleness view stays live between rebuilds rather than baking in age_days.
+
+  - article backlog — counts by curation_status (enriched / mechanical /
+    needs_review), failed-fetch URLs, and the last discovery run.
+
+Reads only filenames/dates under assets/transparency.flocksafety.com (never
+scraped page content) and the curated article-registry JSON. Writes
+docs/data/dashboard.json — a build artifact (gitignored), regenerated on
+every deploy and Flock refresh.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from flock_transparency import (  # noqa: E402
+    DEFAULT_DATA_DIR,
+    STALE_DAYS,
+    crawled_slugs_on_disk,
+    latest_capture_attempt_date,
+    latest_capture_date,
+)
+from lib import (  # noqa: E402
+    FAILED_FILE,
+    agency_display_name,
+    agency_state,
+    load_registry,
+    portal_jsons,
+)
+from article_store import load_registry as load_article_registry  # noqa: E402
+
+# Width of the throughput trend series the dashboard sparkline renders.
+THROUGHPUT_WINDOW_DAYS = 14
+
+# The rolling refresh workflow runs the crawler with --max-age 7 by default
+# (.github/workflows/refresh-flock-data.yml), so an agency is "due" once its
+# latest capture attempt is at least this many days old. STALE_DAYS (14) is
+# the crawler's hard fallback when --max-age isn't passed — shown as the
+# "overdue" threshold.
+REFRESH_MAX_AGE_DEFAULT = 7
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FAILED_URLS = REPO_ROOT / "assets" / "articles" / ".failed_urls.json"
+CRAWL_STATE = REPO_ROOT / "assets" / "articles" / ".crawl_state.json"
+OUT = REPO_ROOT / "docs" / "data" / "dashboard.json"
+
+
+def _slug_to_entry():
+    """Map every on-disk portal slug (base + Flock variants) to its registry entry.
+
+    Crawled directories are named by Flock slug, which may be a flock_slugs
+    variant rather than the registry's base slug — index all of them so the
+    display name resolves regardless of which one a capture landed under.
+    """
+    by_slug = {}
+    for entry in load_registry():
+        candidates = [entry.get("slug"), entry.get("flock_active_slug")]
+        candidates += entry.get("flock_slugs") or []
+        for slug in candidates:
+            if slug and slug not in by_slug:
+                by_slug[slug] = entry
+    return by_slug
+
+
+def _iso_or_none(d):
+    return d.isoformat() if d else None
+
+
+def build_throughput(data_dir, slugs):
+    """Captures landed per day over the trailing window.
+
+    A new dated .json is only written when a portal's content changed, so this
+    is the pipeline's *useful-output* rate — and, since the cron only fires the
+    crawler a fraction of the times it's scheduled, the binding constraint on
+    how fast the whole population gets refreshed. The effective cycle (days to
+    cover everyone once) falls out as total_agencies / captures-per-day.
+    """
+    today = date.today()
+    per_date = {}
+    for slug in slugs:
+        for j in portal_jsons(data_dir / slug):
+            try:
+                d = date.fromisoformat(j.stem)
+            except ValueError:
+                continue
+            age = (today - d).days
+            if 0 <= age < THROUGHPUT_WINDOW_DAYS:
+                per_date[j.stem] = per_date.get(j.stem, 0) + 1
+    # Dense oldest→today series so the sparkline shows zero-capture days too.
+    series = [
+        {"date": (today - timedelta(days=i)).isoformat(),
+         "captures": per_date.get((today - timedelta(days=i)).isoformat(), 0)}
+        for i in range(THROUGHPUT_WINDOW_DAYS - 1, -1, -1)
+    ]
+
+    def mean(n):
+        window = series[-n:]
+        return round(sum(x["captures"] for x in window) / n, 1) if window else 0
+
+    return {"per_day": series, "mean_7d": mean(7), "mean_14d": mean(14)}
+
+
+def build_quarantined(data_dir, slugs, by_slug):
+    """Previously-captured agencies now parked in .failed_slugs.json.
+
+    The crawler skips a quarantined slug on every run until a manual
+    --retry-failed, so these silently fall out of rotation. The file is mostly
+    http_404 probe-guesses that were never real portals; intersecting with
+    crawled_slugs_on_disk (slugs that have a real prior capture) leaves only the
+    genuinely-stuck agencies worth surfacing.
+    """
+    fs_path = data_dir / FAILED_FILE
+    if not fs_path.is_file():
+        return []
+    try:
+        failed = json.loads(fs_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    captured = set(slugs)
+    out = []
+    for slug, info in failed.items():
+        if slug not in captured:
+            continue  # never-real probe guess, not a stuck agency
+        entry = by_slug.get(slug)
+        out.append({
+            "slug": slug,
+            "name": agency_display_name(entry, fallback=slug) if entry else slug,
+            "reason": info.get("reason") if isinstance(info, dict) else str(info),
+            "since": info.get("date") if isinstance(info, dict) else None,
+            "last_capture": _iso_or_none(latest_capture_date(slug, data_dir)),
+        })
+    out.sort(key=lambda x: x["last_capture"] or "")
+    return out
+
+
+def build_crawl():
+    by_slug = _slug_to_entry()
+    slugs = crawled_slugs_on_disk(DEFAULT_DATA_DIR)
+    agencies = []
+    total_captures = 0
+    for slug in slugs:
+        entry = by_slug.get(slug)
+        captures = portal_jsons(DEFAULT_DATA_DIR / slug)
+        total_captures += len(captures)
+        agencies.append({
+            "slug": slug,
+            "name": agency_display_name(entry, fallback=slug) if entry else slug,
+            "state": (agency_state(entry) if entry else None),
+            # last successful parse (.json) vs last attempt (.txt). When the
+            # attempt is newer than the capture, recent crawls are failing to
+            # parse — the page flags that.
+            "last_capture": _iso_or_none(latest_capture_date(slug, DEFAULT_DATA_DIR)),
+            "last_attempt": _iso_or_none(latest_capture_attempt_date(slug, DEFAULT_DATA_DIR)),
+            "captures": len(captures),
+        })
+    # Stalest first — the page re-sorts, but a sensible default helps anyone
+    # eyeballing the raw JSON.
+    agencies.sort(key=lambda a: a["last_attempt"] or "")
+
+    throughput = build_throughput(DEFAULT_DATA_DIR, slugs)
+    rate = throughput["mean_7d"]
+    throughput["effective_cycle_days"] = round(len(agencies) / rate, 1) if rate else None
+
+    return {
+        "stale_days": STALE_DAYS,
+        "refresh_max_age_days": REFRESH_MAX_AGE_DEFAULT,
+        "total_agencies": len(agencies),
+        "total_captures": total_captures,
+        "throughput": throughput,
+        "quarantined": build_quarantined(DEFAULT_DATA_DIR, slugs, by_slug),
+        "agencies": agencies,
+    }
+
+
+def build_articles():
+    counts = {}
+    total = 0
+    for entry in load_article_registry():
+        total += 1
+        status = entry.get("curation_status") or "unknown"
+        counts[status] = counts.get(status, 0) + 1
+
+    failed = 0
+    if FAILED_URLS.is_file():
+        try:
+            failed = len(json.loads(FAILED_URLS.read_text()))
+        except (json.JSONDecodeError, OSError):
+            failed = 0
+
+    last_run, fetched = None, 0
+    if CRAWL_STATE.is_file():
+        try:
+            state = json.loads(CRAWL_STATE.read_text())
+            last_run = state.get("last_run")
+            fetched = len(state.get("fetched") or [])
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return {
+        "total": total,
+        "enriched": counts.get("enriched", 0),
+        "mechanical": counts.get("mechanical", 0),
+        "needs_review": counts.get("needs_review", 0),
+        "failed_urls": failed,
+        "fetched": fetched,
+        "last_crawl_run": last_run,
+    }
+
+
+def main():
+    data = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "crawl": build_crawl(),
+        "articles": build_articles(),
+    }
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(data, indent=2) + "\n")
+    print(
+        f"Wrote {OUT.relative_to(REPO_ROOT)} — "
+        f"{data['crawl']['total_agencies']} agencies, "
+        f"{data['articles']['total']} articles"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/screenshot_pages.py
+++ b/scripts/screenshot_pages.py
@@ -24,6 +24,7 @@ PAGES = [
     # SMPD is the project's canonical subject so it's the natural
     # example for PR previews.
     ("report.html?agency=san-mateo-ca-pd", "report_san-mateo-ca-pd", {"width": 1000, "height": 1400}),
+    ("dashboard.html", "dashboard", {"width": 1000, "height": 1100}),
 ]
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""
+Smoke tests for the backlog dashboard.
+
+Data-shape only (no browser): asserts build_dashboard.py emits the schema
+docs/js/dashboard.js consumes, and that dashboard.html carries the CSP +
+analytics + shared-asset wiring every docs page needs.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+DOCS = Path("docs")
+DASH = DOCS / "data" / "dashboard.json"
+HTML = DOCS / "dashboard.html"
+JS = DOCS / "js" / "dashboard.js"
+
+
+class TestDashboardData:
+    """dashboard.json structure (run `make build` / build_dashboard.py first)."""
+
+    @pytest.fixture(autouse=True)
+    def load(self):
+        assert DASH.exists(), "Run build_dashboard.py first"
+        self.data = json.loads(DASH.read_text())
+
+    def test_top_level_keys(self):
+        assert {"generated_at", "crawl", "articles"} <= set(self.data)
+
+    def test_crawl_config_matches_crawler(self):
+        # These thresholds mirror flock_transparency.STALE_DAYS and the
+        # refresh workflow's --max-age default; dashboard.js renders them.
+        c = self.data["crawl"]
+        assert c["stale_days"] == 14
+        assert c["refresh_max_age_days"] == 7
+
+    def test_crawl_totals(self):
+        c = self.data["crawl"]
+        assert c["total_agencies"] > 100
+        assert len(c["agencies"]) == c["total_agencies"]
+        assert c["total_captures"] >= c["total_agencies"]
+
+    def test_agency_shape(self):
+        for a in self.data["crawl"]["agencies"]:
+            assert {"slug", "name", "state", "last_capture",
+                    "last_attempt", "captures"} <= set(a)
+        assert any(a["last_attempt"] for a in self.data["crawl"]["agencies"])
+
+    def test_agencies_sorted_stalest_first(self):
+        attempts = [a["last_attempt"] for a in self.data["crawl"]["agencies"]
+                    if a["last_attempt"]]
+        assert attempts == sorted(attempts)
+
+    def test_san_mateo_present(self):
+        slugs = {a["slug"] for a in self.data["crawl"]["agencies"]}
+        assert "san-mateo-ca-pd" in slugs
+
+    def test_throughput_shape(self):
+        t = self.data["crawl"]["throughput"]
+        assert {"per_day", "mean_7d", "mean_14d", "effective_cycle_days"} <= set(t)
+        # Dense, oldest→today series the sparkline renders.
+        assert len(t["per_day"]) == 14
+        for pt in t["per_day"]:
+            assert {"date", "captures"} <= set(pt)
+        assert t["per_day"] == sorted(t["per_day"], key=lambda p: p["date"])
+        assert isinstance(t["mean_7d"], (int, float))
+
+    def test_quarantined_shape(self):
+        # Always a list; entries (if any) are previously-captured agencies that
+        # fell out of rotation — never the never-real probe-guess 404s.
+        q = self.data["crawl"]["quarantined"]
+        assert isinstance(q, list)
+        captured = {a["slug"] for a in self.data["crawl"]["agencies"]}
+        for item in q:
+            assert {"slug", "name", "reason", "since", "last_capture"} <= set(item)
+            assert item["slug"] in captured
+
+    def test_articles_shape(self):
+        a = self.data["articles"]
+        assert {"total", "enriched", "mechanical", "needs_review",
+                "failed_urls", "fetched", "last_crawl_run"} <= set(a)
+        # Status buckets never exceed the registry total (an unbucketed
+        # "unknown" status is possible, so this is <= not ==).
+        assert a["total"] >= a["enriched"] + a["mechanical"] + a["needs_review"]
+        assert a["total"] > 0
+
+
+class TestDashboardPage:
+    """dashboard.html / dashboard.js wiring required of every docs page."""
+
+    @pytest.fixture(autouse=True)
+    def load(self):
+        assert HTML.exists()
+        self.html = HTML.read_text()
+
+    def test_csp_allows_local_fetch(self):
+        assert "Content-Security-Policy" in self.html
+        assert "connect-src 'self'" in self.html
+
+    def test_goatcounter_present(self):
+        # Memory: every docs page needs the analytics tag + its CSP entry.
+        assert "gc.zgo.at/count.js" in self.html
+        assert "none-below.goatcounter.com" in self.html
+
+    def test_shared_assets_loaded(self):
+        assert "css/shared.css" in self.html
+        assert "js/utils.js" in self.html
+        assert "js/dashboard.js" in self.html
+
+    def test_js_fetches_dashboard_data(self):
+        assert "data/dashboard.json" in JS.read_text()


### PR DESCRIPTION
A client-side ops page (`docs/dashboard.html`) showing what's waiting to be picked up across the data pipeline. Grew out of a "why are so many portals behind?" question — the answer was GitHub silently dropping most scheduled cron firings (now being fixed with an external `workflow_dispatch` trigger), so this page makes pipeline throughput and backlog visible going forward.

## Panels
- **At a glance** — portals due / overdue, stalest portal, quarantined count, article review/failed counts.
- **Crawl backlog** — portals due for re-crawl, classified by the *same* staleness timer the crawler uses (latest `.txt` attempt vs the refresh max-age). Dates are emitted raw; staleness is recomputed **in-browser against the viewer's clock**, so counts stay live between rebuilds. Filter + due-only toggle.
- **Pipeline health** — captures/day (7-day avg), effective cycle (`agencies ÷ captures-per-day`), and a 14-day trend sparkline.
- **Quarantined** — previously-captured agencies parked in `.failed_slugs.json` (the genuinely-stuck ones, filtered from the ~250 probe-guess 404s), with a `--retry-failed` note.
- **Article pipeline** — curation-status counts, failed-fetch URLs, last discovery run.

## Data + wiring
- `scripts/build_dashboard.py` → `docs/data/dashboard.json` (gitignored build artifact). Reads only filenames/dates under the Flock data dir and the curated article registry — no scraped page content.
- Wired into `make build`, `deploy.yml`, and `refresh-flock-data.yml`; linked from `index.html`; added to `screenshot_pages.py`.
- CSP + GoatCounter + shared CSS/JS per existing page conventions.
- Smoke test `tests/test_dashboard.py` (schema + page-wiring), added to the CI smoke step. 13 assertions passing.

## Notes
- Day-counts are UTC-based to match the crawler's `is_stale` (which runs on a UTC runner), so the dashboard's "due" agrees with what the crawler would actually pick.
- Known limitation: a portal only writes a dated snapshot when its content *changed*, so "days idle" measures days-since-change, not since-checked. Accurate at current cadence; a true "last checked" metric would need the crawler to stamp last-visited (follow-up).