### PR TITLE
Fold Flock rename-split registry rows; add rename/lifecycle detector

### DIFF
--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -2817,9 +2817,10 @@
       "hamilton-township-oh-pd"
     ],
     "flock_names": [
-      "Hamilton Township OH PD"
+      "Hamilton Township OH PD",
+      "Hamilton Township OH PD (Warren County)"
     ],
-    "display_name": null,
+    "display_name": "Hamilton Township OH PD (Warren County)",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -2828,14 +2829,14 @@
     ],
     "flags": [],
     "geo": {
-      "kind": "ambiguous",
-      "fips": "39",
-      "name": "OH",
+      "kind": "cousub",
+      "fips": "3916533068",
+      "name": "Hamilton",
       "state": "OH",
-      "lat": 40.317420761363636,
-      "lng": -82.83129609090909,
-      "note": "township name matches multiple county subdivisions in state"
-    }
+      "lat": 39.317319,
+      "lng": -84.19657
+    },
+    "ori": null
   },
   {
     "agency_id": "14c8d3ff-2f0c-5b4a-a82b-3b75e10d4bec",
@@ -3337,30 +3338,6 @@
     "ori": [
       "CA0170000"
     ]
-  },
-  {
-    "agency_id": "05c2b9c0-aceb-5390-a6dc-2bb64d316ddb",
-    "slug": "las-vegas-metro-police-department-nv",
-    "flock_active_slug": "las-vegas-metro-nv-pd",
-    "flock_slugs": [
-      "las-vegas-metro-nv-pd"
-    ],
-    "flock_names": [
-      "Las Vegas Metro Police Department - NV"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "federal",
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "state-only",
-      "state": "NV"
-    }
   },
   {
     "agency_id": "ad5d1953-7d8a-5cf5-b0c7-c7c12bd430d3",
@@ -7862,9 +7839,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "University of California, Berkeley PD"
+      "University of California, Berkeley PD",
+      "University of California, Berkeley"
     ],
-    "display_name": null,
+    "display_name": "University of California, Berkeley PD",
     "agency_role": "campus_safety",
     "agency_type": "university",
     "website": null,
@@ -7880,7 +7858,10 @@
       "state": "CA",
       "lat": 37.865673,
       "lng": -122.298725
-    }
+    },
+    "ori": [
+      "CA0019700"
+    ]
   },
   {
     "agency_id": "b668cce0-ccee-570e-9eec-780170b75f20",
@@ -8775,39 +8756,15 @@
     }
   },
   {
-    "agency_id": "15b7af9e-7b8f-5619-b162-5d3e588ccf6e",
-    "slug": "chelan-county-wa-so",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Chelan County WA SO"
-    ],
-    "display_name": null,
-    "agency_role": "sheriff",
-    "agency_type": "county",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "county",
-      "fips": "53007",
-      "name": "Chelan",
-      "state": "WA",
-      "lat": 47.860974,
-      "lng": -120.619041
-    }
-  },
-  {
     "agency_id": "28078be2-8b0b-5e5a-80b4-b465d97b06af",
     "slug": "greenbrier-tn-pd-duplicate-do-not-use",
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Greenbrier TN PD (duplicate DO NOT USE)"
+      "Greenbrier TN PD (duplicate DO NOT USE)",
+      "Greenbrier TN PD (duplicate)"
     ],
-    "display_name": null,
+    "display_name": "Greenbrier TN PD (duplicate DO NOT USE)",
     "agency_role": "test",
     "agency_type": "test",
     "website": null,
@@ -8820,7 +8777,8 @@
     "geo": {
       "kind": "state-only",
       "state": "TN"
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "7c432380-2802-5721-a843-f6f99bec2f5d",
@@ -9084,33 +9042,6 @@
       "state": "TX",
       "lat": 28.011794,
       "lng": -97.517157
-    }
-  },
-  {
-    "agency_id": "0a2048c0-304f-50cd-b270-84bfbf59f248",
-    "slug": "inactive-oxnard-ca-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "[INACTIVE] Oxnard CA PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [
-      "inactive"
-    ],
-    "geo": {
-      "kind": "place",
-      "fips": "0654652",
-      "name": "Oxnard",
-      "state": "CA",
-      "lat": 34.199436,
-      "lng": -119.207515
     }
   },
   {
@@ -9667,31 +9598,6 @@
     }
   },
   {
-    "agency_id": "c1b8b042-b50d-5a58-9b88-3a73efd72f28",
-    "slug": "ky-kentucky-state-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "KY - Kentucky State PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "state",
-      "fips": "21",
-      "name": "KY",
-      "state": "KY",
-      "lat": 37.621722758333334,
-      "lng": -85.20171535833333
-    }
-  },
-  {
     "agency_id": "353059f3-c39f-5dd9-982e-fde1783351d8",
     "slug": "dekalb-il-pd",
     "flock_active_slug": null,
@@ -9747,9 +9653,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Corinth City Marshal [inactive]"
+      "Corinth City Marshal [inactive]",
+      "Corinth City Marshal"
     ],
-    "display_name": null,
+    "display_name": "Corinth City Marshal [inactive]",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
@@ -9766,34 +9673,8 @@
       "state": "TX",
       "lat": 33.144714,
       "lng": -97.070766
-    }
-  },
-  {
-    "agency_id": "cf3cd038-b96c-56f6-9fa2-fc41c2bb0a7c",
-    "slug": "avon-oh-pd-inactive",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Avon OH PD [inactive]"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [
-      "inactive"
-    ],
-    "geo": {
-      "kind": "place",
-      "fips": "3903352",
-      "name": "Avon",
-      "state": "OH",
-      "lat": 41.4451,
-      "lng": -82.005109
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "d833098d-8e86-5dd7-ab3d-1bae835f31d9",
@@ -9868,33 +9749,6 @@
       "state": "MO",
       "lat": 38.761902,
       "lng": -91.159306
-    }
-  },
-  {
-    "agency_id": "54799b35-73d9-5a21-89f8-edee65eed42b",
-    "slug": "columbia-heights-mn-pd-inactive",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Columbia Heights MN PD [Inactive]"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [
-      "inactive"
-    ],
-    "geo": {
-      "kind": "place",
-      "fips": "2712700",
-      "name": "Columbia Heights",
-      "state": "MN",
-      "lat": 45.049104,
-      "lng": -93.246749
     }
   },
   {
@@ -10789,16 +10643,19 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Avon OH PD"
+      "Avon OH PD",
+      "Avon OH PD [inactive]"
     ],
-    "display_name": null,
+    "display_name": "Avon OH PD [inactive]",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
     "tags": [
       "public"
     ],
-    "flags": [],
+    "flags": [
+      "inactive"
+    ],
     "geo": {
       "kind": "place",
       "fips": "3903352",
@@ -12258,24 +12115,6 @@
     "ori": [
       "KY1180100"
     ]
-  },
-  {
-    "agency_id": "ffe63970-7777-5dc8-b6f3-6eff6bd83566",
-    "slug": "corinth-city-marshal",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Corinth City Marshal"
-    ],
-    "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "tags": [
-      "needs-review"
-    ],
-    "flags": [],
-    "geo": null
   },
   {
     "agency_id": "e4f3768f-bd9c-590e-9e39-16c4d3214998",
@@ -19625,9 +19464,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Lake Travis ISD TX PD [Inactive]"
+      "Lake Travis ISD TX PD [Inactive]",
+      "Lake Travis ISD TX PD"
     ],
