### PR TITLE
feat: pra_download --active (scrape only non-closed PRAs)

### DIFF
--- a/scripts/build_pra_registry.py
+++ b/scripts/build_pra_registry.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
 """
 Build the PRA registry by combining curated per-PRA metadata.json files with
 data parsed deterministically from the portal's Message_History.pdf exports.
@@ -556,6 +558,23 @@ def build(roots):
         "tags": TAGS,
         "pras": sorted(entries, key=lambda x: x["id"]),
     }
+
+
+def closed_ids(roots=ROOTS):
+    """Set of PRA ids whose display_status is "closed".
+
+    Computed exactly as the registry does — display_status folds in both the
+    curated status_override and the parser's derived status, so it catches the
+    ~40% of closed PRAs that are closed only by derived status, not override.
+    Recomputed from the on-disk *_Message_History.pdf files, so it needs no
+    pre-built (gitignored) registry artifact.
+
+    Consumed by scripts/pra_download.py --active to skip already-closed
+    requests: a closed PRA won't gain new messages. Like build(), this assumes
+    the CWD is the repo root (ROOTS holds repo-relative paths).
+    """
+    registry = build(roots)
+    return {e["id"] for e in registry["pras"] if e["display_status"] == "closed"}
 
 
 def main():

--- a/scripts/pra_download.py
+++ b/scripts/pra_download.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
 """
 Download attachments from the San Mateo public records portal (GovQA).
 
@@ -16,6 +18,7 @@ Regular use:
   uv run python scripts/pra_download.py W012297-030826     # one request
   uv run python scripts/pra_download.py --all              # every request folder
   uv run python scripts/pra_download.py                    # same as --all
+  uv run python scripts/pra_download.py --active           # every folder except closed ones
   uv run python scripts/pra_download.py --discover         # stub new portal ids, then scrape all
 
 After downloading, run OCR to refresh sidecars:
@@ -1481,8 +1484,18 @@ def run(args, config: dict) -> None:
                 print("no new requests on portal")
 
         targets = list(args.requests)
-        if args.all or not targets:
+        if args.all or args.active or not targets:
             targets = discover_requests()
+        if args.active and not args.all:
+            # A closed PRA won't gain new messages, so skip it. --all overrides
+            # (re-checks everything in case a closed request changed).
+            from build_pra_registry import closed_ids
+            closed = closed_ids()
+            skipped = sorted(t for t in targets if t in closed)
+            targets = [t for t in targets if t not in closed]
+            if skipped:
+                print(f"{_c('—', 'yellow', 'bold')} --active: skipping "
+                      f"{len(skipped)} closed PRA(s): {', '.join(skipped)}")
         if not targets:
             print("No target requests.", file=sys.stderr)
             browser.close()
@@ -1511,6 +1524,10 @@ def main() -> int:
                              "or PRA_USERNAME/PRA_PASSWORD env vars)")
     parser.add_argument("--all", action="store_true",
                         help="Iterate every W* folder (default when no ids given)")
+    parser.add_argument("--active", action="store_true",
+                        help="Like --all but skip PRAs already closed (a closed "
+                             "request won't gain new messages). Use --all to "
+                             "re-check closed ones in case something changed.")
     parser.add_argument("--discover", action="store_true",
                         help="Walk the portal list and create stub folders for "
                              "any new request ids before scraping")


### PR DESCRIPTION
Adds a `--active` mode to the PRA scraper: like `--all`, it iterates every `W*` folder, but skips any PRA whose registry `display_status` is **closed**. A closed request won't gain new messages, so re-scraping it is wasted work. Use `--all` to re-check closed ones in case something changed retroactively.

On the current corpus this scrapes **8 of 36** folders instead of all 36.

### Why not a metadata-only check
Of 28 currently-closed PRAs, only 17 carry a curated `status_override: "closed"` — the other **11 are closed solely via the parser's derived status** (e.g. SMPD's "now considers this record request … closed" phrasing). A metadata-only filter would miss ~40% of closed PRAs. So `--active` reuses the registry's `display_status`, which folds in both the override and the derived status.

### How closed-detection works
New `closed_ids()` helper in `build_pra_registry.py` wraps `build()` and returns the set of ids with `display_status == "closed"`. It recomputes from the on-disk `*_Message_History.pdf` files, so it needs **no pre-built (gitignored) registry artifact** — and "closed as of the last scrape" is exactly the right semantics for deciding what to skip this run. The scraper imports it lazily, only when `--active` is used.

### Behavior notes
- `--all` overrides `--active` (if both are passed, everything is scraped).
- Skipped PRAs are printed (`--active: skipping N closed PRA(s): …`) — no silent truncation.
- Adds SPDX AGPL-3.0 headers to the two touched files.

### Companion change (not in this PR)
The `/pra-refresh` skill now maps invocation args: bare → `--active` (default), `all` → `--all`, `new` → `--discover`. (Skill lives in the user's global commands dir, outside the repo.)

### Testing
- `make build` + `make test` — 648 passed.
- Verified `closed_ids()` against the live corpus: 36 folders, 28 closed (skipped), 8 active (scanned); subset/disjoint invariants hold.