### PR TITLE
Geocode all 80 flagged recipients, stop issue-comment floods (#636)

### DIFF
--- a/.github/workflows/refresh-flock-data.yml
+++ b/.github/workflows/refresh-flock-data.yml
@@ -123,6 +123,7 @@ jobs:
           if [ ! -f /tmp/crawl.log ]; then exit 0; fi
           ERRORS=$(grep -E "PARSE_ERROR: " /tmp/crawl.log | sort -u || true)
           if [ -z "$ERRORS" ]; then exit 0; fi
+          ERRORS_HASH=$(echo "$ERRORS" | sha256sum | cut -d' ' -f1)
           {
             echo "Parser tripped on one or more agency portals. Files were"
             echo "saved; re-parse via \`parse --force --slug <slug>\` after"
@@ -133,10 +134,22 @@ jobs:
             echo '```'
             echo
             echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "<!-- parse-errors-hash: $ERRORS_HASH -->"
           } > /tmp/parse-issue-body.md
           EXISTING=$(gh issue list --label parser --state open --json number -q '.[0].number' || true)
           if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body-file /tmp/parse-issue-body.md
+            # Skip the comment when this run's errors match the newest ones
+            # already on the issue — repeat failures on every refresh run
+            # flooded the rolling issue with identical comments (#223).
+            LAST_HASH=$(gh issue view "$EXISTING" --json body,comments \
+              -q '[.body, (.comments[-1].body // "")] | join("\n")' \
+              | grep -oE 'parse-errors-hash: [0-9a-f]+' | tail -1 || true)
+            if [ "$LAST_HASH" = "parse-errors-hash: $ERRORS_HASH" ]; then
+              echo "Same parse errors already reported on issue #$EXISTING; not commenting."
+            else
+              gh issue comment "$EXISTING" --body-file /tmp/parse-issue-body.md
+            fi
           else
             gh issue create \
               --title "Parser tripped on a new Flock portal variant" \
@@ -169,36 +182,46 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! uv run python scripts/check_recipient_coords.py > /tmp/coord-check.txt 2>&1; then
+          if uv run python scripts/check_recipient_coords.py > /tmp/coord-check.txt 2>&1; then
             cat /tmp/coord-check.txt
-            EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
-            if [ -n "$EXISTING" ]; then
-              {
-                echo "Updated from flock refresh:"
-                echo
-                echo '```'
-                cat /tmp/coord-check.txt
-                echo '```'
-              } > /tmp/coord-issue-body.md
-              gh issue comment "$EXISTING" --body-file /tmp/coord-issue-body.md
-            else
-              {
-                echo "The following agencies receive data from public agencies but have no lat/lng in the registry:"
-                echo
-                echo '```'
-                cat /tmp/coord-check.txt
-                echo '```'
-                echo
-                echo "Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
-              } > /tmp/coord-issue-body.md
-              gh issue create \
-                --title "Recipients missing coordinates in agency registry" \
-                --label geocoding \
-                --body-file /tmp/coord-issue-body.md
-            fi
-          else
-            cat /tmp/coord-check.txt
+            exit 0
           fi
+          cat /tmp/coord-check.txt
+          {
+            echo "The following agencies receive data from public agencies but have no lat/lng in the registry:"
+            echo
+            echo '```'
+            cat /tmp/coord-check.txt
+            echo '```'
+            echo
+            echo "Add coordinates to \`assets/agency_registry.json\` so they appear on the sharing map."
+          } > /tmp/coord-issue-body.md
+          EXISTING=$(gh issue list --label geocoding --state open --json number -q '.[0].number' || true)
+          if [ -z "$EXISTING" ]; then
+            gh issue create \
+              --title "Recipients missing coordinates in agency registry" \
+              --label geocoding \
+              --body-file /tmp/coord-issue-body.md
+            exit 0
+          fi
+          # The issue body is bot-owned and always holds the current list.
+          # Only touch the issue when the list changes — commenting the full
+          # list on every refresh run flooded the issue with hundreds of
+          # identical comments (#516, #636).
+          gh issue view "$EXISTING" --json body -q .body | tr -d '\r' > /tmp/coord-issue-old.md
+          if diff -u /tmp/coord-issue-old.md /tmp/coord-issue-body.md > /tmp/coord-issue-diff.txt; then
+            echo "Recipient list unchanged; leaving issue #$EXISTING alone."
+            exit 0
+          fi
+          gh issue edit "$EXISTING" --body-file /tmp/coord-issue-body.md
+          {
+            echo "Recipient list changed:"
+            echo
+            echo '```diff'
+            grep -E '^[-+][^-+]' /tmp/coord-issue-diff.txt || true
+            echo '```'
+          } > /tmp/coord-issue-comment.md
+          gh issue comment "$EXISTING" --body-file /tmp/coord-issue-comment.md
 
       - name: Commit and push
         id: commit

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -7848,8 +7848,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2915670",
+      "name": "Columbia",
+      "state": "MO",
+      "lat": 38.94729,
+      "lng": -92.326387
     }
   },
   {
@@ -7870,8 +7874,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "place",
+      "fips": "0606000",
+      "name": "Berkeley",
+      "state": "CA",
+      "lat": 37.865673,
+      "lng": -122.298725
     }
   },
   {
@@ -9019,8 +9027,8 @@
       "Fort Bend County Const TX Pct 4 (inactive)"
     ],
     "display_name": null,