-    "display_name": null,
+    "display_name": "Lake Travis ISD TX PD [Inactive]",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -19644,7 +19484,8 @@
       "state": "TX",
       "lat": 30.354982,
       "lng": -97.986269
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "3aa99c45-2421-51dd-b623-9de3f2f5787c",
@@ -21019,29 +20860,6 @@
     ]
   },
   {
-    "agency_id": "43f774f4-d8ba-5921-9722-a3a785613fef",
-    "slug": "greenbrier-tn-pd-duplicate",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Greenbrier TN PD (duplicate)"
-    ],
-    "display_name": null,
-    "agency_role": "test",
-    "agency_type": "test",
-    "website": null,
-    "tags": [
-      "private"
-    ],
-    "flags": [
-      "duplicate"
-    ],
-    "geo": {
-      "kind": "state-only",
-      "state": "TN"
-    }
-  },
-  {
     "agency_id": "0d20fd72-db37-5672-98f7-7195c6cc0205",
     "slug": "hardeman-county-tn-so",
     "flock_active_slug": null,
@@ -21570,9 +21388,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Banner Elk NC PD [DO NOT USE]"
+      "Banner Elk NC PD [DO NOT USE]",
+      "Banner Elk NC PD"
     ],
-    "display_name": null,
+    "display_name": "Banner Elk NC PD [DO NOT USE]",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -22760,9 +22579,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Mountain View AR PD"
+      "Mountain View AR PD",
+      "AR - Mountain View PD"
     ],
-    "display_name": null,
+    "display_name": "Mountain View AR PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -22777,7 +22597,8 @@
       "state": "AR",
       "lat": 35.861559,
       "lng": -92.109657
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "b5900bec-80fd-52d3-a0bb-22bbb3383710",
@@ -23891,16 +23712,19 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "East Cleveland OH PD"
+      "East Cleveland OH PD",
+      "East Cleveland OH PD [deactivated]"
     ],
-    "display_name": null,
+    "display_name": "East Cleveland OH PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
     "tags": [
       "public"
     ],
-    "flags": [],
+    "flags": [
+      "deactivated"
+    ],
     "geo": {
       "kind": "place",
       "fips": "3923380",
@@ -23908,7 +23732,8 @@
       "state": "OH",
       "lat": 41.530657,
       "lng": -81.578516
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "2ee38861-654d-5197-88a8-2991301a190a",
@@ -31089,31 +30914,6 @@
     ]
   },
   {
-    "agency_id": "6202f013-25eb-518a-b460-2c6bd405d044",
-    "slug": "lake-travis-isd-tx-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Lake Travis ISD TX PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "4840984",
-      "name": "Lakeway",
-      "state": "TX",
-      "lat": 30.354982,
-      "lng": -97.986269
-    }
-  },
-  {
     "agency_id": "c138f61d-9bf6-5002-b969-ef3f74fe0710",
     "slug": "lakeside-city-tx",
     "flock_active_slug": null,
@@ -33591,9 +33391,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Streetsboro OH PD [inactive]"
+      "Streetsboro OH PD [inactive]",
+      "Streetsboro OH PD"
     ],
-    "display_name": null,
+    "display_name": "Streetsboro OH PD [inactive]",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -33610,7 +33411,8 @@
       "state": "OH",
       "lat": 41.239608,
       "lng": -81.345862
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "7c153e15-688b-5903-9d25-a02ad57a4d8a",
@@ -38791,31 +38593,6 @@
     ]
   },
   {
-    "agency_id": "def23147-b644-5501-b150-9d113ac1f900",
-    "slug": "cozad-ne-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Cozad NE PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "3111020",
-      "name": "Cozad",
-      "state": "NE",
-      "lat": 40.861301,
-      "lng": -99.986366
-    }
-  },
-  {
     "agency_id": "b1c58318-88e3-5467-82cc-f605b6b92c98",
     "slug": "davenport-fl-pd",
     "flock_active_slug": null,
@@ -39420,31 +39197,6 @@
     "ori": [
       "FL0230000"
     ]
-  },
-  {
-    "agency_id": "67ee7c5b-7231-557f-b7a5-d364cf9d5a40",
-    "slug": "hamilton-township-oh-pd-warren-county",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Hamilton Township OH PD (Warren County)"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "county",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "cousub",
-      "fips": "3916533068",
-      "name": "Hamilton",
-      "state": "OH",
-      "lat": 39.317319,
-      "lng": -84.19657
-    }
   },
   {
     "agency_id": "4632fc00-0af1-5ddf-9234-70968d3d43b9",
@@ -53271,33 +53023,6 @@
     ]
   },
   {
-    "agency_id": "dfa420ca-3de7-506d-8bb1-5b17dd76d9e5",
-    "slug": "east-cleveland-oh-pd-deactivated",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "East Cleveland OH PD [deactivated]"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [
-      "deactivated"
-    ],
-    "geo": {
-      "kind": "place",
-      "fips": "3923380",
-      "name": "East Cleveland",
-      "state": "OH",
-      "lat": 41.530657,
-      "lng": -81.578516
-    }
-  },
-  {
     "agency_id": "f5a6d071-3059-5cac-9036-8f490ba63465",
     "slug": "east-hempfield-twp-pa-pd",
     "flock_active_slug": null,
@@ -60105,31 +59830,6 @@
     ]
   },
   {
-    "agency_id": "cf15a8d8-11c9-5ab9-9b85-32210e40e224",
-    "slug": "streetsboro-oh-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Streetsboro OH PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "3975014",
-      "name": "Streetsboro",
-      "state": "OH",
-      "lat": 41.239608,
-      "lng": -81.345862
-    }
-  },
-  {
     "agency_id": "f8a51c54-cafd-5f34-9344-67ae870015d8",
     "slug": "suffolk-va-pd",
     "flock_active_slug": null,
@@ -65275,34 +64975,6 @@
       "lat": 40.198826,
       "lng": -85.395059
     }
-  },
-  {
-    "agency_id": "e01d7b4b-bea9-5f71-87a5-e11eca612faa",
-    "slug": "banner-elk-nc-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Banner Elk NC PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "3703500",
-      "name": "Banner Elk",
-      "state": "NC",
-      "lat": 36.158699,
-      "lng": -81.867556
-    },
-    "ori": [
-      "NC0060200"
-    ]
   },
   {
     "agency_id": "10b7e322-0ca0-597b-b9f1-dcd9f5dab9e2",
@@ -87389,9 +87061,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Woodbury MN"
+      "Woodbury MN",
+      "Woodbury MN DPS"
     ],
-    "display_name": null,
+    "display_name": "Woodbury MN",
     "agency_role": "other",
     "agency_type": "other",
     "website": null,
@@ -87406,7 +87079,8 @@
       "state": "MN",
       "lat": 44.906283,
       "lng": -92.923703
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "f0e4b97a-2f60-5a1b-abe5-049c8e3b94cc",
@@ -89840,31 +89514,6 @@
     "ori": [
       "AR0560300"
     ]
-  },
-  {
-    "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
-    "slug": "ar-mountain-view-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "AR - Mountain View PD"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "0547540",
-      "name": "Mountain View",
-      "state": "AR",
-      "lat": 35.861559,
-      "lng": -92.109657
-    }
   },
   {
     "agency_id": "82224cc9-3df9-5f00-9aaf-a777477d5859",
@@ -102585,9 +102234,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Kentucky State KY PD"
+      "Kentucky State KY PD",
+      "KY - Kentucky State PD"
     ],
