### PR TITLE
fix(docs): make "Findings (view in browser)" actually render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,15 @@ jobs:
           git push origin readme-assets --force
           git checkout main
 
+      - name: Publish full findings PDF to Pages
+        # docs/SMPD_ALPR_Findings.pdf is committed only as a tiny redirect stub, to
+        # keep the binary (and its staleness) out of git. Overwrite it here with the
+        # PDF built above so the Pages site serves the real, current document
+        # same-origin (Pages sends Content-Type: application/pdf + ACAO:*, so it
+        # renders inline in the browser — no pdf.js shim, no CORS-blocked release
+        # fetch). Working-tree only; never committed.
+        run: cp "${{ runner.temp }}/SMPD_ALPR_Findings.pdf" docs/SMPD_ALPR_Findings.pdf
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,16 @@ The PDF generator (`scripts/md_to_pdf.py`) parses the findings markdown by split
 - Empty lines (stripped)
 
 **Release process:**
-- The PDF is a build artifact, not committed to git.
+- The PDF is a build artifact, not committed to git. Only a tiny redirect-stub
+  PDF is committed at `docs/SMPD_ALPR_Findings.pdf`; the deploy workflow overwrites
+  it with the freshly-built PDF in the Pages artifact (working-tree only, never
+  committed), so the live site serves the real, current document same-origin.
 - Pushing changes to `docs/SMPD_ALPR_Findings.md` or `scripts/md_to_pdf.py`
   triggers a GitHub release with the built PDF attached.
-- The Pages site links to the latest release download.
+- The Pages site serves the PDF directly (`SMPD_ALPR_Findings.pdf`); it renders
+  inline because Pages sets `Content-Type: application/pdf` with no attachment
+  disposition. Do NOT route it through mozilla's pdf.js viewer against the release
+  download — that host sends no CORS header, so the cross-origin fetch is blocked.
 
 **Source-numbering integrity:**
 - Every source row must have a unique `| N |` number; every inline `[N]`

--- a/docs/index.html
+++ b/docs/index.html
@@ -133,7 +133,7 @@
 <h2>San Mateo PD investigation</h2>
 <div class="grid">
   <div class="card">
-    <h3><a href="https://mozilla.github.io/pdf.js/web/viewer.html?file=https%3A%2F%2Fgithub.com%2Fnone-below%2Fsm-alpr%2Freleases%2Flatest%2Fdownload%2FSMPD_ALPR_Findings.pdf">Findings (view in browser)</a></h3>
+    <h3><a href="SMPD_ALPR_Findings.pdf">Findings (view in browser)</a></h3>
     <p>Full findings document on the San Mateo Police Department's ALPR program — source citations, QR codes, and appendices. Renders inline; no download triggered.</p>
   </div>
   <div class="card">


### PR DESCRIPTION
The homepage **"Findings (view in browser)"** link was broken: it routed mozilla's pdf.js viewer (hosted on `mozilla.github.io`) at the GitHub **release** asset.

**Root cause — CORS.** The release asset's final host (`release-assets.githubusercontent.com`) sends **no `Access-Control-Allow-Origin` header**, so pdf.js's cross-origin `fetch` is blocked by the browser. `curl` "worked" only because it doesn't enforce CORS. (The release asset also carries `Content-Disposition: attachment`, so linking it directly would just download.)

**Fix — serve the PDF from the Pages site itself.** GitHub Pages sends `Content-Type: application/pdf` + `access-control-allow-origin: *` with **no** attachment disposition, so a plain same-origin link renders inline natively — no pdf.js shim, no CORS.

- `docs/index.html` — link is now the relative `SMPD_ALPR_Findings.pdf`.
- `.github/workflows/deploy.yml` — new step copies the PDF the workflow *already builds* into `docs/` right before the Pages upload. **Working-tree only, never committed**, so the binary and its staleness stay out of git (the problem deliberately solved in `39b018f4`/`3e6461c2`). The 2.4 KB redirect stub remains committed as the git placeholder. The step is ordered *after* the readme-assets `git checkout main` dance so it overwrites the stub last.
- `CLAUDE.md` — release-process note updated (it still claimed the Pages site links to the release download).

**Verified**
- `deploy.yml` parses as valid YAML; step ordering confirmed.
- No other references to the mozilla/pdf.js or release-download link remain.
- Local static server rooted at `docs/`: relative link resolves → `200`, `Content-type: application/pdf`, no disposition → inline render.
- Confirmed the currently-live Pages `SMPD_ALPR_Findings.pdf` already serves `application/pdf` + `ACAO:*`.