-    "agency_role": "other",
-    "agency_type": "county",
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
     "website": null,
     "tags": [
       "needs-review",
@@ -9725,8 +9733,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CA"
+      "kind": "place",
+      "fips": "0653000",
+      "name": "Oakland",
+      "state": "CA",
+      "lat": 37.769846,
+      "lng": -122.22569
     }
   },
   {
@@ -9747,7 +9759,14 @@
     "flags": [
       "inactive"
     ],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4816696",
+      "name": "Corinth",
+      "state": "TX",
+      "lat": 33.144714,
+      "lng": -97.070766
+    }
   },
   {
     "agency_id": "cf3cd038-b96c-56f6-9fa2-fc41c2bb0a7c",
@@ -11304,8 +11323,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1311784",
+      "name": "Buford",
+      "state": "GA",
+      "lat": 34.118562,
+      "lng": -83.98861
     }
   },
   {
@@ -11435,8 +11458,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "PA"
+      "kind": "place",
+      "fips": "4261000",
+      "name": "Pittsburgh",
+      "state": "PA",
+      "lat": 40.439936,
+      "lng": -79.975676
     },
     "ori": [
       "PA0022F9E"
@@ -11763,8 +11790,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1320932",
+      "name": "Cumming",
+      "state": "GA",
+      "lat": 34.206067,
+      "lng": -84.133848
     }
   },
   {
@@ -11891,8 +11922,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4553080",
+      "name": "Orangeburg",
+      "state": "SC",
+      "lat": 33.493596,
+      "lng": -80.86688
     }
   },
   {
@@ -11941,8 +11976,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     },
     "ori": [
       "GA060309E"
@@ -12634,8 +12673,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1374964",
+      "name": "Swainsboro",
+      "state": "GA",
+      "lat": 32.585588,
+      "lng": -82.334784
     }
   },
   {
@@ -13061,7 +13104,14 @@
       "private"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4748000",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.109026,
+      "lng": -89.967455
+    }
   },
   {
     "agency_id": "e21d2016-0503-55e2-a5a0-9cc84c7ab258",
@@ -13072,11 +13122,11 @@
       "Flock Safety - Machine Learning Test"
     ],
     "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
+    "agency_role": "test",
+    "agency_type": "test",
     "website": null,
     "tags": [
-      "needs-review"
+      "private"
     ],
     "flags": [],
     "geo": null
@@ -13286,8 +13336,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4572430",
+      "name": "Travelers Rest",
+      "state": "SC",
+      "lat": 34.959971,
+      "lng": -82.444972
     },
     "ori": [
       "SC0231000"
@@ -13366,8 +13420,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "cousub",
+      "fips": "2604929020",
+      "name": "Flint",
+      "state": "MI",
+      "lat": 43.004396,
+      "lng": -83.765627
     }
   },
   {
@@ -13468,7 +13526,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1345488",
+      "name": "Lawrenceville",
+      "state": "GA",
+      "lat": 33.952875,
+      "lng": -83.992231
+    }
   },
   {
     "agency_id": "d919e136-cd32-54f0-8f04-a6e97894a26d",
@@ -13488,8 +13553,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1373256",
+      "name": "Statesboro",
+      "state": "GA",
+      "lat": 32.437726,
+      "lng": -81.775637
     },
     "ori": [
       "GA0160400"
@@ -13513,8 +13582,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     },
     "ori": [
       "GA0600900"
@@ -13537,8 +13610,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     }
   },
   {
@@ -13613,7 +13690,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1729938",
+      "name": "Glenview",
+      "state": "IL",
+      "lat": 42.085162,
+      "lng": -87.827388
+    }
   },
   {
     "agency_id": "9d50bf7e-cbb8-5650-b04b-4063fbef26c6",
@@ -13768,7 +13852,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1335324",
+      "name": "Griffin",
+      "state": "GA",
+      "lat": 33.243188,
+      "lng": -84.271861
+    }
   },
   {
     "agency_id": "c8d64dad-acbe-514a-a471-0b4a82af40a0",
@@ -13841,8 +13932,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5134304",
+      "name": "Hampden-Sydney",
+      "state": "VA",
+      "lat": 37.244012,
+      "lng": -78.475746
     }
   },
   {
@@ -14555,8 +14650,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2932248",
+      "name": "Hillsboro",
+      "state": "MO",
+      "lat": 38.232954,
+      "lng": -90.567195
     }
   },
   {
@@ -14688,8 +14787,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4740000",
+      "name": "Knoxville",
+      "state": "TN",
+      "lat": 35.97068,
+      "lng": -83.94927
     }
   },
   {
@@ -14701,8 +14804,8 @@
       "La Salle County IL PD - OLD"
     ],
     "display_name": null,