-    "display_name": null,
+    "display_name": "KY - Kentucky State PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -102602,7 +102252,8 @@
       "state": "KY",
       "lat": 37.621722758333334,
       "lng": -85.20171535833333
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "0860b7e0-5f28-51b2-97e0-75887a516e6f",
@@ -110732,9 +110383,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Richland WA PD"
+      "Richland WA PD",
+      "Richland PD WA"
     ],
-    "display_name": null,
+    "display_name": "Richland WA PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -110749,7 +110401,8 @@
       "state": "WA",
       "lat": 46.284086,
       "lng": -119.294046
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "faeaae90-2988-5568-bd81-6eff3b9c11e7",
@@ -119066,31 +118719,6 @@
     ]
   },
   {
-    "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
-    "slug": "richland-pd-wa",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Richland PD WA"
-    ],
-    "display_name": null,
-    "agency_role": "police",
-    "agency_type": "city",
-    "website": null,
-    "tags": [
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "5358235",
-      "name": "Richland",
-      "state": "WA",
-      "lat": 46.284086,
-      "lng": -119.294046
-    }
-  },
-  {
     "agency_id": "f9528ae9-97e1-555d-8dd3-f842543cb473",
     "slug": "sedro-woolley-wa-pd",
     "flock_active_slug": null,
@@ -119501,9 +119129,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "WA - Chelan County SO"
+      "WA - Chelan County SO",
+      "Chelan County WA SO"
     ],
-    "display_name": null,
+    "display_name": "Chelan County WA SO",
     "agency_role": "sheriff",
     "agency_type": "county",
     "website": null,
@@ -122856,16 +122485,19 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Columbia Heights MN PD"
+      "Columbia Heights MN PD",
+      "Columbia Heights MN PD [Inactive]"
     ],
-    "display_name": null,
+    "display_name": "Columbia Heights MN PD [Inactive]",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
     "tags": [
       "public"
     ],
-    "flags": [],
+    "flags": [
+      "inactive"
+    ],
     "geo": {
       "kind": "place",
       "fips": "2712700",
@@ -131296,9 +130928,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "NE - Cozad PD"
+      "NE - Cozad PD",
+      "Cozad NE PD"
     ],
-    "display_name": null,
+    "display_name": "Cozad NE PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -131313,7 +130946,8 @@
       "state": "NE",
       "lat": 40.861301,
       "lng": -99.986366
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "b15c1511-b3b6-5e99-b290-b0df7f6f21fc",
@@ -138167,31 +137801,6 @@
     "ori": [
       "IL0222300"
     ]
-  },
-  {
-    "agency_id": "f2c31c3d-455d-5e50-bdb3-704546e06d5d",
-    "slug": "woodbury-mn-dps",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Woodbury MN DPS"
-    ],
-    "display_name": null,
-    "agency_role": "other",
-    "agency_type": "other",
-    "website": null,
-    "tags": [
-      "needs-review"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "place",
-      "fips": "2771428",
-      "name": "Woodbury",
-      "state": "MN",
-      "lat": 44.906283,
-      "lng": -92.923703
-    }
   },
   {
     "agency_id": "96e8f723-e16d-57dd-8a37-90838394a5c8",
@@ -155634,17 +155243,21 @@
   {
     "agency_id": "03f39921-e81f-5d88-ba5a-cf79a6969ecb",
     "slug": "las-vegas-metro-nv-pd",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Las Vegas Metro NV PD"
+    "flock_active_slug": "las-vegas-metro-nv-pd",
+    "flock_slugs": [
+      "las-vegas-metro-nv-pd"
     ],
-    "display_name": null,
+    "flock_names": [
+      "Las Vegas Metro NV PD",
+      "Las Vegas Metro Police Department - NV"
+    ],
+    "display_name": "Las Vegas Metro Police Department - NV",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
     "tags": [
-      "public"
+      "public",
+      "federal"
     ],
     "geo": {
       "kind": "place",
@@ -155654,7 +155267,8 @@
       "lat": 36.233499,
       "lng": -115.264037
     },
-    "flags": []
+    "flags": [],
+    "ori": null
   },
   {
     "agency_id": "7b4d182e-412e-59e3-9967-75d4f4f1bedf",
@@ -157190,9 +156804,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Oxnard CA PD"
+      "Oxnard CA PD",
+      "[INACTIVE] Oxnard CA PD"
     ],
-    "display_name": null,
+    "display_name": "[INACTIVE] Oxnard CA PD",
     "agency_role": "police",
     "agency_type": "city",
     "website": null,
@@ -157207,7 +156822,9 @@
       "lat": 34.199436,
       "lng": -119.207515
     },
-    "flags": [],
+    "flags": [
+      "inactive"
+    ],
     "ori": [
       "CA0560400"
     ]
@@ -160103,33 +159720,6 @@
     "flags": [],
     "ori": [
       "CA0429700"
-    ]
-  },
-  {
-    "agency_id": "eaef691d-609c-566f-ad67-3a187a241852",
-    "slug": "university-of-california-berkeley",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "University of California, Berkeley"
-    ],
-    "display_name": null,
-    "agency_role": "campus_safety",
-    "agency_type": "university",
-    "website": null,
-    "notes": "Public university (UC Berkeley). Part of the <a href=\"https://www.universityofcalifornia.edu/campuses\" target=\"_blank\">University of California</a> system.",
-    "tags": [
-      "public"
-    ],
-    "geo": {
-      "kind": "manual",
-      "state": "CA",
-      "lat": 37.872,
-      "lng": -122.259
-    },
-    "flags": [],
-    "ori": [
-      "CA0019700"
     ]
   },
   {

--- a/assets/agency_registry.json
+++ b/assets/agency_registry.json
@@ -8977,28 +8977,6 @@
     }
   },
   {
-    "agency_id": "d10f2e4f-ab30-5258-9079-0f2462dd0ec8",
-    "slug": "fort-bend-county-const-tx-pct-4-inactive",
-    "flock_active_slug": null,
-    "flock_slugs": [],
-    "flock_names": [
-      "Fort Bend County Const TX Pct 4 (inactive)"
-    ],
-    "display_name": null,
-    "agency_role": "decommissioned",
-    "agency_type": "decommissioned",
-    "website": null,
-    "tags": [
-      "needs-review",
-      "public"
-    ],
-    "flags": [],
-    "geo": {
-      "kind": "state-only",
-      "state": "TX"
-    }
-  },
-  {
     "agency_id": "ba548af3-04cd-589d-9818-79bacbc1a4d3",
     "slug": "riverbend-houston-tx",
     "flock_active_slug": null,
@@ -38987,9 +38965,10 @@
     "flock_active_slug": null,
     "flock_slugs": [],
     "flock_names": [
-      "Fort Bend County Const TX Pct 4"
+      "Fort Bend County Const TX Pct 4",
+      "Fort Bend County Const TX Pct 4 (inactive)"
     ],
-    "display_name": null,
+    "display_name": "Fort Bend County Const TX Pct 4 (inactive)",
     "agency_role": "other",
     "agency_type": "county",
     "website": null,
@@ -39005,7 +38984,8 @@
       "state": "TX",
       "lat": 29.526602,
       "lng": -95.771015
-    }
+    },
+    "ori": null
   },
   {
     "agency_id": "c05d0a86-674e-5f72-a705-81a4f0348e0f",

--- a/assets/article_registry/art_012.json
+++ b/assets/article_registry/art_012.json
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
+      "agency_id": "1021a1de-0ff9-5461-a877-4431fc6a472a",
       "display_name": "AR - Mountain View PD",
       "state": "AR",
       "score": 45.9,

--- a/assets/article_registry/art_069.json
+++ b/assets/article_registry/art_069.json
@@ -33,7 +33,7 @@
   ],
   "agencies": [
     "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
-    "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
+    "1021a1de-0ff9-5461-a877-4431fc6a472a",
     "6be9f842-1658-5490-8be4-14b77cc1e96d",
     "a597ac19-0e62-585c-82a0-f9c7b87c55e8",
     "f94b9663-269f-51eb-b204-b6d4c8cee4de",
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
+      "agency_id": "1021a1de-0ff9-5461-a877-4431fc6a472a",
       "display_name": "AR - Mountain View PD",
       "state": "AR",
       "score": 9.5,

--- a/assets/article_registry/art_088.json
+++ b/assets/article_registry/art_088.json
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
+      "agency_id": "1021a1de-0ff9-5461-a877-4431fc6a472a",
       "display_name": "AR - Mountain View PD",
       "state": "AR",
       "score": 1.333,

--- a/assets/article_registry/art_130.json
+++ b/assets/article_registry/art_130.json
@@ -43,7 +43,6 @@
     "af2758f7-ea32-50eb-88b3-badb338510ca",
     "37330114-0b02-5b61-a889-2fc214849095",
     "c54ee9d3-4114-5c33-a53b-927a6fb46ae3",
-    "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
     "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
     "ccebeae6-1d27-5e90-933a-4aaac0fd38df"
   ],
