### PR TITLE
Date-window slider on the justifications page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Install Node
+        # Needed by tests/test_justifications_agg.py, which runs the
+        # browser-side justifications aggregator under Node to prove it
+        # still matches build_justifications.py.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install dependencies
         run: uv sync
 
@@ -181,6 +189,9 @@ jobs:
 
       - name: Run smoke tests
         run: uv run pytest tests/test_map_smoke.py tests/test_dashboard.py -v
+
+      - name: Run justifications aggregation parity test
+        run: uv run pytest tests/test_justifications_agg.py -v
 
       - name: Run meeting-watcher tests
         run: uv run pytest tests/test_meeting_watch.py -v

--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 zero-below
 /* Renders per-agency search-justification word clouds from the data
    produced by scripts/build_justifications.py.
 
@@ -71,6 +73,12 @@
       '<th class="num">Median reach</th>' +
       '<th>Flags</th>' +
       '</tr></thead><tbody>';
+    // Case dates are UTC calendar slices (matching the build), while a
+    // narrowed window filters rows by PT day — a row on the window's
+    // last PT day can carry a UTC date one day later, so clamp the
+    // displayed dates to the selected window to avoid showing a span
+    // that pokes past it.
+    var winMaxIso = windowIsFull() ? null : JustAgg.isoFromEpochDay(selEpochEnd);
     for (var i = 0; i < items.length; i++) {
       var phrase = items[i][0];
       var count = items[i][1];
@@ -78,6 +86,10 @@
       var dmin = items[i][3];
       var dmax = items[i][4];
       var nc = items[i][5];
+      if (winMaxIso) {
+        if (dmax && dmax > winMaxIso) dmax = winMaxIso;
+        if (dmin && dmin > winMaxIso) dmin = winMaxIso;
+      }
       // Compute span here too — same date arithmetic as the build
       // does for phrase_details, but the long-active list is a flat
       // tuple so we recompute. Local-tz parsing not needed since we
@@ -470,11 +482,22 @@
   // (data/audit/<slug>.json, fetched once and precomputed by JustAgg).
   // The parity test guarantees the client aggregation equals the build
   // at the full window, so dragging in from "All" never jumps.
+  //
+  // The raw file can run to megabytes (San Mateo is ~2.8 MB gzipped),
+  // so it is fetched lazily on the first slider/preset interaction,
+  // not at page load. Until then the slider renders against a domain
+  // seeded from the build's search_date_min/max; the interaction that
+  // triggered the fetch is parked in pendingPresetKey/pendingSel and
+  // applied when the rows arrive.
   var baseAgencyData = null;   // monolith entry: window-independent fields
   var rawPre = null;           // JustAgg.precompute(rows), or null until loaded
-  var rawLoading = false;
-  var fullEpochMin = null;     // domain: oldest PT day (integer day index)
-  var fullEpochMax = null;     // domain: newest PT day
+  var rawLoading = false;      // fetch in flight
+  var rawFailed = false;       // fetch failed / rows unusable — filtering off
+  var pendingPresetKey = null; // preset clicked while rows were loading
+  var pendingSel = null;       // [start, end] committed while rows were loading
+  var fullSeriesCache = null;  // phrase -> fullPhraseSeries result, per rawPre
+  var fullEpochMin = null;     // domain: oldest day (integer day index; PT once
+  var fullEpochMax = null;     //   raw rows load, build-date-seeded before that)
   var selEpochStart = null;    // current selection
   var selEpochEnd = null;
 
@@ -705,8 +728,16 @@
       return '<div class="empty">No phrases to display for this agency.</div>';
     }
     var displayItems = aggregateItems(items, currentViewMode);
+    // Partner rows carry FULL-window counts (they live in other
+    // agencies' audits, which the date filter can't reach), so
+    // interleaving them with windowed own rows would put two different
+    // time windows in one count-sorted list and one percentage
+    // denominator. Suppress them whenever a date filter is active.
+    var winFull = windowIsFull();
+    var extSuppressed = !winFull && !hideExternal &&
+      externalRows && externalRows.length && currentViewMode === 'phrase';
     var hasExternal = !hideExternal && externalRows && externalRows.length &&
-                      currentViewMode === 'phrase';
+                      currentViewMode === 'phrase' && winFull;
     var combinedTotal = (total || 0) +
       (hasExternal ? (externalTotal || 0) : 0);
     var filterBarHtml = currentViewMode === 'phrase' ? renderFilterBar(items) : '';
@@ -715,7 +746,12 @@
           ? 'Local rows (blue) and partner rows (purple) are interleaved by raw count; ' +
             'percentages are share of all known volume (this agency&rsquo;s own + partners). ' +
             'Click a local row for per-phrase detail.'
-          : 'Click any row for per-phrase detail (timing, network reach, daily cadence).')
+          : (extSuppressed
+              ? 'Partner rows are hidden while a date filter is active &mdash; partner ' +
+                'searches live in other agencies&rsquo; audits and can&rsquo;t be filtered ' +
+                'to this window. Select <em>All</em> to see them again. ' +
+                'Click any row for per-phrase detail.'
+              : 'Click any row for per-phrase detail (timing, network reach, daily cadence).'))
       : 'Aggregated view &mdash; phrases with multiple codes are counted under each, so totals can exceed search count. ' +
         'Switch back to <em>Phrase</em> grouping for clickable rows with detail.';
     var html = renderViewModeToggle() +
@@ -1243,9 +1279,10 @@
     // phrase's FULL history (every search ever, not just the selected
     // window) and gray the bars outside the window, so a narrowed view
     // keeps the long history as context. Otherwise fall back to the
-    // build's windowed series.
+    // build's series (which the full-history one must equal at the
+    // full window — the parity verifier cross-checks the two).
     var dailyHtml = '';
-    var full = (rawPre && phrase) ? JustAgg.fullPhraseSeries(phrase, rawPre) : null;
+    var full = phrase ? getFullPhraseSeries(phrase) : null;
     if (full && full.daily && full.daily.length) {
       var unitF = full.daily_unit === 'week' ? 'week' : 'day';
       dailyHtml = '<div class="phrase-detail-row">' +
@@ -1253,7 +1290,13 @@
         '<div class="phrase-detail-label">Searches per ' + unitF +
         ' &middot; full history' +
         (windowIsFull() ? '' : ' (selected window in color)') + '</div>' +
-        renderDailySparkFull(full) +
+        renderDailySpark(full.daily, full.from, full.daily_unit, true) +
+        '<div class="spark-axis"><span>' + escapeHTML(full.from) +
+        '</span><span>' + escapeHTML(full.to) + '</span></div>' +
+        (windowIsFull() ? '' :
+          '<div class="spark-window-note">Highlighted window: ' +
+          escapeHTML(JustAgg.isoFromEpochDay(selEpochStart)) + ' &rarr; ' +
+          escapeHTML(JustAgg.isoFromEpochDay(selEpochEnd)) + '</div>') +
         '</div></div>';
     } else if (detail.daily && detail.daily.length) {
       var unit = detail.daily_unit === 'week' ? 'week' : 'day';
@@ -1296,71 +1339,41 @@
 
   // Daily-or-weekly density sparkline: one cell per period, height
   // proportional to count. Empty cells stay visible (faint baseline)
-  // so gaps in activity don't visually compress the span.
-  function renderDailySpark(series, fromIso, unit) {
+  // so gaps in activity don't visually compress the span. With
+  // highlightWindow set and a date window active, bars whose period
+  // falls outside the selected window render gray, so the user sees
+  // the full history with the chosen slice highlighted.
+  function renderDailySpark(series, fromIso, unit, highlightWindow) {
     if (!series || !series.length) return '';
     var max = 1;
     for (var i = 0; i < series.length; i++) if (series[i] > max) max = series[i];
-    var fromDate = fromIso ? new Date(fromIso + 'T12:00:00Z') : null;
     var step = unit === 'week' ? 7 : 1;
+    var fromED = (fromIso && typeof JustAgg !== 'undefined')
+      ? JustAgg.epochDayOfIso(fromIso) : NaN;
+    if (!isFinite(fromED)) fromED = null;
+    var gray = !!highlightWindow && !windowIsFull();
     var html = '<div class="daily-spark">';
     for (var i2 = 0; i2 < series.length; i2++) {
       var v = series[i2];
       var ph = max > 0 ? Math.round(100 * v / max) : 0;
       var label = '';
-      if (fromDate) {
-        var d = new Date(fromDate.getTime() + i2 * step * 86400000);
-        label = d.toISOString().slice(0, 10);
+      var inWin = true;
+      if (fromED !== null) {
+        var barStart = fromED + i2 * step;
+        label = JustAgg.isoFromEpochDay(barStart);
+        if (gray) {
+          var barEnd = barStart + step - 1;
+          inWin = (barEnd >= selEpochStart && barStart <= selEpochEnd);
+        }
       }
-      var titleText = (label ? label + ': ' : '') + v +
-        ' search' + (v === 1 ? '' : 'es');
-      var cls = 'spark-bar' + (v === 0 ? ' empty' : '');
-      html += '<div class="' + cls + '" title="' + titleText + '">' +
-        '<div class="spark-fill" style="height:' + ph + '%"></div>' +
-        '</div>';
-    }
-    html += '</div>';
-    return html;
-  }
-
-  // Full-history sparkline: `full` is JustAgg.fullPhraseSeries output
-  // (the phrase's entire span, independent of the selected window).
-  // Bars whose period falls outside the selected window render gray, so
-  // the user sees the long history with the chosen slice highlighted.
-  // A date axis is always drawn (the windowed spark above had none).
-  function renderDailySparkFull(full) {
-    var series = full.daily;
-    if (!series || !series.length) return '';
-    var fromED = full.fromEpochDay;
-    var step = full.step || 1;
-    var max = 1;
-    for (var i = 0; i < series.length; i++) if (series[i] > max) max = series[i];
-    var isFull = windowIsFull();
-    var selS = isFull ? -Infinity : selEpochStart;
-    var selE = isFull ? Infinity : selEpochEnd;
-    var html = '<div class="daily-spark">';
-    for (var i2 = 0; i2 < series.length; i2++) {
-      var v = series[i2];
-      var ph = max > 0 ? Math.round(100 * v / max) : 0;
-      var barStart = fromED + i2 * step;
-      var barEnd = barStart + step - 1;
-      var inWin = (barEnd >= selS && barStart <= selE);
-      var label = JustAgg.isoFromEpochDay(barStart);
-      var titleText = label + (step > 1 ? ' (week)' : '') + ': ' + v +
-        ' search' + (v === 1 ? '' : 'es');
+      var titleText = (label ? label + (step > 1 ? ' (week)' : '') + ': ' : '') +
+        v + ' search' + (v === 1 ? '' : 'es');
       var cls = 'spark-bar' + (v === 0 ? ' empty' : '') + (inWin ? '' : ' out');
       html += '<div class="' + cls + '" title="' + escapeHTML(titleText) + '">' +
         '<div class="spark-fill" style="height:' + ph + '%"></div>' +
         '</div>';
     }
     html += '</div>';
-    html += '<div class="spark-axis"><span>' + escapeHTML(full.from) +
-      '</span><span>' + escapeHTML(full.to) + '</span></div>';
-    if (!isFull) {
-      html += '<div class="spark-window-note">Highlighted window: ' +
-        escapeHTML(JustAgg.isoFromEpochDay(selEpochStart)) + ' &rarr; ' +
-        escapeHTML(JustAgg.isoFromEpochDay(selEpochEnd)) + '</div>';
-    }
     return html;
   }
 
@@ -1688,53 +1701,77 @@
     return [Math.max(fullEpochMin, fullEpochMax - days + 1), fullEpochMax];
   }
 
-  function isPresetActive(p) {
-    var w = presetWindow(p.days);
-    return selEpochStart === w[0] && selEpochEnd === w[1];
+  // The single preset to highlight: 'All' whenever the selection covers
+  // the whole domain (several presets clamp to the full range for a
+  // short-history agency — without this rule, 30d/90d/6mo/1yr/All would
+  // all light up at once), else the first preset whose window matches
+  // the selection exactly.
+  function activePresetKey() {
+    if (windowIsFull()) return 'all';
+    for (var i = 0; i < DW_PRESETS.length; i++) {
+      var w = presetWindow(DW_PRESETS[i].days);
+      if (selEpochStart === w[0] && selEpochEnd === w[1]) return DW_PRESETS[i].k;
+    }
+    return null;
   }
 
-  // Renders the slider control inside the data-window banner. Returns ''
-  // until raw rows are available (own-audit agencies only); shows a
-  // loading line while they're being fetched.
+  // Fill-bar inline style and readout markup are shared between the
+  // full render (renderDateSlider) and the cheap in-place update during
+  // a drag (onSliderInput) so the two can't drift apart.
+  function sliderFillCss(loIdx, hiIdx, total) {
+    var leftPct = total > 0 ? (100 * loIdx / total) : 0;
+    var rightPct = total > 0 ? (100 * hiIdx / total) : 100;
+    return 'left:' + leftPct.toFixed(2) + '%;right:' +
+      (100 - rightPct).toFixed(2) + '%';
+  }
+
+  function readoutHtml(startED, endED) {
+    var span = (endED - startED) + 1;
+    return escapeHTML(JustAgg.isoFromEpochDay(startED)) + ' &rarr; ' +
+      escapeHTML(JustAgg.isoFromEpochDay(endED)) +
+      ' <span class="dw-span">(' + span.toLocaleString() +
+      ' day' + (span === 1 ? '' : 's') + ')</span>';
+  }
+
+  // Renders the slider control inside the data-window banner. The
+  // domain is seeded from the build's window at first paint (so the
+  // control doesn't pop in) and swaps to the PT epoch-day domain once
+  // the raw rows load on first interaction.
   function renderDateSlider() {
-    if (!rawPre) {
-      return rawLoading
-        ? '<div class="date-window-control">' +
-          '<div class="dw-loading">Loading full history to enable date filtering&hellip;</div>' +
-          '</div>'
-        : '';
+    if (fullEpochMin == null || fullEpochMax == null) return '';
+    if (rawFailed) {
+      return '<div class="date-window-control">' +
+        '<div class="dw-loading">Date filtering is unavailable &mdash; ' +
+        'the raw audit rows could not be loaded.</div>' +
+        '</div>';
     }
     var total = fullEpochMax - fullEpochMin;
     var startIdx = selEpochStart - fullEpochMin;
     var endIdx = selEpochEnd - fullEpochMin;
-    var leftPct = total > 0 ? (100 * startIdx / total) : 0;
-    var rightPct = total > 0 ? (100 * endIdx / total) : 100;
-    var fromIso = JustAgg.isoFromEpochDay(selEpochStart);
-    var toIso = JustAgg.isoFromEpochDay(selEpochEnd);
-    var spanDays = (selEpochEnd - selEpochStart) + 1;
     var filtered = !windowIsFull();
+    var activeKey = activePresetKey();
     var presetHtml = DW_PRESETS.map(function (p) {
       return '<button type="button" class="dw-preset' +
-        (isPresetActive(p) ? ' active' : '') +
+        (p.k === activeKey ? ' active' : '') +
         '" data-dw-preset="' + p.k + '">' + p.label + '</button>';
     }).join('');
     return '<div class="date-window-control">' +
       '<div class="dw-top">' +
-      '<span class="dw-readout">' + escapeHTML(fromIso) + ' &rarr; ' + escapeHTML(toIso) +
-      ' <span class="dw-span">(' + spanDays.toLocaleString() +
-      ' day' + (spanDays === 1 ? '' : 's') + ')</span></span>' +
+      '<span class="dw-readout">' + readoutHtml(selEpochStart, selEpochEnd) + '</span>' +
       (filtered ? ' <span class="dw-filtered-badge">Filtered</span>' : '') +
       '<span class="dw-presets">' + presetHtml + '</span>' +
       '</div>' +
       '<div class="dw-slider" id="dw-slider">' +
       '<div class="dw-track"></div>' +
-      '<div class="dw-fill" style="left:' + leftPct.toFixed(2) + '%;right:' +
-      (100 - rightPct).toFixed(2) + '%"></div>' +
+      '<div class="dw-fill" style="' + sliderFillCss(startIdx, endIdx, total) + '"></div>' +
       '<input type="range" id="dw-start" min="0" max="' + total + '" step="1" value="' +
       startIdx + '" aria-label="Window start day">' +
       '<input type="range" id="dw-end" min="0" max="' + total + '" step="1" value="' +
       endIdx + '" aria-label="Window end day">' +
       '</div>' +
+      (rawLoading
+        ? '<div class="dw-loading">Loading full history to apply the date filter&hellip;</div>'
+        : '') +
       '</div>';
   }
 
@@ -1747,6 +1784,12 @@
     var filtered = [];
     for (var i = 0; i < rawPre.length; i++) {
       var pt = rawPre[i].pt;
+      // Rows without a parseable searchDate (pt === null) can't be
+      // placed in time, so they are excluded from any narrowed window
+      // even though the full-window (build) stats count them. The
+      // current corpus has zero such rows; if one ever appears, that
+      // agency's counts will drop by the undated extra on any
+      // narrowing and snap back at "All".
       if (pt && pt.epochDay >= selEpochStart && pt.epochDay <= selEpochEnd) {
         filtered.push(rawPre[i]);
       }
@@ -1767,9 +1810,52 @@
   }
 
   function rerender() {
+    // The innerHTML swap below destroys focus and any expanded phrase
+    // panel; capture both and restore after, so keyboard slider use
+    // and an open expansion survive a window change.
+    var active = document.activeElement;
+    var focusId = active ? active.id : '';
+    var focusPreset = (active && active.classList &&
+      active.classList.contains('dw-preset'))
+      ? active.getAttribute('data-dw-preset') : null;
+    var expanded = [];
+    var exEls = document.querySelectorAll('.expanded[data-phrase]');
+    for (var i = 0; i < exEls.length; i++) {
+      // Only rows with an actual open panel: the drill-down path adds
+      // a transient 'expanded' highlight (1500ms timeout, no detail
+      // row) that must not be resurrected as a real panel. Remember
+      // which container the row lives in (bar list vs long-active
+      // table) so the panel is restored to the same one — the same
+      // phrase can appear in both.
+      var sib = exEls[i].nextElementSibling;
+      if (!sib || !sib.classList || !sib.classList.contains('detail-row')) continue;
+      expanded.push({
+        phrase: exEls[i].getAttribute('data-phrase'),
+        inTable: exEls[i].tagName === 'TR'
+      });
+    }
     var data = windowedAgencyData();
     installPhraseContext(data); // also sets currentAgencyData
     document.getElementById('page').innerHTML = renderAgency(data, currentSlug);
+    for (var j = 0; j < expanded.length; j++) {
+      var rowSel = expanded[j].inTable
+        ? 'tr.bar-row[data-phrase="' + phraseAttr(expanded[j].phrase) + '"]'
+        : '.bar-item[data-phrase="' + phraseAttr(expanded[j].phrase) + '"]';
+      var row = document.querySelector(rowSel);
+      // The phrase may have left the windowed top-50 — skip silently.
+      if (row) {
+        toggleRowExpansion(row, currentDetails[expanded[j].phrase] || null,
+          expanded[j].phrase, currentCounts[expanded[j].phrase] || 0);
+      }
+    }
+    var refocus = null;
+    if (focusId === 'dw-start' || focusId === 'dw-end') {
+      refocus = document.getElementById(focusId);
+    } else if (focusPreset) {
+      refocus = document.querySelector(
+        '.dw-preset[data-dw-preset="' + focusPreset + '"]');
+    }
+    if (refocus) refocus.focus();
   }
 
   // Live feedback during a drag — moves the fill bar and updates the
@@ -1783,18 +1869,10 @@
     var hi = Math.max(+s.value, +e.value);
     var total = fullEpochMax - fullEpochMin;
     var fill = document.querySelector('#dw-slider .dw-fill');
-    if (fill) {
-      fill.style.left = (total > 0 ? 100 * lo / total : 0) + '%';
-      fill.style.right = (total > 0 ? 100 * (1 - hi / total) : 0) + '%';
-    }
+    if (fill) fill.style.cssText = sliderFillCss(lo, hi, total);
     var readout = document.querySelector('.dw-readout');
     if (readout) {
-      var fromIso = JustAgg.isoFromEpochDay(fullEpochMin + lo);
-      var toIso = JustAgg.isoFromEpochDay(fullEpochMin + hi);
-      var span = (hi - lo) + 1;
-      readout.innerHTML = escapeHTML(fromIso) + ' &rarr; ' + escapeHTML(toIso) +
-        ' <span class="dw-span">(' + span.toLocaleString() +
-        ' day' + (span === 1 ? '' : 's') + ')</span>';
+      readout.innerHTML = readoutHtml(fullEpochMin + lo, fullEpochMin + hi);
     }
   }
 
@@ -1802,23 +1880,80 @@
     var s = document.getElementById('dw-start');
     var e = document.getElementById('dw-end');
     if (!s || !e) return;
-    selEpochStart = fullEpochMin + Math.min(+s.value, +e.value);
-    selEpochEnd = fullEpochMin + Math.max(+s.value, +e.value);
+    var lo = fullEpochMin + Math.min(+s.value, +e.value);
+    var hi = fullEpochMin + Math.max(+s.value, +e.value);
+    if (!rawPre) {
+      // Raw rows not loaded yet. A full selection needs no data — and
+      // must also CLEAR anything already parked, so an in-flight fetch
+      // (started by a narrowing the user has since backed out of)
+      // lands on the full window instead of the abandoned one.
+      // Anything narrower parks the request and starts the fetch.
+      if (lo <= fullEpochMin && hi >= fullEpochMax) {
+        pendingSel = null;
+        pendingPresetKey = null;
+        return;
+      }
+      pendingSel = [lo, hi];
+      pendingPresetKey = null;
+      ensureRawRows();
+      return;
+    }
+    // No-op guard: keyboard 'change' fires per arrow key, and each
+    // rerender is a full O(rows) re-aggregation — skip when the
+    // committed window didn't actually move.
+    if (lo === selEpochStart && hi === selEpochEnd) return;
+    selEpochStart = lo;
+    selEpochEnd = hi;
     rerender();
   }
 
   function applyPreset(key) {
-    if (!rawPre) return;
+    if (fullEpochMin == null) return;
     var days = key === 'all' ? null : +key;
+    if (!rawPre) {
+      // Pre-load the selection is always the full window, so 'All' is
+      // already satisfied without fetching anything — but it must
+      // CLEAR anything already parked, so an in-flight fetch (started
+      // by a narrowing the user has since backed out of) lands on the
+      // full window instead of the abandoned one.
+      if (days == null) {
+        pendingSel = null;
+        pendingPresetKey = null;
+        return;
+      }
+      pendingPresetKey = key;
+      pendingSel = null;
+      ensureRawRows();
+      return;
+    }
     var w = presetWindow(days);
+    if (selEpochStart === w[0] && selEpochEnd === w[1]) return;
     selEpochStart = w[0];
     selEpochEnd = w[1];
     rerender();
   }
 
+  // Kick off the raw-rows fetch on first use. Shows the loading line
+  // in place (no full re-render — that would snap the slider thumbs
+  // back while the user's drag is what we're trying to honor).
+  function ensureRawRows() {
+    if (rawPre || rawLoading || rawFailed) return;
+    rawLoading = true;
+    var ctl = document.querySelector('.date-window-control');
+    if (ctl && !ctl.querySelector('.dw-loading')) {
+      var d = document.createElement('div');
+      d.className = 'dw-loading';
+      d.innerHTML = 'Loading full history to apply the date filter&hellip;';
+      ctl.appendChild(d);
+    }
+    loadRawRows(currentSlug);
+  }
+
   // Fetch the agency's raw audit rows (already published, same file the
-  // "View raw audit data" link points at), precompute, and enable the
-  // slider. Falls back silently to the unfiltered build view on error.
+  // "View raw audit data" link points at), precompute, swap the slider
+  // domain from the build-date seed to PT epoch-days, and apply the
+  // interaction that triggered the fetch. Degrades to the unfiltered
+  // build view on failure.
   function loadRawRows(slug) {
     fetch('data/audit/' + encodeURIComponent(slug) + '.json')
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
@@ -1833,13 +1968,59 @@
           if (pt.epochDay > hi) hi = pt.epochDay;
         }
         rawLoading = false;
-        if (!isFinite(lo)) { rawPre = null; rerender(); return; }
+        if (!isFinite(lo)) {
+          // No timestamped rows — nothing to window on.
+          rawFailed = true;
+          pendingPresetKey = null; pendingSel = null;
+          rerender();
+          return;
+        }
         rawPre = pre;
+        fullSeriesCache = null;
         fullEpochMin = lo; fullEpochMax = hi;
-        selEpochStart = lo; selEpochEnd = hi;
+        // Apply the parked interaction. pendingSel is in the seeded
+        // (UTC build-date) domain, which can differ from the PT domain
+        // by a day at each edge — clamp it into the new domain.
+        var s = lo, e = hi;
+        if (pendingPresetKey != null && pendingPresetKey !== 'all') {
+          var w = presetWindow(+pendingPresetKey);
+          s = w[0]; e = w[1];
+        } else if (pendingSel) {
+          s = Math.max(lo, Math.min(hi, pendingSel[0]));
+          e = Math.max(lo, Math.min(hi, pendingSel[1]));
+          if (s > e) { s = lo; e = hi; }
+        }
+        pendingPresetKey = null; pendingSel = null;
+        selEpochStart = s; selEpochEnd = e;
         rerender();
       })
-      .catch(function () { rawLoading = false; rawPre = null; rerender(); });
+      .catch(function (err) {
+        // Degrade to the unfiltered build view, but say so — in the
+        // control (rendered by renderDateSlider) and on the console. A
+        // silent catch here would also swallow bugs anywhere in the
+        // then-chain above, including precompute and rerender.
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn('date filter disabled: raw audit rows failed to load', err);
+        }
+        rawLoading = false;
+        rawFailed = true;
+        pendingPresetKey = null; pendingSel = null;
+        rawPre = null;
+        rerender();
+      });
+  }
+
+  // fullPhraseSeries is an O(rows) scan whose result is window-
+  // independent, so cache it per phrase for the life of the loaded
+  // rows (loadRawRows resets the cache when rawPre changes).
+  function getFullPhraseSeries(phrase) {
+    if (!rawPre) return null;
+    if (fullSeriesCache === null) fullSeriesCache = Object.create(null);
+    var hit = fullSeriesCache[phrase];
+    if (hit !== undefined) return hit;
+    var s = JustAgg.fullPhraseSeries(phrase, rawPre);
+    fullSeriesCache[phrase] = s;
+    return s;
   }
 
   function renderAgency(agencyData, slug) {
@@ -1858,22 +2039,35 @@
       agencyData.row_count
     );
     var windowBanner = '';
-    // The banner shows the FULL data window (from the canonical build
-    // entry); the slider below it shows the currently-selected slice.
-    // When the user narrows the window, agencyData carries the windowed
-    // dates, so read the full range off baseAgencyData instead.
+    // The banner shows the FULL data window; the slider below it shows
+    // the currently-selected slice. When the user narrows the window,
+    // agencyData carries the windowed dates, so read the full range off
+    // baseAgencyData — and once the raw rows are loaded, off the PT
+    // epoch-day domain, so the banner, the slider readout, and the
+    // window semantics all agree. (The build's search_date_min/max are
+    // UTC date slices, which can differ from the PT calendar day by
+    // one at each edge.)
     var fullData = baseAgencyData || agencyData;
-    if (fullData.search_date_min && fullData.search_date_max) {
-      var dms = Date.parse(fullData.search_date_min + 'T12:00:00Z');
-      var dms2 = Date.parse(fullData.search_date_max + 'T12:00:00Z');
-      var spanD = (!isNaN(dms) && !isNaN(dms2))
+    var bannerMin = fullData.search_date_min;
+    var bannerMax = fullData.search_date_max;
+    var spanD = null;
+    if (rawPre && fullEpochMin != null) {
+      bannerMin = JustAgg.isoFromEpochDay(fullEpochMin);
+      bannerMax = JustAgg.isoFromEpochDay(fullEpochMax);
+      spanD = (fullEpochMax - fullEpochMin) + 1;
+    } else if (bannerMin && bannerMax) {
+      var dms = Date.parse(bannerMin + 'T12:00:00Z');
+      var dms2 = Date.parse(bannerMax + 'T12:00:00Z');
+      spanD = (!isNaN(dms) && !isNaN(dms2))
         ? Math.round((dms2 - dms) / 86400000) + 1
         : null;
+    }
+    if (bannerMin && bannerMax) {
       var rawLink = 'data/audit/' + encodeURIComponent(agencyData.slug) + '.json';
       windowBanner = '<div class="audit-window">' +
         '<span class="audit-window-label">Data window</span>' +
-        '<strong>' + escapeHTML(fullData.search_date_min) +
-        ' &rarr; ' + escapeHTML(fullData.search_date_max) + '</strong>' +
+        '<strong>' + escapeHTML(bannerMin) +
+        ' &rarr; ' + escapeHTML(bannerMax) + '</strong>' +
         (spanD ? ' <span class="audit-window-span">(' + spanD +
           ' day' + (spanD === 1 ? '' : 's') + ')</span>' : '') +
         ' <a class="audit-window-raw" href="' + rawLink +
@@ -1895,10 +2089,18 @@
         'sums the search volume across every recipient this agency shares to.' +
         '</span></div>';
     }
+    // When a date filter is active, agencyData carries the windowed
+    // stats and the windowed search_date_min/max — label them as such
+    // so the numbers aren't attributed to the full banner window above.
+    var isWindowed = !!agencyData._windowed;
     var blurb =
       '<p class="blurb">Aggregated free-text reasons that ' +
       escapeHTML(agencyData.display_name) +
-      ' attached to ALPR plate searches in the data window above. ' +
+      (isWindowed
+        ? ' attached to ALPR plate searches in the selected date window (' +
+          escapeHTML(agencyData.search_date_min) + ' &rarr; ' +
+          escapeHTML(agencyData.search_date_max) + '). '
+        : ' attached to ALPR plate searches in the data window above. ') +
       'Reasons are entered by the searching officer and are the agency’s own justification record. ' +
       commentary +
       '</p>';
@@ -1907,7 +2109,8 @@
     var unique = agencyData.unique_reasons;
     var stats =
       '<div class="stats-grid">' +
-      stat('Searches', fmt(agencyData.row_count), 'in audit window') +
+      stat('Searches', fmt(agencyData.row_count),
+        isWindowed ? 'in selected window' : 'in audit window') +
       stat('Unique reasons', fmt(unique),
         shown < unique
           ? 'top ' + fmt(shown) + ' shown below'
@@ -2161,11 +2364,24 @@
         var agencyData = slug ? agencies[slug] : null;
         baseAgencyData = agencyData;
         currentSlug = slug || '';
-        // Own-audit agencies get the date slider, powered by a
-        // background fetch of their raw rows. Show the loading line in
-        // the banner from the first paint so the control doesn't pop in.
+        // Own-audit agencies get the date slider. Seed its domain from
+        // the build's window so the control renders on first paint;
+        // the raw rows (needed to actually re-aggregate) are fetched
+        // lazily on the first slider/preset interaction — most
+        // visitors never filter, and the raw file can run to megabytes
+        // (San Mateo).
         var hasAgg = typeof JustAgg !== 'undefined';
-        rawLoading = !!(agencyData && agencyData.has_own_audit !== false && hasAgg);
+        if (agencyData && agencyData.has_own_audit !== false && hasAgg &&
+            agencyData.search_date_min && agencyData.search_date_max) {
+          var seedMin = JustAgg.epochDayOfIso(agencyData.search_date_min);
+          var seedMax = JustAgg.epochDayOfIso(agencyData.search_date_max);
+          if (isFinite(seedMin) && isFinite(seedMax) && seedMin <= seedMax) {
+            fullEpochMin = seedMin;
+            fullEpochMax = seedMax;
+            selEpochStart = seedMin;
+            selEpochEnd = seedMax;
+          }
+        }
         installPhraseContext(agencyData);
         var page = document.getElementById('page');
         page.innerHTML = renderAgency(agencyData, slug || '');
@@ -2189,7 +2405,6 @@
             onSliderChange();
           }
         });
-        if (rawLoading) loadRawRows(slug);
       })
       .catch(function (err) {
         document.getElementById('page').innerHTML =

--- a/docs/js/justifications.js
+++ b/docs/js/justifications.js
@@ -463,6 +463,26 @@
   // attributes the top N sources inline.
   var hideExternal = false;
 
+  // ── Date-window slider state ──
+  // The page renders from the build's prebuilt per-agency aggregate at
+  // the full window (exact, canonical). When the user narrows the
+  // window, we re-aggregate live from the agency's raw audit rows
+  // (data/audit/<slug>.json, fetched once and precomputed by JustAgg).
+  // The parity test guarantees the client aggregation equals the build
+  // at the full window, so dragging in from "All" never jumps.
+  var baseAgencyData = null;   // monolith entry: window-independent fields
+  var rawPre = null;           // JustAgg.precompute(rows), or null until loaded
+  var rawLoading = false;
+  var fullEpochMin = null;     // domain: oldest PT day (integer day index)
+  var fullEpochMax = null;     // domain: newest PT day
+  var selEpochStart = null;    // current selection
+  var selEpochEnd = null;
+
+  function windowIsFull() {
+    return rawPre === null ||
+      (selEpochStart <= fullEpochMin && selEpochEnd >= fullEpochMax);
+  }
+
   // For agencies without their own published audit. Replaces the
   // data-window banner / stats grid / own-audit framing with a
   // brief "no own audit" callout that surfaces what's known: this
@@ -556,6 +576,13 @@
       'almost certainly included. ' +
       '<a class="external-summary-jump" href="#external-bars">' +
       'Top phrases &darr;</a>' +
+      // The date slider filters this agency's OWN audit rows; partner
+      // searches live in other agencies' audits (not fetched here), so
+      // this cross-agency total always reflects the full data window.
+      (windowIsFull() ? '' :
+        '<div class="external-breakdown-est">Cross-agency partner totals ' +
+        'cover the full data window &mdash; the date filter applies to ' +
+        escapeHTML(agencyData.display_name) + '&rsquo;s own searches only.</div>') +
       breakdown +
       '</div>';
   }
@@ -1212,14 +1239,33 @@
         summarySentences.join(' ') + '</div>'
       : '';
 
+    // Daily/weekly cadence. When the raw rows are loaded we draw the
+    // phrase's FULL history (every search ever, not just the selected
+    // window) and gray the bars outside the window, so a narrowed view
+    // keeps the long history as context. Otherwise fall back to the
+    // build's windowed series.
     var dailyHtml = '';
-    if (detail.daily && detail.daily.length) {
+    var full = (rawPre && phrase) ? JustAgg.fullPhraseSeries(phrase, rawPre) : null;
+    if (full && full.daily && full.daily.length) {
+      var unitF = full.daily_unit === 'week' ? 'week' : 'day';
+      dailyHtml = '<div class="phrase-detail-row">' +
+        '<div class="phrase-detail-chart phrase-detail-chart-full">' +
+        '<div class="phrase-detail-label">Searches per ' + unitF +
+        ' &middot; full history' +
+        (windowIsFull() ? '' : ' (selected window in color)') + '</div>' +
+        renderDailySparkFull(full) +
+        '</div></div>';
+    } else if (detail.daily && detail.daily.length) {
       var unit = detail.daily_unit === 'week' ? 'week' : 'day';
       dailyHtml = '<div class="phrase-detail-row">' +
         '<div class="phrase-detail-chart phrase-detail-chart-full">' +
         '<div class="phrase-detail-label">Searches per ' + unit +
         ' (' + detail.daily.length + ' ' + unit + 's)</div>' +
         renderDailySpark(detail.daily, detail.from, detail.daily_unit) +
+        (detail.from && detail.to
+          ? '<div class="spark-axis"><span>' + escapeHTML(detail.from) +
+            '</span><span>' + escapeHTML(detail.to) + '</span></div>'
+          : '') +
         '</div></div>';
     }
 
@@ -1277,11 +1323,58 @@
     return html;
   }
 
+  // Full-history sparkline: `full` is JustAgg.fullPhraseSeries output
+  // (the phrase's entire span, independent of the selected window).
+  // Bars whose period falls outside the selected window render gray, so
+  // the user sees the long history with the chosen slice highlighted.
+  // A date axis is always drawn (the windowed spark above had none).
+  function renderDailySparkFull(full) {
+    var series = full.daily;
+    if (!series || !series.length) return '';
+    var fromED = full.fromEpochDay;
+    var step = full.step || 1;
+    var max = 1;
+    for (var i = 0; i < series.length; i++) if (series[i] > max) max = series[i];
+    var isFull = windowIsFull();
+    var selS = isFull ? -Infinity : selEpochStart;
+    var selE = isFull ? Infinity : selEpochEnd;
+    var html = '<div class="daily-spark">';
+    for (var i2 = 0; i2 < series.length; i2++) {
+      var v = series[i2];
+      var ph = max > 0 ? Math.round(100 * v / max) : 0;
+      var barStart = fromED + i2 * step;
+      var barEnd = barStart + step - 1;
+      var inWin = (barEnd >= selS && barStart <= selE);
+      var label = JustAgg.isoFromEpochDay(barStart);
+      var titleText = label + (step > 1 ? ' (week)' : '') + ': ' + v +
+        ' search' + (v === 1 ? '' : 'es');
+      var cls = 'spark-bar' + (v === 0 ? ' empty' : '') + (inWin ? '' : ' out');
+      html += '<div class="' + cls + '" title="' + escapeHTML(titleText) + '">' +
+        '<div class="spark-fill" style="height:' + ph + '%"></div>' +
+        '</div>';
+    }
+    html += '</div>';
+    html += '<div class="spark-axis"><span>' + escapeHTML(full.from) +
+      '</span><span>' + escapeHTML(full.to) + '</span></div>';
+    if (!isFull) {
+      html += '<div class="spark-window-note">Highlighted window: ' +
+        escapeHTML(JustAgg.isoFromEpochDay(selEpochStart)) + ' &rarr; ' +
+        escapeHTML(JustAgg.isoFromEpochDay(selEpochEnd)) + '</div>';
+    }
+    return html;
+  }
+
   // Click-handler for bar rows / cloud words / case-callout rows.
   // Toggles a sibling detail row containing renderPhraseDetail output
   // for the clicked phrase. Single delegated listener attached at
   // init time.
   function handleExpandClick(ev) {
+    // Date-window preset buttons.
+    var presetBtn = ev.target.closest && ev.target.closest('.dw-preset');
+    if (presetBtn) {
+      applyPreset(presetBtn.getAttribute('data-dw-preset'));
+      return;
+    }
     // Local-only toggle — flip the global flag and re-render.
     if (ev.target && ev.target.id === 'local-only-toggle') {
       hideExternal = !!ev.target.checked;
@@ -1579,6 +1672,176 @@
     return 'Predominantly free-text: many distinct reasons, no single phrase carries the bulk of searches.';
   }
 
+  // ── Date-window slider ──────────────────────────────────────────
+
+  var DW_PRESETS = [
+    { k: '30', label: '30d', days: 30 },
+    { k: '90', label: '90d', days: 90 },
+    { k: '180', label: '6mo', days: 180 },
+    { k: '365', label: '1yr', days: 365 },
+    { k: 'all', label: 'All', days: null }
+  ];
+
+  // [startEpochDay, endEpochDay] for a preset; `days` null means full range.
+  function presetWindow(days) {
+    if (days == null) return [fullEpochMin, fullEpochMax];
+    return [Math.max(fullEpochMin, fullEpochMax - days + 1), fullEpochMax];
+  }
+
+  function isPresetActive(p) {
+    var w = presetWindow(p.days);
+    return selEpochStart === w[0] && selEpochEnd === w[1];
+  }
+
+  // Renders the slider control inside the data-window banner. Returns ''
+  // until raw rows are available (own-audit agencies only); shows a
+  // loading line while they're being fetched.
+  function renderDateSlider() {
+    if (!rawPre) {
+      return rawLoading
+        ? '<div class="date-window-control">' +
+          '<div class="dw-loading">Loading full history to enable date filtering&hellip;</div>' +
+          '</div>'
+        : '';
+    }
+    var total = fullEpochMax - fullEpochMin;
+    var startIdx = selEpochStart - fullEpochMin;
+    var endIdx = selEpochEnd - fullEpochMin;
+    var leftPct = total > 0 ? (100 * startIdx / total) : 0;
+    var rightPct = total > 0 ? (100 * endIdx / total) : 100;
+    var fromIso = JustAgg.isoFromEpochDay(selEpochStart);
+    var toIso = JustAgg.isoFromEpochDay(selEpochEnd);
+    var spanDays = (selEpochEnd - selEpochStart) + 1;
+    var filtered = !windowIsFull();
+    var presetHtml = DW_PRESETS.map(function (p) {
+      return '<button type="button" class="dw-preset' +
+        (isPresetActive(p) ? ' active' : '') +
+        '" data-dw-preset="' + p.k + '">' + p.label + '</button>';
+    }).join('');
+    return '<div class="date-window-control">' +
+      '<div class="dw-top">' +
+      '<span class="dw-readout">' + escapeHTML(fromIso) + ' &rarr; ' + escapeHTML(toIso) +
+      ' <span class="dw-span">(' + spanDays.toLocaleString() +
+      ' day' + (spanDays === 1 ? '' : 's') + ')</span></span>' +
+      (filtered ? ' <span class="dw-filtered-badge">Filtered</span>' : '') +
+      '<span class="dw-presets">' + presetHtml + '</span>' +
+      '</div>' +
+      '<div class="dw-slider" id="dw-slider">' +
+      '<div class="dw-track"></div>' +
+      '<div class="dw-fill" style="left:' + leftPct.toFixed(2) + '%;right:' +
+      (100 - rightPct).toFixed(2) + '%"></div>' +
+      '<input type="range" id="dw-start" min="0" max="' + total + '" step="1" value="' +
+      startIdx + '" aria-label="Window start day">' +
+      '<input type="range" id="dw-end" min="0" max="' + total + '" step="1" value="' +
+      endIdx + '" aria-label="Window end day">' +
+      '</div>' +
+      '</div>';
+  }
+
+  // Per-agency data for the current selection: the canonical prebuilt
+  // entry at the full window, else a live re-aggregation from raw rows
+  // merged with the window-independent fields.
+  function windowedAgencyData() {
+    if (!baseAgencyData) return null;
+    if (windowIsFull()) return baseAgencyData;
+    var filtered = [];
+    for (var i = 0; i < rawPre.length; i++) {
+      var pt = rawPre[i].pt;
+      if (pt && pt.epochDay >= selEpochStart && pt.epochDay <= selEpochEnd) {
+        filtered.push(rawPre[i]);
+      }
+    }
+    var agg = JustAgg.aggregate(filtered);
+    var merged = {};
+    var k;
+    for (k in baseAgencyData) {
+      if (Object.prototype.hasOwnProperty.call(baseAgencyData, k)) merged[k] = baseAgencyData[k];
+    }
+    for (k in agg) {
+      if (Object.prototype.hasOwnProperty.call(agg, k)) merged[k] = agg[k];
+    }
+    merged.search_date_min = JustAgg.isoFromEpochDay(selEpochStart);
+    merged.search_date_max = JustAgg.isoFromEpochDay(selEpochEnd);
+    merged._windowed = true;
+    return merged;
+  }
+
+  function rerender() {
+    var data = windowedAgencyData();
+    installPhraseContext(data); // also sets currentAgencyData
+    document.getElementById('page').innerHTML = renderAgency(data, currentSlug);
+  }
+
+  // Live feedback during a drag — moves the fill bar and updates the
+  // readout without a full re-render (which would destroy the thumb
+  // mid-drag). The expensive re-aggregation happens on 'change'.
+  function onSliderInput() {
+    var s = document.getElementById('dw-start');
+    var e = document.getElementById('dw-end');
+    if (!s || !e) return;
+    var lo = Math.min(+s.value, +e.value);
+    var hi = Math.max(+s.value, +e.value);
+    var total = fullEpochMax - fullEpochMin;
+    var fill = document.querySelector('#dw-slider .dw-fill');
+    if (fill) {
+      fill.style.left = (total > 0 ? 100 * lo / total : 0) + '%';
+      fill.style.right = (total > 0 ? 100 * (1 - hi / total) : 0) + '%';
+    }
+    var readout = document.querySelector('.dw-readout');
+    if (readout) {
+      var fromIso = JustAgg.isoFromEpochDay(fullEpochMin + lo);
+      var toIso = JustAgg.isoFromEpochDay(fullEpochMin + hi);
+      var span = (hi - lo) + 1;
+      readout.innerHTML = escapeHTML(fromIso) + ' &rarr; ' + escapeHTML(toIso) +
+        ' <span class="dw-span">(' + span.toLocaleString() +
+        ' day' + (span === 1 ? '' : 's') + ')</span>';
+    }
+  }
+
+  function onSliderChange() {
+    var s = document.getElementById('dw-start');
+    var e = document.getElementById('dw-end');
+    if (!s || !e) return;
+    selEpochStart = fullEpochMin + Math.min(+s.value, +e.value);
+    selEpochEnd = fullEpochMin + Math.max(+s.value, +e.value);
+    rerender();
+  }
+
+  function applyPreset(key) {
+    if (!rawPre) return;
+    var days = key === 'all' ? null : +key;
+    var w = presetWindow(days);
+    selEpochStart = w[0];
+    selEpochEnd = w[1];
+    rerender();
+  }
+
+  // Fetch the agency's raw audit rows (already published, same file the
+  // "View raw audit data" link points at), precompute, and enable the
+  // slider. Falls back silently to the unfiltered build view on error.
+  function loadRawRows(slug) {
+    fetch('data/audit/' + encodeURIComponent(slug) + '.json')
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (audit) {
+        var rows = (audit && audit.rows) || [];
+        var pre = rows.length ? JustAgg.precompute(rows) : [];
+        var lo = Infinity, hi = -Infinity;
+        for (var i = 0; i < pre.length; i++) {
+          var pt = pre[i].pt;
+          if (!pt) continue;
+          if (pt.epochDay < lo) lo = pt.epochDay;
+          if (pt.epochDay > hi) hi = pt.epochDay;
+        }
+        rawLoading = false;
+        if (!isFinite(lo)) { rawPre = null; rerender(); return; }
+        rawPre = pre;
+        fullEpochMin = lo; fullEpochMax = hi;
+        selEpochStart = lo; selEpochEnd = hi;
+        rerender();
+      })
+      .catch(function () { rawLoading = false; rawPre = null; rerender(); });
+  }
+
   function renderAgency(agencyData, slug) {
     currentSlug = slug || '';
     if (!agencyData) {
@@ -1595,17 +1858,22 @@
       agencyData.row_count
     );
     var windowBanner = '';
-    if (agencyData.search_date_min && agencyData.search_date_max) {
-      var dms = Date.parse(agencyData.search_date_min + 'T12:00:00Z');
-      var dms2 = Date.parse(agencyData.search_date_max + 'T12:00:00Z');
+    // The banner shows the FULL data window (from the canonical build
+    // entry); the slider below it shows the currently-selected slice.
+    // When the user narrows the window, agencyData carries the windowed
+    // dates, so read the full range off baseAgencyData instead.
+    var fullData = baseAgencyData || agencyData;
+    if (fullData.search_date_min && fullData.search_date_max) {
+      var dms = Date.parse(fullData.search_date_min + 'T12:00:00Z');
+      var dms2 = Date.parse(fullData.search_date_max + 'T12:00:00Z');
       var spanD = (!isNaN(dms) && !isNaN(dms2))
         ? Math.round((dms2 - dms) / 86400000) + 1
         : null;
       var rawLink = 'data/audit/' + encodeURIComponent(agencyData.slug) + '.json';
       windowBanner = '<div class="audit-window">' +
         '<span class="audit-window-label">Data window</span>' +
-        '<strong>' + escapeHTML(agencyData.search_date_min) +
-        ' &rarr; ' + escapeHTML(agencyData.search_date_max) + '</strong>' +
+        '<strong>' + escapeHTML(fullData.search_date_min) +
+        ' &rarr; ' + escapeHTML(fullData.search_date_max) + '</strong>' +
         (spanD ? ' <span class="audit-window-span">(' + spanD +
           ' day' + (spanD === 1 ? '' : 's') + ')</span>' : '') +
         ' <a class="audit-window-raw" href="' + rawLink +
@@ -1615,6 +1883,7 @@
         'Flock exposes a rolling ~30-day window; older rows persist here only ' +
         'because they were captured before they aged out.' +
         '</span>' +
+        renderDateSlider() +
         '<span class="audit-window-scope">' +
         '<strong>Scope:</strong> only searches run by ' +
         escapeHTML(agencyData.display_name) + '&rsquo;s own staff. ' +
@@ -1889,17 +2158,38 @@
           reportLink.href = 'report.html?agency=' + encodeURIComponent(slug);
         }
         wireAgencySearch(agencies, slug);
-        installPhraseContext(slug ? agencies[slug] : null);
-        document.getElementById('page').innerHTML =
-          renderAgency(slug ? agencies[slug] : null, slug || '');
-        document.getElementById('page').addEventListener('click', handleExpandClick);
-        document.getElementById('page').addEventListener('keydown', function (ev) {
+        var agencyData = slug ? agencies[slug] : null;
+        baseAgencyData = agencyData;
+        currentSlug = slug || '';
+        // Own-audit agencies get the date slider, powered by a
+        // background fetch of their raw rows. Show the loading line in
+        // the banner from the first paint so the control doesn't pop in.
+        var hasAgg = typeof JustAgg !== 'undefined';
+        rawLoading = !!(agencyData && agencyData.has_own_audit !== false && hasAgg);
+        installPhraseContext(agencyData);
+        var page = document.getElementById('page');
+        page.innerHTML = renderAgency(agencyData, slug || '');
+        page.addEventListener('click', handleExpandClick);
+        page.addEventListener('keydown', function (ev) {
           if (ev.key !== 'Enter' && ev.key !== ' ') return;
           var row = ev.target.closest('.bar-item, tr.bar-row');
           if (!row) return;
           ev.preventDefault();
           handleExpandClick({ target: row });
         });
+        // Delegated slider listeners survive the per-render innerHTML
+        // rebuild because they're bound to #page, not the inputs.
+        page.addEventListener('input', function (ev) {
+          if (ev.target && (ev.target.id === 'dw-start' || ev.target.id === 'dw-end')) {
+            onSliderInput();
+          }
+        });
+        page.addEventListener('change', function (ev) {
+          if (ev.target && (ev.target.id === 'dw-start' || ev.target.id === 'dw-end')) {
+            onSliderChange();
+          }
+        });
+        if (rawLoading) loadRawRows(slug);
       })
       .catch(function (err) {
         document.getElementById('page').innerHTML =

--- a/docs/js/justifications_agg.js
+++ b/docs/js/justifications_agg.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 zero-below
 /* Client-side re-implementation of scripts/build_justifications.py's
    per-agency aggregation, so the justifications page can re-aggregate a
    narrowed date window live from the already-published raw audit rows
@@ -5,10 +7,15 @@
 
    PARITY CONTRACT: aggregate(allRows) must equal the build's per-agency
    entry for every window-dependent field. scripts/verify_justifications_agg.js
-   asserts this against docs/data/justifications.json — run it (or
-   `make test`, via tests/test_justifications_agg.py) after touching
-   either this file or build_justifications.py. The two are a matched
-   pair; if you change the parser/tokenizer in one, change it in both.
+   asserts this against docs/data/justifications.json. After touching
+   build_justifications.py, run `make build` first — the check compares
+   against the built artifacts, and `make test` alone will not pick up
+   generator changes — then the verifier (or `make test`, via
+   tests/test_justifications_agg.py). The two are a matched pair; if you
+   change the parser/tokenizer in one, change it in both. The verifier
+   fails closed: a per-agency field added to the build that aggregate()
+   doesn't reproduce is an error until it is either ported here or
+   explicitly allowlisted as window-independent there.
 
    Works in the browser (exposes window.JustAgg) and in Node
    (module.exports) so the same code is what's tested and what ships. */