-    "agency_role": "police",
-    "agency_type": "county",
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
     "website": null,
     "tags": [
       "public"
@@ -14761,8 +14864,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4740000",
+      "name": "Knoxville",
+      "state": "TN",
+      "lat": 35.97068,
+      "lng": -83.94927
     }
   },
   {
@@ -14783,8 +14890,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4530895",
+      "name": "Greenwood",
+      "state": "SC",
+      "lat": 34.195409,
+      "lng": -82.153666
     },
     "ori": [
       "SC0240500"
@@ -15001,8 +15112,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2148000",
+      "name": "Louisville",
+      "state": "KY",
+      "lat": 38.224728,
+      "lng": -85.740614
     }
   },
   {
@@ -15022,8 +15137,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "KY"
+      "kind": "place",
+      "fips": "2148000",
+      "name": "Louisville",
+      "state": "KY",
+      "lat": 38.224728,
+      "lng": -85.740614
     }
   },
   {
@@ -15322,8 +15441,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3755000",
+      "name": "Raleigh",
+      "state": "NC",
+      "lat": 35.831868,
+      "lng": -78.641042
     }
   },
   {
@@ -15343,8 +15466,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1706613",
+      "name": "Bloomington",
+      "state": "IL",
+      "lat": 40.475777,
+      "lng": -88.969912
     }
   },
   {
@@ -15392,7 +15519,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "1349008",
+      "name": "Macon-Bibb County",
+      "state": "GA",
+      "lat": 32.808845,
+      "lng": -83.694194
+    }
   },
   {
     "agency_id": "2db4d130-ca61-5205-80d1-186063c14d83",
@@ -15411,8 +15545,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5180864",
+      "name": "Verona",
+      "state": "VA",
+      "lat": 38.194307,
+      "lng": -79.009469
     }
   },
   {
@@ -15516,8 +15654,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "MO"
+      "kind": "place",
+      "fips": "2937000",
+      "name": "Jefferson City",
+      "state": "MO",
+      "lat": 38.567461,
+      "lng": -92.175254
     }
   },
   {
@@ -15647,8 +15789,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1304000",
+      "name": "Atlanta",
+      "state": "GA",
+      "lat": 33.762909,
+      "lng": -84.422675
     },
     "ori": [
       "GA0604400"
@@ -15976,8 +16122,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5157000",
+      "name": "Norfolk",
+      "state": "VA",
+      "lat": 36.923015,
+      "lng": -76.244641
     },
     "ori": [
       "VA1170400"
@@ -16000,8 +16150,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5157000",
+      "name": "Norfolk",
+      "state": "VA",
+      "lat": 36.923015,
+      "lng": -76.244641
     }
   },
   {
@@ -16050,8 +16204,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3728000",
+      "name": "Greensboro",
+      "state": "NC",
+      "lat": 36.09485,
+      "lng": -79.823624
     }
   },
   {
@@ -16233,8 +16391,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1754820",
+      "name": "Oak Lawn",
+      "state": "IL",
+      "lat": 41.713885,
+      "lng": -87.752777
     }
   },
   {
@@ -16697,8 +16859,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4846056",
+      "name": "Magnolia",
+      "state": "TX",
+      "lat": 30.213032,
+      "lng": -95.7426
     }
   },
   {
@@ -16747,8 +16913,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4515295",
+      "name": "Clinton",
+      "state": "SC",
+      "lat": 34.473887,
+      "lng": -81.860899
     },
     "ori": [
       "SC0309E00"
@@ -16827,8 +16997,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1749009",
+      "name": "Milan",
+      "state": "IL",
+      "lat": 41.435497,
+      "lng": -90.562661
     }
   },
   {
@@ -16849,8 +17023,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1379948",
+      "name": "Waleska",
+      "state": "GA",
+      "lat": 34.317022,
+      "lng": -84.550982
     }
   },
   {
@@ -16927,8 +17105,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1718823",
+      "name": "Decatur",
+      "state": "IL",
+      "lat": 39.855983,
+      "lng": -88.933746
     }
   },
   {
@@ -17116,8 +17298,12 @@
       "inactive"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "MI"
+      "kind": "cousub",
+      "fips": "2614543800",
+      "name": "Kochville",
+      "state": "MI",
+      "lat": 43.505646,
+      "lng": -83.98515
     }
   },
   {
@@ -17214,8 +17400,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0135800",
+      "name": "Homewood",
+      "state": "AL",
+      "lat": 33.45855,
+      "lng": -86.80965
     },
     "ori": [
       "AL001419E"
@@ -17266,8 +17456,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1717887",
+      "name": "Crystal Lake",
+      "state": "IL",
+      "lat": 42.233209,
+      "lng": -88.33436
     }
   },
   {
@@ -17592,8 +17786,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "IL"
+      "kind": "place",
+      "fips": "1772000",
+      "name": "Springfield",
+      "state": "IL",
+      "lat": 39.791063,
+      "lng": -89.644572
     }
   },
   {
@@ -18122,11 +18320,11 @@
       "Test IL - PD - Do not use"
     ],
     "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
