### PR TITLE
chore: slug probe finds

### DIFF
--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1517,6 +1517,14 @@
         "chesterfield-county-va-po": "http_404"
       }
     },
+    "494a32c2-2763-55c3-8842-27dad589ad32": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T08:58:32.766325+00:00",
+      "tried": {
+        "samford-university-al-pd": "http_404"
+      }
+    },
     "49b7e68a-8261-5236-85bc-9854e46387a9": {
       "exhausted": false,
       "found": null,
@@ -4181,6 +4189,14 @@
         "prescott-valley-az-pd": "http_200"
       }
     },
+    "c9751186-93a1-586a-96c0-92bfc49d6c54": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T08:58:28.971706+00:00",
+      "tried": {
+        "olivewood-community-association-ca-pd": "http_404"
+      }
+    },
     "c9dacd3f-79dc-593d-8c1e-11c91d429a2b": {
       "exhausted": false,
       "found": null,
@@ -4256,6 +4272,14 @@
       "last_probed": "2026-05-16T01:26:18.602979+00:00",
       "tried": {
         "maumee-oh-pd": "http_404"
+      }
+    },
+    "cdf714bf-7371-5225-aac6-c7f2ec74d8de": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T08:58:23.441819+00:00",
+      "tried": {
+        "airway-heights-wa-pd": "http_404"
       }
     },
     "cdfd2ca3-f75b-52a9-ba8a-a37162349117": {
@@ -5289,6 +5313,6 @@
       }
     }
   },
-  "updated": "2026-06-05T05:05:51.902953+00:00",
+  "updated": "2026-06-05T08:58:32.807322+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -223,6 +223,12 @@
         "stamping-ground-ky-pd": "http_404"
       }
     },
+    "09ec3f20-81f7-53a6-b6f3-0f89aae411e3": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:04:58.374828+00:00",
+      "tried": {}
+    },
     "0a9f6f92-fc21-5938-80a2-d0abe88afa88": {
       "exhausted": false,
       "found": "kent-wa-pd",
@@ -1262,6 +1268,12 @@
         "detroit-mi-pd": "http_404"
       }
     },
+    "3f6c1ca6-44d5-55c6-a73f-066bda052c1a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:05:51.853594+00:00",
+      "tried": {}
+    },
     "3f81bdf2-d1cd-56ec-82ed-d206b8bce10c": {
       "exhausted": false,
       "found": "murfreesboro-tn-pd",
@@ -1302,6 +1314,12 @@
       "tried": {
         "yelm-wa-pd": "http_200"
       }
+    },
+    "40be66c5-0c12-5d7d-af04-9b7f57f1b13e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:05:34.693131+00:00",
+      "tried": {}
     },
     "4109cb58-5415-50f6-a322-2bff979a4919": {
       "exhausted": false,
@@ -1569,6 +1587,12 @@
       "exhausted": false,
       "found": null,
       "last_probed": "2026-06-03T22:55:03.597674+00:00",
+      "tried": {}
+    },
+    "4dbd0622-ec7c-546f-b018-9c55f83d579f": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:04:50.563627+00:00",
       "tried": {}
     },
     "4e3f6084-585f-58ac-b00a-3b21f8b5d200": {
@@ -2777,6 +2801,14 @@
       "last_probed": "2026-05-21T22:53:20.897818+00:00",
       "tried": {
         "blue-island-il-pd": "http_200"
+      }
+    },
+    "8706dd16-9417-56e0-9a5c-c7c8facb8a4a": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:05:20.915264+00:00",
+      "tried": {
+        "wonder-lake-il-pd": "http_404"
       }
     },
     "87147070-af8c-5f25-a680-a2ef1b6a42bd": {
@@ -4534,6 +4566,12 @@
         "foothill-deanza-ca-police-department": "http_404"
       }
     },
+    "deb06e26-53eb-5809-9dcb-b175788ad5aa": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T05:05:25.390176+00:00",
+      "tried": {}
+    },
     "df8bf624-7dd9-5f4f-961c-4ee511165e59": {
       "exhausted": false,
       "found": null,
@@ -5251,6 +5289,6 @@
       }
     }
   },
-  "updated": "2026-06-04T23:54:34.720510+00:00",
+  "updated": "2026-06-05T05:05:51.902953+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -1727,6 +1727,14 @@
         "village-at-hiddenbrooke-ca-pd": "http_404"
       }
     },
