### PR TITLE
Flag SB34 recipients that ran federal/out-of-state LE searches

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1519,10 +1519,59 @@
   }
 
   // ── Checklists ──
+  // Recipients of THIS agency's ALPR data whose own published search-audit
+  // logs contain searches naming a federal LE agency (USMS / FBI / DEA /
+  // ATF / DHS / Secret Service). Distinct from the "no_federal_sharing"
+  // check above, which catches sharing TO a federal entity directly. Here
+  // the recipient is itself a California agency, but because this agency
+  // granted it access, those federal-tagged searches reach this agency's
+  // plate data. Built pattern-side in federal_le_queries.py, so the list
+  // grows automatically as new agencies enter such reasons.
+  function renderFederalQueryFlag(report) {
+    const recips = report.federal_query_recipients || [];
+    if (!recips.length) return "";
+    const n = recips.length;
+    const who = escapeHtml(shortAgencyName(report) || report.name || "This agency");
+
+    let html = `<div class="fed-query-flag">`;
+    html += `<div class="fed-query-header">⚠ ${n} recipient${n === 1 ? "" : "s"} of this agency's ALPR data ran federal or out-of-state law-enforcement searches</div>`;
+    html += `<div class="fed-query-sub">${who} grants the California agencies below access to its license-plate data. Each one's <em>own</em> public search-audit log records searches whose stated reason names a federal or out-of-state agency. California Civil Code &sect;1798.90.55(b), as read by AG Bulletin 2023-DLE-06, limits ALPR sharing to California public agencies and excludes federal and out-of-state agencies &mdash; so a search run for such an agency reaches ${who}'s data through that grant.</div>`;
+    html += `<ul class="fed-query-list">`;
+    recips.forEach(function(r) {
+      const url = `https://transparency.flocksafety.com/${r.slug}`;
+      const cats = (r.categories || []).map(function(c) {
+        return `${c.count}&nbsp;${escapeHtml(c.label)}`;
+      }).join(", ");
+      let when = "";
+      if (r.date_min) {
+        when = r.date_max && r.date_max !== r.date_min
+          ? ` <span class="muted">(${r.date_min} – ${r.date_max})</span>`
+          : ` <span class="muted">(${r.date_min})</span>`;
+      }
+      const sample = (r.samples && r.samples.length)
+        ? `<div class="fed-query-sample">e.g. &ldquo;${escapeHtml(r.samples[0])}&rdquo;</div>`
+        : "";
+      html += `<li>`;
+      html += `<a href="${url}" target="_blank" rel="noopener">${escapeHtml(r.name)}</a>`;
+      html += ` &mdash; <strong>${r.total}</strong> flagged search${r.total === 1 ? "" : "es"}: ${cats}${when}`;
+      html += sample;
+      html += `</li>`;
+    });
+    html += `</ul>`;
+    html += `<div class="fed-query-foot">Counts are unioned from each recipient's published Flock search-audit log. The reason field is officer-entered free text &mdash; it reflects what was typed, and does not by itself establish that data was delivered to a federal agency (e.g. a joint task force may include both state and federal officers). Follow each link to verify against the recipient's live audit.</div>`;
+    html += `</div>`;
+    return html;
+  }
+
   function renderSB34Checklist(report, meta) {
     if (report.state !== "CA") return "";
     const items = report.checklist_sb34 || [];
-    if (!items.length) return "";
+    const fedQueryHtml = renderFederalQueryFlag(report);
+    // No checklist signals but a federal-query flag still applies: emit
+    // the section with just the heading + flag rather than dropping it.
+    if (!items.length) {
+      return fedQueryHtml ? `<h2>SB 34 Compliance Concerns</h2>${fedQueryHtml}` : "";
+    }
 
     let html = `<h2>SB 34 Compliance Concerns</h2>`;
     html += `<p class="muted">Signals tied to California Civil Code &sect;1798.90.51&ndash;.55. Red items indicate potential compliance concerns a council member may want to raise with their agency.</p>`;
@@ -1540,6 +1589,7 @@
     // substantial compliance gaps.
     html += `<p class="legal-note" style="border-left: 3px solid var(--warn-border); background: var(--warn-bg); color: #78350f; margin: 6px 0 10px 0"><strong>Surface-signal checks only.</strong> A green check means the signal appears on the transparency page &mdash; not that the agency substantively complies. A posted policy may be stale, an &ldquo;audit process&rdquo; may not be executed, a clean sharing list may include unvetted recipients. Starting point for questions, not a compliance certification.</p>`;
     html += renderChecklistItems(items, { report: report });
+    html += fedQueryHtml;
     return html;
   }
 