+    "agency_role": "test",
+    "agency_type": "test",
     "website": null,
     "tags": [
-      "public"
+      "private"
     ],
     "flags": [],
     "geo": {
@@ -18150,7 +18348,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "2973618",
+      "name": "Town and Country",
+      "state": "MO",
+      "lat": 38.630602,
+      "lng": -90.477191
+    }
   },
   {
     "agency_id": "5293b0f3-ec8d-5fd7-a52d-168b57ddc295",
@@ -18197,8 +18402,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4748000",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.109026,
+      "lng": -89.967455
     }
   },
   {
@@ -18350,8 +18559,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0177256",
+      "name": "Tuscaloosa",
+      "state": "AL",
+      "lat": 33.234404,
+      "lng": -87.5283
     }
   },
   {
@@ -18456,8 +18669,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0177256",
+      "name": "Tuscaloosa",
+      "state": "AL",
+      "lat": 33.234404,
+      "lng": -87.5283
     }
   },
   {
@@ -18616,8 +18833,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "VA"
+      "kind": "place",
+      "fips": "5167000",
+      "name": "Richmond",
+      "state": "VA",
+      "lat": 37.531399,
+      "lng": -77.476009
     },
     "ori": [
       "VA1300300"
@@ -18918,8 +19139,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "GA"
+      "kind": "place",
+      "fips": "1379808",
+      "name": "Waco",
+      "state": "GA",
+      "lat": 33.7026,
+      "lng": -85.189244
     },
     "ori": [
       "GA0710500"
@@ -19192,8 +19417,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CO"
+      "kind": "county",
+      "fips": "28159",
+      "name": "Winston",
+      "state": "MS",
+      "lat": 33.078724,
+      "lng": -89.037391
     }
   },
   {
@@ -19214,8 +19443,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "NC"
+      "kind": "place",
+      "fips": "3775000",
+      "name": "Winston-Salem",
+      "state": "NC",
+      "lat": 36.102863,
+      "lng": -80.260829
     },
     "ori": [
       "NC0340300"
@@ -19239,8 +19472,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "SC"
+      "kind": "place",
+      "fips": "4561405",
+      "name": "Rock Hill",
+      "state": "SC",
+      "lat": 34.938216,
+      "lng": -81.019177
     },
     "ori": [
       "SC0460600"
@@ -19401,8 +19638,12 @@
       "inactive"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4840984",
+      "name": "Lakeway",
+      "state": "TX",
+      "lat": 30.354982,
+      "lng": -97.986269
     }
   },
   {
@@ -19422,8 +19663,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4840984",
+      "name": "Lakeway",
+      "state": "TX",
+      "lat": 30.354982,
+      "lng": -97.986269
     }
   },
   {
@@ -19502,8 +19747,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4805000",
+      "name": "Austin",
+      "state": "TX",
+      "lat": 30.298622,
+      "lng": -97.754134
     },
     "ori": [
       "TX227279E"
@@ -19525,7 +19774,14 @@
       "public"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4805000",
+      "name": "Austin",
+      "state": "TX",
+      "lat": 30.298622,
+      "lng": -97.754134
+    }
   },
   {
     "agency_id": "b779b2fe-4892-5835-bb42-83a4d2ea4639",
@@ -19959,8 +20215,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CT"
+      "kind": "place",
+      "fips": "0937000",
+      "name": "Hartford",
+      "state": "CT",
+      "lat": 41.765933,
+      "lng": -72.681579
     },
     "ori": [
       "CT0020000"
@@ -20031,8 +20291,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CT"
+      "kind": "place",
+      "fips": "0982800",
+      "name": "West Haven",
+      "state": "CT",
+      "lat": 41.272121,
+      "lng": -72.967497
     }
   },
   {
@@ -20053,8 +20317,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "CT"
+      "kind": "place",
+      "fips": "0982660",
+      "name": "West Hartford",
+      "state": "CT",
+      "lat": 41.766568,
+      "lng": -72.754944
     }
   },
   {
@@ -20352,8 +20620,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4706740",
+      "name": "Blountville",
+      "state": "TN",
+      "lat": 36.532994,
+      "lng": -82.32887
     },
     "ori": [
       "TN0820800"
@@ -20657,8 +20929,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4738320",
+      "name": "Johnson City",
+      "state": "TN",
+      "lat": 36.342325,
+      "lng": -82.380915
     }
   },
   {
@@ -21060,8 +21336,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4740000",
+      "name": "Knoxville",
+      "state": "TN",
+      "lat": 35.97068,
+      "lng": -83.94927
     }
   },
   {
@@ -21082,8 +21362,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4748000",
+      "name": "Memphis",
+      "state": "TN",
+      "lat": 35.109026,
+      "lng": -89.967455
     },
     "ori": [
       "TN0792400"
@@ -21159,8 +21443,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TN"
+      "kind": "place",
+      "fips": "4779980",
+      "name": "White Bluff",
+      "state": "TN",
+      "lat": 36.100947,
+      "lng": -87.211874
     },
     "ori": [
       "TN0220300"
@@ -21429,24 +21717,6 @@
       "kind": "state-only",
       "state": "VA"
     }
-  },
-  {
-    "agency_id": "0bf7878d-415e-5d4d-92fd-c44280ef0e82",
-    "slug": "265",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "265"
-    ],
-    "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "tags": [
-      "needs-review"
-    ],
-    "flags": [],
-    "geo": null
   },
   {
     "agency_id": "fd74ddc3-184d-5628-8e8c-f80bc92fd49a",
@@ -27611,7 +27881,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "place",
+      "fips": "4833188",
+      "name": "Hemphill",
+      "state": "TX",
+      "lat": 31.3433,
+      "lng": -93.851913
+    }
   },
   {
     "agency_id": "bf5b6336-9225-5112-b80c-3157ecc2aa64",
@@ -31312,8 +31589,8 @@
       "Melrose Park (IL) Regional RTIC - DO NOT USE"
     ],
     "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