@@ -118,17 +117,8 @@
       ]
     },
     {
-      "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
-      "display_name": "Richland PD WA",
-      "state": "WA",
-      "score": 2.75,
-      "matched_forms": [
-        "Richland Police"
-      ]
-    },
-    {
       "agency_id": "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
-      "display_name": "Richland WA PD",
+      "display_name": "Richland PD WA",
       "state": "WA",
       "score": 2.75,
       "matched_forms": [

--- a/assets/article_registry/art_159.json
+++ b/assets/article_registry/art_159.json
@@ -34,7 +34,6 @@
     "b24c55d3-3dd6-55d6-a443-d361be29e6aa",
     "83b05b01-74fd-5e6d-9188-816a601a64dd",
     "485d236f-0919-564f-807f-406dc4e3b6b4",
-    "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
     "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
     "b8e97fdd-b1c4-5f64-b530-e8546ff5d182",
     "5c703ef7-9b84-562a-8b8c-b4011feb6be7",
@@ -73,17 +72,8 @@
       ]
     },
     {
-      "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
-      "display_name": "Richland PD WA",
-      "state": "WA",
-      "score": 4.9,
-      "matched_forms": [
-        "Richland"
-      ]
-    },
-    {
       "agency_id": "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
-      "display_name": "Richland WA PD",
+      "display_name": "Richland PD WA",
       "state": "WA",
       "score": 4.9,
       "matched_forms": [

--- a/assets/article_registry/art_176.json
+++ b/assets/article_registry/art_176.json
@@ -85,7 +85,7 @@
       ]
     },
     {
-      "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
+      "agency_id": "1021a1de-0ff9-5461-a877-4431fc6a472a",
       "display_name": "AR - Mountain View PD",
       "state": "AR",
       "score": 1.5,

--- a/assets/article_registry/art_177.json
+++ b/assets/article_registry/art_177.json
@@ -34,7 +34,6 @@
     "8171a2b1-544d-544d-8a90-31029959bd72",
     "ae292ffc-510d-5af1-b78d-7c026bfe1754",
     "b111be54-e0b4-5bc2-83c9-ad2285eccaaf",
-    "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
     "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
     "80fc5e77-78d4-5499-abf4-9cda8cfb284d"
   ],
