### PR TITLE
fix(verify): epsilon tolerance in justifications parity pct check

### DIFF
--- a/scripts/verify_justifications_agg.js
+++ b/scripts/verify_justifications_agg.js
@@ -60,8 +60,13 @@ const WINDOW_INDEPENDENT = new Set([
   'search_date_max',
 ]);
 
-// Python round() is half-to-even, JS Math.round half-up — allow 0.1.
+// Python round() is half-to-even, JS Math.round half-up — a value on a
+// .x5 boundary can round one ulp apart, so allow a full 0.1 divergence.
+// The +EPS guards the comparison itself: both sides are already rounded to
+// one decimal, and e.g. 31.3 - 31.2 is 0.10000000000000142 in IEEE-754, so a
+// bare `> 0.1` would reject a legitimately-tolerated one-step difference.
 const PCT_FIELDS = new Set(['top1_share_pct', 'top3_share_pct']);
+const PCT_TOLERANCE = 0.1 + 1e-9;
 
 // Canonical JSON with object keys sorted recursively, so we compare
 // values rather than key insertion order (the Python build emits
@@ -119,7 +124,7 @@ function main() {
         continue;
       }
       if (PCT_FIELDS.has(f)) {
-        if (Math.abs((got[f] || 0) - (a[f] || 0)) > 0.1) {
+        if (Math.abs((got[f] || 0) - (a[f] || 0)) > PCT_TOLERANCE) {
           problems.push({ slug, field: f + ' (got ' + got[f] + ' want ' + a[f] + ')' });
         }
       } else if (canon(got[f]) !== canon(a[f])) {


### PR DESCRIPTION
## Problem

The flock-refresh CI on #641 fails the justifications aggregation parity test:

```
PARITY FAILURES (2):
  top1_share_pct (got 31.3 want 31.2): 2 agencies — kings-county-ca-das-office, wilton-ct-pd
```

This is **not** a real drift between `build_justifications.py` and `docs/js/justifications_agg.js`. It's a float-comparison bug in the parity verifier itself.

## Root cause

`scripts/verify_justifications_agg.js` deliberately tolerates a 0.1 divergence on `top1_share_pct`/`top3_share_pct` because Python `round()` is half-to-even and JS `Math.round` is half-up — a value on a `.x5` boundary rounds one step apart. But the guard was a bare `> 0.1`, and 0.1 has no exact IEEE-754 representation:

```js
Math.abs(31.3 - 31.2)          // 0.10000000000000142
0.10000000000000142 > 0.1      // true  ← false positive
```

The #641 data refresh happened to land two agencies' `top1_share` exactly on such a boundary, so a legitimately-tolerated one-step difference tripped the strict comparison.

## Fix

Widen the guard by a float epsilon: `0.1 + 1e-9`. A genuine aggregation divergence differs by ≥ 0.2 (or is a non-pct field, caught by the exact `canon` comparison), so this cannot mask real drift.

## Verification

Reproduced against #641's actual refreshed data (built `docs/data/audit/` + `docs/data/justifications.json` from that branch's assets):

- **Unpatched verifier** → `PARITY FAILURES (2)`, exit 1 (matches CI)
- **Patched verifier** → `parity OK: 103 own-audit agencies match the build`, exit 0

Once merged, #641 (and any future refresh that hits a rounding boundary) will pass after rebasing onto main.