+    "agency_role": "decommissioned",
+    "agency_type": "decommissioned",
     "website": null,
     "tags": [
       "needs-review"
@@ -64467,8 +64744,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "AL"
+      "kind": "place",
+      "fips": "0138272",
+      "name": "Jacksonville",
+      "state": "AL",
+      "lat": 33.810066,
+      "lng": -85.755217
     }
   },
   {
@@ -81950,8 +82231,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "county",
+      "fips": "48491",
+      "name": "Williamson",
+      "state": "TX",
+      "lat": 30.649082,
+      "lng": -97.605065
     }
   },
   {
@@ -89102,7 +89387,14 @@
       "needs-review"
     ],
     "flags": [],
-    "geo": null
+    "geo": {
+      "kind": "county",
+      "fips": "01111",
+      "name": "Randolph",
+      "state": "AL",
+      "lat": 33.296461,
+      "lng": -85.464064
+    }
   },
   {
     "agency_id": "f0d21634-6075-57d9-b5c2-08b1908dcf93",
@@ -96719,8 +97011,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4866000",
+      "name": "Savannah",
+      "state": "TX",
+      "lat": 33.225738,
+      "lng": -96.908125
     }
   },
   {
@@ -108202,8 +108498,12 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "OK"
+      "kind": "place",
+      "fips": "4055000",
+      "name": "Oklahoma City",
+      "state": "OK",
+      "lat": 35.467079,
+      "lng": -97.513657
     }
   },
   {
@@ -109815,8 +110115,11 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "manual",
+      "name": "New Caney",
+      "state": "TX",
+      "lat": 30.1395,
+      "lng": -95.2171
     }
   },
   {
@@ -147169,8 +147472,12 @@
       "needs-review"
     ],
     "geo": {
-      "kind": "state-only",
-      "state": "TX"
+      "kind": "place",
+      "fips": "4872656",
+      "name": "The Woodlands",
+      "state": "TX",
+      "lat": 30.172562,
+      "lng": -95.509813
     },
     "flags": []
   },

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-05-29.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-05-29.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 512507,
   "hotlist_hits_30d": 4589,
   "searches_30d": 555,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-05.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-05.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 517564,
   "hotlist_hits_30d": 4482,
   "searches_30d": 507,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-12.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-12.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 531773,
   "hotlist_hits_30d": 5108,
   "searches_30d": 529,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-19.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-19.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 536655,
   "hotlist_hits_30d": 4233,
   "searches_30d": 490,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-26.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-06-26.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 544654,
   "hotlist_hits_30d": 3668,
   "searches_30d": 496,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/assets/transparency.flocksafety.com/sparks-nv-pd/2026-07-03.json
+++ b/assets/transparency.flocksafety.com/sparks-nv-pd/2026-07-03.json
@@ -16,9 +16,7 @@
   "vehicles_detected_30d": 552247,
   "hotlist_hits_30d": 1957,
   "searches_30d": 546,
-  "sharing_outbound": [
-    "265"
-  ],
+  "sharing_outbound": [],
   "sharing_inbound": [],
   "overview": "Sparks Police Department uses Flock Safety technology to capture objective evidence without compromising on individual privacy. Sparks Police Department utilizes retroactive search to solve crimes after they've occurred. Additionally, Sparks Police Department utilizes real time alerting of hotlist vehicles to capture wanted criminals. In an effort to ensure proper usage and guardrails are in place, they have made the below policies and usage statistics available to the public.",
   "policy_info": "",