--- a/docs/report.html
+++ b/docs/report.html
@@ -362,6 +362,52 @@
     margin-top: 3px;
   }
   .data-concern-source a { color: #b91c1c; }
+  /* Federal-LE query flag — recipients of this agency's ALPR data whose
+     own audit logs show searches naming a federal agency. Red callout in
+     the SB 34 section, styled like .data-concerns. */
+  .fed-query-flag {
+    background: #fef2f2;
+    border: 1px solid #dc2626;
+    border-left: 4px solid #dc2626;
+    border-radius: 4px;
+    padding: 10px 14px;
+    margin: 12px 0 16px 0;
+  }
+  .fed-query-header {
+    font-weight: bold;
+    color: #991b1b;
+    font-size: 11pt;
+    margin-bottom: 4px;
+  }
+  .fed-query-sub {
+    font-size: 9.5pt;
+    color: #7f1d1d;
+    margin-bottom: 8px;
+    line-height: 1.4;
+  }
+  .fed-query-list {
+    margin: 0;
+    padding-left: 20px;
+  }
+  .fed-query-list li {
+    margin: 4px 0;
+    color: #450a0a;
+    font-size: 10pt;
+    line-height: 1.35;
+  }
+  .fed-query-list a { color: #b91c1c; font-weight: 600; }
+  .fed-query-sample {
+    font-size: 9pt;
+    color: #7f1d1d;
+    font-style: italic;
+    margin: 1px 0 0 2px;
+  }
+  .fed-query-foot {
+    font-size: 8.5pt;
+    color: #7f1d1d;
+    margin-top: 8px;
+    line-height: 1.35;
+  }
   /* Mini regional map — inline SVG showing subject agency surrounded
      by geocoded outbound recipients. Floated left so the surrounding
      sharing-section text (reach metrics, flagged recipients) wraps

--- a/scripts/build_report_data.py
+++ b/scripts/build_report_data.py
@@ -54,6 +54,7 @@ from gazetteer import (
     population_meta,
 )
 from fbi_crime import audit_searches_30d, load_crime, searches_per_crime
+from federal_le_queries import build_index as build_federal_le_index
 
 GRAPH_PATH = Path("assets/transparency.flocksafety.com/.sharing_graph_full.json")
 DATA_DIR = Path("assets/transparency.flocksafety.com")
@@ -704,6 +705,18 @@ def main():
     for e in registry:
         for fs in e.get("flock_slugs", []):
             slug_to_id.setdefault(fs, e["agency_id"])
+
+    # ── Federal-LE / out-of-state query index ──
+    # Scan every published audit log for reason text naming a federal LE
+    # agency (USMS / FBI / DEA / ATF / DHS / Secret Service) or an
+    # out-of-state LE agency (e.g. "Assist Talent PD (Oregon)"). Keyed by
+    # agency_id. Pattern-driven (see federal_le_queries.py), so a new
+    # agency entering such reasons is picked up automatically. Used below
+    # to flag, in each agency's SB 34 section, any OUTBOUND recipient that
+    # has run such queries — the recipient can reach the sharer's plate
+    # data on those searches, putting it within range of an entity outside
+    # §1798.90.5(f)'s "public agency" definition.
+    federal_le_index = build_federal_le_index(AUDIT_DIR, key_by=slug_to_id)
 
     graph = json.loads(GRAPH_PATH.read_text())
     graph_agencies = graph["agencies"]
@@ -1686,6 +1699,33 @@ def main():
                         pass
                 flagged_recipients.append(entry_out)
 
+        # ── Federal-LE query exposure ──
+        # Outbound recipients whose OWN published audit log contains
+        # searches naming a federal LE agency (USMS / FBI / DEA / ATF /
+        # DHS / Secret Service — see federal_le_queries.py). Distinct from
+        # the "no_federal_sharing" check, which catches sharing TO a
+        # federal entity directly. Here the recipient is a California
+        # agency, but because it can reach this agency's plate data, those
+        # federal-tagged searches put this agency's data within range of an
+        # entity outside §1798.90.5(f)'s "public agency" definition.
+        federal_query_recipients = []
+        for target_id in outbound_ids:
+            summary = federal_le_index.get(target_id)
+            if not summary:
+                continue
+            tr = reg_by_id.get(target_id, {})
+            federal_query_recipients.append({
+                "agency_id": target_id,
+                "slug": id_to_slug.get(target_id, target_id),
+                "name": agency_display_name(tr, id_to_slug.get(target_id, target_id)),
+                "total": summary["total"],
+                "categories": summary["categories"],
+                "samples": summary["samples"],
+                "date_min": summary["date_min"],
+                "date_max": summary["date_max"],
+            })
+        federal_query_recipients.sort(key=lambda r: (-r["total"], r["name"]))
+
         # Removed-flagged: targets that were in sharing at some point,
         # have since been removed, and would be flagged by current
         # registry classification. Dedupe by agency_id keeping the most
@@ -2068,6 +2108,7 @@ def main():
             "checklist_sb34": checklist_sb34,
             "checklist_transparency": checklist_transparency,
             "flagged_recipients": flagged_recipients,
+            "federal_query_recipients": federal_query_recipients,
             "removed_flagged_recipients": removed_flagged_recipients,
             "outbound": outbound_list,
             "inbound": inbound_list,

--- a/scripts/federal_le_queries.py
+++ b/scripts/federal_le_queries.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""
+Pattern-driven detection of federal-law-enforcement references in ALPR
+audit-log reason fields.
+
+California Civil Code §1798.90.55(b), as read by the Attorney General's
+Bulletin 2023-DLE-06 (Oct 27, 2023), limits ALPR-data sharing to
+California public agencies as defined in §1798.90.5(f) — a definition the
+AG says "does not include out-of-state or federal law enforcement
+agencies." A California agency that runs an ALPR search whose reason text
+names a federal LE agency (U.S. Marshals, FBI, DEA, ATF, DHS/ICE/CBP/HSI,
+Secret Service) is, on the face of the reason, querying shared networks
+for the benefit of an entity outside that definition.
+
+Why patterns instead of a hardcoded agency list
+------------------------------------------------
+The flag is keyed on the REASON TEXT, not on a fixed roster of agencies.
+That makes it self-extending: when a new agency starts entering
+"USMS case" / "FBI assist" reasons in its published audit log, it is
+picked up automatically on the next build — no edit to this file needed.
+The hardcoded part is the *vocabulary* of federal-LE references we have
+observed, not the list of offenders.
+
+Calibration
+-----------
+Patterns are deliberately narrow (word-boundaried) so they don't false-
+positive on look-alikes:
+  - "Marshall" (a surname / place name) is NOT matched by the USMS
+    pattern, which requires "USMS", "U.S. Marshal", or "Marshals Service".
+  - "idea" / "dead" / "deal" are NOT matched by the DEA pattern (\bdea\b).
+  - "service" / "police" / "notice" do NOT trip the "ice" fragment in the
+    DHS group, which is bounded as \bice\b.
+This set reproduces the hand-curated meeting-prep dataset
+(meeting-prep/chief/share-federal-le/) with zero spurious agencies across
+every published California audit log.
+
+Trust note
+----------
+The reason field is officer-entered free text scraped from third-party
+transparency portals. It is treated strictly as regex input here and is
+never executed or interpreted. The audit logs this module reads
+(docs/data/audit/<slug>.json, built by build_audit_log.py) are themselves
+deterministic JSON, and are already published verbatim on the project's
+Pages site — surfacing a sample reason adds no new exposure.
+
+Out-of-state assists
+--------------------
+The same statute bars out-of-state sharing too, so a reason naming another
+state's LE agency (e.g. "Assist Talent PD (Oregon)") is flagged as well.
+A bare state-name scan is noisy — state names collide with street and
+place names ("Washington Blvd") and with California places named after
+states ("Nevada City") — so detection requires a non-CA state name beside
+a law-enforcement token (PD / police / sheriff / SO / trooper / DPS). This
+ignores "offender from out of state" phrasings (a suspect's origin, not a
+data transfer). See OUT_OF_STATE_CATEGORY.
+
+Note: this is distinct from an out-of-state *recipient* (an agency
+physically in another state), which is detected from registry geotags
+elsewhere — here the recipient is itself a California agency, but its
+search's reason names an out-of-state agency.
+
+CLI:
+  uv run python scripts/federal_le_queries.py            # summary table
+  uv run python scripts/federal_le_queries.py --json     # full index as JSON
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+AUDIT_DIR = Path("docs/data/audit")
+
+# Ordered list of federal-LE categories. `key` is the stable identifier,
+# `label` is the human-facing name used in the report callout, `re` is the
+# detection pattern (case-insensitive). Order is the first-match priority
+# for classify_reason(); in practice the categories are disjoint in the
+# observed data, so a row's total is never double-counted.
+FEDERAL_LE_CATEGORIES = [
+    {
+        "key": "usms",
+        "label": "U.S. Marshals",
+        "re": re.compile(r"\busms\b|\bu\.?\s*s\.?\s*marshal|\bmarshals?\s+service\b", re.I),
+    },
+    {
+        "key": "fbi",
+        "label": "FBI",
+        "re": re.compile(r"\bfbi\b", re.I),
+    },
+    {
+        "key": "dea",
+        "label": "DEA",
+        "re": re.compile(r"\bdea\b", re.I),
+    },
+    {
+        "key": "atf",
+        "label": "ATF",
+        "re": re.compile(r"\batf\b", re.I),
+    },
+    {
+        "key": "dhs",
+        "label": "DHS / ICE / CBP / HSI",
+        "re": re.compile(
+            r"\bdhs\b|\bhsi\b|\bcbp\b|\bice\b|homeland|border\s+patrol|\bcustoms\b", re.I
+        ),
+    },
+    {
+        "key": "usss",
+        "label": "U.S. Secret Service",
+        "re": re.compile(r"\busss\b|secret\s+service|\bpotus\b", re.I),
+    },
+]
+
+# ── Out-of-state assist ──
+# §1798.90.55(b) / AG Bulletin 2023-DLE-06 bar out-of-state sharing on the
+# same footing as federal. Detecting it from the reason text is trickier
+# than the federal acronyms: a bare state-name scan collides with street
+# and place names ("Washington Blvd", "Virginia St") and with California
+# places named after states ("Nevada City"). So we require a non-California
+# state name to sit next to a law-enforcement token (PD / police / sheriff
+# / SO / trooper / DPS), which is how an assist for another state's agency
+# reads — e.g. "Assist Talent PD (Oregon)". "Nevada" is guarded against the
+# CA "Nevada City" / "Nevada County". This deliberately ignores phrasings
+# like "offender from out of state" (a suspect's origin, not a transfer of
+# data to another state's agency). Validated to yield exactly the one
+# observed assist (Manteca → Oregon) with zero false positives across all
+# published CA audit logs; it remains self-extending for future rows.
+_NON_CA_STATES = (
+    r"Alabama|Alaska|Arizona|Arkansas|Colorado|Connecticut|Delaware|Florida|"
+    r"Georgia|Hawaii|Idaho|Illinois|Indiana|Iowa|Kansas|Kentucky|Louisiana|"
+    r"Maine|Maryland|Massachusetts|Michigan|Minnesota|Mississippi|Missouri|"
+    r"Montana|Nebraska|Nevada(?!\s+(?:City|County))|New\s+Hampshire|"
+    r"New\s+Jersey|New\s+Mexico|New\s+York|North\s+Carolina|North\s+Dakota|"
+    r"Ohio|Oklahoma|Oregon|Pennsylvania|Rhode\s+Island|South\s+Carolina|"
+    r"South\s+Dakota|Tennessee|Texas|Utah|Vermont|Virginia|Washington|"
+    r"West\s+Virginia|Wisconsin|Wyoming"
+)
+_LE_TOKEN = r"PD|police|sheriff|deputies|trooper|troopers|DPS|state\s+police|SO"
+_OOS_RE = re.compile(
+    rf"(?:\b(?:{_LE_TOKEN})\b.{{0,25}}\b(?:{_NON_CA_STATES})\b)"
+    rf"|(?:\b(?:{_NON_CA_STATES})\b.{{0,25}}\b(?:{_LE_TOKEN})\b)",
+    re.I,
+)
+OUT_OF_STATE_CATEGORY = {
+    "key": "oos",
+    "label": "Out-of-state assist",
+    "re": _OOS_RE,
+}
+
+# Federal categories take priority over out-of-state (a "FBI / Oregon PD"
+# reason classifies as fbi). Out-of-state is checked last.
+DETECT_CATEGORIES = FEDERAL_LE_CATEGORIES + [OUT_OF_STATE_CATEGORY]
+
+_LABEL_BY_KEY = {c["key"]: c["label"] for c in DETECT_CATEGORIES}
+
+
+def classify_reason(reason):
+    """Return the category key of the first detection pattern that matches
+    `reason`, or None. First-match priority follows DETECT_CATEGORIES order
+    (federal acronyms first, out-of-state last)."""
+    if not reason:
+        return None
+    text = str(reason)
+    for cat in DETECT_CATEGORIES:
+        if cat["re"].search(text):
+            return cat["key"]
+    return None
+
+
+def scan_rows(rows, max_samples=2):
+    """Scan a list of audit rows for federal-LE or out-of-state reason refs.
+
+    Returns a summary dict, or None when nothing matches:
+
+        {
+          "total": 9,                       # rows matching any pattern
+          "categories": [                   # sorted by count desc, then key
+              {"key": "fbi",  "label": "FBI",            "count": 5},
+              {"key": "usms", "label": "U.S. Marshals",  "count": 4},
+          ],
+          "samples": ["FBI ASSIST: BANK THEFT", "Usms case"],
+          "date_min": "2026-03-04",
+          "date_max": "2026-05-31",
+        }
+
+    `samples` holds up to `max_samples` distinct verbatim reason strings
+    (truncated), for a concrete, verifiable callout.
+    """
+    counts = {}
+    distinct_reasons = {}  # lower-cased -> original, dedup while preserving first form
+    dates = []
+    for r in rows or []:
+        key = classify_reason(r.get("reason"))
+        if not key:
+            continue
+        counts[key] = counts.get(key, 0) + 1
+        sd = (r.get("searchDate") or "")[:10]
+        if sd:
+            dates.append(sd)
+        reason = str(r.get("reason") or "").strip()
+        if reason:
+            distinct_reasons.setdefault(reason.lower(), reason)
+
+    if not counts:
+        return None
+
+    # Prefer the shortest distinct reasons as samples. The shortest tend to
+    # be generic ("Usms case", "dea inquiry") rather than longer free-text
+    # that may embed a subject's name — surfaced text stays minimal even
+    # though the underlying audit log is already public.
+    samples = [
+        s if len(s) <= 80 else s[:77] + "…"
+        for s in sorted(distinct_reasons.values(), key=lambda s: (len(s), s.lower()))[:max_samples]
+    ]
+
+    categories = sorted(
+        ({"key": k, "label": _LABEL_BY_KEY[k], "count": n} for k, n in counts.items()),
+        key=lambda c: (-c["count"], c["key"]),
+    )
+    return {
+        "total": sum(counts.values()),
+        "categories": categories,
+        "samples": samples,
+        "date_min": min(dates) if dates else None,
+        "date_max": max(dates) if dates else None,
+    }
+
+
+def build_index(audit_dir=AUDIT_DIR, key_by=None, max_samples=2):
+    """Scan every audit log under `audit_dir` and return a per-agency index
+    of federal-LE query activity.
+
+    `key_by`: optional {slug: agency_id} map. When provided, the returned
+    dict is keyed by agency_id (slugs absent from the map fall back to the
+    slug); otherwise it is keyed by slug. Each value is the scan_rows()
+    summary with the source `slug` attached. Agencies with no matches are
+    omitted.
+    """
+    audit_dir = Path(audit_dir)
+    index = {}
+    if not audit_dir.is_dir():
+        return index
+    for path in sorted(audit_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        slug = data.get("portal") or path.stem
+        summary = scan_rows(data.get("rows") or [], max_samples=max_samples)
+        if not summary:
+            continue
+        summary["slug"] = slug
+        key = (key_by or {}).get(slug, slug)
+        index[key] = summary
+    return index
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--audit-dir", default=str(AUDIT_DIR),
+                    help="directory of <slug>.json audit logs (default: %(default)s)")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the full index as JSON instead of a table")
+    args = ap.parse_args()
+
+    index = build_index(args.audit_dir)
+    if args.json:
+        print(json.dumps(index, indent=2, sort_keys=True))
+        return 0
+
+    if not index:
+        print("no federal-LE references found", file=sys.stderr)
+        return 0
+
+    rows = sorted(index.values(), key=lambda s: (-s["total"], s["slug"]))
+    total_rows = sum(s["total"] for s in rows)
+    print(f"{len(rows)} agencies with federal-LE query references "
+          f"({total_rows} rows total)\n")
+    for s in rows:
+        cats = ", ".join(f"{c['count']} {c['label']}" for c in s["categories"])
+        window = f"{s['date_min']}..{s['date_max']}" if s["date_min"] else "—"
+        print(f"  {s['slug']:<28} {s['total']:>4}  [{cats}]  {window}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_federal_le_queries.py
+++ b/tests/test_federal_le_queries.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""Tests for the pattern-driven federal-LE query detector.
+
+The detection patterns are the load-bearing part: too loose and benign
+reasons get flagged as federal-LE activity; too tight and real references
+slip through. These tests lock the calibrated behavior, especially the
+false-positive exclusions (Marshall / idea / service-fragment).
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "federal_le_queries",
+    Path(__file__).parent.parent / "scripts" / "federal_le_queries.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+classify_reason = _mod.classify_reason
+scan_rows = _mod.scan_rows
+build_index = _mod.build_index
+
+
+# ── classify_reason: positive matches (verbatim from observed portals) ──
+
+@pytest.mark.parametrize("reason,expected", [
+    ("Usms case", "usms"),
+    ("usms cas", "usms"),
+    ("U.S. Marshal warrant", "usms"),
+    ("US Marshals Service assist", "usms"),
+    ("FBI ASSIST: BANK THEFT", "fbi"),
+    ("AOA for fbi", "fbi"),
+    ("dea inquiry", "dea"),
+    ("ATF case 12345", "atf"),
+    ("DHS AOD", "dhs"),
+    ("HSI request", "dhs"),
+    ("CBP lookout", "dhs"),
+    ("ICE detainer", "dhs"),
+    ("Homeland Security tip", "dhs"),
+    ("Border Patrol assist", "dhs"),
+    ("POTUS threat. Search for USSS", "usss"),
+    ("Secret Service detail", "usss"),
+    # Out-of-state assist: non-CA state name beside an LE token.
+    ("Assist Talent PD (Oregon) BOL Fraud S-Veh", "oos"),
+    ("Oregon State Police BOL", "oos"),
+    ("assist for Texas DPS", "oos"),
+    ("Clark County Nevada sheriff request", "oos"),  # Nevada (not "Nevada City")
+])
+def test_classify_positive(reason, expected):
+    assert classify_reason(reason) == expected
+
+
+# ── classify_reason: false-positive exclusions ──
+# These are the look-alikes the narrow patterns must NOT match. "Marshall"
+# is the surname/place case that the broad \bmarshal pattern over-matched
+# (Buena Park PD); the rest guard the short-token patterns.
+
+@pytest.mark.parametrize("reason", [
+    "Officer Marshall responding",       # surname, not U.S. Marshals
+    "Marshall Street collision",         # place name
+    "good idea to check this plate",     # 'idea' must not trip \bdea\b
+    "dead body investigation",           # 'dead'
+    "narcotics deal in progress",        # 'deal'
+    "service of a search warrant",       # 'service' must not trip \bice\b
+    "police welfare check",              # 'police'
+    "notice to appear follow-up",        # 'notice'
+    "stolen vehicle recovery",           # nothing federal
+    "187 PC homicide",                   # penal code, historically a false ICE hit
+    # Out-of-state guards: a state name with no adjacent LE token, a CA
+    # place named after a state, and the "from out of state" origin phrase
+    # must all stay unflagged.
+    "Washington Blvd collision",         # street, no LE token
+    "Virginia St burglary",              # street, no LE token
+    "Nevada City PD assist",             # CA agency (Nevada County, CA)
+    "Nevada County sheriff request",     # CA agency
+    "offender from out of state",        # suspect origin, not a transfer
+    "suspect last seen in Oregon",       # travel, no LE token nearby
+    "",                                  # empty
+    None,                                # missing
+])
+def test_classify_no_false_positive(reason):
+    assert classify_reason(reason) is None
+
+
+def test_classify_first_match_priority():
+    # A reason naming two agencies resolves to the first category in
+    # DETECT_CATEGORIES order (usms before fbi; federal before out-of-state).
+    assert classify_reason("USMS / FBI joint fugitive task force") == "usms"
+    assert classify_reason("FBI assist for Oregon State Police") == "fbi"
+
+
+# ── scan_rows aggregation ──
+
+def _rows(*specs):
+    """specs: (reason, searchDate) tuples → audit-row dicts."""
+    return [{"reason": r, "searchDate": d} for r, d in specs]
+
+
+def test_scan_rows_none_when_empty():
+    assert scan_rows([]) is None
+    assert scan_rows(_rows(("stolen vehicle", "2026-01-01T00:00:00Z"))) is None
+
+
+def test_scan_rows_counts_and_categories():
+    rows = _rows(
+        ("Usms case", "2026-03-04T10:00:00Z"),
+        ("Usms request DAI smith", "2026-03-05T10:00:00Z"),
+        ("FBI ASSIST: BANK THEFT", "2026-04-01T10:00:00Z"),
+        ("FBI safe streets", "2026-04-02T10:00:00Z"),
+        ("FBI assist again", "2026-04-03T10:00:00Z"),
+        ("stolen vehicle", "2026-04-04T10:00:00Z"),  # ignored
+    )
+    out = scan_rows(rows, max_samples=2)
+    assert out["total"] == 5
+    # Categories sorted by count desc: FBI (3) before USMS (2).
+    assert [c["key"] for c in out["categories"]] == ["fbi", "usms"]
+    assert out["categories"][0] == {"key": "fbi", "label": "FBI", "count": 3}
+    assert out["date_min"] == "2026-03-04"
+    assert out["date_max"] == "2026-04-03"  # the ignored row's date excluded
+
+
+def test_scan_rows_prefers_shortest_sample():
+    # The shortest distinct reason is surfaced first, keeping a potential
+    # subject name ("...smith") out of the headline sample.
+    rows = _rows(
+        ("Usms request DAI smith", "2026-03-05T10:00:00Z"),
+        ("Usms case", "2026-03-04T10:00:00Z"),
+    )
+    out = scan_rows(rows, max_samples=1)
+    assert out["samples"] == ["Usms case"]
+
+
+def test_scan_rows_sample_truncated():
+    long_reason = "USMS " + "x" * 200
+    out = scan_rows(_rows((long_reason, "2026-03-04T10:00:00Z")), max_samples=1)
+    assert out["samples"][0].endswith("…")
+    assert len(out["samples"][0]) <= 80
+
+
+# ── build_index over a directory of audit JSONs ──
+
+def test_build_index(tmp_path):
+    (tmp_path / "stockton-ca-pd.json").write_text(json.dumps({
+        "portal": "stockton-ca-pd",
+        "rows": _rows(
+            ("Usms case", "2026-03-04T10:00:00Z"),
+            ("Usms case", "2026-03-05T10:00:00Z"),
+            ("traffic stop", "2026-03-06T10:00:00Z"),
+        ),
+    }))
+    (tmp_path / "clean-ca-pd.json").write_text(json.dumps({
+        "portal": "clean-ca-pd",
+        "rows": _rows(("stolen vehicle", "2026-03-04T10:00:00Z")),
+    }))
+
+    # Keyed by slug by default; clean agency omitted.
+    by_slug = build_index(tmp_path)
+    assert set(by_slug) == {"stockton-ca-pd"}
+    assert by_slug["stockton-ca-pd"]["total"] == 2
+
+    # key_by remaps to agency_id and attaches the source slug.
+    by_id = build_index(tmp_path, key_by={"stockton-ca-pd": "AID-1"})
+    assert set(by_id) == {"AID-1"}
+    assert by_id["AID-1"]["slug"] == "stockton-ca-pd"
+
+
+def test_build_index_missing_dir(tmp_path):
+    assert build_index(tmp_path / "does-not-exist") == {}


### PR DESCRIPTION
## What

Adds a red callout to each California agency's per-city report (**SB 34 Compliance Concerns** section) listing **outbound recipients whose own published search-audit log shows searches naming a federal or out-of-state law-enforcement agency** — USMS / FBI / DEA / ATF / DHS·ICE·CBP·HSI / Secret Service, or an out-of-state agency.

The concern: the agency grants those recipients access to its plate data, so a federal- or out-of-state-tagged search reaches its data through an entity outside CA Civil Code §1798.90.5(f)'s "public agency" definition (AG Bulletin 2023-DLE-06).

## How — pattern-driven, self-extending

Detection keys on the **reason text**, not a fixed roster of agencies (`scripts/federal_le_queries.py`). A new agency that starts entering "USMS case" / "FBI assist" reasons is picked up automatically on the next build. The audit builder already runs before the report builder in every pipeline, so `docs/data/audit/*.json` is available.

Calibration: reproduces the hand-curated `meeting-prep/chief/share-federal-le/` dataset (Stockton 128 USMS, Humboldt 5 FBI + 4 USMS, Yuba City DEA, Palm Springs DHS, Bakersfield USSS, Manteca→Oregon, …) with **zero false positives across all 97 CA audit logs**:

- Federal acronyms are word-boundaried so look-alikes don't match (`Marshall`≠USMS, `idea`/`dead`≠DEA, `service`/`police`≠the `ice` fragment).
- Out-of-state requires a non-CA state name **beside an LE token** (PD/police/sheriff/SO/trooper/DPS), guarding street/place collisions (`Washington Blvd`) and CA places named after states (`Nevada City`). "offender from out of state" (a suspect's origin, not a data transfer) is intentionally ignored.

This is distinct from the existing **geotag-based out-of-state *recipient*** flag (`out_of_state` kind / `no_out_of_state_sharing` check): here the recipient is itself a CA agency, but its search's *reason* names an out-of-state agency.

The callout includes the editorial caveat that the reason field is officer-entered free text and does not by itself prove data was delivered to the named agency, and links each recipient to its live portal for verification.

## Files

- `scripts/federal_le_queries.py` — patterns + scanner + CLI (`uv run python scripts/federal_le_queries.py`) *(new)*
- `scripts/build_report_data.py` — adds `federal_query_recipients` per report
- `docs/js/report.js` — `renderFederalQueryFlag` in the SB 34 section
- `docs/report.html` — `.fed-query-flag` styles
- `tests/test_federal_le_queries.py` — 45 tests (positives + false-positive guards) *(new)*

## Verification

- `uv run pytest tests/test_federal_le_queries.py` → 45 pass (69 with audit tests)
- Rendered SMPD (shares to Stockton +5) and Atherton (shares to Manteca) reports; callout displays correctly for both the federal and out-of-state cases.

## Not in this PR

Self-side flag (an agency's *own* report noting its own federal searches, e.g. Stockton's 128 USMS) — follow-up.