@@ -102,9 +109,11 @@
   };
 
   // ── Regexes (mirror build_justifications.py; see notes there) ──
-  // JS \w is ASCII-only where Python used re.UNICODE; audit reason text
-  // is overwhelmingly ASCII, and the parity test guards any divergence.
-  var PUNCT_RE = /[^\w\s./()-]+/g;
+  // Python compiled \w with re.UNICODE (letters/digits in any script,
+  // plus underscore); JS \w is ASCII-only, so spell out the Unicode
+  // property classes to keep non-ASCII reason text normalizing the
+  // same way. The parity test guards any residual divergence.
+  var PUNCT_RE = /[^\p{L}\p{N}_\s./()-]+/gu;
   var TOKEN_RE = /[A-Za-z]{2,}|[0-9]{2,5}(?:\.[0-9]+)?/g;
   var LONG_DIGITS_RE = /\b\d{8,}\b/g;
   var WS_RE = /\s+/g;
@@ -179,13 +188,27 @@
   });
   var _ptCache = Object.create(null);
 
+  // Timestamps must carry an explicit UTC offset ('Z' or ±HH[:]MM),
+  // mirroring Python's parse_search_date_pt, which returns None for
+  // naive datetimes. Without this check, JS `new Date` would silently
+  // parse a naive timestamp in the VIEWER's local zone and diverge
+  // from the build. This is an approximation of fromisoformat's aware
+  // formats, not a clone (e.g. Python also accepts ±HH:MM:SS offsets;
+  // engines differ on space-separated dates): Flock emits only
+  // 'YYYY-MM-DDTHH:MM:SS[.fff]Z', and the parity test over the real
+  // corpus is the guard if that ever changes.
+  var TZ_OFFSET_RE = /(?:Z|[+-]\d{2}:?\d{2})$/;
+
   function ptPartsFromIso(iso) {
     if (!iso) return null;
-    var key = iso.slice(0, 13); // YYYY-MM-DDTHH
+    var s = String(iso);
+    if (!TZ_OFFSET_RE.test(s)) return null;
+    var d = new Date(s);
+    var t = d.getTime();
+    if (isNaN(t)) return null;
+    var key = Math.floor(t / 3600000); // UTC hour index
     var cached = _ptCache[key];
     if (cached !== undefined) return cached;
-    var d = new Date(iso);
-    if (isNaN(d.getTime())) { _ptCache[key] = null; return null; }
     var parts = _ptFmt.formatToParts(d);
     var y, mo, da, hr;
     for (var i = 0; i < parts.length; i++) {
@@ -258,12 +281,6 @@
     return (n == null) ? arr : arr.slice(0, n);
   }
 
-  function median(sortedNums) {
-    var n = sortedNums.length;
-    if (!n) return 0;
-    return sortedNums[Math.floor(n / 2)];
-  }
-
   // Mirror of compute_phrase_details(): {phrase: detail} for each phrase
   // in the set, single pass over rows. `pre` are precomputed rows.
   function computePhraseDetails(phraseSet, pre) {
@@ -304,34 +321,12 @@
         weekly: acc.weekly
       };
       if (dateCounts.size) {
-        var keys = Array.from(dateCounts.keys()).sort();
-        var fromIso = keys[0];
-        var toIso = keys[keys.length - 1];
-        var fromED = epochDayOfIso(fromIso);
-        var toED = epochDayOfIso(toIso);
-        var span = (toED - fromED) + 1;
-        d.from = fromIso;
-        d.to = toIso;
-        d.span_days = span;
-        var series = [];
-        var cur;
-        if (span <= 365) {
-          for (cur = fromED; cur <= toED; cur++) {
-            series.push(dateCounts.get(isoFromEpochDay(cur)) || 0);
-          }
-          d.daily = series;
-          d.daily_unit = 'day';
-        } else {
-          for (cur = fromED; cur <= toED; cur += 7) {
-            var wt = 0;
-            for (var off = 0; off < 7; off++) {
-              wt += dateCounts.get(isoFromEpochDay(cur + off)) || 0;
-            }
-            series.push(wt);
-          }
-          d.daily = series;
-          d.daily_unit = 'week';
-        }
+        var s = seriesFromDateCounts(dateCounts);
+        d.from = s.from;
+        d.to = s.to;
+        d.span_days = s.span_days;
+        d.daily = s.daily;
+        d.daily_unit = s.daily_unit;
       }
       if (ncs.length) {
         d.nc_min = ncs[0];
@@ -351,6 +346,47 @@
     // stable integer day index.
     var y = +iso.slice(0, 4), m = +iso.slice(5, 7), da = +iso.slice(8, 10);
     return Math.floor(Date.UTC(y, m - 1, da) / 86400000);
+  }
+
+  // Zero-filled daily series across the span of a Map of ISO date ->
+  // count; weekly 7-day buckets anchored at the first date when the
+  // span exceeds 365 days (mirror of the series logic in Python's
+  // compute_phrase_details). Single implementation shared by
+  // computePhraseDetails (parity-gated against the build) and
+  // fullPhraseSeries (cross-checked against phrase_details by the
+  // verifier) so the two bucketings cannot drift. Returns
+  // {from,to,span_days,daily,daily_unit,fromEpochDay}, or null for an
+  // empty Map.
+  function seriesFromDateCounts(dates) {
+    if (!dates.size) return null;
+    var keys = Array.from(dates.keys()).sort();
+    var fromIso = keys[0];
+    var toIso = keys[keys.length - 1];
+    var fromED = epochDayOfIso(fromIso);
+    var toED = epochDayOfIso(toIso);
+    var span = (toED - fromED) + 1;
+    var series = [];
+    var unit;
+    var cur;
+    if (span <= 365) {
+      unit = 'day';
+      for (cur = fromED; cur <= toED; cur++) {
+        series.push(dates.get(isoFromEpochDay(cur)) || 0);
+      }
+    } else {
+      unit = 'week';
+      for (cur = fromED; cur <= toED; cur += 7) {
+        var wt = 0;
+        for (var off = 0; off < 7; off++) {
+          wt += dates.get(isoFromEpochDay(cur + off)) || 0;
+        }
+        series.push(wt);
+      }
+    }
+    return {
+      from: fromIso, to: toIso, span_days: span,
+      daily: series, daily_unit: unit, fromEpochDay: fromED
+    };
   }
 
   // Mirror of find_long_active_cases(). Uses the UTC date slice for the
@@ -495,10 +531,13 @@
     return (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
   }
 
-  // Per-phrase daily series over the phrase's FULL span (every row, not
-  // a window) — used by the expand panel to show full history with the
-  // out-of-window portion grayed. Returns {from,to,span_days,daily,
-  // daily_unit,fromEpochDay} or null.
+  // Per-phrase daily/weekly series over the phrase's FULL span (every
+  // row, not a window) — used by the expand panel to show full history
+  // with the out-of-window portion grayed. Built by the same
+  // seriesFromDateCounts the parity-gated aggregation uses, and the
+  // verifier additionally cross-checks it against phrase_details at
+  // the full window. Returns the seriesFromDateCounts shape, or null
+  // when the phrase has no timestamped rows.
   function fullPhraseSeries(phrase, pre) {
     var dates = new Map();
     for (var i = 0; i < pre.length; i++) {
@@ -506,29 +545,7 @@
       if (p.norm !== phrase || !p.pt) continue;
       dates.set(p.pt.dateISO, (dates.get(p.pt.dateISO) || 0) + 1);
     }
-    if (!dates.size) return null;
-    var keys = Array.from(dates.keys()).sort();
-    var fromED = epochDayOfIso(keys[0]);
-    var toED = epochDayOfIso(keys[keys.length - 1]);
-    var span = (toED - fromED) + 1;
-    var series = [];
-    var unit, step;
-    var cur;
-    if (span <= 365) {
-      unit = 'day'; step = 1;
-      for (cur = fromED; cur <= toED; cur++) series.push(dates.get(isoFromEpochDay(cur)) || 0);
-    } else {
-      unit = 'week'; step = 7;
-      for (cur = fromED; cur <= toED; cur += 7) {
-        var wt = 0;
-        for (var off = 0; off < 7; off++) wt += dates.get(isoFromEpochDay(cur + off)) || 0;
-        series.push(wt);
-      }
-    }
-    return {
-      from: keys[0], to: keys[keys.length - 1], span_days: span,
-      daily: series, daily_unit: unit, fromEpochDay: fromED, step: step
-    };
+    return seriesFromDateCounts(dates);
   }
 
   var api = {

--- a/docs/js/justifications_agg.js
+++ b/docs/js/justifications_agg.js
@@ -1,0 +1,552 @@
+/* Client-side re-implementation of scripts/build_justifications.py's
+   per-agency aggregation, so the justifications page can re-aggregate a
+   narrowed date window live from the already-published raw audit rows
+   (data/audit/<slug>.json) without a server round-trip.
+
+   PARITY CONTRACT: aggregate(allRows) must equal the build's per-agency
+   entry for every window-dependent field. scripts/verify_justifications_agg.js
+   asserts this against docs/data/justifications.json — run it (or
+   `make test`, via tests/test_justifications_agg.py) after touching
+   either this file or build_justifications.py. The two are a matched
+   pair; if you change the parser/tokenizer in one, change it in both.
+
+   Works in the browser (exposes window.JustAgg) and in Node
+   (module.exports) so the same code is what's tested and what ships. */
+
+(function (root) {
+  'use strict';
+
+  // ── Constants copied verbatim from build_justifications.py ──
+  var TOP_VERBATIM = 50;
+  var TOP_TOKENS = 50;
+  var LONG_ACTIVE_MIN_COUNT = 10;
+  var LONG_ACTIVE_MIN_DAYS = 7;
+  var LONG_ACTIVE_TOP = 8;
+  var BLANK_LABEL = '(blank)';
+
+  var STOPWORDS = {
+    'a': 1, 'an': 1, 'and': 1, 'the': 1, 'of': 1, 'to': 1, 'in': 1,
+    'on': 1, 'for': 1, 'with': 1, 'by': 1, 'at': 1, 'or': 1, 'is': 1,
+    'was': 1, 'be': 1, 'as': 1, 'from': 1, 'this': 1, 'that': 1, 'it': 1,
+    'its': 1, 'into': 1, 'out': 1, 'no': 1, 'not': 1,
+    'vehicle': 1, 'veh': 1, 'vehicles': 1, 'plate': 1, 'plates': 1,
+    'license': 1, 'lic': 1, 'search': 1, 'searches': 1, 'lookup': 1,
+    'lookups': 1, 'case': 1, 'report': 1,
+    'pc': 1, 'cvc': 1, 'hsc': 1, 'wic': 1, 'vc': 1, 'cvv': 1, 'hs': 1
+  };
+
+  var DROP_VERBATIM = {
+    '': 1, '-': 1, '.': 1, 'n/a': 1, 'na': 1, 'none': 1,
+    'test': 1, 'testing': 1
+  };
+
+  // California penal / vehicle / health-and-safety / W&I codes.
+  var PENAL_CODES = {
+    '10851': 'Vehicle theft (CVC)',
+    '20001': 'Hit and run with injury (CVC)',
+    '20002': 'Hit and run, property (CVC)',
+    '23103': 'Reckless driving (CVC)',
+    '23152': 'DUI (CVC)',
+    '23153': 'DUI causing injury (CVC)',
+    '2800': 'Failure to yield to officer (CVC)',
+    '14601': 'Driving on suspended license (CVC)',
+    '187': 'Murder (PC)',
+    '192': 'Manslaughter (PC)',
+    '211': 'Robbery (PC)',
+    '215': 'Carjacking (PC)',
+    '220': 'Assault to commit a felony (PC)',
+    '240': 'Assault (PC)',
+    '242': 'Battery (PC)',
+    '243': 'Battery — specific (PC)',
+    '245': 'Assault with a deadly weapon (PC)',
+    '246': 'Shooting at occupied vehicle/dwelling (PC)',
+    '261': 'Rape (PC)',
+    '273.5': 'Domestic violence (PC)',
+    '288': 'Lewd act on child (PC)',
+    '459': 'Burglary (PC)',
+    '460': 'Burglary — degree (PC)',
+    '466': 'Burglary tools (PC)',
+    '470': 'Forgery (PC)',
+    '484': 'Theft (PC)',
+    '487': 'Grand theft (PC)',
+    '488': 'Petty theft (PC)',
+    '490.4': 'Organized retail theft (PC)',
+    '496': 'Receiving stolen property (PC)',
+    '496d': 'Receiving stolen vehicle (PC)',
+    '530.5': 'Identity theft (PC)',
+    '594': 'Vandalism (PC)',
+    '207': 'Kidnapping (PC)',
+    '314': 'Indecent exposure (PC)',
+    '415': 'Disturbing the peace (PC)',
+    '422': 'Criminal threats (PC)',
+    '451': 'Arson (PC)',
+    '452': 'Reckless burning (PC)',
+    '417': 'Brandishing a weapon (PC)',
+    '25400': 'Carrying a concealed firearm (PC)',
+    '25850': 'Carrying a loaded firearm (PC)',
+    '29800': 'Felon in possession of firearm (PC)',
+    '11350': 'Possession of controlled substance (HSC)',
+    '11351': 'Possession for sale (HSC)',
+    '11352': 'Sale/transport, narcotics (HSC)',
+    '11377': 'Possession of methamphetamine (HSC)',
+    '11378': 'Possession for sale, methamphetamine (HSC)',
+    '11379': 'Sale/transport, methamphetamine (HSC)',
+    '5150': 'Mental-health hold (WIC)',
+    '300': 'Dependent child (WIC)',
+    '601': 'Status offense — minor (WIC)',
+    '602': 'Delinquent minor (WIC)',
+    '1030': 'Stolen vehicle (radio code)',
+    '1065': 'Missing person (radio)',
+    '10-65': 'Missing person (radio)',
+    '23101': 'Reckless / DUI causing injury (CVC, historic)'
+  };
+
+  // ── Regexes (mirror build_justifications.py; see notes there) ──
+  // JS \w is ASCII-only where Python used re.UNICODE; audit reason text
+  // is overwhelmingly ASCII, and the parity test guards any divergence.
+  var PUNCT_RE = /[^\w\s./()-]+/g;
+  var TOKEN_RE = /[A-Za-z]{2,}|[0-9]{2,5}(?:\.[0-9]+)?/g;
+  var LONG_DIGITS_RE = /\b\d{8,}\b/g;
+  var WS_RE = /\s+/g;
+  var CODE_AFFIX = '(?:cvc|cvv|hsc|wic|hs|pc|vc)';
+  var CODE_PREFIX_RE = new RegExp('\\b' + CODE_AFFIX + '\\s*(\\d+(?:\\.\\d+)?)\\b', 'g');
+  var CODE_SUFFIX_RE = new RegExp('\\b(\\d+(?:\\.\\d+)?)\\s*' + CODE_AFFIX + '\\b', 'g');
+  var CASE_NUMBER_RE = /^\d{2,4}-\d{3,8}$/;
+  var PLATE_RE = /\b(?=[A-Za-z0-9]{6,8}\b)(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z0-9]+\b/g;
+
+  // ── Reason normalization / tokenization (mirror of the Python) ──
+
+  // Returns a normalized whole-reason string, BLANK_LABEL for empty, or
+  // null for filler (test / n/a) that should be dropped entirely.
+  function normalizeReason(raw) {
+    if (raw === null || raw === undefined) return BLANK_LABEL;
+    var s = String(raw).trim().toLowerCase();
+    if (!s) return BLANK_LABEL;
+    s = s.replace(PUNCT_RE, ' ');
+    s = s.replace(WS_RE, ' ').trim();
+    if (!s) return BLANK_LABEL;
+    if (DROP_VERBATIM[s] === 1) return null;
+    return s;
+  }
+
+  function tokenize(reasonNorm) {
+    var out = [];
+    if (!reasonNorm) return out;
+    var s = reasonNorm.replace(CODE_PREFIX_RE, '$1');
+    s = s.replace(CODE_SUFFIX_RE, '$1');
+    s = s.replace(LONG_DIGITS_RE, ' ');
+    s = s.replace(PLATE_RE, ' ');
+    var m;
+    TOKEN_RE.lastIndex = 0;
+    while ((m = TOKEN_RE.exec(s)) !== null) {
+      var tok = m[0];
+      if (STOPWORDS[tok] === 1) continue;
+      out.push(tok);
+    }
+    return out;
+  }
+
+  // Ordered, de-duplicated [code, label] pairs detected in a phrase.
+  function detectCodes(phrase) {
+    var out = [];
+    if (!phrase) return out;
+    var s = phrase.replace(CODE_PREFIX_RE, '$1');
+    s = s.replace(CODE_SUFFIX_RE, '$1');
+    s = s.replace(LONG_DIGITS_RE, ' ');
+    s = s.replace(PLATE_RE, ' ');
+    var seen = {};
+    var m;
+    TOKEN_RE.lastIndex = 0;
+    while ((m = TOKEN_RE.exec(s)) !== null) {
+      var tok = m[0];
+      var label = PENAL_CODES[tok];
+      if (label && seen[tok] !== 1) {
+        seen[tok] = 1;
+        out.push([tok, label]);
+      }
+    }
+    return out;
+  }
+
+  // ── Pacific-time conversion, memoized by UTC-hour (PT date/hour/weekday
+  // are constant within a UTC hour, so this bounds Intl calls to the
+  // number of distinct UTC hours in the data). Uses the IANA tz database
+  // (same source as Python's zoneinfo) so it matches the build. ──
+  var _ptFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', hourCycle: 'h23'
+  });
+  var _ptCache = Object.create(null);
+
+  function ptPartsFromIso(iso) {
+    if (!iso) return null;
+    var key = iso.slice(0, 13); // YYYY-MM-DDTHH
+    var cached = _ptCache[key];
+    if (cached !== undefined) return cached;
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) { _ptCache[key] = null; return null; }
+    var parts = _ptFmt.formatToParts(d);
+    var y, mo, da, hr;
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i];
+      if (p.type === 'year') y = +p.value;
+      else if (p.type === 'month') mo = +p.value;
+      else if (p.type === 'day') da = +p.value;
+      else if (p.type === 'hour') hr = +p.value;
+    }
+    if (hr === 24) hr = 0; // some engines emit '24' for midnight
+    var utcMid = Date.UTC(y, mo - 1, da);
+    var res = {
+      hour: hr,
+      // weekday Mon=0..Sun=6 (ISO), matching Python date.weekday()
+      weekday: (new Date(utcMid).getUTCDay() + 6) % 7,
+      epochDay: Math.floor(utcMid / 86400000),
+      dateISO: pad4(y) + '-' + pad2(mo) + '-' + pad2(da)
+    };
+    _ptCache[key] = res;
+    return res;
+  }
+
+  function pad2(n) { return n < 10 ? '0' + n : '' + n; }
+  function pad4(n) { return n < 1000 ? ('000' + n).slice(-4) : '' + n; }
+
+  function parseIntStrict(raw) {
+    if (raw === null || raw === undefined || raw === '') return null;
+    var s = String(raw).trim();
+    if (!/^[+-]?\d+$/.test(s)) return null;
+    return parseInt(s, 10);
+  }
+
+  function isoFromEpochDay(epochDay) {
+    var d = new Date(epochDay * 86400000);
+    return d.getUTCFullYear() + '-' + pad2(d.getUTCMonth() + 1) + '-' + pad2(d.getUTCDate());
+  }
+
+  // ── Per-row precompute (run once per agency load). Derives the
+  // expensive fields so window re-aggregation is plain counting. ──
+  function precompute(rows) {
+    var out = new Array(rows.length);
+    for (var i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      var raw = r.reason;
+      if (raw === null || raw === undefined || !String(raw).trim()) raw = r.offenseType;
+      if (raw === null || raw === undefined || !String(raw).trim()) raw = r.caseNumber;
+      var norm = normalizeReason(raw);
+      var pt = ptPartsFromIso(r.searchDate);
+      var utcDate = r.searchDate ? String(r.searchDate).slice(0, 10) : '';
+      out[i] = {
+        norm: norm,                       // null | '(blank)' | phrase
+        tokens: (norm && norm !== BLANK_LABEL) ? tokenize(norm) : null,
+        isCase: (norm && CASE_NUMBER_RE.test(norm)) || false,
+        nc: parseIntStrict(r.networkCount),
+        pt: pt,                           // null | {hour,weekday,epochDay,dateISO}
+        utcDate: utcDate
+      };
+    }
+    return out;
+  }
+
+  // ── Helpers mirroring the Python aggregation pieces ──
+
+  // Stable count-descending order over a Map (insertion order preserved
+  // for ties), matching Python Counter.most_common().
+  function mostCommon(map, n) {
+    var arr = [];
+    map.forEach(function (count, key) { arr.push([key, count]); });
+    arr.sort(function (a, b) { return b[1] - a[1]; }); // stable in modern JS
+    return (n == null) ? arr : arr.slice(0, n);
+  }
+
+  function median(sortedNums) {
+    var n = sortedNums.length;
+    if (!n) return 0;
+    return sortedNums[Math.floor(n / 2)];
+  }
+
+  // Mirror of compute_phrase_details(): {phrase: detail} for each phrase
+  // in the set, single pass over rows. `pre` are precomputed rows.
+  function computePhraseDetails(phraseSet, pre) {
+    var accum = Object.create(null);
+    var phrases = Object.keys(phraseSet);
+    if (!phrases.length) return {};
+    for (var i = 0; i < phrases.length; i++) {
+      accum[phrases[i]] = {
+        hourly: new Array(24).fill(0),
+        weekly: new Array(7).fill(0),
+        ncs: [],
+        dates: new Map()
+      };
+    }
+    for (var j = 0; j < pre.length; j++) {
+      var p = pre[j];
+      // Mirror of `if norm not in accum: continue`. Filler rows (norm
+      // null) and any phrase outside the top set are skipped.
+      if (p.norm === null) continue;
+      var a = accum[p.norm];
+      if (a === undefined) continue;
+      if (p.pt) {
+        a.hourly[p.pt.hour] += 1;
+        a.weekly[p.pt.weekday] += 1;
+        a.dates.set(p.pt.dateISO, (a.dates.get(p.pt.dateISO) || 0) + 1);
+      }
+      if (p.nc !== null) a.ncs.push(p.nc);
+    }
+    var out = {};
+    for (var k = 0; k < phrases.length; k++) {
+      var phrase = phrases[k];
+      var acc = accum[phrase];
+      var ncs = acc.ncs.slice().sort(function (x, y) { return x - y; });
+      var dateCounts = acc.dates;
+      var d = {
+        days: dateCounts.size,
+        hourly: acc.hourly,
+        weekly: acc.weekly
+      };
+      if (dateCounts.size) {
+        var keys = Array.from(dateCounts.keys()).sort();
+        var fromIso = keys[0];
+        var toIso = keys[keys.length - 1];
+        var fromED = epochDayOfIso(fromIso);
+        var toED = epochDayOfIso(toIso);
+        var span = (toED - fromED) + 1;
+        d.from = fromIso;
+        d.to = toIso;
+        d.span_days = span;
+        var series = [];
+        var cur;
+        if (span <= 365) {
+          for (cur = fromED; cur <= toED; cur++) {
+            series.push(dateCounts.get(isoFromEpochDay(cur)) || 0);
+          }
+          d.daily = series;
+          d.daily_unit = 'day';
+        } else {
+          for (cur = fromED; cur <= toED; cur += 7) {
+            var wt = 0;
+            for (var off = 0; off < 7; off++) {
+              wt += dateCounts.get(isoFromEpochDay(cur + off)) || 0;
+            }
+            series.push(wt);
+          }
+          d.daily = series;
+          d.daily_unit = 'week';
+        }
+      }
+      if (ncs.length) {
+        d.nc_min = ncs[0];
+        d.nc_med = ncs[Math.floor(ncs.length / 2)];
+        d.nc_max = ncs[ncs.length - 1];
+        var over = 0;
+        for (var z = 0; z < ncs.length; z++) if (ncs[z] >= 100) over++;
+        d.nc_over_100 = over;
+      }
+      out[phrase] = d;
+    }
+    return out;
+  }
+
+  function epochDayOfIso(iso) {
+    // iso is a PT calendar date YYYY-MM-DD; treat as UTC midnight for a
+    // stable integer day index.
+    var y = +iso.slice(0, 4), m = +iso.slice(5, 7), da = +iso.slice(8, 10);
+    return Math.floor(Date.UTC(y, m - 1, da) / 86400000);
+  }
+
+  // Mirror of find_long_active_cases(). Uses the UTC date slice for the
+  // span (as the Python does), not the PT date.
+  function findLongActiveCases(pre) {
+    var byPhrase = new Map();
+    for (var i = 0; i < pre.length; i++) {
+      var p = pre[i];
+      if (!p.norm || !p.isCase) continue;
+      var b = byPhrase.get(p.norm);
+      if (!b) { b = { dates: [], ncs: [] }; byPhrase.set(p.norm, b); }
+      if (p.utcDate) b.dates.push(p.utcDate);
+      if (p.nc !== null) b.ncs.push(p.nc);
+    }
+    var out = [];
+    byPhrase.forEach(function (b, phrase) {
+      var dates = b.dates;
+      if (!dates.length) return;
+      var distinct = new Set(dates).size;
+      var count = dates.length;
+      if (count < LONG_ACTIVE_MIN_COUNT || distinct < LONG_ACTIVE_MIN_DAYS) return;
+      var ncs = b.ncs.slice().sort(function (x, y) { return x - y; });
+      var medianNc = ncs.length ? ncs[Math.floor(ncs.length / 2)] : null;
+      out.push([phrase, count, distinct, minStr(dates), maxStr(dates), medianNc]);
+    });
+    out.sort(function (a, b) { return b[1] - a[1]; });
+    return out.slice(0, LONG_ACTIVE_TOP);
+  }
+
+  function minStr(arr) { var m = arr[0]; for (var i = 1; i < arr.length; i++) if (arr[i] < m) m = arr[i]; return m; }
+  function maxStr(arr) { var m = arr[0]; for (var i = 1; i < arr.length; i++) if (arr[i] > m) m = arr[i]; return m; }
+
+  function round1(x) { return Math.round(x * 10) / 10; }
+
+  // ── Main aggregation: mirror of process_agency(), over precomputed
+  // rows already filtered to the desired window. Returns the
+  // window-dependent fields of the build's per-agency dict. ──
+  function aggregate(pre) {
+    var verbatim = new Map();
+    var tokenCounts = new Map();
+    var blank = 0;
+    var lengths = [];
+    var hourDow = [];
+    for (var d = 0; d < 7; d++) hourDow.push(new Array(24).fill(0));
+    var timedRows = 0;
+
+    for (var i = 0; i < pre.length; i++) {
+      var p = pre[i];
+      var norm = p.norm;
+      if (norm === null) {
+        blank += 1;
+      } else if (norm === BLANK_LABEL) {
+        blank += 1;
+        verbatim.set(norm, (verbatim.get(norm) || 0) + 1);
+      } else {
+        verbatim.set(norm, (verbatim.get(norm) || 0) + 1);
+        lengths.push(norm.length);
+        var toks = p.tokens || [];
+        for (var t = 0; t < toks.length; t++) {
+          tokenCounts.set(toks[t], (tokenCounts.get(toks[t]) || 0) + 1);
+        }
+      }
+      if (p.pt) {
+        hourDow[p.pt.weekday][p.pt.hour] += 1;
+        timedRows += 1;
+      }
+    }
+
+    var total = pre.length;
+    var result = {
+      row_count: total,
+      blank_reasons: blank,
+      unique_reasons: verbatim.size,
+      median_length_chars: 0,
+      top1_share_pct: 0,
+      top3_share_pct: 0,
+      verbatim: [],
+      tokens: [],
+      penal_codes: [],
+      hour_dow: hourDow,
+      timed_rows: timedRows,
+      long_active_cases: [],
+      phrase_details: {},
+      verbatim_shown: 0,
+      tokens_shown: 0
+    };
+    if (!verbatim.size) return result;
+
+    var topVerbatimPairs = mostCommon(verbatim, TOP_VERBATIM);
+    var phraseSet = Object.create(null);
+    for (var v = 0; v < topVerbatimPairs.length; v++) phraseSet[topVerbatimPairs[v][0]] = 1;
+    var longActive = findLongActiveCases(pre);
+    for (var la = 0; la < longActive.length; la++) phraseSet[longActive[la][0]] = 1;
+    var phraseDetails = computePhraseDetails(phraseSet, pre);
+
+    var topVerbatim = [];
+    for (var vp = 0; vp < topVerbatimPairs.length; vp++) {
+      var phrase = topVerbatimPairs[vp][0];
+      var c = topVerbatimPairs[vp][1];
+      var codes = (phrase === BLANK_LABEL) ? [] : detectCodes(phrase);
+      topVerbatim.push([phrase, c, codes.length ? codes : null, phraseDetails[phrase] || null]);
+    }
+
+    var topTokens = [];
+    var tokenPairs = mostCommon(tokenCounts, TOP_TOKENS);
+    for (var tp = 0; tp < tokenPairs.length; tp++) {
+      if (PENAL_CODES[tokenPairs[tp][0]] === undefined) {
+        topTokens.push([tokenPairs[tp][0], tokenPairs[tp][1]]);
+      }
+    }
+
+    var codeRows = [];
+    var allTokenPairs = mostCommon(tokenCounts, null);
+    for (var ap = 0; ap < allTokenPairs.length; ap++) {
+      var label = PENAL_CODES[allTokenPairs[ap][0]];
+      if (label) codeRows.push([allTokenPairs[ap][0], label, allTokenPairs[ap][1]]);
+    }
+
+    var top1 = topVerbatimPairs.length ? topVerbatimPairs[0][1] : 0;
+    var top3 = 0;
+    for (var w = 0; w < Math.min(3, topVerbatimPairs.length); w++) top3 += topVerbatimPairs[w][1];
+
+    var sortedLengths = lengths.slice().sort(function (x, y) { return x - y; });
+
+    result.median_length_chars = sortedLengths.length ? Math.trunc(medianFloat(sortedLengths)) : 0;
+    result.top1_share_pct = total ? round1(100 * top1 / total) : 0;
+    result.top3_share_pct = total ? round1(100 * top3 / total) : 0;
+    result.verbatim = topVerbatim;
+    result.tokens = topTokens;
+    result.penal_codes = codeRows;
+    result.long_active_cases = longActive;
+    result.phrase_details = phraseDetails;
+    result.verbatim_shown = topVerbatim.length;
+    result.tokens_shown = topTokens.length;
+    return result;
+  }
+
+  // Python statistics.median: mean of two middle elements for even n.
+  function medianFloat(sorted) {
+    var n = sorted.length;
+    if (n % 2 === 1) return sorted[(n - 1) / 2];
+    return (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  }
+
+  // Per-phrase daily series over the phrase's FULL span (every row, not
+  // a window) — used by the expand panel to show full history with the
+  // out-of-window portion grayed. Returns {from,to,span_days,daily,
+  // daily_unit,fromEpochDay} or null.
+  function fullPhraseSeries(phrase, pre) {
+    var dates = new Map();
+    for (var i = 0; i < pre.length; i++) {
+      var p = pre[i];
+      if (p.norm !== phrase || !p.pt) continue;
+      dates.set(p.pt.dateISO, (dates.get(p.pt.dateISO) || 0) + 1);
+    }
+    if (!dates.size) return null;
+    var keys = Array.from(dates.keys()).sort();
+    var fromED = epochDayOfIso(keys[0]);
+    var toED = epochDayOfIso(keys[keys.length - 1]);
+    var span = (toED - fromED) + 1;
+    var series = [];
+    var unit, step;
+    var cur;
+    if (span <= 365) {
+      unit = 'day'; step = 1;
+      for (cur = fromED; cur <= toED; cur++) series.push(dates.get(isoFromEpochDay(cur)) || 0);
+    } else {
+      unit = 'week'; step = 7;
+      for (cur = fromED; cur <= toED; cur += 7) {
+        var wt = 0;
+        for (var off = 0; off < 7; off++) wt += dates.get(isoFromEpochDay(cur + off)) || 0;
+        series.push(wt);
+      }
+    }
+    return {
+      from: keys[0], to: keys[keys.length - 1], span_days: span,
+      daily: series, daily_unit: unit, fromEpochDay: fromED, step: step
+    };
+  }
+
+  var api = {
+    precompute: precompute,
+    aggregate: aggregate,
+    fullPhraseSeries: fullPhraseSeries,
+    epochDayOfIso: epochDayOfIso,
+    isoFromEpochDay: isoFromEpochDay,
+    // exported for tests / debugging
+    normalizeReason: normalizeReason,
+    tokenize: tokenize,
+    detectCodes: detectCodes,
+    BLANK_LABEL: BLANK_LABEL
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    root.JustAgg = api;
+  }
+})(typeof self !== 'undefined' ? self : this);