--- a/scripts/build_agency_registry.py
+++ b/scripts/build_agency_registry.py
@@ -86,7 +86,8 @@ KNOWN_PRIVATE = [
 
 TEST_NAMES = [
     "Demo", "Delete", "DNU", "DUPLICATE", "Test Demo",
-    "Decommissioned", "Jaime LE Training",
+    "Decommissioned", "Jaime LE Training", "Do Not Use",
+    "Machine Learning Test",
 ]
 
 

--- a/scripts/flock_transparency.py
+++ b/scripts/flock_transparency.py
@@ -810,7 +810,11 @@ def _parse_org_names(body):
             names[-1] = f"{names[-1]}, {part}"
         else:
             names.append(part)
-    return names
+    # Some portals fill the shared-orgs section with a bare count instead
+    # of a partner list ("External organizations with access: 265" on
+    # sparks-nv-pd). A pure number is never an org name — drop it rather
+    # than minting a fake agency (issue #636).
+    return [n for n in names if not n.isdigit()]
 
 
 _PORTAL_CONTENT_MARKERS = (

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -671,6 +671,14 @@ MANUAL_OVERRIDES = {
         "kind": "manual", "name": "Wexford", "state": "PA",
         "lat": 40.6470, "lng": -80.0590,
     },
+    # Montgomery County Constable Pct 4 — office at 21130 US-59,
+    # New Caney, TX (unincorporated; not a census place). The account
+    # name is a comma-split fragment of "Montgomery County Constable,
+    # Precinct 4 (TX)" (issue #636).
+    "c555da83-0c47-5b2b-8988-5a09bf3ef980": {
+        "kind": "manual", "name": "New Caney", "state": "TX",
+        "lat": 30.1395, "lng": -95.2171,
+    },
 }
 
 
@@ -786,6 +794,81 @@ GAZ_OVERRIDES = {
     "592bf6b8-db27-5a54-8802-34d5b841b2ba": ("cousub", "East Hanover", "NJ"),  # East Hanover Twp (Morris Co.)
     "c639c3ab-f1e6-504c-baed-b5ed04d33181": ("cousub", "Monroe", "NJ", "34023"),  # Monroe Twp (Middlesex Co.)
     "ec54b02b-0101-59bc-a7a0-27cc6f96accc": ("cousub", "Lisbon", "CT"),  # Town of Lisbon (resident troopers)
+    # issue #636 — recipients missing coordinates (researched + verified
+    # per-entity; see the issue for the triage record)
+    "5095ae77-a4ff-57bd-956a-5d09630dff5f": ("place", "Hemphill", "TX"),  # 1st Judicial District
+    "4a90ab8e-1b8b-5a79-994e-49dd35818740": ("place", "Jacksonville", "AL"),  # AL - Jacksonville State University Campus PD
+    "c753700e-a641-5f4b-a85c-14b657a14822": ("county", "Randolph", "AL"),  # Alabama Drug Enforcement Task Force Region G
+    "e82c9df2-d04b-5dda-bb3a-b99e2ef82931": ("place", "Buford", "GA"),  # Buford City Schools GA
+    "a5f6beb7-35d3-51a8-aff2-d8d009f96609": ("place", "Pittsburgh", "PA"),  # Carnegie Mellon University PA PD
+    "0e88d56f-0f2c-5484-ae48-b6a011079bda": ("place", "Cumming", "GA"),  # City of Cumming - City Center GA
+    "8576dbae-204e-50a2-8aea-28833c64442d": ("place", "Orangeburg", "SC"),  # Claflin University SC PD
+    "b24639ba-80bc-59af-9c86-da976dd41a34": ("place", "Atlanta", "GA"),  # Clark Atlanta University GA PD
+    "5b1daea9-ac4e-50ac-bd09-ccbbb9716c62": ("place", "Corinth", "TX"),  # Corinth City Marshal [inactive]
+    "595c59c6-1d8b-513a-aa22-fc0e4c1b59f9": ("place", "Swainsboro", "GA"),  # East Georgia State College Campus PD (GA)
+    "4d11f85a-c572-5307-a191-01fccb09acff": ("place", "Johnson City", "TN"),  # East Tennessee State University TN Campus PD
+    "238ad3de-f4cd-5cbf-9aaf-121bb1243444": ("place", "Savannah", "TX"),  # Elm Ridge TX PD
+    "727f66e6-bff5-5b50-b250-6af9200d9453": ("place", "Memphis", "TN"),  # FedEx Air Carrier PD
+    "5ebd965e-7d8f-5c61-8e8e-4979011f1bb9": ("place", "Travelers Rest", "SC"),  # Furman University SC PD
+    "513e2c7e-7c22-5e33-b341-28b85fa3eb45": ("place", "Glenview", "IL"),  # GPSDC (Glenview Dispatch)
+    "36b4faf1-d039-55ef-9dc3-40b8e556404c": ("cousub", "Flint", "MI", "26049"),  # Genesee Co. MI 911 Dispatch Authority
+    "29f8e61a-a729-5dc2-a83e-6890367c2e4a": ("place", "Lawrenceville", "GA"),  # Georgia Gwinnett College PD
+    "d919e136-cd32-54f0-8f04-a6e97894a26d": ("place", "Statesboro", "GA"),  # Georgia Southern University PD (GA)
+    "0a0db7cb-160e-5aed-823e-f11ba091e7cb": ("place", "Atlanta", "GA"),  # Georgia State University GA PD
+    "32851fd9-6d22-589d-b7cd-0ff8df78611a": ("place", "Atlanta", "GA"),  # Georgia Tech GA PD
+    "db24fdeb-80e4-51c2-9a78-cb56b57b70bd": ("place", "Griffin", "GA"),  # Griffin Judicial Circuit
+    "e587d408-7d98-542c-b982-0293da8e129b": ("place", "Hampden-Sydney", "VA"),  # Hampden-Sydney College Campus VA PD
+    "0d679b98-fa65-50aa-a172-8347bf2fe7b8": ("place", "Hillsboro", "MO"),  # Jefferson College Campus MO PD
+    "cc3b2418-9795-5de1-99a4-3cb8cab8cecb": ("place", "Knoxville", "TN"),  # Knoxville Fire Dept TN
+    "01b34cf7-422f-5ddf-b5c3-95e400e0c4b8": ("place", "Lakeway", "TX"),  # Lake Travis ISD TX PD [Inactive]
+    "05b77c43-33f5-5f4f-809d-a76385765016": ("place", "Knoxville", "TN"),  # Lakeshore Park Conservancy (TN)
+    "3aa99c45-2421-51dd-b623-9de3f2f5787c": ("place", "Lakeway", "TX"),  # Lakeway & Bee Cave TX PD(Disp)
+    "2c89a44e-a806-5053-8523-6a998f0055ea": ("place", "Greenwood", "SC"),  # Lander University SC PD
+    "322365a4-00c4-5999-a24b-6fdc1ccb8b35": ("place", "Louisville", "KY"),  # Louisville Metro KY Alcoholic Beverage Control
+    "4923d2ca-c927-5c91-9ede-c6968d133c84": ("place", "Louisville", "KY"),  # Louisville Metro KY Arson Bureau
+    "537b9143-dd76-5e15-a652-f974af6d962b": ("place", "Raleigh", "NC"),  # Meredith College Campus PD (NC)
+    "b86094fb-9d4f-5e4b-a0b6-2f10f32ee624": ("place", "Bloomington", "IL"),  # Metcom Disptach Center IL
+    "9cb6fc81-0706-5a2d-ae5a-3c44be5274b6": ("place", "Macon-Bibb County", "GA"),  # Middle Georgia State University Campus PD
+    "2db4d130-ca61-5205-80d1-186063c14d83": ("place", "Verona", "VA"),  # Middle River VA Jail
+    "4000b55a-faea-5357-860e-702733e8f126": ("place", "Jefferson City", "MO"),  # Missouri Capitol MO PD
+    "062ed728-9122-528d-b281-2a9099be966f": ("place", "Atlanta", "GA"),  # Morehouse College GA PD
+    "0dcdadc8-a6d0-57cf-9f43-300ac3acab55": ("place", "Norfolk", "VA"),  # Norfolk State University VA PD
+    "1fc2cc4a-2531-5a63-aa4e-64eeb60f1020": ("place", "Norfolk", "VA"),  # Norfolk VA Housing Authority
+    "5792ba00-373f-5e22-a66d-ccfc634a29c3": ("place", "Greensboro", "NC"),  # North Carolina A&T University NC PD
+    "08d63ca5-d642-5cc7-a47d-d2ec7c700530": ("place", "Blountville", "TN"),  # Northeast State Community College TN
+    "598aca59-bd7e-5d67-80df-e93bcbdef150": ("place", "Oklahoma City", "OK"),  # OK - 477
+    "0facc144-81b9-5951-9e3d-be23cb11656a": ("place", "Oak Lawn", "IL"),  # OLREC IL Dispatch
+    "03e33852-8173-5c02-acb9-f1acace99988": ("place", "Oakland", "CA"),  # Port Of Oakland (CA)
+    "cf916c0a-c36c-52b7-9bd3-b82703c502bb": ("place", "The Woodlands", "TX"),  # Precinct 3 (TX)
+    "43ff10f6-3ea5-5df1-b594-dc3dd2dfc324": ("place", "Magnolia", "TX"),  # Precinct 5 (TX)
+    "65d079be-0bf9-5384-bd97-d01b6c77cd3f": ("place", "Clinton", "SC"),  # Presbyterian College SC PD
+    "d38ca136-aa34-59e8-b13c-59cdf8567b88": ("place", "Milan", "IL"),  # QComm911 Dispatch IL
+    "d27486bc-f265-5158-a0ae-10038f258e62": ("county", "Williamson", "TX"),  # Regional Vehicle Burglary Suppression Taskforce TX
+    "34fafb70-7bc2-5eb9-8057-e18b1a94ff8b": ("place", "Waleska", "GA"),  # Reinhardt University GA PD
+    "e57e14ad-2bd8-5df7-a315-f2723972292a": ("place", "Decatur", "IL"),  # Richland Community College Campus IL PD
+    "e47473b6-09f4-51d2-af5e-777a47048145": ("place", "Crystal Lake", "IL"),  # SEECOM Dispatch Center IL
+    "90b3e5a4-915e-51ac-b486-4018e64a1a0b": ("cousub", "Kochville", "MI"),  # Saginaw Valley State University PD (MI) [Inactive]
+    "494a32c2-2763-55c3-8842-27dad589ad32": ("place", "Homewood", "AL"),  # Samford University AL PD
+    "14e400d1-5c90-54ae-a2fd-3a659dbc6b33": ("place", "Knoxville", "TN"),  # South College TN PD
+    "cdcbf72d-b0ce-59bf-b973-e00dfdc32bde": ("place", "Memphis", "TN"),  # Southwest Tennessee Community College TN PD
+    "110d1853-7254-5be2-9520-ca30d756e920": ("place", "Springfield", "IL"),  # Springfield Park District IL PD
+    "e8c47b49-e42f-5119-b523-fbbfc7584532": ("place", "Austin", "TX"),  # St. Edward's University (TX)
+    "070d9906-8500-55b2-8ff6-1a6bbc3981d6": ("place", "Hartford", "CT"),  # State Capitol CT PD
+    "343ba750-f243-5c12-b481-0ebf04c57414": ("place", "Memphis", "TN"),  # TN - Loeb Properties Inc - Security
+    "6a4187fd-6b1a-5bc9-acfb-ca201fc7204d": ("place", "Austin", "TX"),  # Texas Parks & Wildlife Department
+    "34865368-fd21-5ffa-a764-a0033c556f9a": ("place", "Town and Country", "MO"),  # The West Central Dispatch Center (WCDC)
+    "62b9849e-9459-5c94-9126-0606536f1432": ("place", "White Bluff", "TN"),  # Town of Whitebluff TN PD
+    "18271f3b-d3be-5d62-a8ce-4474d4da86f1": ("place", "Tuscaloosa", "AL"),  # Tuscaloosa Academy (AL)
+    "b885c35d-d975-5e7c-8dc1-16da3a5ba133": ("place", "Tuscaloosa", "AL"),  # University of Alabama AL PD
+    "33a31834-8b55-5873-8508-38830443168a": ("place", "Berkeley", "CA"),  # University of California, Berkeley PD
+    "3d7326eb-a86e-5074-a75e-5d9d5a2f9019": ("place", "Columbia", "MO"),  # University of Missouri Campus MO PD
+    "e200e57b-8244-52ac-ae67-b4551a015b2c": ("place", "West Haven", "CT"),  # University of New Haven CT PD
+    "91defbf0-3fdb-5aec-a570-b6fed9fc7d37": ("place", "West Hartford", "CT"),  # University of Saint Joseph CT Public Safety
+    "757e5e7d-4ff4-58f9-8be5-aa9ff29ccdce": ("place", "Richmond", "VA"),  # Virginia Commonwealth University VA PD
+    "0e406815-56da-5b2e-81bc-cb1cf63f4a40": ("place", "Waco", "GA"),  # West Georgia Technical College (GA)
+    "a4f56a5f-9099-5866-9dd0-dc1df44cf4ce": ("county", "Winston", "MS"),  # Winston Count MS CO
+    "68af1aa4-7d22-522e-8c81-16a59402cc63": ("place", "Winston-Salem", "NC"),  # Winston Salem State University NC PD
+    "8de1aa86-5746-54ab-b18f-f7fd35e8fdb1": ("place", "Rock Hill", "SC"),  # Winthrop University SC PD
 }
 
 


### PR DESCRIPTION
Fixes #636.

Triage of the recipients-missing-coordinates backlog, plus the comment flood that killed #516 (and #223).

## Geocoding (80/80 resolved — `check_recipient_coords.py` now clean)

Every entity was researched and web-verified individually; uncertain/manual/unresolvable findings got an independent adversarial re-check, and every place/county name was validated against the Census gazetteer before landing in `GAZ_OVERRIDES`/`MANUAL_OVERRIDES`.

- **73 `GAZ_OVERRIDES` + 1 `MANUAL_OVERRIDES`** — mostly university PDs (UC Berkeley PD alone has 111 senders), IL/MI dispatch centers, and one-offs like Port of Oakland (23 senders, all CA). Notable identifications:
  - `OK - 477` = Oklahoma Bureau of Narcotics (state agency code 477), Oklahoma City
  - `1st Judicial District` = 1st JD District Attorney (Sabine/San Augustine counties), Hemphill TX
  - `Elm Ridge TX PD` = Elm Ridge Water Control & Improvement District PD, Savannah CDP, Denton County
  - `Winston Count MS CO` = Winston County, MS (registry had state=CO from the trailing "CO" token)
  - `Alabama Drug Enforcement Task Force Region G` → Randolph County AL (grant-administering county; no published office)
  - `Regional Vehicle Burglary Suppression Taskforce TX` → Williamson County TX (interlocal agreement, no lead agency)
- **5 rows junk-marked** per existing convention: 2 test accounts (`Flock Safety - Machine Learning Test`, `Test IL - PD - Do not use`) and 3 decommissioned duplicates (`La Salle County IL PD - OLD`, `Fort Bend County Const TX Pct 4 (inactive)`, `Melrose Park (IL) Regional RTIC - DO NOT USE`) whose active counterparts carry the same edges.
- **`265` deleted** — not an agency: Sparks NV's portal shows the *count* "External organizations with access: 265" and the parser ingested it as a partner name. `_parse_org_names` now drops pure-numeric names; the six sparks-nv-pd snapshots were re-parsed (corpus diff: `sharing_outbound ["265"] → []`, nothing else).
- `TEST_NAMES` gains "Do Not Use" / "Machine Learning Test" so future junk auto-classifies.

## Comment-flood fix

The refresh workflow commented the full (usually unchanged) list on the open geocoding issue on every run — #516 died at 100 comments, #636 hit 328 in three days. The geocoding issue body is now bot-owned and always holds the current list; a comment (with the diff) posts only when the list changes. The parser rolling issue (#223 died the same way) now hashes the error set and skips comments when the newest report already matches.

## Verification

- `make build` + `make test`: 666 passed
- `scripts/check_recipient_coords.py`: "All public-agency recipients have coordinates."
- sparks re-parse corpus diff limited to the `265` removal
- workflow YAML parses; both edited `run:` blocks pass `bash -n`

Follow-up filed separately: several of these "entities" (`Precinct 3/4/5 (TX)`, `1st Judicial District` + `District Attorney's Office TX`, bare `Montgomery County Constable`) are comma-split fragments of single Flock account names — fixing the split cascades into new agency_ids, so it needs its own carefully-diffed change. The fragments are geocoded to their verified real locations in the meantime.