@@ -70,17 +69,8 @@
       ]
     },
     {
-      "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
-      "display_name": "Richland PD WA",
-      "state": "WA",
-      "score": 2.933,
-      "matched_forms": [
-        "Richland Police Department"
-      ]
-    },
-    {
       "agency_id": "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
-      "display_name": "Richland WA PD",
+      "display_name": "Richland PD WA",
       "state": "WA",
       "score": 2.933,
       "matched_forms": [

--- a/assets/article_registry/art_227.json
+++ b/assets/article_registry/art_227.json
@@ -39,7 +39,7 @@
     "db910469-5ced-5aa1-a674-5281b9542b3b",
     "c2fe92ce-a388-5dfb-bce8-7cc80482f298",
     "5a1588da-969e-5a60-be2e-5fe547c2716d",
-    "cccec80d-f9a8-5296-a394-27cc4a9aa2d6"
+    "1abc6989-6a40-58ed-ad2c-eb6fa70648ac"
   ],
   "agency_candidates": [
     {
@@ -124,7 +124,7 @@
       ]
     },
     {
-      "agency_id": "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
+      "agency_id": "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
       "display_name": "Richland PD WA",
       "state": "WA",
       "score": 2.633,
@@ -136,7 +136,7 @@
   "primary_subject_agency_ids": [
     "ab8f096c-5091-5b76-b9a0-1c0cd5c9bfe7",
     "5a1588da-969e-5a60-be2e-5fe547c2716d",
-    "cccec80d-f9a8-5296-a394-27cc4a9aa2d6",
+    "1abc6989-6a40-58ed-ad2c-eb6fa70648ac",
     "96d2eb94-ea06-5bc6-9e06-faff521982f0",
     "c2fe92ce-a388-5dfb-bce8-7cc80482f298",
     "e8d2706e-5bb2-56b2-94d1-f7234d6f97f0"

--- a/assets/article_registry/art_6245a215c47c.json
+++ b/assets/article_registry/art_6245a215c47c.json
@@ -39,7 +39,6 @@
     "971ef5e8-3761-532f-ac31-4406140dcbe0",
     "e1cd8f7f-abbd-536c-b8a5-f5516061c4b0",
     "2e1e1b36-7a6b-5c97-8143-65347503186c",
-    "0a2048c0-304f-50cd-b270-84bfbf59f248",
     "1b106ca6-6fdd-51e8-a479-6408673c0e53"
   ],
   "agency_candidates": [
@@ -109,15 +108,6 @@
     {
       "agency_id": "2e1e1b36-7a6b-5c97-8143-65347503186c",
       "display_name": "Oxnard CA PD",
-      "state": "CA",
-      "score": 2.6,
-      "matched_forms": [
-        "Oxnard"
-      ]
-    },
-    {
-      "agency_id": "0a2048c0-304f-50cd-b270-84bfbf59f248",
-      "display_name": "[INACTIVE] Oxnard CA PD",
       "state": "CA",
       "score": 2.6,
       "matched_forms": [

--- a/assets/article_registry/art_c772cf0bfd49.json
+++ b/assets/article_registry/art_c772cf0bfd49.json
@@ -33,7 +33,6 @@
     "c0283c21-1bfd-5fef-9c0e-6d9ff8c7c964",
     "b9391335-eecf-56e2-8c6a-ed8e5cc4bd7b",
     "6d11ec03-586d-570a-b110-56f9e37261ff",
-    "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
     "1021a1de-0ff9-5461-a877-4431fc6a472a",
     "67bc50f4-d2c0-573f-af3e-5b388b2dc3b0",
     "3e92d55d-2470-5f53-8711-dc0b817bcb2a"
@@ -68,17 +67,8 @@
       ]
     },
     {
-      "agency_id": "fb01478d-3233-55c1-a65c-74b6e23a6b6a",
-      "display_name": "AR - Mountain View PD",
-      "state": "AR",
-      "score": 2.667,
-      "matched_forms": [
-        "Mountain View Police"
-      ]
-    },
-    {
       "agency_id": "1021a1de-0ff9-5461-a877-4431fc6a472a",
-      "display_name": "Mountain View AR PD",
+      "display_name": "AR - Mountain View PD",
       "state": "AR",
       "score": 2.667,
       "matched_forms": [

--- a/assets/transparency.flocksafety.com/.slug_probe_state.json
+++ b/assets/transparency.flocksafety.com/.slug_probe_state.json
@@ -102,7 +102,7 @@
         "des-peres-mo-dps-mo-pd": "http_404"
       }
     },
-    "05c2b9c0-aceb-5390-a6dc-2bb64d316ddb": {
+    "03f39921-e81f-5d88-ba5a-cf79a6969ecb": {
       "exhausted": false,
       "found": "las-vegas-metro-nv-pd",
       "last_probed": "2026-05-07T05:04:03.620433+00:00",
@@ -4885,7 +4885,7 @@
       "last_probed": "2026-06-02T20:30:33.273377+00:00",
       "tried": {}
     },
-    "eaef691d-609c-566f-ad67-3a187a241852": {
+    "33a31834-8b55-5873-8508-38830443168a": {
       "exhausted": false,
       "found": null,
       "last_probed": "2026-04-27T23:38:47.747105+00:00",

--- a/scripts/detect_renames.py
+++ b/scripts/detect_renames.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""Detect Flock agency lifecycle events from the sharing-list time series.
+
+Each portal slug has a ~weekly series of snapshot JSONs
+  assets/transparency.flocksafety.com/<slug>/<YYYY-MM-DD>.json
+whose ``sharing_outbound`` / ``sharing_inbound`` arrays name partner agencies.
+Diffing consecutive snapshots per slug and aggregating the SAME change across
+many portals in a short window reveals three event classes:
+
+  RENAME            mass ``(-"X", +"X'")`` where X and X' are the same place
+                    (identical core-place tokens after stripping role/status/
+                    state words). Flock renamed X -> X'.
+  SYSTEMIC_REMOVAL  mass ``-X`` with no similar add -> X left the network
+                    (decommission / de-federation). The offboarding signal.
+  NEW_JOIN          mass ``+X`` with no similar remove -> X joined the network.
+
+The single guard against combinatorial false positives (a portal that drops
+several partners and adds several unrelated ones in the same refresh) is that a
+RENAME pair must share an IDENTICAL core-place token set — this is what stops
+e.g. "El Cerrito CA PD" pairing with "San Diego County CA SO" when San Diego
+merely joins ~100 portals the same week.
+
+For RENAME events the tool also resolves both spellings against the agency
+registry and flags SPLITS: the two spellings minted two different agency_ids,
+so one real agency is fractured into two rows and needs a registry fold
+(see scripts/fold_registry_renames.py).
+
+Read-only. Reads only the deterministic ``.json`` snapshots, never the sibling
+scraped ``.html`` / ``.txt``.
+
+Usage:
+  uv run python scripts/detect_renames.py
+  uv run python scripts/detect_renames.py --json outputs/renames.json
+  uv run python scripts/detect_renames.py --min-portals 3 --splits-only
+"""
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import portal_jsons, resolve_agency  # noqa: E402
+
+DATA_DIR = Path("assets/transparency.flocksafety.com")
+
+_STATE_RE = re.compile(
+    r"\b(A[LKZR]|C[AOT]|DE|FL|GA|HI|I[ADLN]|K[SY]|LA|M[ADEINOST]|"
+    r"N[CDEHJMVY]|O[HKR]|PA|RI|S[CD]|T[NX]|UT|V[AT]|W[AIVY])\b"
+)
+
+# Generic role/status words stripped before comparing two names. 'county' and
+# 'city' are DELIBERATELY kept — they distinguish a City PD from a County SO in
+# the same place (e.g. Yuba City PD vs Yuba County SO), which must NOT merge.
+_ROLE_WORDS = {
+    "pd", "police", "department", "dept", "so", "sheriff", "sheriffs",
+    "office", "dps", "university", "of", "the", "district", "dist",
+    "campus", "co", "inactive", "deactivated", "dnu", "do", "not", "use",
+}
+
+
+def sharing_names(path):
+    """Set of partner-agency name strings in a snapshot's sharing lists."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    out = set()
+    for key in ("sharing_outbound", "sharing_inbound"):
+        val = data.get(key)
+        if isinstance(val, list):
+            out.update(n.strip() for n in val if isinstance(n, str) and n.strip())
+    return out
+
+
+def core_tokens(name):
+    """Normalized set of place tokens: drop status tags, punctuation, role words."""
+    n = re.sub(r"\[.*?\]|\(.*?\)", " ", name.lower())   # drop [Inactive], (deactivated)
+    n = re.sub(r"[^a-z0-9 ]", " ", n)
+    return frozenset(t for t in n.split() if t not in _ROLE_WORDS)
+
+
+def _states(name):
+    return set(_STATE_RE.findall(name))
+
+
+def same_place(a, b):
+    """True iff a and b name the same place, differing only in role / format /
+    status / state-position — the anti-false-positive gate for renames."""
+    if a == b:
+        return False
+    ta, tb = core_tokens(a), core_tokens(b)
+    if not ta or ta != tb:
+        return False
+    sa, sb = _states(a), _states(b)
+    return not (sa and sb and sa != sb)
+
+
+def _window(dates):
+    ds = sorted(dates)
+    return f"{ds[0]}..{ds[-1]}" if ds else "?"
+
+
+def _confidence(n):
+    return "high" if n >= 3 else ("med" if n == 2 else "low")
+
+
+def detect(data_dir, min_portals):
+    """Walk every slug's snapshot series and aggregate the three event classes."""
+    rename_hits = defaultdict(lambda: {"slugs": set(), "dates": set()})   # (old, new)
+    removed_hits = defaultdict(lambda: {"slugs": set(), "dates": set()})  # name
+    added_hits = defaultdict(lambda: {"slugs": set(), "dates": set()})    # name
+
+    slugs = 0
+    for slug_dir in sorted(data_dir.iterdir()):
+        if not slug_dir.is_dir() or slug_dir.name.startswith("."):
+            continue
+        snaps = portal_jsons(slug_dir)
+        if len(snaps) < 2:
+            continue
+        slugs += 1
+        slug = slug_dir.name
+        prev = None
+        for path in snaps:
+            date = path.stem
+            cur = sharing_names(path)
+            if prev is not None:
+                removed = prev - cur
+                added = cur - prev
+                matched_removed, matched_added = set(), set()
+                if removed and added:
+                    for old in removed:
+                        for new in added:
+                            if same_place(old, new):
+                                hit = rename_hits[(old, new)]
+                                hit["slugs"].add(slug)
+                                hit["dates"].add(date)
+                                matched_removed.add(old)
+                                matched_added.add(new)
+                for nm in removed - matched_removed:
+                    removed_hits[nm]["slugs"].add(slug)
+                    removed_hits[nm]["dates"].add(date)
+                for nm in added - matched_added:
+                    added_hits[nm]["slugs"].add(slug)
+                    added_hits[nm]["dates"].add(date)
+            prev = cur
+
+    rename_names = set()
+    for old, new in rename_hits:
+        rename_names.add(old)
+        rename_names.add(new)
+
+    def rid(name):
+        e = resolve_agency(name=name)
+        return e["agency_id"] if e else None
+
+    renames = []
+    for (old, new), info in rename_hits.items():
+        old_id, new_id = rid(old), rid(new)
+        renames.append({
+            "old": old, "new": new,
+            "portals": len(info["slugs"]),
+            "confidence": _confidence(len(info["slugs"])),
+            "window": _window(info["dates"]),
+            "old_id": old_id, "new_id": new_id,
+            "registry_split": bool(old_id and new_id and old_id != new_id),
+        })
+    renames.sort(key=lambda r: -r["portals"])
+
+    removals = []
+    for nm, info in removed_hits.items():
+        n = len(info["slugs"])
+        if n >= min_portals and nm not in rename_names:
+            removals.append({
+                "name": nm, "portals": n, "window": _window(info["dates"]),
+                "agency_id": rid(nm),
+            })
+    removals.sort(key=lambda r: -r["portals"])
+
+    joins = []
+    for nm, info in added_hits.items():
+        n = len(info["slugs"])
+        if n >= min_portals and nm not in rename_names:
+            joins.append({
+                "name": nm, "portals": n, "window": _window(info["dates"]),
+                "agency_id": rid(nm),
+            })
+    joins.sort(key=lambda r: -r["portals"])
+
+    return {"slugs_scanned": slugs, "renames": renames,
+            "systemic_removals": removals, "new_joins": joins}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--data-dir", type=Path, default=DATA_DIR)
+    ap.add_argument("--min-portals", type=int, default=3,
+                    help="distinct-portal threshold for a systemic removal/join (default 3)")
+    ap.add_argument("--json", type=Path, default=None, help="also write full results as JSON")
+    ap.add_argument("--splits-only", action="store_true",
+                    help="print only RENAME events that fractured the registry")
+    args = ap.parse_args()
+
+    res = detect(args.data_dir, args.min_portals)
+    splits = [r for r in res["renames"] if r["registry_split"]]
+
+    print(f"scanned {res['slugs_scanned']} slugs\n")
+
+    print("== RENAMES (registry SPLIT = needs fold) ==")
+    for r in res["renames"]:
+        if args.splits_only and not r["registry_split"]:
+            continue
+        flag = "  SPLIT->FOLD" if r["registry_split"] else ""
+        print(f"  {r['portals']:>3} [{r['confidence']:>4}] {r['old']!r} -> {r['new']!r} "
+              f"| {r['window']}{flag}")
+
+    if not args.splits_only:
+        print(f"\n== SYSTEMIC REMOVALS (>= {args.min_portals} portals; decommission/de-federation signal) ==")
+        for r in res["systemic_removals"]:
+            print(f"  {r['portals']:>3} {r['name']!r} | {r['window']}")
+
+        print(f"\n== NEW JOINS (>= {args.min_portals} portals) ==")
+        for r in res["new_joins"]:
+            print(f"  {r['portals']:>3} {r['name']!r} | {r['window']}")
+
+    print(f"\nrenames={len(res['renames'])} splits={len(splits)} "
+          f"removals={len(res['systemic_removals'])} joins={len(res['new_joins'])}")
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(res, indent=2) + "\n")
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fold_registry_renames.py
+++ b/scripts/fold_registry_renames.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 zero-below
+"""Fold registry rows fractured by Flock renames (driven by detect_renames.py).
+
+When Flock renames an agency X -> X', the registry derives a new slug from the
+new display name and mints a SECOND agency_id, splitting one real agency into
+two rows. This tool merges each such split back into one row.
+
+Merge rule (matches the hand-verified UCB / Las Vegas Metro folds):
+  - CANONICAL survivor = the row whose ``.slug`` is a real crawled portal slug
+    (so the crawl binds via ``.slug`` directly); else the field-richest row
+    (better geo: place > manual > state-only; then has ORI). Deterministic
+    tie-break on agency_id.
+  - Preserve the UNION of fields: all ``flock_names`` spellings, richer ``geo``,
+    unioned ``ori`` / ``tags`` / ``flags``, ``website`` fallback. ``display_name``
+    is set to the CURRENT (post-rename) spelling. ``flock_slugs`` keeps only REAL
+    portal slugs (phantom name-derived slugs are dropped — they have no captures
+    and ``--prune`` would strip them anyway).
+  - Delete the other row(s).
+
+Hard safety guard — a group is SKIPPED (never merged) and reported when its rows
+disagree on ``agency_role`` or ``agency_type``. A City PD and a County SO in the
+same place are different agencies; this stops the role-word-strip false match
+(e.g. "Sacramento SO - CA" vs "Sacramento CA PD").
+
+Transitive: three spellings of one agency (e.g. Banner Elk / (DNU) / [DO NOT USE])
+are unioned into a single survivor via connected components.
+
+Format-preserving: reproduces ``json.dumps(indent=2)`` and refuses to write if it
+cannot round-trip the file, so the diff is limited to the touched rows.
+Dry-run by default.
+
+Usage:
+  uv run python scripts/fold_registry_renames.py                  # dry run, high-confidence (>=3 portals)
+  uv run python scripts/fold_registry_renames.py --min-portals 2  # include medium
+  uv run python scripts/fold_registry_renames.py --write
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from lib import portal_jsons  # noqa: E402
+from detect_renames import detect, DATA_DIR  # noqa: E402
+
+REGISTRY_PATH = Path("assets/agency_registry.json")
+ARTICLE_DIR = Path("assets/article_registry")
+PROBE_STATE = Path("assets/transparency.flocksafety.com/.slug_probe_state.json")
+
+
+def _dedup(seq):
+    seen, out = set(), []
+    for x in seq:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def repoint_refs(remap, article_dir=ARTICLE_DIR, probe_state=PROBE_STATE):
+    """Repoint agency_id references (dropped id -> survivor id) in committed
+    data that keys on agency_id, so folding a row never leaves a dangling
+    reference. Covers the article registry (``agencies`` /
+    ``primary_subject_agency_ids`` id lists and ``agency_candidates[].agency_id``)
+    and the slug-probe cache (top-level keys). Format-preserving. Returns the
+    list of changed paths."""
+    changed = []
+    if not remap:
+        return changed
+    if article_dir.is_dir():
+        for shard in sorted(article_dir.glob("*.json")):
+            raw = shard.read_text(encoding="utf-8")
+            if not any(d in raw for d in remap):
+                continue
+            data = json.loads(raw)
+            for field in ("agencies", "primary_subject_agency_ids"):
+                if isinstance(data.get(field), list):
+                    data[field] = _dedup(remap.get(x, x) for x in data[field])
+            if isinstance(data.get("agency_candidates"), list):
+                seen, newc = set(), []
+                for c in data["agency_candidates"]:
+                    if isinstance(c, dict) and c.get("agency_id") in remap:
+                        c = {**c, "agency_id": remap[c["agency_id"]]}
+                    aid = c.get("agency_id") if isinstance(c, dict) else c
+                    if aid in seen:
+                        continue  # dedup (list is score-sorted; keep first)
+                    seen.add(aid)
+                    newc.append(c)
+                data["agency_candidates"] = newc
+            out = json.dumps(data, indent=2) + "\n"   # matches article_store.py
+            if out != raw:
+                shard.write_text(out)
+                changed.append(str(shard))
+    if probe_state.exists():
+        raw = probe_state.read_text(encoding="utf-8")
+        data = json.loads(raw) if any(d in raw for d in remap) else None
+        # Probe records nest under .agencies keyed by agency_id. Only rewrite if
+        # we can round-trip the file exactly (keeps the diff to the touched keys).
+        if isinstance(data, dict) and isinstance(data.get("agencies"), dict) \
+                and json.dumps(data, indent=2) + "\n" == raw:
+            new_ag = {}
+            for k, v in data["agencies"].items():
+                new_ag.setdefault(remap.get(k, k), v)  # survivor's own record wins on collision
+            if new_ag != data["agencies"]:
+                data["agencies"] = new_ag
+                probe_state.write_text(json.dumps(data, indent=2) + "\n")
+                changed.append(str(probe_state))
+    return changed
+
+
+def _confirmed_portal_slugs(data_dir):
+    """Slugs with at least one committed snapshot .json on disk."""
+    out = set()
+    for d in data_dir.iterdir():
+        if d.is_dir() and not d.name.startswith(".") and portal_jsons(d):
+            out.add(d.name)
+    return out
+
+
+def _geo_rank(geo):
+    """Rank a geo by usefulness: having coords dominates, then specificity.
+    Kinds: place > cousub/county > manual > state/state-only > ambiguous."""
+    if not isinstance(geo, dict):
+        return 0
+    spec = {"place": 4, "cousub": 3, "county": 3, "manual": 2,
+            "state": 1, "state-only": 1, "ambiguous": 0}.get(geo.get("kind"), 0)
+    has_coords = geo.get("lat") is not None and geo.get("lng") is not None
+    return (10 if has_coords else 0) + spec
+
+
+def _as_list(v):
+    return list(v) if isinstance(v, list) else ([] if v is None else [v])
+
+
+def _union(*lists):
+    seen, out = set(), []
+    for lst in lists:
+        for x in lst:
+            if x not in seen:
+                seen.add(x)
+                out.append(x)
+    return out
+
+
+class _DSU:
+    def __init__(self):
+        self.p = {}
+
+    def find(self, x):
+        self.p.setdefault(x, x)
+        while self.p[x] != x:
+            self.p[x] = self.p[self.p[x]]
+            x = self.p[x]
+        return x
+
+    def union(self, a, b):
+        self.p[self.find(a)] = self.find(b)
+
+
+def _serialize(rows):
+    return json.dumps(rows, indent=2, ensure_ascii=True) + "\n"
+
+
+def plan_folds(registry, splits, confirmed, force_ids=frozenset()):
+    """Return (merges, skips) for the given split edges. Pure — no mutation.
+    A group whose every member id is in ``force_ids`` bypasses the role/type
+    guard (a reviewed manual override, e.g. a same-agency city/county
+    disambiguator)."""
+    by_id = {r["agency_id"]: r for r in registry if r.get("agency_id")}
+
+    # Connected components over split edges; keep per-group edge evidence.
+    dsu = _DSU()
+    edges = []
+    for s in splits:
+        a, b = s["old_id"], s["new_id"]
+        if a in by_id and b in by_id and a != b:
+            dsu.union(a, b)
+            edges.append(s)
+
+    groups = {}
+    for s in edges:
+        root = dsu.find(s["old_id"])
+        groups.setdefault(root, {"ids": set(), "edges": []})
+        groups[root]["ids"].update([s["old_id"], s["new_id"]])
+        groups[root]["edges"].append(s)
+
+    merges, skips = [], []
+    for grp in groups.values():
+        members = [by_id[i] for i in grp["ids"]]
+        roles = {m.get("agency_role") for m in members}
+        types = {m.get("agency_type") for m in members}
+        label = " | ".join(sorted(m.get("slug") or "(null)" for m in members))
+        forced = grp["ids"] <= force_ids
+        if not forced and (len(roles) > 1 or len(types) > 1):
+            skips.append({"ids": sorted(grp["ids"]), "label": label,
+                          "reason": f"role/type mismatch roles={sorted(map(str,roles))} "
+                                    f"types={sorted(map(str,types))} — likely NOT the same agency"})
+            continue
+
+        # Survivor: prefer a real-portal owner, then richer geo, then has ORI,
+        # then deterministic (lowest agency_id).
+        def owns_portal(m):
+            slugs = [m.get("slug")] + _as_list(m.get("flock_slugs"))
+            return any(s in confirmed for s in slugs if s)
+
+        def quality(m):  # higher is better: real portal, then richer geo, then has ORI
+            return (owns_portal(m), _geo_rank(m.get("geo")), bool(m.get("ori")))
+        best = max(quality(m) for m in members)
+        survivor = min((m for m in members if quality(m) == best),
+                       key=lambda m: m["agency_id"])  # deterministic tie-break
+        others = [m for m in members if m["agency_id"] != survivor["agency_id"]]
+
+        # Current spelling = new-name of the strongest edge in the group.
+        cur_edge = max(grp["edges"], key=lambda e: e["portals"])
+        current_name = cur_edge["new"]
+
+        all_names = _union(_as_list(survivor.get("flock_names")),
+                           *[_as_list(m.get("flock_names")) for m in others],
+                           *[[e["old"], e["new"]] for e in grp["edges"]])
+        richest_geo = max(members, key=lambda m: _geo_rank(m.get("geo"))).get("geo")
+        merged_slugs = [s for s in _union(
+            _as_list(survivor.get("flock_slugs")),
+            *[_as_list(m.get("flock_slugs")) for m in others],
+            [m.get("slug") for m in members],
+        ) if s in confirmed]
+        active = survivor.get("flock_active_slug")
+        if active not in confirmed:
+            active = merged_slugs[0] if merged_slugs else None
+        website = survivor.get("website") or next(
+            (m.get("website") for m in others if m.get("website")), None)
+
+        merges.append({
+            "survivor_id": survivor["agency_id"],
+            "survivor_slug": survivor.get("slug"),
+            "drop_ids": [m["agency_id"] for m in others],
+            "portals": cur_edge["portals"],
+            "confidence": cur_edge["confidence"],
+            "fields": {
+                "flock_names": all_names,
+                "display_name": current_name,
+                "geo": richest_geo,
+                "ori": (_union(_as_list(survivor.get("ori")),
+                               *[_as_list(m.get("ori")) for m in others]) or None),
+                "tags": _union(_as_list(survivor.get("tags")),
+                               *[_as_list(m.get("tags")) for m in others]),
+                "flags": _union(_as_list(survivor.get("flags")),
+                                *[_as_list(m.get("flags")) for m in others]),
+                "website": website,
+                "flock_slugs": merged_slugs,
+                "flock_active_slug": active,
+            },
+        })
+    return merges, skips
+
+
+def apply_merges(registry, merges):
+    drop = {i for m in merges for i in m["drop_ids"]}
+    patch = {m["survivor_id"]: m["fields"] for m in merges}
+    out = []
+    for row in registry:
+        aid = row.get("agency_id")
+        if aid in drop:
+            continue
+        if aid in patch:
+            row = dict(row)
+            row.update(patch[aid])
+        out.append(row)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--data-dir", type=Path, default=DATA_DIR)
+    ap.add_argument("--min-portals", type=int, default=3,
+                    help="only fold renames seen on >= this many portals (default 3 = high confidence)")
+    ap.add_argument("--write", action="store_true", help="apply the folds (default: dry run)")
+    ap.add_argument("--force-ids", default="",
+                    help="comma-separated agency_ids: merge that group even if rows disagree "
+                         "on agency_role/agency_type (reviewed manual override)")
+    ap.add_argument("--repoint-from", type=Path, default=None,
+                    help="JSON {dropped_id: survivor_id}: only repoint references (article "
+                         "registry, probe cache) for folds already applied to the registry; "
+                         "does not touch the registry")
+    args = ap.parse_args()
+
+    # Repoint-only mode: fix dangling references left by folds applied earlier.
+    if args.repoint_from:
+        remap = json.loads(args.repoint_from.read_text())
+        if args.write:
+            changed = repoint_refs(remap)
+            print(f"repointed {len(remap)} id(s) across {len(changed)} file(s):")
+            for c in changed:
+                print(f"  {c}")
+        else:
+            print(f"DRY RUN — would repoint {len(remap)} id(s). rerun with --write")
+        return
+
+    raw = REGISTRY_PATH.read_text(encoding="utf-8")
+    if _serialize(json.loads(raw)) != raw:
+        sys.exit("ABORT: cannot reproduce registry serialization; refusing to touch it.")
+    registry = json.loads(raw)
+
+    res = detect(args.data_dir, min_portals=3)
+    splits = [r for r in res["renames"]
+              if r["registry_split"] and r["portals"] >= args.min_portals]
+    confirmed = _confirmed_portal_slugs(args.data_dir)
+    force_ids = frozenset(i.strip() for i in args.force_ids.split(",") if i.strip())
+    merges, skips = plan_folds(registry, splits, confirmed, force_ids=force_ids)
+
+    print(f"splits>= {args.min_portals} portals: {len(splits)}  "
+          f"-> merges: {len(merges)}  skipped: {len(skips)}\n")
+    for m in merges:
+        print(f"  MERGE [{m['confidence']}/{m['portals']}p] keep {m['survivor_slug']} "
+              f"({m['survivor_id'][:8]}) <- drop {[i[:8] for i in m['drop_ids']]}")
+        print(f"        names={m['fields']['flock_names']}")
+        print(f"        display={m['fields']['display_name']!r} geo={(m['fields']['geo'] or {}).get('kind')} "
+              f"slugs={m['fields']['flock_slugs']}")
+    for s in skips:
+        print(f"  SKIP  {s['label']}\n        {s['reason']}")
+
+    if args.write and merges:
+        new_rows = apply_merges(registry, merges)
+        out = _serialize(new_rows)
+        REGISTRY_PATH.write_text(out)
+        print(f"\nWROTE {REGISTRY_PATH}: {len(registry)} -> {len(new_rows)} rows")
+        remap = {d: m["survivor_id"] for m in merges for d in m["drop_ids"]}
+        changed = repoint_refs(remap)
+        if changed:
+            print(f"repointed refs in {len(changed)} file(s): "
+                  + ", ".join(c.split('/')[-1] for c in changed))
+    elif args.write:
+        print("\nnothing to write")
+    else:
+        print("\nDRY RUN — rerun with --write to apply")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/geocode_agencies.py
+++ b/scripts/geocode_agencies.py
@@ -735,7 +735,7 @@ GAZ_OVERRIDES = {
     "799ad8b7-438d-5086-a14c-d396754a5644": ("place", "Lima", "OH"),  # Johnny Appleseed Metro Park District
     "c5cde259-f76e-50ed-87c9-6b4dc48f9cf3": ("place", "Frankfort", "KY"),  # Kentucky AG
     "85363fab-8619-55e4-aa45-15949bb864d2": ("place", "Painesville", "OH"),  # Lake Metroparks Rangers
-    "6202f013-25eb-518a-b460-2c6bd405d044": ("place", "Lakeway", "TX"),  # Lake Travis ISD
+    "01b34cf7-422f-5ddf-b5c3-95e400e0c4b8": ("place", "Lakeway", "TX"),  # Lake Travis ISD
     "04cf4606-6e6f-59ce-b518-1c9cdde0c183": ("place", "West Columbia", "SC"),  # Lexington Medical Center
     "954e73b9-7cf7-5c4f-b490-a65a1a9cc357": ("place", "Milford", "MA"),  # Massachusetts Dept of Correction
     "e6113b72-79ed-5300-834b-f749e617f7be": ("place", "Newtown", "PA"),  # MAGLOCLEN RISS center


### PR DESCRIPTION
## Problem
Flock renames an agency by changing its display name. The registry derives each row's slug — and thus its `agency_id` (`uuid5("flock-registry:"+slug)`) — from that name, so a rename mints a **second row** and fractures one real agency across two ids. Partners' sharing-list references then scatter across both, and the sharing map draws phantom `[inferred]` edges (surfaced via an Alameda County SO → El Cerrito phantom edge).

## What this adds
**`scripts/detect_renames.py`** — classifies three lifecycle events from each portal's snapshot time series (diffing consecutive `sharing_outbound`/`sharing_inbound`):
- **rename** — the same `(-X, +X')` pair across ≥N portals, X/X' sharing identical core-place tokens
- **systemic removal** — mass `-X` with no similar add (decommission / de-federation)
- **new join** — mass `+X` with no similar remove

An identical-core-token guard blocks combinatorial false pairings. For renames it resolves both spellings to registry ids and flags splits. _Validated: El Cerrito's contract cancellation shows as a 136-portal systemic removal in its cancellation window._

**`scripts/fold_registry_renames.py`** — folds split rows onto one survivor (real-portal-slug owner, else richest geo by has-coords + specificity), unioning `flock_names`/`geo`/`ori`/`tags`/`flags` and setting the current `display_name`; keeps only real portal slugs in `flock_slugs`. **Hard guard:** skips (never merges) any group whose rows disagree on `agency_role`/`agency_type` — e.g. a City PD vs a County SO. Transitive (union-find), format-preserving, dry-run by default.

## Registry changes
Folded **19 splits** (5945 → 5926 rows on current main): UC Berkeley, Las Vegas Metro, Kentucky State, Cozad NE, Richland WA, Chelan County WA, East Cleveland OH, Mountain View AR, Fort Bend County TX, Banner Elk NC, Columbia Heights MN, Greenbrier TN, Streetsboro OH, Woodbury MN, Corinth, Avon OH, Lake Travis ISD TX, Oxnard, plus Hamilton Township OH via `--force-ids` (same agency; a `(Warren County)` disambiguator tripped the city/county guard).

Fort Bend also needed `--force-ids` after rebasing: main's refresh relabeled the dead row `decommissioned`, which trips the role/type guard. Same survivor as the original fold.

**3 splits held by the guard** for review: Sacramento (correctly distinct — SO vs PD), Brazoria, and a Banner-Elk `test`-type residual.

## Tests
`make test` — 683 passed (one pre-existing parity failure fixed on main by #650; branch is rebased past it).