--- a/docs/justifications.html
+++ b/docs/justifications.html
@@ -1248,8 +1248,147 @@
     border-radius: 3px;
     font-size: 9pt;
   }
+  /* ── Date-window slider (lives inside the .audit-window banner) ── */
+  .date-window-control {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid #a5f3fc;
+  }
+  .dw-top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .dw-readout {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    color: #0e7490;
+    font-size: 10.5pt;
+  }
+  .dw-span {
+    color: #155e75;
+    font-weight: 400;
+    font-size: 9.5pt;
+  }
+  .dw-filtered-badge {
+    display: inline-block;
+    font-size: 8pt;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #92400e;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-radius: 999px;
+    padding: 1px 8px;
+  }
+  .dw-presets { display: flex; flex-wrap: wrap; gap: 4px; margin-left: auto; }
+  .dw-preset {
+    font-family: inherit;
+    font-size: 9pt;
+    font-weight: 600;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid #a5f3fc;
+    background: #fff;
+    color: #0e7490;
+    cursor: pointer;
+  }
+  .dw-preset:hover { background: #cffafe; }
+  .dw-preset.active { background: #0891b2; border-color: #0891b2; color: #fff; }
+  .dw-slider {
+    position: relative;
+    height: 30px;
+    margin: 8px 2px 0;
+  }
+  .dw-track {
+    position: absolute;
+    top: 13px; left: 0; right: 0;
+    height: 4px;
+    background: #a5f3fc;
+    border-radius: 2px;
+  }
+  .dw-fill {
+    position: absolute;
+    top: 13px;
+    height: 4px;
+    background: #0891b2;
+    border-radius: 2px;
+  }
+  .dw-slider input[type=range] {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%;
+    height: 30px;
+    margin: 0;
+    background: transparent;
+    pointer-events: none;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  .dw-slider input[type=range]::-webkit-slider-runnable-track {
+    background: transparent;
+    height: 30px;
+    border: none;
+  }
+  .dw-slider input[type=range]::-moz-range-track {
+    background: transparent;
+    height: 30px;
+    border: none;
+  }
+  .dw-slider input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    pointer-events: auto;
+    width: 16px; height: 16px;
+    margin-top: 7px;
+    border-radius: 50%;
+    background: #0e7490;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+  }
+  .dw-slider input[type=range]::-moz-range-thumb {
+    pointer-events: auto;
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    background: #0e7490;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+  }
+  .dw-slider input[type=range]:focus-visible::-webkit-slider-thumb {
+    outline: 2px solid #2563eb; outline-offset: 1px;
+  }
+  .dw-loading {
+    font-size: 9pt;
+    color: #155e75;
+    font-style: italic;
+    margin-top: 8px;
+  }
+
+  /* Out-of-window bars in the per-phrase expand sparkline render gray so
+     the full history stays visible as context when a window is selected. */
+  .daily-spark .spark-bar.out .spark-fill { background: #cbd5e1; }
+  .daily-spark .spark-bar.out.empty .spark-fill { background: transparent; }
+  .spark-axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 7.5pt;
+    color: #94a3b8;
+    font-variant-numeric: tabular-nums;
+    margin-top: 3px;
+  }
+  .spark-window-note {
+    font-size: 8.5pt;
+    color: #0e7490;
+    margin-top: 3px;
+  }
+
   @media (max-width: 720px) {
     .toolbar select { width: 100%; min-width: 0; }
+    .dw-presets { margin-left: 0; }
   }
 </style>
 </head>
@@ -1271,6 +1410,7 @@
 </div>
 
 <script src="js/utils.js"></script>
+<script src="js/justifications_agg.js"></script>
 <script src="js/justifications.js"></script>
 <script data-goatcounter="https://none-below.goatcounter.com/count"
         async src="https://gc.zgo.at/count.js"></script>

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -25,6 +25,14 @@ token cloud:
   - Plate-pattern strings (mixed letter+digit, 5-8 chars) are excluded.
 
 Output: docs/data/justifications.json
+
+PARITY CONTRACT: docs/js/justifications_agg.js re-implements this
+module's per-agency aggregation so the justifications page can
+re-aggregate a narrowed date window live in the browser. If you change
+the parser, tokenizer, penal-code table, or any per-agency aggregate
+here, mirror it there. tests/test_justifications_agg.py
+(scripts/verify_justifications_agg.js) asserts the two agree at the full
+window for every own-audit agency and will fail if they drift.
 """
 
 import json

--- a/scripts/build_justifications.py
+++ b/scripts/build_justifications.py
@@ -32,7 +32,11 @@ re-aggregate a narrowed date window live in the browser. If you change
 the parser, tokenizer, penal-code table, or any per-agency aggregate
 here, mirror it there. tests/test_justifications_agg.py
 (scripts/verify_justifications_agg.js) asserts the two agree at the full
-window for every own-audit agency and will fail if they drift.
+window for every own-audit agency and will fail if they drift — run
+`make build` first so the compared artifacts reflect your change
+(`make test` alone will not rebuild them). The check fails closed: a
+NEW per-agency field added here trips it until the field is either
+ported to the JS or allowlisted as window-independent in the verifier.
 """
 
 import json

--- a/scripts/verify_justifications_agg.js
+++ b/scripts/verify_justifications_agg.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 zero-below
 /* Parity check: the browser-side aggregation in
    docs/js/justifications_agg.js must reproduce, at the full date window,
    exactly what scripts/build_justifications.py wrote into
@@ -8,10 +10,24 @@
 
    For every own-audit agency, it reads the raw rows from
    docs/data/audit/<slug>.json, runs JustAgg.aggregate over ALL rows,
-   and deep-compares each window-dependent field against the published
-   per-agency entry. Integer/string fields must match exactly; the two
-   percent fields are allowed a 0.1 tolerance (Python round() is
-   half-to-even, JS Math.round is half-up).
+   and deep-compares the result against the published per-agency entry.
+
+   The check FAILS CLOSED on schema drift: rather than listing the
+   window-dependent fields (a list that would silently go stale when
+   build_justifications.py grows a field), it keeps one allowlist of
+   window-INDEPENDENT keys and requires every other key of each build
+   entry to be reproduced by aggregate() — and every aggregate() key to
+   exist in the build entry. A new per-agency field therefore breaks
+   this check until it is either ported to justifications_agg.js or
+   consciously added to WINDOW_INDEPENDENT below (in which case the
+   page's windowed view keeps showing its full-window value).
+
+   Integer/string fields must match exactly; the two percent fields are
+   allowed a 0.1 tolerance (Python round() is half-to-even, JS
+   Math.round is half-up). JustAgg.fullPhraseSeries — the series the
+   expand panel actually renders once raw rows load, which is not part
+   of aggregate()'s output — is additionally cross-checked against the
+   parity-gated phrase_details series for every published phrase.
 
    Usage:  node scripts/verify_justifications_agg.js
    Exit 0 on full parity, 1 on any mismatch. */
@@ -26,16 +42,26 @@ const JUST = path.join(ROOT, 'docs', 'data', 'justifications.json');
 const AUDIT_DIR = path.join(ROOT, 'docs', 'data', 'audit');
 const Agg = require(path.join(ROOT, 'docs', 'js', 'justifications_agg.js'));
 
-// Window-dependent fields the build emits that aggregate() reproduces.
-const EXACT_SCALARS = [
-  'row_count', 'blank_reasons', 'unique_reasons',
-  'median_length_chars', 'verbatim_shown', 'tokens_shown', 'timed_rows'
-];
-const PCT_FIELDS = ['top1_share_pct', 'top3_share_pct'];
-const DEEP_FIELDS = [
-  'verbatim', 'tokens', 'penal_codes', 'hour_dow',
-  'long_active_cases', 'phrase_details'
-];
+// Keys of a build entry that do NOT depend on the selected date window:
+// identity/registry fields, portal policy text, the cross-agency
+// external aggregate (partner rows live in other agencies' audits), the
+// audit CSV schema, and the build's UTC-sliced date bounds. Everything
+// else must be reproduced by JustAgg.aggregate().
+const WINDOW_INDEPENDENT = new Set([
+  'has_own_audit',
+  'slug',
+  'display_name',
+  'acceptable_use_policy',
+  'prohibited_uses',
+  'external_aggregated',
+  'audit_schema',
+  'has_justification_column',
+  'search_date_min',
+  'search_date_max',
+]);
+
+// Python round() is half-to-even, JS Math.round half-up — allow 0.1.
+const PCT_FIELDS = new Set(['top1_share_pct', 'top3_share_pct']);
 
 // Canonical JSON with object keys sorted recursively, so we compare
 // values rather than key insertion order (the Python build emits
@@ -51,10 +77,14 @@ function canon(v) {
   return JSON.stringify(v);
 }
 
-function diffField(slug, name, got, want, problems) {
-  if (canon(got) !== canon(want)) {
-    problems.push({ slug, field: name });
-  }
+// The series fields of a phrase_details entry / fullPhraseSeries
+// result, for the cross-check between the two.
+function seriesView(d) {
+  if (!d || !d.from) return null;
+  return {
+    from: d.from, to: d.to, span_days: d.span_days,
+    daily: d.daily, daily_unit: d.daily_unit,
+  };
 }
 
 function main() {
@@ -78,13 +108,43 @@ function main() {
     const pre = Agg.precompute(rows);
     const got = Agg.aggregate(pre);
 
-    for (const f of EXACT_SCALARS) diffField(slug, f, got[f], a[f], problems);
-    for (const f of PCT_FIELDS) {
-      if (Math.abs((got[f] || 0) - (a[f] || 0)) > 0.1) {
-        problems.push({ slug, field: f + ' (got ' + got[f] + ' want ' + a[f] + ')' });
+    for (const f of Object.keys(a)) {
+      if (WINDOW_INDEPENDENT.has(f)) continue;
+      if (!(f in got)) {
+        problems.push({
+          slug,
+          field: f + ' (in build output but not reproduced by aggregate() — ' +
+            'port it to justifications_agg.js or add it to WINDOW_INDEPENDENT)',
+        });
+        continue;
+      }
+      if (PCT_FIELDS.has(f)) {
+        if (Math.abs((got[f] || 0) - (a[f] || 0)) > 0.1) {
+          problems.push({ slug, field: f + ' (got ' + got[f] + ' want ' + a[f] + ')' });
+        }
+      } else if (canon(got[f]) !== canon(a[f])) {
+        problems.push({ slug, field: f });
       }
     }
-    for (const f of DEEP_FIELDS) diffField(slug, f, got[f], a[f], problems);
+    for (const f of Object.keys(got)) {
+      if (!(f in a) && !WINDOW_INDEPENDENT.has(f)) {
+        problems.push({
+          slug,
+          field: f + ' (returned by aggregate() but absent from the build output)',
+        });
+      }
+    }
+
+    // fullPhraseSeries must agree with the parity-checked phrase_details
+    // series at the full window for every published phrase.
+    const details = a.phrase_details || {};
+    for (const phrase of Object.keys(details)) {
+      const want = seriesView(details[phrase]);
+      const fs2 = Agg.fullPhraseSeries(phrase, pre);
+      if (canon(seriesView(fs2)) !== canon(want)) {
+        problems.push({ slug, field: 'fullPhraseSeries(' + phrase + ')' });
+      }
+    }
     checked++;
   }
 

--- a/scripts/verify_justifications_agg.js
+++ b/scripts/verify_justifications_agg.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/* Parity check: the browser-side aggregation in
+   docs/js/justifications_agg.js must reproduce, at the full date window,
+   exactly what scripts/build_justifications.py wrote into
+   docs/data/justifications.json. This protects the date-window slider
+   (which re-aggregates client-side) from silently diverging from the
+   canonical build.
+
+   For every own-audit agency, it reads the raw rows from
+   docs/data/audit/<slug>.json, runs JustAgg.aggregate over ALL rows,
+   and deep-compares each window-dependent field against the published
+   per-agency entry. Integer/string fields must match exactly; the two
+   percent fields are allowed a 0.1 tolerance (Python round() is
+   half-to-even, JS Math.round is half-up).
+
+   Usage:  node scripts/verify_justifications_agg.js
+   Exit 0 on full parity, 1 on any mismatch. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const JUST = path.join(ROOT, 'docs', 'data', 'justifications.json');
+const AUDIT_DIR = path.join(ROOT, 'docs', 'data', 'audit');
+const Agg = require(path.join(ROOT, 'docs', 'js', 'justifications_agg.js'));
+
+// Window-dependent fields the build emits that aggregate() reproduces.
+const EXACT_SCALARS = [
+  'row_count', 'blank_reasons', 'unique_reasons',
+  'median_length_chars', 'verbatim_shown', 'tokens_shown', 'timed_rows'
+];
+const PCT_FIELDS = ['top1_share_pct', 'top3_share_pct'];
+const DEEP_FIELDS = [
+  'verbatim', 'tokens', 'penal_codes', 'hour_dow',
+  'long_active_cases', 'phrase_details'
+];
+
+// Canonical JSON with object keys sorted recursively, so we compare
+// values rather than key insertion order (the Python build emits
+// phrase_details keys in set-hash order; the JS port uses insertion
+// order — same data, different order).
+function canon(v) {
+  if (Array.isArray(v)) return '[' + v.map(canon).join(',') + ']';
+  if (v && typeof v === 'object') {
+    return '{' + Object.keys(v).sort().map(function (k) {
+      return JSON.stringify(k) + ':' + canon(v[k]);
+    }).join(',') + '}';
+  }
+  return JSON.stringify(v);
+}
+
+function diffField(slug, name, got, want, problems) {
+  if (canon(got) !== canon(want)) {
+    problems.push({ slug, field: name });
+  }
+}
+
+function main() {
+  if (!fs.existsSync(JUST)) {
+    console.error('missing ' + JUST + ' — run build_justifications.py first');
+    process.exit(2);
+  }
+  const data = JSON.parse(fs.readFileSync(JUST, 'utf8'));
+  const agencies = data.agencies || {};
+  let checked = 0;
+  let skipped = 0;
+  const problems = [];
+
+  for (const slug of Object.keys(agencies)) {
+    const a = agencies[slug];
+    if (a.has_own_audit === false) { skipped++; continue; }
+    const auditPath = path.join(AUDIT_DIR, slug + '.json');
+    if (!fs.existsSync(auditPath)) { skipped++; continue; }
+    const audit = JSON.parse(fs.readFileSync(auditPath, 'utf8'));
+    const rows = audit.rows || [];
+    const pre = Agg.precompute(rows);
+    const got = Agg.aggregate(pre);
+
+    for (const f of EXACT_SCALARS) diffField(slug, f, got[f], a[f], problems);
+    for (const f of PCT_FIELDS) {
+      if (Math.abs((got[f] || 0) - (a[f] || 0)) > 0.1) {
+        problems.push({ slug, field: f + ' (got ' + got[f] + ' want ' + a[f] + ')' });
+      }
+    }
+    for (const f of DEEP_FIELDS) diffField(slug, f, got[f], a[f], problems);
+    checked++;
+  }
+
+  if (problems.length) {
+    console.error('PARITY FAILURES (' + problems.length + '):');
+    const byField = {};
+    for (const p of problems) {
+      byField[p.field] = byField[p.field] || [];
+      byField[p.field].push(p.slug);
+    }
+    for (const field of Object.keys(byField)) {
+      const slugs = byField[field];
+      console.error('  ' + field + ': ' + slugs.length + ' agencies — ' +
+        slugs.slice(0, 5).join(', ') + (slugs.length > 5 ? ', …' : ''));
+    }
+    console.error('checked ' + checked + ' own-audit agencies, skipped ' + skipped);
+    process.exit(1);
+  }
+
+  console.log('parity OK: ' + checked + ' own-audit agencies match the build (skipped ' + skipped + ')');
+  process.exit(0);
+}
+
+main();

--- a/tests/test_justifications_agg.py
+++ b/tests/test_justifications_agg.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
 """Parity gate for the justifications date-window slider.
 
 The slider re-aggregates a narrowed window in the browser from

--- a/tests/test_justifications_agg.py
+++ b/tests/test_justifications_agg.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Parity gate for the justifications date-window slider.
+
+The slider re-aggregates a narrowed window in the browser from
+docs/js/justifications_agg.js. That file is a hand-maintained port of
+scripts/build_justifications.py's per-agency aggregation; if the two
+drift, the page silently shows numbers that disagree with the canonical
+build. scripts/verify_justifications_agg.js asserts they agree at the
+full window for every own-audit agency. This test just runs it under
+pytest so `make test` / CI catch drift.
+
+Skipped when Node is unavailable (the aggregation is JS); CI installs
+Node so the gate runs there.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+VERIFIER = ROOT / "scripts" / "verify_justifications_agg.js"
+JUST = ROOT / "docs" / "data" / "justifications.json"
+AUDIT_DIR = ROOT / "docs" / "data" / "audit"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_js_aggregation_matches_build():
+    assert JUST.exists(), "run build_justifications.py first (make build)"
+    assert AUDIT_DIR.exists(), "run build_audit_log.py first (make build)"
+    result = subprocess.run(
+        ["node", str(VERIFIER)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    # On failure the verifier prints a per-field breakdown to stderr.
+    assert result.returncode == 0, (
+        "justifications_agg.js diverged from build_justifications.py:\n"
+        + result.stdout
+        + result.stderr
+    )


### PR DESCRIPTION
## What

Adds a **date-window slider** to the per-agency justifications page so you can narrow the lookback. Especially useful for San Mateo, whose PRA-sourced audit history spans years (2023-01-01 → today, ~75k rows), and for the lengthening history we have on other agencies. Narrowing re-aggregates **every own-data section** together: headline stats, top-reason bars, token cloud, detected penal/vehicle codes, and the day×hour timing heatmap.

## How it works

The page already publishes each agency's raw audit rows at `data/audit/<slug>.json` (the "View raw audit data" link). The slider fetches those rows once, precomputes per-row fields, and re-aggregates client-side as the window changes — plain counting per drag, so it stays responsive even on San Mateo's 75k rows.

At the **full window** the page still renders the canonical build output, so dragging in from "All" never jumps. The browser aggregation is a faithful port of `build_justifications.py` into `docs/js/justifications_agg.js`.

### Parity gate (no drift)
`scripts/verify_justifications_agg.js` re-runs the JS aggregation over every own-audit agency and asserts it equals `justifications.json` at the full window — exact match for all 103 own-audit agencies. `tests/test_justifications_agg.py` runs this under pytest, and CI now installs Node so the Python build and the JS port can't silently diverge. The matched-pair contract is documented in both file headers.

## UI

- Dual-handle slider + presets (30d / 90d / 6mo / 1yr / All), live readout, and a "Filtered" badge, inside the data-window banner.
- **Per-phrase expand:** the sparkline now shows the phrase's *full history* with a visible date axis (it had no dates before); when a window is active, in-window bars are colored and out-of-window bars are grayed, with a "Highlighted window" label.
- The cross-agency **partner-searches** section is labeled as full-window when a filter is active — those rows live in other agencies' audits and aren't fetched here, so the slider can't filter them.

## Verification

- Browser-tested on San Mateo end-to-end: 74,730 → 7,495 searches at 90d, drag works, grayed history + axis render, no console errors.
- Edge cases checked: external-only agency shows no slider; Fontana (audit with no reason column) still gets the slider for its heatmap/stats.
- Full suite: **667 passed**.