### PR TITLE
Warn on content-changed re-download of a produced PRA file (re-upload defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
             tests/test_discover_reject_issue.py \
             -v
 
+      - name: Run PRA download immutability tests
+        run: uv run pytest tests/test_pra_immutability.py -v
+
       - name: Check recipient coordinates
         id: coords
         run: |

--- a/scripts/pra_download.py
+++ b/scripts/pra_download.py
@@ -332,6 +332,15 @@ def _resolve_collision_path(folder: Path, name: str, new_bytes: bytes) -> Path:
         existing_hashed = folder / f"{out.stem}.{existing_hash}{out.suffix}"
         if existing_hashed != hashed and not existing_hashed.exists():
             out.rename(existing_hashed)
+        # A produced file's content changed under the same name — most likely SMPD
+        # re-uploaded a "fixed" copy. Never lose the original: both versions are kept
+        # as content-hashed siblings. Warn loudly so a re-upload isn't ingested unnoticed
+        # (and so an audit re-upload doesn't silently double-count in the pipeline).
+        warn(
+            f"   ⚠ CONTENT CHANGED for {sanitize(name)}: differs from a copy already on disk. "
+            f"Original preserved as {existing_hashed.name}; new copy saved as {hashed.name}. "
+            f"Review for a re-uploaded/edited version before ingesting."
+        )
         return hashed
 
     peer_pattern = re.compile(

--- a/tests/test_pra_immutability.py
+++ b/tests/test_pra_immutability.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""A re-downloaded produced file whose content changed (e.g. SMPD re-uploads a
+'fixed' copy) must never overwrite the original, and must warn loudly."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import pra_download as pd  # noqa: E402
+
+
+def test_changed_content_preserves_original_and_warns(tmp_path, capsys):
+    (tmp_path / "audit.pdf").write_bytes(b"ORIGINAL-BYTES")
+    out = pd._resolve_collision_path(tmp_path, "audit.pdf", b"REUPLOADED-DIFFERENT")
+    names = sorted(p.name for p in tmp_path.iterdir())
+    # original is preserved (renamed to a content-hashed sibling), never lost
+    assert "audit.pdf" not in names
+    assert any(n.startswith("audit.") and n.endswith(".pdf") for n in names)
+    # the new copy gets its own distinct hashed path (written by the caller, not here)
+    assert out.name.startswith("audit.") and out.name.endswith(".pdf")
+    assert out.name not in names
+    # and a loud warning was emitted
+    combined = capsys.readouterr()
+    assert "CONTENT CHANGED" in (combined.out + combined.err)
+
+
+def test_identical_content_is_silent_and_keeps_name(tmp_path, capsys):
+    (tmp_path / "audit.pdf").write_bytes(b"SAME-BYTES")
+    out = pd._resolve_collision_path(tmp_path, "audit.pdf", b"SAME-BYTES")
+    assert out.name == "audit.pdf"
+    combined = capsys.readouterr()
+    assert "CONTENT CHANGED" not in (combined.out + combined.err)


### PR DESCRIPTION
Defends against silently ingesting a "fixed" copy if SMPD re-uploads a produced audit/attachment file.

## Behavior
- A produced file (non message-history) whose content changes under the same name is **already** preserved as a content-hashed sibling — never overwritten. This adds a **loud `CONTENT CHANGED` warning** naming the preserved original and the new copy, so a re-upload/edit is flagged for review rather than ingested unnoticed.
- **Message-history PDFs keep updating** normally (the thread legitimately grows).
- Identical re-downloads stay silent (no churn).

## Notes / known follow-ups (not in this PR)
- The original is preserved but **renamed** to its hashed sibling; a fuller "keep original in place + write re-upload to a non-ingested location" would also require excluding re-uploads from `parse_pra_audit` (`folder.glob("*.pdf")`), which would otherwise **double-count** a re-uploaded audit file. Deferred as its own change.
- Context: this came out of the W012541 audit-PDF editing finding; the `__2_` suffix on the edited Feb 2026 file shows re-uploads do happen on this portal.

Test added (`tests/test_pra_immutability.py`) and wired into the CI test list.