+    "5202aca8-787f-59c3-b5cb-0cdf00956ee2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T15:41:38.652635+00:00",
+      "tried": {
+        "greenfield-wi-pd": "http_404"
+      }
+    },
     "531db486-3572-57ef-8871-8a70d17afcbc": {
       "exhausted": false,
       "found": null,
@@ -2027,9 +2035,10 @@
     "6318e935-4c02-5b9a-822e-7a5a10f531e7": {
       "exhausted": false,
       "found": null,
-      "last_probed": "2026-05-07T08:07:13.973209+00:00",
+      "last_probed": "2026-06-05T15:41:43.084907+00:00",
       "tried": {
-        "spring-arbor-mi-pd": "http_404"
+        "spring-arbor-mi-pd": "http_404",
+        "spring-arbor-mi-po": "http_404"
       }
     },
     "63552230-ad62-5c7b-bbeb-70dc52bab263": {
@@ -4179,6 +4188,14 @@
         "sardis-city-al-pd": "http_404"
       }
     },
+    "c8292ee5-a094-5f13-9bb7-e117318a72c1": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T15:41:33.527352+00:00",
+      "tried": {
+        "talladega-county-al-so": "http_404"
+      }
+    },
     "c8c14234-8395-53c7-984b-a7d4d89ffec7": {
       "exhausted": false,
       "found": null,
@@ -5349,6 +5366,6 @@
       }
     }
   },
-  "updated": "2026-06-05T12:29:07.824414+00:00",
+  "updated": "2026-06-05T15:41:43.120888+00:00",
   "version": 1
 }

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -183,6 +183,14 @@
         "farmer-city-il-pd": "http_404"
       }
     },
+    "0847bdf0-9571-5d27-a60a-cbc2a1587e06": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T12:28:56.927101+00:00",
+      "tried": {
+        "washington-county-in-so": "http_404"
+      }
+    },
     "08514a25-077d-52d1-a7e3-5bcc3ef1be56": {
       "exhausted": false,
       "found": null,
@@ -479,6 +487,14 @@
       "last_probed": "2026-05-18T17:22:14.809929+00:00",
       "tried": {
         "johnson-county-ks-so": "http_404"
+      }
+    },
+    "19d6264c-35c8-5b9e-9b44-aed517bcc3b0": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T12:29:07.783698+00:00",
+      "tried": {
+        "milford-in-pd": "http_404"
       }
     },
     "19f7b6cc-d156-57a7-9f61-a0e846b224f2": {
@@ -2843,6 +2859,12 @@
         "hamilton-township-oh-pd": "http_200"
       }
     },
+    "87b90910-8734-5f30-9600-96e914cf81ca": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T12:28:39.790487+00:00",
+      "tried": {}
+    },
     "87ced6b8-24d2-5127-8bdb-2333a325cbfd": {
       "exhausted": false,
       "found": null,
@@ -4498,6 +4520,14 @@
         "celina-tx-pd": "http_404"
       }
     },
+    "dbddc725-7762-5263-a342-7fb00d5d9c9e": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T12:29:01.621301+00:00",
+      "tried": {
+        "port-aransas-tx-pd": "http_404"
+      }
+    },
     "dbfeb93f-10ea-5aaf-8862-a6b186764b79": {
       "exhausted": false,
       "found": null,
@@ -5126,6 +5156,12 @@
         "charlottesville-va-pd": "http_200"
       }
     },
+    "f5ff64c9-367b-545a-87ab-a0a0a477fac2": {
+      "exhausted": false,
+      "found": null,
+      "last_probed": "2026-06-05T12:28:30.940324+00:00",
+      "tried": {}
+    },
     "f652c7a2-33f8-571b-ba6c-2b7a8982ef98": {
       "exhausted": false,
       "found": null,
@@ -5313,6 +5349,6 @@
       }
     }
   },
-  "updated": "2026-06-05T08:58:32.807322+00:00",
+  "updated": "2026-06-05T12:29:07.824414+00:00",
   "version": 1
 }


### PR DESCRIPTION
Automated rolling slug probe. Each run attempts up to 3 candidate slugs across two tiers: Tier A — registry entries with no flock_active_slug set (peer-outbound discoveries that need a first try). Tier B — registry entries whose flock_active_slug is in failed_slugs.json (variant search on broken slugs). Default budget split is 2:1 favoring tier A because its single-try hit rate is higher. On a hit, the registry is updated and the captured page is archived under the new slug, so the primary crawler picks up refresh on its next run.