### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -414,5 +414,5 @@
     "https://www.almanacnews.com/investigative-story/2025/08/19/menlo-park-police-broke-state-law-shared-license-plate-data-out-of-state/",
     "https://www.almanacnews.com/woodside/2026/02/19/woodside-looks-into-stronger-safeguards-for-its-license-plate-cameras-data-security/"
   ],
-  "last_run": "2026-06-05T17:55:40Z"
+  "last_run": "2026-06-05T19:04:51Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -414,5 +414,5 @@
     "https://www.almanacnews.com/investigative-story/2025/08/19/menlo-park-police-broke-state-law-shared-license-plate-data-out-of-state/",
     "https://www.almanacnews.com/woodside/2026/02/19/woodside-looks-into-stronger-safeguards-for-its-license-plate-cameras-data-security/"
   ],
-  "last_run": "2026-06-05T19:04:51Z"
+  "last_run": "2026-06-05T20:54:10Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 413
- Curation: enriched: 332 · mechanical: 58 · needs_review: 23
- Scanner: REVIEW REQUIRED: 288 · WARNINGS: 123 · CLEAN: 2
- Wayback: saved: 171 · submit-failed: 113 · poll-failed: 100 · existing: 15 · save-failed: 14
- PDF: rendered: 339 · skipped-curl-fallback: 74
- Top sources: eff.org (28), smdailyjournal.com (16), thenewstribune.com (13), oaklandside.org (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
