### PR TITLE
chore: article registry updates

### DIFF
--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T18:17:56Z"
+  "last_run": "2026-06-06T20:19:33Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T16:16:52Z"
+  "last_run": "2026-06-06T18:17:56Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T22:13:54Z"
+  "last_run": "2026-06-07T00:15:23Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T14:51:27Z"
+  "last_run": "2026-06-06T16:16:52Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T20:19:33Z"
+  "last_run": "2026-06-06T22:13:54Z"
 }

--- a/assets/articles/.crawl_state.json
+++ b/assets/articles/.crawl_state.json
@@ -416,5 +416,5 @@
     "https://oaklandside.org/2026/06/05/flock-cameras-oakland-600-million-license-plate-reader/",
     "https://www.heraldnet.com/2026/06/05/everett-settles-flock-records-case-for-25k/"
   ],
-  "last_run": "2026-06-06T12:13:53Z"
+  "last_run": "2026-06-06T14:51:27Z"
 }


### PR DESCRIPTION
Automated rolling article crawl + curation + RSS discovery.

Each cron tick fetches a few queued URLs, runs the injection 
scanner, renders a Playwright PDF, submits a Wayback save, and 
builds a registry entry. With `ANTHROPIC_API_KEY` set, eligible 
articles also get Phase-2 semantic enrichment.

## In this PR — 0 new article(s)

_(no new articles since last merge — this PR is currently a state-only update)_

## Stats

- **Total articles in registry:** 415
- Curation: enriched: 332 · mechanical: 60 · needs_review: 23
- Scanner: REVIEW REQUIRED: 290 · WARNINGS: 123 · CLEAN: 2
- Wayback: saved: 172 · submit-failed: 113 · poll-failed: 101 · existing: 15 · save-failed: 14
- PDF: rendered: 340 · skipped-curl-fallback: 75
- Top sources: eff.org (28), smdailyjournal.com (16), oaklandside.org (14), thenewstribune.com (13), kvue.com (12), evanstonroundtable.com (12), oakpark.com (12), kqed.org (11)
- Queue remaining: 0 priority + 0 auto = 0

---
_Body auto-generated by `scripts/article_pr_body.py` on each cron tick. Edits will be overwritten._
